### PR TITLE
KNOX-1791 - MasterService should be a field on GatewayServices

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -112,7 +112,7 @@ public class Pac4jDispatcherFilter implements Filter {
         keystoreService = services.getService(GatewayServices.KEYSTORE_SERVICE);
         cryptoService = services.getService(GatewayServices.CRYPTO_SERVICE);
         aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
-        masterService = services.getService("MasterService");
+        masterService = services.getService(GatewayServices.MASTER_SERVICE);
       }
     }
     // crypto service, alias service and cluster name are mandatory

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -369,7 +369,7 @@ public class GatewayServer {
       httpsConfig.setSecureScheme( "https" );
       httpsConfig.setSecurePort( connectorPort );
       httpsConfig.addCustomizer( new SecureRequestCustomizer() );
-      SSLService ssl = services.getService("SSLService");
+      SSLService ssl = services.getService(GatewayServices.SSL_SERVICE);
       SslContextFactory sslContextFactory = (SslContextFactory)ssl.buildSslContextFactory( config.getIdentityKeystorePath(), config.getIdentityKeystoreType(), config.getIdentityKeyAlias() );
       connector = new ServerConnector( server, sslContextFactory, new HttpConnectionFactory( httpsConfig ) );
     } else {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
@@ -59,7 +59,7 @@ public class CLIGatewayServices implements GatewayServices {
 
     ms = new CLIMasterService();
     ms.init(config, options);
-    services.put("MasterService", ms);
+    services.put(MASTER_SERVICE, ms);
 
     ks = new DefaultKeystoreService();
     ks.setMasterService(ms);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -63,7 +63,7 @@ public class DefaultGatewayServices implements GatewayServices {
   public void init(GatewayConfig config, Map<String,String> options) throws ServiceLifecycleException {
     ms = new DefaultMasterService();
     ms.init(config, options);
-    services.put("MasterService", ms);
+    services.put(MASTER_SERVICE, ms);
 
     ks = new DefaultKeystoreService();
     ks.setMasterService(ms);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -253,7 +253,7 @@ public class SimpleDescriptorHandler {
         try {
             GatewayServices services = GatewayServer.getGatewayServices();
             if (services != null) {
-                MasterService ms = services.getService("MasterService");
+                MasterService ms = services.getService(GatewayServices.MASTER_SERVICE);
                 if (ms != null) {
                     KeystoreService ks = services.getService(GatewayServices.KEYSTORE_SERVICE);
                     if (ks != null) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -684,7 +684,7 @@ public class KnoxCLI extends Configured implements Tool {
          if ( !isForceRequired(config, ks) || force) {
            char[] passphrase = as.getGatewayIdentityPassphrase();
            if (passphrase == null) {
-             MasterService ms = services.getService("MasterService");
+             MasterService ms = services.getService(GatewayServices.MASTER_SERVICE);
              passphrase = ms.getMasterSecret();
            }
            ks.addSelfSignedCertForGateway(config.getIdentityKeyAlias(), passphrase, hostname);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -670,7 +670,7 @@ public class KnoxCLITest {
     KnoxCLI cli = new KnoxCLI();
     int rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    MasterService ms = cli.getGatewayServices().getService("MasterService");
+    MasterService ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
     String master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master, is( "master" ) );
     assertThat( outContent.toString(StandardCharsets.UTF_8.name()), containsString( "Master secret has been persisted to disk." ) );
@@ -770,7 +770,7 @@ public class KnoxCLITest {
     cli.setConf( config );
     rc = cli.run(args);
     assertEquals(0, rc);
-    MasterService ms = cli.getGatewayServices().getService("MasterService");
+    MasterService ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
     // assertTrue(ms.getClass().getName(), ms.getClass().getName().equals("kjdfhgjkhfdgjkh"));
     assertEquals(new String(ms.getMasterSecret()), "master", new String(ms.getMasterSecret()));
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("Master secret has been persisted to disk."));
@@ -792,7 +792,7 @@ public class KnoxCLITest {
     cli.setConf(config);
     rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    MasterService ms = cli.getGatewayServices().getService("MasterService");
+    MasterService ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
     String master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master.length(), is( 36 ) );
     assertThat( master.indexOf( '-' ), is( 8 ) );
@@ -809,7 +809,7 @@ public class KnoxCLITest {
     outContent.reset();
     cli = new KnoxCLI();
     rc = cli.run(args);
-    ms = cli.getGatewayServices().getService("MasterService");
+    ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
     String master2 = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master2.length(), is( 36 ) );
     assertThat( UUID.fromString( master2 ), notNullValue() );
@@ -838,7 +838,7 @@ public class KnoxCLITest {
 
     rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    ms = cli.getGatewayServices().getService("MasterService");
+    ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
     String master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master, is( "test-master-1" ) );
     assertThat( outContent.toString(StandardCharsets.UTF_8.name()), containsString( "Master secret has been persisted to disk." ) );
@@ -852,7 +852,7 @@ public class KnoxCLITest {
     args = new String[]{ "create-master", "--master", "test-master-2", "--force" };
     rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    ms = cli.getGatewayServices().getService("MasterService");
+    ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
     master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master, is( "test-master-2" ) );
     assertThat( outContent.toString(StandardCharsets.UTF_8.name()), containsString( "Master secret has been persisted to disk." ) );

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -80,7 +80,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     }
     if (Boolean.parseBoolean(filterConfig.getInitParameter("useTwoWaySsl"))) {
       char[] keypass = null;
-      MasterService ms = services.getService("MasterService");
+      MasterService ms = services.getService(GatewayServices.MASTER_SERVICE);
       AliasService as = services.getService(GatewayServices.ALIAS_SERVICE);
       try {
         keypass = as.getGatewayIdentityPassphrase();

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/GatewayServices.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/GatewayServices.java
@@ -27,21 +27,23 @@ public interface GatewayServices extends Service,
   String GATEWAY_CLUSTER_ATTRIBUTE = "org.apache.knox.gateway.gateway.cluster";
   String GATEWAY_SERVICES_ATTRIBUTE = "org.apache.knox.gateway.gateway.services";
 
-  String SSL_SERVICE = "SSLService";
-  String CRYPTO_SERVICE = "CryptoService";
+  /* ************************************************************************************
+   * Service Name Constants
+   * ************************************************************************************ */
   String ALIAS_SERVICE = "AliasService";
-  String KEYSTORE_SERVICE = "KeystoreService";
-  String TOKEN_SERVICE = "TokenService";
-  String SERVICE_REGISTRY_SERVICE = "ServiceRegistryService";
-  String HOST_MAPPING_SERVICE = "HostMappingService";
-  String SERVER_INFO_SERVICE = "ServerInfoService";
-  String TOPOLOGY_SERVICE = "TopologyService";
-  String SERVICE_DEFINITION_REGISTRY = "ServiceDefinitionRegistry";
-  String METRICS_SERVICE = "MetricsService";
-
-  String REMOTE_REGISTRY_CLIENT_SERVICE = "RemoteConfigRegistryClientService";
-
   String CLUSTER_CONFIGURATION_MONITOR_SERVICE = "ClusterConfigurationMonitorService";
+  String CRYPTO_SERVICE = "CryptoService";
+  String HOST_MAPPING_SERVICE = "HostMappingService";
+  String KEYSTORE_SERVICE = "KeystoreService";
+  String MASTER_SERVICE = "MasterService";
+  String METRICS_SERVICE = "MetricsService";
+  String REMOTE_REGISTRY_CLIENT_SERVICE = "RemoteConfigRegistryClientService";
+  String SERVER_INFO_SERVICE = "ServerInfoService";
+  String SERVICE_DEFINITION_REGISTRY = "ServiceDefinitionRegistry";
+  String SERVICE_REGISTRY_SERVICE = "ServiceRegistryService";
+  String SSL_SERVICE = "SSLService";
+  String TOKEN_SERVICE = "TokenService";
+  String TOPOLOGY_SERVICE = "TopologyService";
 
   Collection<String> getServiceNames();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -174,7 +174,7 @@ public class SimpleDescriptorHandlerFuncTest {
       MasterService ms = EasyMock.createNiceMock(MasterService.class);
       EasyMock.expect(ms.getMasterSecret()).andReturn(testMasterSecret.toCharArray()).anyTimes();
       EasyMock.replay(ms);
-      EasyMock.expect(gatewayServices.getService("MasterService")).andReturn(ms).anyTimes();
+      EasyMock.expect(gatewayServices.getService(GatewayServices.MASTER_SERVICE)).andReturn(ms).anyTimes();
 
       // Keystore Service
       KeystoreService ks = EasyMock.createNiceMock(KeystoreService.class);


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

Currently "MasterService" is a string throughout the code base. This should be a field on the interface GatewayServices like other services.

- Added `GatewayServices.MASTER_SERVICE` constant.
- Alphabetized service name constants in `GatewayServices` 
- Replaced "MasterService" strings speckled throughout the code with `GatewayServices.MASTER_SERVICE`
- Replaced an instance of "SSLService" with "GatewayServices.SSL_SERVICE"

## How was this patch tested?

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
