### PR TITLE
KNOX-1421 - Enable OWASP Dependency Check

### DIFF
--- a/build-tools/src/main/resources/build-tools/dependency-check/suppressions.xml
+++ b/build-tools/src/main/resources/build-tools/dependency-check/suppressions.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+    <suppress>
+        <notes><![CDATA[file name: curator-.*.jar]]></notes>
+        <gav regex="true">^org\.apache\.curator:curator-.*:.*$</gav>
+        <cpe>cpe:/a:apache:zookeeper</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: gateway-.*.jar]]></notes>
+        <gav regex="true">^org\.apache\.knox:gateway-.*:.*$</gav>
+        <cpe>cpe:/a:apache:ambari</cpe>
+        <cpe>cpe:/a:apache:apache_http_server</cpe>
+        <cpe>cpe:/a:apache:apache_test</cpe>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+        <cpe>cpe:/a:apache:hive</cpe>
+        <cpe>cpe:/a:apache:http_server</cpe>
+        <cpe>cpe:/a:apache:nifi</cpe>
+        <cpe>cpe:/a:apache:shiro</cpe>
+        <cpe>cpe:/a:apache:storm</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: hadoop-examples-.*.jar]]></notes>
+        <gav regex="true">^org\.apache\.knox:hadoop-examples:.*$</gav>
+        <cpe>cpe:/a:apache:hadoop</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: zookeeper.*.jar]]></notes>
+        <gav regex="true">^org\.apache\.zookeeper:zookeeper:.*$</gav>
+        <cve>CVE-2014-0085</cve>
+        <cve>CVE-2018-8012</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: groovy-.*.jar]]></notes>
+        <gav regex="true">^org\.codehaus\.groovy:groovy-.*:.*$</gav>
+        <cve>CVE-2016-6497</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: xz-.*.jar]]></notes>
+        <gav regex="true">^org\.tukaani:xz:.*$</gav>
+        <cve>CVE-2015-4035</cve>
+    </suppress>
+</suppressions>

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -177,6 +177,10 @@
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jdk.tools</groupId>
+                    <artifactId>jdk.tools</artifactId>
+                </exclusion>
             </exclusions>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>apache</artifactId>
         <version>21</version>
     </parent>
-    
+
     <groupId>org.apache.knox</groupId>
     <artifactId>gateway</artifactId>
     <version>1.2.0-SNAPSHOT</version>
@@ -153,6 +153,7 @@
         <cors-filter.version>2.6</cors-filter.version>
         <curator.version>4.0.1</curator.version>
         <curator-test.version>2.12.0</curator-test.version>
+        <dependency-check-maven.version>3.3.2</dependency-check-maven.version>
         <easymock.version>4.0.1</easymock.version>
         <eclipselink.version>2.7.3</eclipselink.version>
         <ehcache.version>2.6.11</ehcache.version>
@@ -206,7 +207,7 @@
         <zip4j.version>1.3.2</zip4j.version>
         <zookeeper.version>3.4.10</zookeeper.version>
     </properties>
-    
+
     <profiles>
         <profile>
             <id>package</id>
@@ -253,6 +254,37 @@
             <properties>
                 <failsafe.group>org.apache.knox.test.category.VerifyTest</failsafe.group>
             </properties>
+        </profile>
+        <profile>
+            <id>owasp</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>${dependency-check-maven.version}</version>
+                        <configuration>
+                            <suppressionFiles>
+                                <suppressionFile>build-tools/dependency-check/suppressions.xml</suppressionFile>
+                            </suppressionFiles>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>aggregate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.knox</groupId>
+                                <artifactId>build-tools</artifactId>
+                                <version>1.0.0</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 
@@ -1033,6 +1065,12 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-mapreduce-client-core</artifactId>
                 <version>${hadoop.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jdk.tools</groupId>
+                        <artifactId>jdk.tools</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This is for review only. Patches will be attached to KNOX-1421