### PR TITLE
KNOX-1758 - New Ant target to ease starting test servers enabling remote debugging

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -420,7 +420,7 @@ Release build file for the Apache Knox Gateway
         </exec>
     </target>
 
-    <target name="start-debug-gateway" description="Start test gateway server.">
+    <target name="start-debug-gateway" description="Start test gateway server enabling remote debugging.">
         <exec executable="java" dir="${install.dir}/${gateway-artifact}-${gateway-version}">
             <arg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"/>
             <arg value="-jar"/>
@@ -443,4 +443,6 @@ Release build file for the Apache Knox Gateway
     <target name="start-test-servers" depends="start-test-ldap,start-test-gateway" description="Start test LDAP and test gateway servers."/>
     <target name="stop-test-servers" depends="stop-test-gateway,stop-test-ldap" description="Stop test LDAP server and gateway servers."/>
     <target name="restart-test-servers" depends="stop-test-servers,start-test-servers" description="Restart test LDAP and gateway servers."/>
+    <target name="start-test-servers-debug" depends="start-test-ldap,start-debug-gateway" description="Start test LDAP and test gateway servers enabling remote debugging."/>
+
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We do support (re-) starting test servers without debug mode; I added a new Ant target to start test servers where remote debugging is enabled for the gateway.

**Note**: this PR is created for review only; the patch - if approved - will be attached to [KNOX-1758](https://issues.apache.org/jira/browse/KNOX-1758).

## How was this patch tested?

Manually tested
```
HW15069:knox smolnar$ ant start-test-servers-debug
Buildfile: /Users/smolnar/projects/knox/build.xml

start-test-ldap:
     [exec] Starting LDAP succeeded with PID 26571.

start-debug-gateway:
     [exec] Listening for transport dt_socket at address: 5005
```
