### PR TITLE
KNOX-1757. Increasing test timeout from 1 second to 3 seconds

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/deploy/DeploymentFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/deploy/DeploymentFactoryTest.java
@@ -157,7 +157,7 @@ public class DeploymentFactoryTest {
     }
   }
 
-  @Test( timeout = TestUtils.SHORT_TIMEOUT )
+  @Test( timeout = TestUtils.MEDIUM_TIMEOUT )
   public void test_validateNoAppsWithDuplicateUrlsInTopology() {
     DeploymentFactory.validateNoAppsWithDuplicateUrlsInTopology( null );
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`org.apache.knox.gateway.deploy.DeploymentFactoryTest.test_validateNoAppsWithDuplicateUrlsInTopology()` failed periodically due to the given 1 second timeout was not enough (at least locally in my computer); I was not able to reproduce this by increasing the timeout to 3 seconds.

**Note**: this PR is created for review only; the patch - if approved - will be attached to [KNOX-1757](https://issues.apache.org/jira/browse/KNOX-1757).

## How was this patch tested?

Executing JUnit tests:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 23:10 min
[INFO] Finished at: 2019-02-05T14:29:18+01:00
[INFO] Final Memory: 346M/1874M
[INFO] ------------------------------------------------------------------------
```
