### PR TITLE
KNOX-440: HttpFS impersonation issue

### DIFF
--- a/gateway-provider-identity-assertion-pseudo/src/main/java/org/apache/hadoop/gateway/identityasserter/filter/IdentityAsserterHttpServletRequestWrapper.java
+++ b/gateway-provider-identity-assertion-pseudo/src/main/java/org/apache/hadoop/gateway/identityasserter/filter/IdentityAsserterHttpServletRequestWrapper.java
@@ -43,7 +43,7 @@ public class IdentityAsserterHttpServletRequestWrapper extends HttpServletReques
   private static IdentityAsserterMessages log = MessagesFactory.get( IdentityAsserterMessages.class );
 
   private static final String PRINCIPAL_PARAM = "user.name";
-  private static final String DOAS_PRINCIPAL_PARAM = "doAs";
+  private static final String DOAS_PRINCIPAL_PARAM = "doas";
   
   String username = null;
 


### PR DESCRIPTION
KNOX puts 'doAs' parameter to impersonate certain user. However, HttpFS does not accept it; it accepts 'doas' instead. According to WebHDFS REST API specification (http://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Proxy_Users), 'doas' is the correct one.
