### PR TITLE
KNOX-1789 - Refactor RemoteAliasService to use service loading

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -228,6 +228,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   static final String DISPATCH_HOST_WHITELIST          = GATEWAY_CONFIG_FILE_PREFIX + ".dispatch.whitelist";
   static final String DISPATCH_HOST_WHITELIST_SERVICES = DISPATCH_HOST_WHITELIST + ".services";
 
+  static final String REMOTE_ALIAS_SERVICE_CONFIG_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.config.prefix";
+  static final String REMOTE_ALIAS_SERVICE_CONFIG_PREFIX_DEFAULT = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.config";
+
   private static final List<String> DEFAULT_GLOBAL_RULES_SERVICES = Arrays.asList(
       "NAMENODE", "JOBTRACKER", "WEBHDFS", "WEBHCAT",
       "OOZIE", "WEBHBASE", "HIVE", "RESOURCEMANAGER");
@@ -942,8 +945,17 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public boolean isRemoteAliasServiceEnabled() {
-    final String result = get( REMOTE_ALIAS_SERVICE_ENABLED, Boolean.toString(DEFAULT_REMOTE_ALIAS_SERVICE_ENABLED));
-    return Boolean.parseBoolean(result);
+    return getBoolean( REMOTE_ALIAS_SERVICE_ENABLED, DEFAULT_REMOTE_ALIAS_SERVICE_ENABLED);
+  }
+
+  @Override
+  public String getRemoteAliasServiceConfigurationPrefix() {
+    return get(REMOTE_ALIAS_SERVICE_CONFIG_PREFIX, REMOTE_ALIAS_SERVICE_CONFIG_PREFIX_DEFAULT);
+  }
+
+  @Override
+  public Map<String, String> getRemoteAliasServiceConfiguration() {
+    return getPropsWithPrefix(getRemoteAliasServiceConfigurationPrefix());
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/RemoteAliasService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/RemoteAliasService.java
@@ -17,34 +17,25 @@
  */
 package org.apache.knox.gateway.services.security.impl;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.GatewayMessages;
-import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.security.RemoteAliasServiceProvider;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
-import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClient;
-import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
-import org.apache.knox.gateway.services.security.EncryptionResult;
 import org.apache.knox.gateway.services.security.MasterService;
 import org.apache.knox.gateway.util.PasswordUtils;
-import org.apache.zookeeper.ZooDefs;
 
-import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 /**
- * An {@link AliasService} implementation based on
- * remote service registry.
+ * An {@link AliasService} implementation based on remote service registry.
  * <p>
  * This class encapsulates the default AliasService implementation which uses
  * local keystore to store the aliases. The order in which Aliases are stored are
@@ -56,154 +47,20 @@ import java.util.Map;
  * @since 1.1.0
  */
 public class RemoteAliasService implements AliasService {
-
-  public static final String PATH_KNOX = "/knox";
-  public static final String PATH_KNOX_SECURITY = PATH_KNOX + "/security";
-  public static final String PATH_KNOX_ALIAS_STORE_TOPOLOGY =
-      PATH_KNOX_SECURITY + "/topology";
-  public static final String PATH_SEPARATOR = "/";
   public static final String DEFAULT_CLUSTER_NAME = "__gateway";
+  public static final String REMOTE_ALIAS_SERVICE_TYPE = "type";
 
   private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
-  // N.B. This is ZooKeeper-specific, and should be abstracted when another registry is supported
-  private static final RemoteConfigurationRegistryClient.EntryACL AUTHENTICATED_USERS_ALL;
 
-  static {
-    AUTHENTICATED_USERS_ALL = new RemoteConfigurationRegistryClient.EntryACL() {
-      @Override
-      public String getId() {
-        return "";
-      }
+  private final AliasService localAliasService;
+  private final MasterService ms;
 
-      @Override
-      public String getType() {
-        return "auth";
-      }
-
-      @Override
-      public Object getPermissions() {
-        return ZooDefs.Perms.ALL;
-      }
-
-      @Override
-      public boolean canRead() {
-        return true;
-      }
-
-      @Override
-      public boolean canWrite() {
-        return true;
-      }
-    };
-  }
-
-  private RemoteConfigurationRegistryClient remoteClient;
-  private ConfigurableEncryptor encryptor;
-  /**
-   * Default alias service
-   */
-  private AliasService localAliasService;
-  private RemoteConfigurationRegistryClientService registryClientService;
-  private MasterService ms;
+  private AliasService remoteAliasServiceImpl;
   private GatewayConfig config;
 
-  /* create an instance */
-  public RemoteAliasService() {
-    super();
-  }
-
-  /**
-   * Build an entry path for the given cluster and alias
-   */
-  private static String buildAliasEntryName(final String clusterName,
-      final String alias) {
-    return buildClusterEntryName(clusterName) + PATH_SEPARATOR + alias;
-  }
-
-  /**
-   * Build an entry path for the given cluster
-   */
-  private static String buildClusterEntryName(final String clusterName) {
-    return PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR + clusterName;
-  }
-
-  /**
-   * Ensure that the given entry path exists.
-   */
-  private static void ensureEntry(final String path,
-      final RemoteConfigurationRegistryClient remoteClient) {
-    if (!remoteClient.entryExists(path)) {
-      remoteClient.createEntry(path);
-    } else {
-      // Validate the ACL
-      List<RemoteConfigurationRegistryClient.EntryACL> entryACLs = remoteClient
-          .getACL(path);
-      for (RemoteConfigurationRegistryClient.EntryACL entryACL : entryACLs) {
-        // N.B. This is ZooKeeper-specific, and should be abstracted when another registry is supported
-        // For now, check for world:anyone with ANY permissions (even read-only)
-        if (entryACL.getType().equals("world") && entryACL.getId()
-            .equals("anyone")) {
-          LOG.suspectWritableRemoteConfigurationEntry(path);
-
-          // If the client is authenticated, but "anyone" can write the content, then the content may not
-          // be trustworthy.
-          if (remoteClient.isAuthenticationConfigured()) {
-            LOG.correctingSuspectWritableRemoteConfigurationEntry(path);
-
-            // Replace the existing ACL with one that permits only authenticated users
-            remoteClient.setACL(path,
-                Collections.singletonList(AUTHENTICATED_USERS_ALL));
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Check to make sure all the required entries are properly set up
-   */
-  private static void checkPathsExist(
-      final RemoteConfigurationRegistryClient remoteClient) {
-    ensureEntry(PATH_KNOX, remoteClient);
-    ensureEntry(PATH_KNOX_SECURITY, remoteClient);
-    ensureEntry(PATH_KNOX_ALIAS_STORE_TOPOLOGY, remoteClient);
-    ensureEntry(
-        PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR + DEFAULT_CLUSTER_NAME,
-        remoteClient);
-  }
-
-  /**
-   * Returns an empty list if the given list is null,
-   * else returns the given list.
-   */
-  private static List<String> safe(final List<String> given) {
-    return given == null ? Collections.EMPTY_LIST : given;
-  }
-
-  /**
-   * Set a {@link RemoteConfigurationRegistryClientService} instance
-   * used to talk to remote remote service registry.
-   * @param registryClientService registryClientService to set
-   */
-  public void setRegistryClientService(
-      final RemoteConfigurationRegistryClientService registryClientService) {
-    this.registryClientService = registryClientService;
-  }
-
-  /**
-   * Set a {@link MasterService} instance.
-   * @param ms master service to set
-   */
-  public void setMasterService(final MasterService ms) {
-    this.ms = ms;
-  }
-
-  /**
-   * Set local alias service
-   * @param localAliasService local alias service to set
-   */
-  public void setLocalAliasService(AliasService localAliasService) {
+  public RemoteAliasService(AliasService localAliasService, MasterService ms) {
     this.localAliasService = localAliasService;
+    this.ms = ms;
   }
 
   /**
@@ -214,24 +71,22 @@ public class RemoteAliasService implements AliasService {
    * @return List of all the aliases
    */
   @Override
-  public List<String> getAliasesForCluster(final String clusterName)
-      throws AliasServiceException {
-
+  public List<String> getAliasesForCluster(final String clusterName) throws AliasServiceException {
     List<String> remoteAliases = new ArrayList<>();
 
     /* If we have remote registry configured, query it */
-    if (remoteClient != null && config.isRemoteAliasServiceEnabled()) {
-      remoteAliases = remoteClient
-          .listChildEntries(buildClusterEntryName(clusterName));
+    if (remoteAliasServiceImpl != null) {
+      remoteAliases = remoteAliasServiceImpl.getAliasesForCluster(clusterName);
     }
 
     List<String> localAliases = localAliasService
         .getAliasesForCluster(clusterName);
 
-    /* merge */
-    for (final String alias : safe(localAliases)) {
-      if (!remoteAliases.contains(alias.toLowerCase(Locale.ROOT))) {
-        remoteAliases.add(alias);
+    if(localAliases != null) {
+      for (final String alias : localAliases) {
+        if (!remoteAliases.contains(alias.toLowerCase(Locale.ROOT))) {
+          remoteAliases.add(alias);
+        }
       }
     }
 
@@ -249,31 +104,14 @@ public class RemoteAliasService implements AliasService {
     /* first add the alias to the local keystore */
     localAliasService.addAliasForCluster(clusterName, alias, value);
 
-    if (remoteClient != null && config.isRemoteAliasServiceEnabled()) {
-
-      final String aliasEntryPath = buildAliasEntryName(clusterName, alias);
-
-      /* Ensure the entries are properly set up */
-      checkPathsExist(remoteClient);
-      ensureEntry(buildClusterEntryName(clusterName), remoteClient);
-      try {
-        remoteClient.createEntry(aliasEntryPath, encrypt(value));
-      } catch (Exception e) {
-        throw new AliasServiceException(e);
-      }
-
-      if (remoteClient.getEntryData(aliasEntryPath) == null) {
-        throw new IllegalStateException(String.format(Locale.ROOT,
-            "Failed to store alias %s for cluster %s in remote registry", alias,
-            clusterName));
-      }
+    if (remoteAliasServiceImpl != null) {
+      remoteAliasServiceImpl.addAliasForCluster(clusterName, alias, value);
     }
   }
 
   @Override
-  public void removeAliasForCluster(final String clusterName,
-      final String givenAlias) throws AliasServiceException {
-
+  public void removeAliasForCluster(final String clusterName, final String givenAlias)
+      throws AliasServiceException {
     /* convert all alias names to lower case since JDK expects the same behaviour */
     final String alias = givenAlias.toLowerCase(Locale.ROOT);
 
@@ -281,21 +119,8 @@ public class RemoteAliasService implements AliasService {
     localAliasService.removeAliasForCluster(clusterName, alias);
 
     /* If we have remote registry configured, query it */
-    if (remoteClient != null && config.isRemoteAliasServiceEnabled()) {
-
-      final String aliasEntryPath = buildAliasEntryName(clusterName, alias);
-
-      if (remoteClient.entryExists(aliasEntryPath)) {
-        remoteClient.deleteEntry(aliasEntryPath);
-
-        if (remoteClient.entryExists(aliasEntryPath)) {
-          throw new IllegalStateException(String.format(Locale.ROOT,
-              "Failed to delete alias %s for cluster %s in remote registry",
-              alias, clusterName));
-        }
-      }
-    } else {
-      LOG.missingClientConfigurationForRemoteMonitoring();
+    if (remoteAliasServiceImpl != null) {
+      remoteAliasServiceImpl.removeAliasForCluster(clusterName, alias);
     }
   }
 
@@ -308,39 +133,19 @@ public class RemoteAliasService implements AliasService {
   @Override
   public char[] getPasswordFromAliasForCluster(String clusterName,
       String givenAlias, boolean generate) throws AliasServiceException {
-
     /* convert all alias names to lower case since JDK expects the same behaviour */
     final String alias = givenAlias.toLowerCase(Locale.ROOT);
+
+    /* Generate a new password  */
+    if (generate) {
+      generateAliasForCluster(clusterName, alias);
+    }
 
     char[] password = null;
 
     /* try to get it from remote registry */
-    if (remoteClient != null && config.isRemoteAliasServiceEnabled()) {
-
-      checkPathsExist(remoteClient);
-      String encrypted = null;
-
-      if(remoteClient.entryExists(buildAliasEntryName(clusterName, alias))) {
-        encrypted = remoteClient
-            .getEntryData(buildAliasEntryName(clusterName, alias));
-      }
-
-      /* Generate a new password */
-      if (encrypted == null) {
-
-        /* Generate a new password  */
-        if (generate) {
-          generateAliasForCluster(clusterName, alias);
-          password = getPasswordFromAliasForCluster(clusterName, alias);
-        }
-
-      } else {
-        try {
-          password = decrypt(encrypted).toCharArray();
-        } catch (final Exception e) {
-          throw new AliasServiceException(e);
-        }
-      }
+    if (remoteAliasServiceImpl != null) {
+      password = remoteAliasServiceImpl.getPasswordFromAliasForCluster(clusterName, alias);
     }
 
     /*
@@ -351,8 +156,7 @@ public class RemoteAliasService implements AliasService {
      */
     if(password == null) {
       /* try to get it from the local keystore, ignore generate flag. */
-      password = localAliasService
-          .getPasswordFromAliasForCluster(clusterName, alias, generate);
+      password = localAliasService.getPasswordFromAliasForCluster(clusterName, alias);
     }
 
     /* found nothing */
@@ -360,11 +164,8 @@ public class RemoteAliasService implements AliasService {
   }
 
   @Override
-  public void generateAliasForCluster(final String clusterName,
-      final String givenAlias) throws AliasServiceException {
-
-    /* convert all alias names to lower case since JDK expects the same behaviour */
-    final String alias = givenAlias.toLowerCase(Locale.ROOT);
+  public void generateAliasForCluster(final String clusterName, final String alias)
+      throws AliasServiceException {
     /* auto-generated password */
     final String passwordString = PasswordUtils.generatePassword(16);
     addAliasForCluster(clusterName, alias, passwordString);
@@ -378,40 +179,22 @@ public class RemoteAliasService implements AliasService {
 
   @Override
   public char[] getGatewayIdentityPassphrase() throws AliasServiceException {
-    char[] passphrase = getPasswordFromAliasForGateway(config.getIdentityKeyPassphraseAlias());
-    if (passphrase == null) {
-      // Fall back to the keystore password if a key-specific password was not explicitly set.
-      passphrase = getGatewayIdentityKeystorePassword();
-    }
-    if (passphrase == null) {
-      // Use the master password if not password was found
-      passphrase = ms.getMasterSecret();
-    }
-    return passphrase;
+    return getPasswordFromAliasForGateway(config.getIdentityKeyPassphraseAlias());
   }
 
   @Override
   public char[] getGatewayIdentityKeystorePassword() throws AliasServiceException {
-    return getKeystorePassword(config.getIdentityKeystorePasswordAlias());
+    return getPasswordFromAliasForGateway(config.getIdentityKeystorePasswordAlias());
   }
 
   @Override
   public char[] getSigningKeyPassphrase() throws AliasServiceException {
-    char[] passphrase = getPasswordFromAliasForGateway(config.getSigningKeyPassphraseAlias());
-    if (passphrase == null) {
-      // Fall back to the keystore password if a key-specific password was not explicitly set.
-      passphrase = getSigningKeystorePassword();
-    }
-    if (passphrase == null) {
-      // Use the master password if not password was found
-      passphrase = ms.getMasterSecret();
-    }
-    return passphrase;
+    return getPasswordFromAliasForGateway(config.getSigningKeyPassphraseAlias());
   }
 
   @Override
   public char[] getSigningKeystorePassword() throws AliasServiceException {
-    return getKeystorePassword(config.getSigningKeystorePasswordAlias());
+    return getPasswordFromAliasForGateway(config.getIdentityKeystorePasswordAlias());
   }
 
   @Override
@@ -428,264 +211,39 @@ public class RemoteAliasService implements AliasService {
   }
 
   @Override
-  public void init(final GatewayConfig config,
-      final Map<String, String> options) throws ServiceLifecycleException {
+  public void init(final GatewayConfig config, final Map<String, String> options)
+      throws ServiceLifecycleException {
     this.config = config;
+    Map<String, String> remoteAliasServiceConfigs = config.getRemoteAliasServiceConfiguration();
 
-    /* setup and initialize encryptor for encryption and decryption of passwords */
-    encryptor = new ConfigurableEncryptor(new String(ms.getMasterSecret()));
-    encryptor.init(config);
-
-    /* If we have remote registry configured, query it */
-    final String clientName = config.getRemoteConfigurationMonitorClientName();
-    if (clientName != null) {
-
-      if (registryClientService != null) {
-
-        remoteClient = registryClientService.get(clientName);
-
-      } else {
-        throw new ServiceLifecycleException(
-            "Remote configuration registry not initialized");
+    if(config.isRemoteAliasServiceEnabled() && remoteAliasServiceConfigs != null) {
+      String remoteAliasServiceType = remoteAliasServiceConfigs.get(REMOTE_ALIAS_SERVICE_TYPE);
+      ServiceLoader<RemoteAliasServiceProvider> providers =
+          ServiceLoader.load(RemoteAliasServiceProvider.class);
+      for (RemoteAliasServiceProvider provider : providers) {
+        if(provider.getType().equalsIgnoreCase(remoteAliasServiceType)) {
+          LOG.remoteAliasServiceEnabled();
+          remoteAliasServiceImpl = provider.newInstance(localAliasService, ms);
+          remoteAliasServiceImpl.init(config, options);
+          break;
+        }
       }
-
     } else {
-      LOG.missingClientConfigurationForRemoteMonitoring();
+      LOG.remoteAliasServiceDisabled();
     }
   }
 
   @Override
   public void start() throws ServiceLifecycleException {
-
-    if (remoteClient != null && config.isRemoteAliasServiceEnabled()) {
-
-      /* ensure that nodes are properly setup */
-      ensureEntries(remoteClient);
-
-      /* Confirm access to the remote aliases directory */
-      final List<String> aliases = remoteClient
-          .listChildEntries(PATH_KNOX_ALIAS_STORE_TOPOLOGY);
-      if (aliases == null) {
-        // Either the entry does not exist, or there is an authentication problem
-        throw new IllegalStateException(
-            "Unable to access remote path: " + PATH_KNOX_ALIAS_STORE_TOPOLOGY);
-      }
-
-      /* Register a listener for aliases entry additions/removals */
-      try {
-        remoteClient.addChildEntryListener(PATH_KNOX_ALIAS_STORE_TOPOLOGY,
-            new RemoteAliasChildListener(this));
-      } catch (final Exception e) {
-        throw new IllegalStateException(
-            "Unable to add listener for path " + PATH_KNOX_ALIAS_STORE_TOPOLOGY,
-            e);
-      }
+    if (remoteAliasServiceImpl != null) {
+      remoteAliasServiceImpl.start();
     }
-
-    if(!config.isRemoteAliasServiceEnabled()) {
-      LOG.remoteAliasServiceDisabled();
-    } else {
-      LOG.remoteAliasServiceEnabled();
-    }
-
   }
 
   @Override
   public void stop() throws ServiceLifecycleException {
-    if(remoteClient != null && config.isRemoteAliasServiceEnabled()) {
-      try {
-        remoteClient.removeEntryListener(PATH_KNOX_ALIAS_STORE_TOPOLOGY);
-      } catch (final Exception e) {
-        LOG.errorRemovingRemoteListener(PATH_KNOX_ALIAS_STORE_TOPOLOGY, e.toString());
-      }
-    }
-  }
-
-  /**
-   * Add the alias to the local keystore.
-   * Most likely this will be called by remote registry watch listener.
-   *
-   * @param clusterName Name of the cluster
-   * @param alias       Alias name to be added
-   * @param value       alias value to be added
-   * @throws AliasServiceException exception on failure adding alias
-   */
-  public void addAliasForClusterLocally(final String clusterName,
-      final String alias, final String value) throws AliasServiceException {
-    localAliasService.addAliasForCluster(clusterName, alias, value);
-  }
-
-  /**
-   * Remove the given alias from local keystore.
-   * Most likely this will be called by remote registry watch listener.
-   *
-   * @param clusterName Name of the cluster
-   * @param alias       Alias name to be removed
-   * @throws AliasServiceException exception on failure removing alias
-   */
-  public void removeAliasForClusterLocally(final String clusterName,
-      final String alias) throws AliasServiceException {
-    LOG.removeAliasLocally(clusterName, alias);
-    localAliasService.removeAliasForCluster(clusterName, alias);
-  }
-
-  /**
-   * Ensure that the nodes are properly set up.
-   */
-  private void ensureEntries(
-      final RemoteConfigurationRegistryClient remoteClient) {
-    ensureEntry(PATH_KNOX, remoteClient);
-    ensureEntry(PATH_KNOX_SECURITY, remoteClient);
-    ensureEntry(PATH_KNOX_ALIAS_STORE_TOPOLOGY, remoteClient);
-    ensureEntry(
-        PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR + DEFAULT_CLUSTER_NAME,
-        remoteClient);
-  }
-
-  private char[] getKeystorePassword(String alias) throws AliasServiceException {
-    char[] passphrase = getPasswordFromAliasForGateway(alias);
-    if (passphrase == null) {
-      passphrase = ms.getMasterSecret();
-    }
-    return passphrase;
-  }
-
-
-  /**
-   * Encrypt the clear text with master password.
-   * @param clear clear text to be encrypted
-   * @return encrypted and base 64 encoded result.
-   * @throws Exception exception on failure
-   */
-  public String encrypt(final String clear) throws Exception {
-
-    final EncryptionResult result = encryptor.encrypt(clear);
-
-    return Base64.encodeBase64String(
-        (Base64.encodeBase64String(result.salt) + "::" + Base64
-            .encodeBase64String(result.iv) + "::" + Base64
-            .encodeBase64String(result.cipher)).getBytes(StandardCharsets.UTF_8));
-  }
-
-  /**
-   * Function to decrypt the encrypted text using master secret.
-   *
-   * @param encoded encoded and encrypted string.
-   * @return decrypted password.
-   * @throws Exception exception on failure
-   */
-  public String decrypt(final String encoded) throws Exception {
-
-    final String line = new String(Base64.decodeBase64(encoded), StandardCharsets.UTF_8);
-    final String[] parts = line.split("::");
-    if(parts.length != 3) {
-      throw new IllegalArgumentException("Data should have 3 parts split by ::");
-    }
-    return new String(encryptor
-        .decrypt(Base64.decodeBase64(parts[0]), Base64.decodeBase64(parts[1]),
-            Base64.decodeBase64(parts[2])), StandardCharsets.UTF_8);
-  }
-
-  /**
-   * A listener that listens for changes to the child nodes.
-   */
-  private class RemoteAliasChildListener
-      implements RemoteConfigurationRegistryClient.ChildEntryListener {
-
-    final RemoteAliasService remoteAliasService;
-
-    RemoteAliasChildListener (final RemoteAliasService remoteAliasService ) {
-      this.remoteAliasService = remoteAliasService;
-    }
-
-    @Override
-    public void childEvent(final RemoteConfigurationRegistryClient client,
-        final Type type, final String path) {
-
-      final String subPath = StringUtils.substringAfter(path,
-          PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR);
-      final String[] paths = StringUtils.split(subPath, '/');
-
-      switch (type) {
-      case REMOVED:
-        try {
-          /* remove listener */
-          client.removeEntryListener(path);
-
-          if (GatewayServer.getGatewayServices() != null) {
-            /* remove the alias from local keystore */
-            final AliasService aliasService = GatewayServer.getGatewayServices()
-                .getService(GatewayServices.ALIAS_SERVICE);
-            if (paths.length > 1
-                    && aliasService instanceof RemoteAliasService) {
-              ((RemoteAliasService) aliasService)
-                  .removeAliasForClusterLocally(paths[0], paths[1]);
-            }
-          }
-        } catch (final Exception e) {
-          LOG.errorRemovingAliasLocally(paths[0], paths[1], e.toString());
-        }
-        break;
-
-      case ADDED:
-        /* do not set listeners on cluster name but on respective aliases */
-        if (paths.length > 1) {
-          LOG.addAliasLocally(paths[0], paths[1]);
-          try {
-            client.addEntryListener(path,
-                new RemoteAliasEntryListener(paths[0], paths[1], remoteAliasService));
-          } catch (final Exception e) {
-            LOG.errorRemovingAliasLocally(paths[0], paths[1], e.toString());
-          }
-        } else if (subPath != null) {
-          /* Add a child listener for the cluster */
-          LOG.addRemoteListener(path);
-          try {
-            client.addChildEntryListener(path, new RemoteAliasChildListener(remoteAliasService));
-          } catch (Exception e) {
-            LOG.errorAddingRemoteListener(path, e.toString());
-          }
-        }
-
-        break;
-      }
-    }
-  }
-
-  /**
-   * A listener that listens for changes to node value.
-   */
-  private static class RemoteAliasEntryListener
-      implements RemoteConfigurationRegistryClient.EntryListener {
-
-    final String cluster;
-    final String alias;
-    final RemoteAliasService remoteAliasService;
-
-    RemoteAliasEntryListener(final String cluster, final String alias, final RemoteAliasService remoteAliasService) {
-      this.cluster = cluster;
-      this.alias = alias;
-      this.remoteAliasService = remoteAliasService;
-    }
-
-    @Override
-    public void entryChanged(final RemoteConfigurationRegistryClient client,
-        final String path, final byte[] data) {
-
-      if (GatewayServer.getGatewayServices() != null) {
-        final AliasService aliasService = GatewayServer.getGatewayServices()
-            .getService(GatewayServices.ALIAS_SERVICE);
-
-        if (aliasService instanceof RemoteAliasService) {
-          try {
-            ((RemoteAliasService) aliasService).addAliasForClusterLocally(cluster, alias,
-                remoteAliasService.decrypt(new String(data, StandardCharsets.UTF_8)));
-          } catch (final Exception e) {
-            /* log and move on */
-            LOG.errorAddingAliasLocally(cluster, alias, e.toString());
-          }
-        }
-      }
+    if(remoteAliasServiceImpl != null) {
+      remoteAliasServiceImpl.stop();
     }
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasService.java
@@ -1,0 +1,508 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.impl;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClient;
+import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.EncryptionResult;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.util.PasswordUtils;
+import org.apache.zookeeper.ZooDefs;
+
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.apache.knox.gateway.services.security.impl.RemoteAliasService.DEFAULT_CLUSTER_NAME;
+
+/**
+ * An {@link AliasService} implementation based on zookeeper remote service registry.
+ */
+public class ZookeeperRemoteAliasService implements AliasService {
+  public static final String TYPE = "zookeeper";
+
+  public static final String PATH_KNOX = "/knox";
+  public static final String PATH_KNOX_SECURITY = PATH_KNOX + "/security";
+  public static final String PATH_KNOX_ALIAS_STORE_TOPOLOGY =
+      PATH_KNOX_SECURITY + "/topology";
+  public static final String PATH_SEPARATOR = "/";
+
+  private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+  // N.B. This is ZooKeeper-specific, and should be abstracted when another registry is supported
+  private static final RemoteConfigurationRegistryClient.EntryACL AUTHENTICATED_USERS_ALL =
+      new RemoteConfigurationRegistryClient.EntryACL() {
+        @Override
+        public String getId() {
+          return "";
+        }
+
+        @Override
+        public String getType() {
+          return "auth";
+        }
+
+        @Override
+        public Object getPermissions() {
+          return ZooDefs.Perms.ALL;
+        }
+
+        @Override
+        public boolean canRead() {
+          return true;
+        }
+
+        @Override
+        public boolean canWrite() {
+          return true;
+        }
+      };
+
+  private final AliasService localAliasService;
+  private final MasterService ms;
+  private final RemoteConfigurationRegistryClientService remoteConfigurationRegistryClientService;
+
+  private RemoteConfigurationRegistryClient remoteClient;
+  private ConfigurableEncryptor encryptor;
+  private GatewayConfig config;
+
+  ZookeeperRemoteAliasService(AliasService localAliasService, MasterService ms,
+      RemoteConfigurationRegistryClientService remoteConfigurationRegistryClientService) {
+    this.localAliasService = localAliasService;
+    this.ms = ms;
+    this.remoteConfigurationRegistryClientService = remoteConfigurationRegistryClientService;
+  }
+
+  /**
+   * Build an entry path for the given cluster and alias
+   */
+  private static String buildAliasEntryName(final String clusterName,
+      final String alias) {
+    return buildClusterEntryName(clusterName) + PATH_SEPARATOR + alias;
+  }
+
+  /**
+   * Build an entry path for the given cluster
+   */
+  private static String buildClusterEntryName(final String clusterName) {
+    return PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR + clusterName;
+  }
+
+  /**
+   * Ensure that the given entry path exists.
+   */
+  private static void ensureEntry(final String path,
+      final RemoteConfigurationRegistryClient remoteClient) {
+    if (!remoteClient.entryExists(path)) {
+      remoteClient.createEntry(path);
+    } else {
+      // Validate the ACL
+      List<RemoteConfigurationRegistryClient.EntryACL> entryACLs = remoteClient
+          .getACL(path);
+      for (RemoteConfigurationRegistryClient.EntryACL entryACL : entryACLs) {
+        // N.B. This is ZooKeeper-specific, and should be abstracted when another registry is supported
+        // For now, check for world:anyone with ANY permissions (even read-only)
+        if (entryACL.getType().equals("world") && entryACL.getId()
+            .equals("anyone")) {
+          LOG.suspectWritableRemoteConfigurationEntry(path);
+
+          // If the client is authenticated, but "anyone" can write the content, then the content may not
+          // be trustworthy.
+          if (remoteClient.isAuthenticationConfigured()) {
+            LOG.correctingSuspectWritableRemoteConfigurationEntry(path);
+
+            // Replace the existing ACL with one that permits only authenticated users
+            remoteClient.setACL(path,
+                Collections.singletonList(AUTHENTICATED_USERS_ALL));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Check to make sure all the required entries are properly set up
+   */
+  private static void checkPathsExist(
+      final RemoteConfigurationRegistryClient remoteClient) {
+    ensureEntry(PATH_KNOX, remoteClient);
+    ensureEntry(PATH_KNOX_SECURITY, remoteClient);
+    ensureEntry(PATH_KNOX_ALIAS_STORE_TOPOLOGY, remoteClient);
+    ensureEntry(
+        PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR + DEFAULT_CLUSTER_NAME,
+        remoteClient);
+  }
+
+  /**
+   * Get a list of all aliases for a given cluster.
+   * Remote aliases are preferred over local.
+   *
+   * @param clusterName cluster name
+   * @return List of all the aliases
+   */
+  @Override
+  public List<String> getAliasesForCluster(final String clusterName) throws AliasServiceException {
+    List<String> remoteAliases = new ArrayList<>();
+
+    /* If we have remote registry configured, query it */
+    if (remoteClient != null) {
+      remoteAliases = remoteClient
+          .listChildEntries(buildClusterEntryName(clusterName));
+    }
+
+    return remoteAliases;
+  }
+
+  @Override
+  public void addAliasForCluster(final String clusterName,
+      final String alias, final String value)
+      throws AliasServiceException {
+    if (remoteClient != null) {
+      final String aliasEntryPath = buildAliasEntryName(clusterName, alias);
+
+      /* Ensure the entries are properly set up */
+      checkPathsExist(remoteClient);
+      ensureEntry(buildClusterEntryName(clusterName), remoteClient);
+      try {
+        remoteClient.createEntry(aliasEntryPath, encrypt(value));
+      } catch (Exception e) {
+        throw new AliasServiceException(e);
+      }
+
+      if (remoteClient.getEntryData(aliasEntryPath) == null) {
+        throw new IllegalStateException(String.format(Locale.ROOT,
+            "Failed to store alias %s for cluster %s in remote registry", alias,
+            clusterName));
+      }
+    }
+  }
+
+  @Override
+  public void removeAliasForCluster(final String clusterName, final String alias)
+      throws AliasServiceException {
+    /* If we have remote registry configured, query it */
+    if (remoteClient != null) {
+      final String aliasEntryPath = buildAliasEntryName(clusterName, alias);
+
+      if (remoteClient.entryExists(aliasEntryPath)) {
+        remoteClient.deleteEntry(aliasEntryPath);
+
+        if (remoteClient.entryExists(aliasEntryPath)) {
+          throw new IllegalStateException(String.format(Locale.ROOT,
+              "Failed to delete alias %s for cluster %s in remote registry",
+              alias, clusterName));
+        }
+      }
+    }
+  }
+
+  @Override
+  public char[] getPasswordFromAliasForCluster(String clusterName, String alias)
+      throws AliasServiceException {
+    return getPasswordFromAliasForCluster(clusterName, alias, false);
+  }
+
+  @Override
+  public char[] getPasswordFromAliasForCluster(String clusterName,
+      String givenAlias, boolean generate) throws AliasServiceException {
+
+    /* convert all alias names to lower case since JDK expects the same behaviour */
+    final String alias = givenAlias.toLowerCase(Locale.ROOT);
+
+    char[] password = null;
+
+    /* try to get it from remote registry */
+    if (remoteClient != null) {
+      checkPathsExist(remoteClient);
+      String encrypted = null;
+
+      if(remoteClient.entryExists(buildAliasEntryName(clusterName, alias))) {
+        encrypted = remoteClient
+            .getEntryData(buildAliasEntryName(clusterName, alias));
+      }
+
+      /* Generate a new password */
+      if (encrypted == null) {
+
+        /* Generate a new password  */
+        if (generate) {
+          generateAliasForCluster(clusterName, alias);
+          password = getPasswordFromAliasForCluster(clusterName, alias);
+        }
+
+      } else {
+        try {
+          password = decrypt(encrypted).toCharArray();
+        } catch (final Exception e) {
+          throw new AliasServiceException(e);
+        }
+      }
+    }
+
+    /* found nothing */
+    return password;
+  }
+
+  @Override
+  public void generateAliasForCluster(final String clusterName, final String alias)
+      throws AliasServiceException {
+    /* auto-generated password */
+    final String passwordString = PasswordUtils.generatePassword(16);
+    addAliasForCluster(clusterName, alias, passwordString);
+  }
+
+  @Override
+  public char[] getPasswordFromAliasForGateway(String alias)
+      throws AliasServiceException {
+    return getPasswordFromAliasForCluster(DEFAULT_CLUSTER_NAME, alias);
+  }
+
+  @Override
+  public char[] getGatewayIdentityPassphrase() throws AliasServiceException {
+    return getPasswordFromAliasForGateway(config.getIdentityKeyPassphraseAlias());
+  }
+
+  @Override
+  public char[] getGatewayIdentityKeystorePassword() throws AliasServiceException {
+    return getPasswordFromAliasForGateway(config.getIdentityKeystorePasswordAlias());
+  }
+
+  @Override
+  public char[] getSigningKeyPassphrase() throws AliasServiceException {
+    return getPasswordFromAliasForGateway(config.getSigningKeyPassphraseAlias());
+  }
+
+  @Override
+  public char[] getSigningKeystorePassword() throws AliasServiceException {
+    return getPasswordFromAliasForGateway(config.getSigningKeystorePasswordAlias());
+  }
+
+  @Override
+  public void generateAliasForGateway(final String alias) throws AliasServiceException {
+    generateAliasForCluster(DEFAULT_CLUSTER_NAME, alias);
+  }
+
+  @Override
+  public Certificate getCertificateForGateway(final String alias)
+      throws AliasServiceException {
+    throw new AliasServiceException(new UnsupportedOperationException());
+  }
+
+  @Override
+  public void init(final GatewayConfig config, final Map<String, String> options)
+      throws ServiceLifecycleException {
+    this.config = config;
+
+    /* If we have remote registry configured, query it */
+    final String clientName = config.getRemoteConfigurationMonitorClientName();
+    if (clientName != null && remoteConfigurationRegistryClientService != null) {
+      remoteClient = remoteConfigurationRegistryClientService.get(clientName);
+
+      /* ensure that nodes are properly setup */
+      ensureEntries(remoteClient);
+
+      /* Confirm access to the remote aliases directory */
+      final List<String> aliases = remoteClient.listChildEntries(PATH_KNOX_ALIAS_STORE_TOPOLOGY);
+      if (aliases == null) {
+        // Either the entry does not exist, or there is an authentication problem
+        throw new IllegalStateException(
+            "Unable to access remote path: " + PATH_KNOX_ALIAS_STORE_TOPOLOGY);
+      }
+
+      /* Register a listener for aliases entry additions/removals */
+      try {
+        remoteClient.addChildEntryListener(PATH_KNOX_ALIAS_STORE_TOPOLOGY,
+            new RemoteAliasChildListener(this));
+      } catch (final Exception e) {
+        throw new IllegalStateException(
+            "Unable to add listener for path " + PATH_KNOX_ALIAS_STORE_TOPOLOGY,
+            e);
+      }
+
+      encryptor = new ConfigurableEncryptor(new String(ms.getMasterSecret()));
+      encryptor.init(config);
+    } else {
+      LOG.missingClientConfigurationForRemoteMonitoring();
+    }
+  }
+
+  @Override
+  public void start() throws ServiceLifecycleException {
+
+  }
+
+  @Override
+  public void stop() throws ServiceLifecycleException {
+    if(remoteClient != null) {
+      try {
+        remoteClient.removeEntryListener(PATH_KNOX_ALIAS_STORE_TOPOLOGY);
+      } catch (final Exception e) {
+        LOG.errorRemovingRemoteListener(PATH_KNOX_ALIAS_STORE_TOPOLOGY, e.toString());
+      }
+    }
+  }
+
+  /**
+   * Encrypt the clear text with master password.
+   * @param clear clear text to be encrypted
+   * @return encrypted and base 64 encoded result.
+   * @throws Exception exception on failure
+   */
+  String encrypt(final String clear) throws Exception {
+    final EncryptionResult result = encryptor.encrypt(clear);
+
+    return Base64.encodeBase64String(
+        (Base64.encodeBase64String(result.salt) + "::" +
+             Base64.encodeBase64String(result.iv) + "::" +
+             Base64.encodeBase64String(result.cipher)).getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Function to decrypt the encrypted text using master secret.
+   *
+   * @param encoded encoded and encrypted string.
+   * @return decrypted password.
+   * @throws Exception exception on failure
+   */
+  String decrypt(final String encoded) throws Exception {
+    final String line = new String(Base64.decodeBase64(encoded), StandardCharsets.UTF_8);
+    final String[] parts = line.split("::");
+    if(parts.length != 3) {
+      throw new IllegalArgumentException("Data should have 3 parts split by ::");
+    }
+    return new String(encryptor.decrypt(
+        Base64.decodeBase64(parts[0]),
+        Base64.decodeBase64(parts[1]),
+        Base64.decodeBase64(parts[2])), StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Ensure that the nodes are properly set up.
+   */
+  private void ensureEntries(
+      final RemoteConfigurationRegistryClient remoteClient) {
+    ensureEntry(PATH_KNOX, remoteClient);
+    ensureEntry(PATH_KNOX_SECURITY, remoteClient);
+    ensureEntry(PATH_KNOX_ALIAS_STORE_TOPOLOGY, remoteClient);
+    ensureEntry(
+        PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR + DEFAULT_CLUSTER_NAME,
+        remoteClient);
+  }
+
+  /**
+   * A listener that listens for changes to the child nodes.
+   */
+  private class RemoteAliasChildListener
+      implements RemoteConfigurationRegistryClient.ChildEntryListener {
+
+    final ZookeeperRemoteAliasService remoteAliasService;
+
+    RemoteAliasChildListener (final ZookeeperRemoteAliasService remoteAliasService ) {
+      this.remoteAliasService = remoteAliasService;
+    }
+
+    @Override
+    public void childEvent(final RemoteConfigurationRegistryClient client,
+        final Type type, final String path) {
+
+      final String subPath = StringUtils.substringAfter(path,
+          PATH_KNOX_ALIAS_STORE_TOPOLOGY + PATH_SEPARATOR);
+      final String[] paths = StringUtils.split(subPath, '/');
+
+      switch (type) {
+      case REMOVED:
+        try {
+          /* remove listener */
+          client.removeEntryListener(path);
+          if (paths.length > 1) {
+            localAliasService.removeAliasForCluster(paths[0], paths[1]);
+          }
+        } catch (final Exception e) {
+          LOG.errorRemovingAliasLocally(paths[0], paths[1], e.toString());
+        }
+        break;
+
+      case ADDED:
+        /* do not set listeners on cluster name but on respective aliases */
+        if (paths.length > 1) {
+          LOG.addAliasLocally(paths[0], paths[1]);
+          try {
+            client.addEntryListener(path,
+                new RemoteAliasEntryListener(paths[0], paths[1],
+                    remoteAliasService, localAliasService));
+          } catch (final Exception e) {
+            LOG.errorRemovingAliasLocally(paths[0], paths[1], e.toString());
+          }
+        } else if (subPath != null) {
+          /* Add a child listener for the cluster */
+          LOG.addRemoteListener(path);
+          try {
+            client.addChildEntryListener(path, new RemoteAliasChildListener(remoteAliasService));
+          } catch (Exception e) {
+            LOG.errorAddingRemoteListener(path, e.toString());
+          }
+        }
+
+        break;
+      }
+    }
+  }
+
+  /**
+   * A listener that listens for changes to node value.
+   */
+  private class RemoteAliasEntryListener
+      implements RemoteConfigurationRegistryClient.EntryListener {
+    final String cluster;
+    final String alias;
+    final AliasService remoteAliasService;
+    final AliasService localAliasService;
+
+    RemoteAliasEntryListener(final String cluster, final String alias,
+                             final AliasService remoteAliasService,
+                             final AliasService localAliasService) {
+      this.cluster = cluster;
+      this.alias = alias;
+      this.remoteAliasService = remoteAliasService;
+      this.localAliasService = localAliasService;
+    }
+
+    @Override
+    public void entryChanged(final RemoteConfigurationRegistryClient client,
+        final String path, final byte[] data) {
+      try {
+        localAliasService.addAliasForCluster(cluster, alias,
+            decrypt(new String(data, StandardCharsets.UTF_8)));
+      } catch (final Exception e) {
+        /* log and move on */
+        LOG.errorAddingAliasLocally(cluster, alias, e.toString());
+      }
+    }
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasServiceProvider.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasServiceProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.impl;
+
+import org.apache.knox.gateway.security.RemoteAliasServiceProvider;
+import org.apache.knox.gateway.service.config.remote.zk.ZooKeeperClientServiceProvider;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.MasterService;
+
+public class ZookeeperRemoteAliasServiceProvider implements RemoteAliasServiceProvider {
+  @Override
+  public String getType() {
+    return ZookeeperRemoteAliasService.TYPE;
+  }
+
+  @Override
+  public AliasService newInstance(AliasService localAliasService, MasterService ms) {
+    return new ZookeeperRemoteAliasService(localAliasService, ms,
+        new ZooKeeperClientServiceProvider().newInstance());
+  }
+}

--- a/gateway-server/src/main/resources/META-INF/services/org.apache.knox.gateway.security.RemoteAliasServiceProvider
+++ b/gateway-server/src/main/resources/META-INF/services/org.apache.knox.gateway.security.RemoteAliasServiceProvider
@@ -1,0 +1,19 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasServiceProvider

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/RemoteAliasServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/RemoteAliasServiceTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.impl;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.knox.gateway.services.security.impl.RemoteAliasService.REMOTE_ALIAS_SERVICE_TYPE;
+import static org.easymock.EasyMock.capture;
+
+/**
+ * Test for {@link RemoteAliasService}
+ */
+public class RemoteAliasServiceTest {
+  @Rule
+  public final TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void testNoRemoteAlias() throws Exception {
+    GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gc.isRemoteAliasServiceEnabled())
+        .andReturn(false).anyTimes();
+    String keystoreDir = testFolder.newFolder().getAbsolutePath();
+    EasyMock.expect(gc.getGatewayKeystoreDir()).andReturn(keystoreDir).anyTimes();
+
+    EasyMock.replay(gc);
+
+    final String expectedClusterName = "sandbox";
+    final String expectedAlias = "knox.test.alias";
+    final String expectedPassword = "dummyPassword";
+
+    final String expectedClusterNameDev = "development";
+    final String expectedAliasDev = "knox.test.alias.dev";
+    final String expectedPasswordDev = "otherDummyPassword";
+
+    final DefaultMasterService ms = EasyMock
+        .createNiceMock(DefaultMasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("knox".toCharArray())
+        .anyTimes();
+    EasyMock.replay(ms);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(gc, Collections.emptyMap());
+
+    DefaultAliasService defaultAlias = new DefaultAliasService();
+    defaultAlias.setKeystoreService(ks);
+    defaultAlias.setMasterService(ms);
+    defaultAlias.init(gc, Collections.emptyMap());
+
+    final RemoteAliasService remoteAliasService = new RemoteAliasService(defaultAlias, ms);
+    remoteAliasService.init(gc, Collections.emptyMap());
+    remoteAliasService.start();
+
+    /* Put */
+    remoteAliasService.addAliasForCluster(expectedClusterName, expectedAlias,
+        expectedPassword);
+    remoteAliasService.addAliasForCluster(expectedClusterNameDev, expectedAliasDev,
+        expectedPasswordDev);
+
+    /* GET all Aliases */
+    List<String> aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+    List<String> aliasesDev = remoteAliasService
+        .getAliasesForCluster(expectedClusterNameDev);
+
+    Assert.assertEquals(aliases.size(), 1);
+    Assert.assertEquals(aliasesDev.size(), 1);
+
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(expectedAlias));
+    Assert.assertTrue("Expected alias 'knox.test.alias.dev' not found ",
+        aliasesDev.contains(expectedAliasDev));
+
+    final char[] result = remoteAliasService
+        .getPasswordFromAliasForCluster(expectedClusterName, expectedAlias);
+    final char[] result1 = remoteAliasService
+        .getPasswordFromAliasForCluster(expectedClusterNameDev,
+            expectedAliasDev);
+
+    Assert.assertEquals(expectedPassword, new String(result));
+    Assert.assertEquals(expectedPasswordDev, new String(result1));
+
+    /* Remove */
+    remoteAliasService.removeAliasForCluster(expectedClusterNameDev, expectedAliasDev);
+
+    /* Make sure expectedAliasDev is removed*/
+    aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+    aliasesDev = remoteAliasService.getAliasesForCluster(expectedClusterNameDev);
+
+    Assert.assertEquals(aliasesDev.size(), 0);
+    Assert.assertFalse("Expected alias 'knox.test.alias.dev' to be removed but found.",
+        aliasesDev.contains(expectedAliasDev));
+
+    Assert.assertEquals(aliases.size(), 1);
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(expectedAlias));
+
+    /* Test auto-generate password for alias */
+    final String testAutoGeneratedpasswordAlias = "knox.test.alias.auto";
+
+    final char[] autoGeneratedPassword = remoteAliasService
+        .getPasswordFromAliasForCluster(expectedClusterName,
+            testAutoGeneratedpasswordAlias, true);
+    aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+
+    Assert.assertNotNull(autoGeneratedPassword);
+    Assert.assertEquals(aliases.size(), 2);
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(testAutoGeneratedpasswordAlias));
+  }
+
+  @Test
+  public void testNoRemoteAliasNoConfigs() throws Exception {
+    GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gc.isRemoteAliasServiceEnabled())
+        .andReturn(true).anyTimes();
+    String keystoreDir = testFolder.newFolder().getAbsolutePath();
+    EasyMock.expect(gc.getGatewayKeystoreDir()).andReturn(keystoreDir).anyTimes();
+
+    EasyMock.replay(gc);
+
+    final String expectedClusterName = "sandbox";
+    final String expectedAlias = "knox.test.alias";
+    final String expectedPassword = "dummyPassword";
+
+    final String expectedClusterNameDev = "development";
+    final String expectedAliasDev = "knox.test.alias.dev";
+    final String expectedPasswordDev = "otherDummyPassword";
+
+    final DefaultMasterService ms = EasyMock
+                                        .createNiceMock(DefaultMasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("knox".toCharArray())
+        .anyTimes();
+    EasyMock.replay(ms);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(gc, Collections.emptyMap());
+
+    DefaultAliasService defaultAlias = new DefaultAliasService();
+    defaultAlias.setKeystoreService(ks);
+    defaultAlias.setMasterService(ms);
+    defaultAlias.init(gc, Collections.emptyMap());
+
+    final RemoteAliasService remoteAliasService = new RemoteAliasService(defaultAlias, ms);
+    remoteAliasService.init(gc, Collections.emptyMap());
+    remoteAliasService.start();
+
+    /* Put */
+    remoteAliasService.addAliasForCluster(expectedClusterName, expectedAlias,
+        expectedPassword);
+    remoteAliasService.addAliasForCluster(expectedClusterNameDev, expectedAliasDev,
+        expectedPasswordDev);
+
+    /* GET all Aliases */
+    List<String> aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+    List<String> aliasesDev = remoteAliasService
+                                  .getAliasesForCluster(expectedClusterNameDev);
+
+    Assert.assertEquals(aliases.size(), 1);
+    Assert.assertEquals(aliasesDev.size(), 1);
+
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(expectedAlias));
+    Assert.assertTrue("Expected alias 'knox.test.alias.dev' not found ",
+        aliasesDev.contains(expectedAliasDev));
+
+    final char[] result = remoteAliasService
+                              .getPasswordFromAliasForCluster(expectedClusterName, expectedAlias);
+    final char[] result1 = remoteAliasService
+                               .getPasswordFromAliasForCluster(expectedClusterNameDev,
+                                   expectedAliasDev);
+
+    Assert.assertEquals(expectedPassword, new String(result));
+    Assert.assertEquals(expectedPasswordDev, new String(result1));
+
+    /* Remove */
+    remoteAliasService.removeAliasForCluster(expectedClusterNameDev, expectedAliasDev);
+
+    /* Make sure expectedAliasDev is removed*/
+    aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+    aliasesDev = remoteAliasService.getAliasesForCluster(expectedClusterNameDev);
+
+    Assert.assertEquals(aliasesDev.size(), 0);
+    Assert.assertFalse("Expected alias 'knox.test.alias.dev' to be removed but found.",
+        aliasesDev.contains(expectedAliasDev));
+
+    Assert.assertEquals(aliases.size(), 1);
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(expectedAlias));
+
+    /* Test auto-generate password for alias */
+    final String testAutoGeneratedpasswordAlias = "knox.test.alias.auto";
+
+    final char[] autoGeneratedPassword = remoteAliasService
+                                             .getPasswordFromAliasForCluster(expectedClusterName,
+                                                 testAutoGeneratedpasswordAlias, true);
+    aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+
+    Assert.assertNotNull(autoGeneratedPassword);
+    Assert.assertEquals(aliases.size(), 2);
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(testAutoGeneratedpasswordAlias));
+  }
+
+  @Test
+  public void testRemoteAliasServiceLoading() throws Exception {
+    Map<String, String> remoteAliasConfigs = new HashMap<>();
+    remoteAliasConfigs.put(REMOTE_ALIAS_SERVICE_TYPE, "test");
+
+    GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gc.isRemoteAliasServiceEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(gc.getRemoteAliasServiceConfiguration()).andReturn(remoteAliasConfigs).anyTimes();
+    EasyMock.replay(gc);
+
+    final String expectedClusterName = "sandbox";
+    final String expectedAlias = "knox.test.alias";
+    final String expectedPassword = "dummyPassword";
+
+    final String expectedClusterNameDev = "development";
+    final String expectedAliasDev = "knox.test.alias.dev";
+    final String expectedPasswordDev = "otherDummyPassword";
+
+    final DefaultMasterService ms = EasyMock
+                                        .createNiceMock(DefaultMasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("knox".toCharArray())
+        .anyTimes();
+    EasyMock.replay(ms);
+
+    // Mock Alias Service
+    final DefaultAliasService defaultAlias = EasyMock
+                                                 .createNiceMock(DefaultAliasService.class);
+    // Captures for validating the alias creation for a generated topology
+    final Capture<String> capturedCluster = EasyMock.newCapture();
+    final Capture<String> capturedAlias = EasyMock.newCapture();
+    final Capture<String> capturedPwd = EasyMock.newCapture();
+
+    defaultAlias
+        .addAliasForCluster(capture(capturedCluster), capture(capturedAlias),
+            capture(capturedPwd));
+    EasyMock.expectLastCall().anyTimes();
+
+    /* defaultAlias.getAliasesForCluster() never returns null */
+    EasyMock.expect(defaultAlias.getAliasesForCluster(expectedClusterName))
+        .andReturn(new ArrayList<>()).anyTimes();
+    EasyMock.expect(defaultAlias.getAliasesForCluster(expectedClusterNameDev))
+        .andReturn(new ArrayList<>()).anyTimes();
+
+    EasyMock.replay(defaultAlias);
+
+    final RemoteAliasService remoteAliasService = new RemoteAliasService(defaultAlias, ms);
+    remoteAliasService.init(gc, Collections.emptyMap());
+    remoteAliasService.start();
+
+    /* Put */
+    remoteAliasService.addAliasForCluster(expectedClusterName, expectedAlias,
+        expectedPassword);
+    remoteAliasService.addAliasForCluster(expectedClusterNameDev, expectedAliasDev,
+        expectedPasswordDev);
+
+    /* GET all Aliases */
+    List<String> aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+    List<String> aliasesDev = remoteAliasService
+                                  .getAliasesForCluster(expectedClusterNameDev);
+
+    Assert.assertEquals(aliases.size(), 1);
+    Assert.assertEquals(aliasesDev.size(), 1);
+
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(expectedAlias));
+    Assert.assertTrue("Expected alias 'knox.test.alias.dev' not found ",
+        aliasesDev.contains(expectedAliasDev));
+
+    final char[] result = remoteAliasService
+                              .getPasswordFromAliasForCluster(expectedClusterName, expectedAlias);
+    final char[] result1 = remoteAliasService
+                               .getPasswordFromAliasForCluster(expectedClusterNameDev,
+                                   expectedAliasDev);
+
+    Assert.assertEquals(expectedPassword, new String(result));
+    Assert.assertEquals(expectedPasswordDev, new String(result1));
+
+    /* Remove */
+    remoteAliasService.removeAliasForCluster(expectedClusterNameDev, expectedAliasDev);
+
+    /* Make sure expectedAliasDev is removed*/
+    aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+    aliasesDev = remoteAliasService.getAliasesForCluster(expectedClusterNameDev);
+
+    Assert.assertEquals(aliasesDev.size(), 0);
+    Assert.assertFalse("Expected alias 'knox.test.alias.dev' to be removed but found.",
+        aliasesDev.contains(expectedAliasDev));
+
+    Assert.assertEquals(aliases.size(), 1);
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(expectedAlias));
+
+    /* Test auto-generate password for alias */
+    final String testAutoGeneratedpasswordAlias = "knox.test.alias.auto";
+
+    final char[] autoGeneratedPassword = remoteAliasService
+                                             .getPasswordFromAliasForCluster(expectedClusterName,
+                                                 testAutoGeneratedpasswordAlias, true);
+    aliases = remoteAliasService.getAliasesForCluster(expectedClusterName);
+
+    Assert.assertNotNull(autoGeneratedPassword);
+    Assert.assertEquals(aliases.size(), 2);
+    Assert.assertTrue("Expected alias 'knox.test.alias' not found ",
+        aliases.contains(testAutoGeneratedpasswordAlias));
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/RemoteAliasServiceTestProvider.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/RemoteAliasServiceTestProvider.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.impl;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.security.RemoteAliasServiceProvider;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.util.PasswordUtils;
+
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RemoteAliasServiceTestProvider implements RemoteAliasServiceProvider {
+  @Override
+  public String getType() {
+    return "test";
+  }
+
+  @Override
+  public AliasService newInstance(AliasService localAliasService, MasterService masterService) {
+    return new TestAliasService();
+  }
+
+  private class TestAliasService implements AliasService {
+    private final Map<String, Map<String, String>> aliases = new HashMap<>();
+    private GatewayConfig config;
+
+    @Override
+    public List<String> getAliasesForCluster(String clusterName) {
+      return new ArrayList<>(aliases.getOrDefault(clusterName, Collections.emptyMap()).keySet());
+    }
+
+    @Override
+    public void addAliasForCluster(String clusterName, String alias, String value) {
+      if(!aliases.containsKey(clusterName)) {
+        aliases.put(clusterName, new HashMap<>());
+      }
+      aliases.get(clusterName).put(alias, value);
+    }
+
+    @Override
+    public void removeAliasForCluster(String clusterName, String alias) {
+      aliases.getOrDefault(clusterName, new HashMap<>()).remove(alias);
+    }
+
+    @Override
+    public char[] getPasswordFromAliasForCluster(String clusterName, String alias) {
+      return aliases.getOrDefault(clusterName, new HashMap<>()).get(alias).toCharArray();
+    }
+
+    @Override
+    public char[] getPasswordFromAliasForCluster(String clusterName, String alias, boolean generate) {
+      if(generate) {
+        generateAliasForCluster(clusterName, alias);
+      }
+      return getPasswordFromAliasForCluster(clusterName, alias);
+    }
+
+    @Override
+    public void generateAliasForCluster(String clusterName, String alias) {
+      addAliasForCluster(clusterName, alias, PasswordUtils.generatePassword(16));
+    }
+
+    @Override
+    public char[] getPasswordFromAliasForGateway(String alias) {
+      return getPasswordFromAliasForCluster(RemoteAliasService.DEFAULT_CLUSTER_NAME, alias);
+    }
+
+    @Override
+    public char[] getGatewayIdentityPassphrase() {
+      return getPasswordFromAliasForGateway(config.getIdentityKeyPassphraseAlias());
+    }
+
+    @Override
+    public char[] getGatewayIdentityKeystorePassword() {
+      return getPasswordFromAliasForGateway(config.getIdentityKeystorePasswordAlias());
+    }
+
+    @Override
+    public char[] getSigningKeyPassphrase() {
+      return getPasswordFromAliasForGateway(config.getSigningKeyPassphraseAlias());
+    }
+
+    @Override
+    public char[] getSigningKeystorePassword() {
+      return getPasswordFromAliasForGateway(config.getSigningKeystorePasswordAlias());
+    }
+
+    @Override
+    public void generateAliasForGateway(String alias) {
+      generateAliasForCluster(RemoteAliasService.DEFAULT_CLUSTER_NAME, alias);
+    }
+
+    @Override
+    public Certificate getCertificateForGateway(String alias) throws AliasServiceException {
+      throw new AliasServiceException(new UnsupportedOperationException());
+    }
+
+    @Override
+    public void init(GatewayConfig config, Map<String, String> options) {
+      this.config = config;
+    }
+
+    @Override
+    public void start() {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+  }
+}

--- a/gateway-server/src/test/resources/META-INF/services/org.apache.knox.gateway.security.RemoteAliasServiceProvider
+++ b/gateway-server/src/test/resources/META-INF/services/org.apache.knox.gateway.security.RemoteAliasServiceProvider
@@ -1,0 +1,19 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+org.apache.knox.gateway.services.security.impl.RemoteAliasServiceTestProvider

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -476,6 +476,20 @@ public interface GatewayConfig {
   boolean isRemoteAliasServiceEnabled();
 
   /**
+   * Returns prefix for the remote alias service configuration
+   *
+   * @return the prefix for the remote alias service configuration
+   */
+  String getRemoteAliasServiceConfigurationPrefix();
+
+  /**
+   * Uses result of getRemoteAliasServiceConfigurationPrefix to return configurations
+   *
+   * @return Map of configurations that apply to the remote alias service
+   */
+  Map<String, String> getRemoteAliasServiceConfiguration();
+
+  /**
    * Get the list of those topology names which should be treated as read-only, regardless of their actual read-write
    * status.
    *

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/RemoteAliasServiceProvider.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/RemoteAliasServiceProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.security;
+
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.MasterService;
+
+public interface RemoteAliasServiceProvider {
+  String getType();
+
+  AliasService newInstance(AliasService localAliasService, MasterService masterService);
+}

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -653,6 +653,16 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getRemoteAliasServiceConfigurationPrefix() {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getRemoteAliasServiceConfiguration() {
+    return Collections.emptyMap();
+  }
+
+  @Override
   public int getClusterMonitorPollingInterval(String type) {
     return 600;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The RemoteAliasService should use service loading to ensure make the RemoteAliasService extensible. Moved existing Zookeeper impl to its own class and loaded via service loading.

## How was this patch tested?
`mvn -T.5C verify -Ppackage,release`