### PR TITLE
KNOX-1290. Add Log Search knox proxy definition

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/logsearch/0.5.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/logsearch/0.5.0/rewrite.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<rules>
+
+  <rule dir="IN" name="LOGSEARCH/logsearch/inbound/root" pattern="*://*:*/**/logsearch/">
+    <rewrite template="{$serviceUrl[LOGSEARCH]}/"/>
+  </rule>
+
+  <rule dir="IN" name="LOGSEARCH/logsearch/inbound" pattern="*://*:*/**/logsearch/{**}?{**}">
+    <rewrite template="{$serviceUrl[LOGSEARCH]}/{**}?{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="LOGSEARCH/logsearch/outbound/basepath" pattern="/">
+    <rewrite template='{$frontend[path]}/logsearch/'/>
+  </rule>
+
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/logsearch/0.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/logsearch/0.5.0/service.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<service role="LOGSEARCH" name="logsearch" version="0.5.0">
+  
+  <routes>
+
+    <route path="/logsearch">
+      <rewrite apply="LOGSEARCH/logsearch/outbound" to="response.body"/>
+      <rewrite apply="LOGSEARCH/logsearch/inbound" to="request.body"/>
+    </route>
+
+    <route path="/logsearch/">
+      <rewrite apply="LOGSEARCH/logsearch/outbound" to="response.body"/>
+      <rewrite apply="LOGSEARCH/logsearch/inbound" to="request.body"/>
+    </route>
+
+    <route path="/logsearch/**?**">
+      <rewrite apply="LOGSEARCH/logsearch/outbound" to="response.body"/>
+      <rewrite apply="LOGSEARCH/logsearch/inbound" to="request.body"/>
+    </route>
+
+  </routes>
+
+  <dispatch classname="org.apache.knox.gateway.dispatch.PassAllHeadersDispatch"/>
+
+</service>


### PR DESCRIPTION
Adding logsearch gateway definition to knox (version 0.5.0)

notes: logsearch rewrite is pretty simple as we have a base url in our home page

please review @lmccay 