### PR TITLE
KNOX-1162 - Logging stacktrace for FATAL messages and displaying a meaningful error message in case of missing/non-parsable JAAS configuration

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -34,13 +34,13 @@ import java.util.Set;
 public interface GatewayMessages {
 
   @Message( level = MessageLevel.FATAL, text = "Failed to parse command line: {0}" )
-  void failedToParseCommandLine( @StackTrace( level = MessageLevel.DEBUG ) ParseException e );
+  void failedToParseCommandLine( @StackTrace( level = MessageLevel.FATAL ) ParseException e );
 
   @Message( level = MessageLevel.INFO, text = "Starting gateway..." )
   void startingGateway();
 
   @Message( level = MessageLevel.FATAL, text = "Failed to start gateway: {0}" )
-  void failedToStartGateway( @StackTrace( level = MessageLevel.DEBUG ) Exception e );
+  void failedToStartGateway( @StackTrace( level = MessageLevel.FATAL ) Exception e );
 
   @Message( level = MessageLevel.INFO, text = "Started gateway on port {0}." )
   void startedGateway( int port );
@@ -227,7 +227,7 @@ public interface GatewayMessages {
   void failedToReloadTopologies( @StackTrace( level = MessageLevel.DEBUG ) Exception e );
 
   @Message( level = MessageLevel.FATAL, text = "Unsupported encoding: {0}" )
-  void unsupportedEncoding( @StackTrace( level = MessageLevel.DEBUG ) Exception e );
+  void unsupportedEncoding( @StackTrace( level = MessageLevel.FATAL ) Exception e );
 
   @Message( level = MessageLevel.ERROR, text = "Failed to persist master secret: {0}" )
   void failedToPersistMasterSecret( @StackTrace( level = MessageLevel.DEBUG ) Exception e );

--- a/gateway-service-remoteconfig/pom.xml
+++ b/gateway-service-remoteconfig/pom.xml
@@ -38,6 +38,10 @@
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-configinjector</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/CuratorClientService.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/CuratorClientService.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.knox.gateway.config.ConfigurationException;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.service.config.remote.RemoteConfigurationMessages;
@@ -73,8 +74,12 @@ class CuratorClientService implements ZooKeeperClientService {
       // Load the remote registry configurations
       List<RemoteConfigurationRegistryConfig> registryConfigs = new ArrayList<>(RemoteConfigurationRegistriesAccessor.getRemoteRegistryConfigurations(config));
 
-        // Configure registry authentication
+      // Configure registry authentication
+      try {
         RemoteConfigurationRegistryJAASConfig.configure(registryConfigs, aliasService);
+      } catch (ConfigurationException e) {
+        throw new ServiceLifecycleException("Error while configuring registry authentication", e);
+      }
 
         if (registryConfigs.size() > 1) {
             // Warn about current limit on number of supported client configurations

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfig.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfig.java
@@ -65,7 +65,7 @@ class RemoteConfigurationRegistryJAASConfig extends Configuration {
         try {
           delegate = Configuration.getConfiguration();
         } catch(Exception e) {
-          //populate the original error with a meaningful message; logging will happen later in the upper in the call hierarchy
+          //populate the original error with a meaningful message; logging will happen later in the call hierarchy
           final String message = String.format(Locale.ROOT, "Error while getting secure configuration. This error usually indicates an issue within the supplied JAAS configuration: %s",
               System.getProperty(GatewayConfig.KRB5_LOGIN_CONFIG, "Undefined"));
           throw new ConfigurationException(message, e);

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfig.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfig.java
@@ -36,6 +36,8 @@ import java.util.Map;
  */
 class RemoteConfigurationRegistryJAASConfig extends Configuration {
 
+   static final String JAAS_CONFIG_ERRROR_PREFIX = "Error while getting secure configuration. This error usually indicates an issue within the supplied JAAS configuration";
+
     // Underlying SASL mechanisms supported
     enum SASLMechanism {
         Unsupported,
@@ -66,8 +68,7 @@ class RemoteConfigurationRegistryJAASConfig extends Configuration {
           delegate = Configuration.getConfiguration();
         } catch(Exception e) {
           //populate the original error with a meaningful message; logging will happen later in the call hierarchy
-          final String message = String.format(Locale.ROOT, "Error while getting secure configuration. This error usually indicates an issue within the supplied JAAS configuration: %s",
-              System.getProperty(GatewayConfig.KRB5_LOGIN_CONFIG, "Undefined"));
+          final String message = String.format(Locale.ROOT, "%s: %s", JAAS_CONFIG_ERRROR_PREFIX, System.getProperty(GatewayConfig.KRB5_LOGIN_CONFIG, "Undefined"));
           throw new ConfigurationException(message, e);
         }
 

--- a/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
+++ b/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
@@ -53,8 +53,6 @@ public class RemoteConfigurationRegistryJAASConfigTest {
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
-    private static final String JAAS_CONFIG_ERRROR_PREFIX = "Error while getting secure configuration. This error usually indicates an issue within the supplied JAAS configuration";
-
     @Test
     public void testZooKeeperDigestContextEntry() throws Exception {
         List<RemoteConfigurationRegistryConfig> registryConfigs = new ArrayList<>();
@@ -191,7 +189,7 @@ public class RemoteConfigurationRegistryJAASConfigTest {
       System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, "nonExistingFilePath");
 
       expectedException.expect(ConfigurationException.class);
-      expectedException.expectMessage(startsWith(JAAS_CONFIG_ERRROR_PREFIX));
+      expectedException.expectMessage(startsWith(RemoteConfigurationRegistryJAASConfig.JAAS_CONFIG_ERRROR_PREFIX));
 
       try {
         RemoteConfigurationRegistryJAASConfig.configure(registryConfigs, null);
@@ -207,7 +205,7 @@ public class RemoteConfigurationRegistryJAASConfigTest {
       System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, jaasConfigFilePath);
 
       expectedException.expect(ConfigurationException.class);
-      expectedException.expectMessage(startsWith(JAAS_CONFIG_ERRROR_PREFIX));
+      expectedException.expectMessage(startsWith(RemoteConfigurationRegistryJAASConfig.JAAS_CONFIG_ERRROR_PREFIX));
 
       try {
         RemoteConfigurationRegistryJAASConfig.configure(registryConfigs, null);

--- a/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
+++ b/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
@@ -16,14 +16,25 @@
  */
 package org.apache.knox.gateway.service.config.remote.zk;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.knox.gateway.config.ConfigurationException;
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.service.config.remote.RemoteConfigurationRegistryConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.easymock.EasyMock;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +46,14 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class RemoteConfigurationRegistryJAASConfigTest {
+
+    @Rule
+    public final TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private static final String JAAS_CONFIG_ERRROR_PREFIX = "Error while getting secure configuration. This error usually indicates an issue within the supplied JAAS configuration";
 
     @Test
     public void testZooKeeperDigestContextEntry() throws Exception {
@@ -164,6 +183,54 @@ public class RemoteConfigurationRegistryJAASConfigTest {
         } finally {
             Configuration.setConfiguration(null);
         }
+    }
+
+    @Test
+    public void shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeRead() throws Exception {
+      final List<RemoteConfigurationRegistryConfig> registryConfigs = new ArrayList<>();
+      System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, "nonExistingFilePath");
+
+      expectedException.expect(ConfigurationException.class);
+      expectedException.expectMessage(startsWith(JAAS_CONFIG_ERRROR_PREFIX));
+
+      try {
+        RemoteConfigurationRegistryJAASConfig.configure(registryConfigs, null);
+      } finally {
+        System.clearProperty(GatewayConfig.KRB5_LOGIN_CONFIG);
+      }
+    }
+
+    @Test
+    public void shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeParsed() throws Exception {
+      final List<RemoteConfigurationRegistryConfig> registryConfigs = new ArrayList<>();
+      final String jaasConfigFilePath = writeInvalidJaasConf();
+      System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, jaasConfigFilePath);
+
+      expectedException.expect(ConfigurationException.class);
+      expectedException.expectMessage(startsWith(JAAS_CONFIG_ERRROR_PREFIX));
+
+      try {
+        RemoteConfigurationRegistryJAASConfig.configure(registryConfigs, null);
+      } finally {
+        System.clearProperty(GatewayConfig.KRB5_LOGIN_CONFIG);
+      }
+    }
+
+    private String writeInvalidJaasConf() throws IOException {
+      final File jaasConfigFile = testFolder.newFile("jaas.conf");
+      final String jaasConfig = "com.sun.security.jgss.initiate {" +
+        "com.sun.security.auth.module.Krb5LoginModule required" +
+        "renewTGT=false" +
+        "doNotPrompt=true" +
+        "useKeyTab=true" +
+        "keyTab=/etc/security/keytabs/knox.service.keytab" + //note the missing quotes; it should be keyTab="/etc/security/keytabs/knox.service.keytab"
+        "principal=\"knox/myHost@myRealm\"" +
+        "storeKey=true" +
+        "useTicketCache=false; " +
+        "};";
+
+      FileUtils.writeStringToFile(jaasConfigFile, jaasConfig, StandardCharsets.UTF_8);
+      return jaasConfigFile.getAbsolutePath();
     }
 
     private static RemoteConfigurationRegistryConfig createDigestConfig(String entryName,

--- a/gateway-util-urltemplate/src/test/java/org/apache/knox/gateway/util/urltemplate/MatcherTest.java
+++ b/gateway-util-urltemplate/src/test/java/org/apache/knox/gateway/util/urltemplate/MatcherTest.java
@@ -796,7 +796,7 @@ public class MatcherTest {
     Template template;
     Template input;
     Matcher<String> stringMatcher;
-    Matcher<?>.Match match;
+    Matcher<String>.Match match;
 
 //    template = Parser.parse( "*://*:*/**/webhdfs/v1/**?**" );
 //    input = Parser.parse( "http://localhost:53221/gateway/cluster/webhdfs/v1/tmp/GatewayWebHdfsFuncTest/testBasicHdfsUseCase/dir?user.name=hdfs&op=MKDIRS" );


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there is a misconfiguration in the supplied JAAS configuration (i.e. `conf/krb5JAASLogin.conf`) the server fails to start and the information in gateway.log wasn't at all helpful. To make it better the following changes have been made:
- *all* `FATAL` messages are logged with the full stack trace
- in case the supplied JAAS configuration file does not exist or cannot be parsed we wrap the `IOException` coming from security login configuration into our own `ConfigurationException` with a meaningful error message

(an additional change is to fix a unit test case in `MatcherTest` to avoid compilation error; I'm not sure how it was working before but it constantly fails locally for me)

## How was this patch tested?

Added new unit test cases and executed them (including integration tests):
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:18 min (Wall Clock)
[INFO] Finished at: 2019-02-15T23:48:43+01:00
[INFO] Final Memory: 265M/1643M
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing the following manual test has been executed:

1. stopped the gateway server
2. built and deployed the new version of the gateway server (with my changes)
3. updated `/etc/knox/conf/krb5JAASLogin.conf`: removed surrounding quotes from the `keytab` property (which is invalid)
4. tried to start the gateway. As expected it failed to start
5. checked the log file if the enhanced error message appeared:

```
2019-02-15 23:05:44,047 FATAL knox.gateway (GatewayServer.java:main(168)) - Failed to start gateway: org.apache.knox.gateway.services.ServiceLifecycleException: Error while configuring registry authentication
org.apache.knox.gateway.services.ServiceLifecycleException: Error while configuring registry authentication
        at org.apache.knox.gateway.service.config.remote.zk.CuratorClientService.init(CuratorClientService.java:81)
        at org.apache.knox.gateway.services.DefaultGatewayServices.init(DefaultGatewayServices.java:79)
        at org.apache.knox.gateway.GatewayServer.main(GatewayServer.java:159)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
        at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
        at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
        at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
        at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)
Caused by: org.apache.knox.gateway.config.ConfigurationException: Error while getting secure configuration. This error usually indicates an issue within the supplied JAAS configuration: /etc/knox/conf/krb5JAASLogin.conf
        at org.apache.knox.gateway.service.config.remote.zk.RemoteConfigurationRegistryJAASConfig.<init>(RemoteConfigurationRegistryJAASConfig.java:71)
        at org.apache.knox.gateway.service.config.remote.zk.RemoteConfigurationRegistryJAASConfig.configure(RemoteConfigurationRegistryJAASConfig.java:61)
        at org.apache.knox.gateway.service.config.remote.zk.CuratorClientService.init(CuratorClientService.java:79)
        ... 11 more
Caused by: java.lang.SecurityException: java.io.IOException: Configuration Error:
        Line 7: expected [option key]
        at sun.security.provider.ConfigFile$Spi.<init>(ConfigFile.java:137)
        at sun.security.provider.ConfigFile.<init>(ConfigFile.java:102)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at java.lang.Class.newInstance(Class.java:442)
        at javax.security.auth.login.Configuration$2.run(Configuration.java:255)
        at javax.security.auth.login.Configuration$2.run(Configuration.java:247)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.login.Configuration.getConfiguration(Configuration.java:246)
        at org.apache.knox.gateway.service.config.remote.zk.RemoteConfigurationRegistryJAASConfig.<init>(RemoteConfigurationRegistryJAASConfig.java:66)
        ... 13 more
Caused by: java.io.IOException: Configuration Error:
        Line 7: expected [option key]
        at sun.security.provider.ConfigFile$Spi.ioException(ConfigFile.java:666)
        at sun.security.provider.ConfigFile$Spi.match(ConfigFile.java:572)
        at sun.security.provider.ConfigFile$Spi.parseLoginEntry(ConfigFile.java:477)
        at sun.security.provider.ConfigFile$Spi.readConfig(ConfigFile.java:427)
        at sun.security.provider.ConfigFile$Spi.init(ConfigFile.java:329)
        at sun.security.provider.ConfigFile$Spi.init(ConfigFile.java:271)
        at sun.security.provider.ConfigFile$Spi.<init>(ConfigFile.java:135)
        ... 24 more
```