### PR TITLE
Provide informative error in place on NPE

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/hadoop/gateway/filter/ShiroSubjectIdentityAdapter.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/hadoop/gateway/filter/ShiroSubjectIdentityAdapter.java
@@ -93,6 +93,11 @@ public class ShiroSubjectIdentityAdapter implements Filter {
         }
       };
       Subject shiroSubject = SecurityUtils.getSubject();
+
+      if (shiroSubject == null || shiroSubject.getPrincipal() == null) {
+        throw new IllegalStateException("Unable to determine authenticated user from Shiro, please check that your Knox Shiro configuration is correct");
+      }
+
       final String principal = (String) shiroSubject.getPrincipal().toString();
       HashSet emptySet = new HashSet();
       Set<Principal> principals = new HashSet<>();


### PR DESCRIPTION
When Shiro provider is used if the user doesn't enable authentication or
enables anonymous authentication then Knox will hit an NPE because it
assumes the Shiro Subject is populated.  This commit adds a check and
adds a specific error message which indicates what the problem is and
how to fix it