### PR TITLE
KNOX-768 - Pass-through service definition and rewrite rules for Knox & Kafka

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/kafka/0.10.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/kafka/0.10.0/rewrite.xml
@@ -1,0 +1,5 @@
+<rules>
+  <rule dir="IN" name="KAFKA/kafka/inbound" pattern="*://*:*/**/kafka/{path=**}?{**}">
+    <rewrite template="{$serviceUrl[KAFKA]}/{path=**}?{**}"/>
+  </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/kafka/0.10.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/kafka/0.10.0/service.xml
@@ -1,0 +1,5 @@
+<service role="KAFKA" name="kafka" version="0.0.1">
+  <routes>
+    <route path="/kafka/**"/>
+  </routes>
+</service>


### PR DESCRIPTION
KNOX-768 - Preliminary pass-through service definition and rewrite rules for Knox & Confluent Kafka REST (v3.2.1).

Only supports producer at this time.
