### PR TITLE
KNOX-1793 - DefaultKeystoreService should not validate the signing key on initialization

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayResources.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayResources.java
@@ -82,4 +82,22 @@ public interface GatewayResources {
 
   @Resource( text="Forward method: {0} to default context: {1}" )
   String forwardToDefaultTopology(String method, String context );
+
+  @Resource( text="The keystore used to acquire the signing key is not available. The file could be missing or the password could be incorrect: {0}")
+  String signingKeystoreNotAvailable( String path );
+
+  @Resource( text="Provisioned signing key passphrase cannot be acquired using the alias name {0}.")
+  String signingKeyPassphraseNotAvailable( String alias);
+
+  @Resource( text="The public signing key was not found in the signing keystore using the alias name {0}.")
+  String publicSigningKeyNotFound( String alias );
+
+  @Resource( text="The private signing key was not found in the signing keystore using the alias name {0}. The alias could be missing or the password could be incorrect.")
+  String privateSigningKeyNotFound( String alias );
+
+  @Resource( text="The private signing key found in the signing keystore using the alias name {0} is not a RSAPrivateKey")
+  String privateSigningKeyWrongType( String alias );
+
+  @Resource( text="The public signing key found in the signing keystore using the alias name {0} is not a RSAPublicKey")
+  String publicSigningKeyWrongType( String alias );
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -162,6 +162,8 @@ public class DefaultGatewayServices implements GatewayServices {
     SSLService ssl = (SSLService) services.get(SSL_SERVICE);
     ssl.start();
 
+    (services.get(TOKEN_SERVICE)).start();
+
     ServerInfoService sis = (ServerInfoService) services.get(SERVER_INFO_SERVICE);
     sis.start();
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -33,7 +33,6 @@ import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
 import org.apache.knox.gateway.services.hostmap.impl.DefaultHostMapperService;
 import org.apache.knox.gateway.services.registry.impl.DefaultServiceRegistryService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
-import org.apache.knox.gateway.services.security.SSLService;
 import org.apache.knox.gateway.services.security.impl.DefaultAliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
 import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
@@ -50,6 +49,33 @@ import java.util.Map;
 public class DefaultGatewayServices implements GatewayServices {
 
   private static GatewayMessages log = MessagesFactory.get( GatewayMessages.class );
+
+  private static final String[] SERVICE_START_ORDER = new String[]{
+      MASTER_SERVICE,
+      KEYSTORE_SERVICE,
+      ALIAS_SERVICE,
+      SSL_SERVICE,
+      TOKEN_SERVICE,
+      SERVER_INFO_SERVICE,
+      REMOTE_REGISTRY_CLIENT_SERVICE,
+      CLUSTER_CONFIGURATION_MONITOR_SERVICE,
+      TOPOLOGY_SERVICE,
+      METRICS_SERVICE
+  };
+
+  // TODO: This is the original order of service to stop... however maybe reverse of start should be done instead
+  private static final String[] SERVICE_STOP_ORDER = new String[]{
+      MASTER_SERVICE,
+      KEYSTORE_SERVICE,
+      CLUSTER_CONFIGURATION_MONITOR_SERVICE,
+      ALIAS_SERVICE,
+      SSL_SERVICE,
+      TOKEN_SERVICE,
+      SERVER_INFO_SERVICE,
+      REMOTE_REGISTRY_CLIENT_SERVICE,
+      TOPOLOGY_SERVICE,
+      METRICS_SERVICE
+  };
 
   private Map<String,Service> services = new HashMap<>();
   private DefaultMasterService ms;
@@ -152,56 +178,16 @@ public class DefaultGatewayServices implements GatewayServices {
 
   @Override
   public void start() throws ServiceLifecycleException {
-    ms.start();
-
-    ks.start();
-
-    Service alias = services.get(ALIAS_SERVICE);
-    alias.start();
-
-    SSLService ssl = (SSLService) services.get(SSL_SERVICE);
-    ssl.start();
-
-    (services.get(TOKEN_SERVICE)).start();
-
-    ServerInfoService sis = (ServerInfoService) services.get(SERVER_INFO_SERVICE);
-    sis.start();
-
-    RemoteConfigurationRegistryClientService clientService =
-                            (RemoteConfigurationRegistryClientService)services.get(REMOTE_REGISTRY_CLIENT_SERVICE);
-    clientService.start();
-
-    (services.get(CLUSTER_CONFIGURATION_MONITOR_SERVICE)).start();
-
-    DefaultTopologyService tops = (DefaultTopologyService)services.get(TOPOLOGY_SERVICE);
-    tops.start();
-
-    DefaultMetricsService metricsService = (DefaultMetricsService) services.get(METRICS_SERVICE);
-    metricsService.start();
+    for(String service: SERVICE_START_ORDER) {
+      services.get(service).start();
+    }
   }
 
   @Override
   public void stop() throws ServiceLifecycleException {
-    ms.stop();
-
-    ks.stop();
-
-    (services.get(CLUSTER_CONFIGURATION_MONITOR_SERVICE)).stop();
-
-    Service alias = services.get(ALIAS_SERVICE);
-    alias.stop();
-
-    SSLService ssl = (SSLService) services.get(SSL_SERVICE);
-    ssl.stop();
-
-    ServerInfoService sis = (ServerInfoService) services.get(SERVER_INFO_SERVICE);
-    sis.stop();
-
-    DefaultTopologyService tops = (DefaultTopologyService)services.get(TOPOLOGY_SERVICE);
-    tops.stop();
-
-    DefaultMetricsService metricsService = (DefaultMetricsService) services.get(METRICS_SERVICE);
-    metricsService.stop();
+    for(String service: SERVICE_STOP_ORDER) {
+      services.get(service).stop();
+    }
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -66,8 +66,6 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
   private static GatewayResources RES = ResourcesFactory.get( GatewayResources.class );
 
   private GatewayConfig config;
-  private String signingKeystoreName;
-  private String signingKeyAlias;
   private Map<String, Map<String, String>> cache = new ConcurrentHashMap<>();
   private Lock readLock;
   private Lock writeLock;
@@ -86,32 +84,6 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
     if (!ksd.exists()) {
       if( !ksd.mkdirs() ) {
         throw new ServiceLifecycleException( RES.failedToCreateKeyStoreDirectory( ksd.getAbsolutePath() ) );
-      }
-    }
-
-    signingKeystoreName = config.getSigningKeystoreName();
-    // ensure that the keystore actually exists and fail to start if not
-    if (signingKeystoreName != null) {
-      File sks = new File(this.keyStoreDir, signingKeystoreName);
-      if (!sks.exists()) {
-        throw new ServiceLifecycleException("Configured signing keystore does not exist.");
-      }
-      signingKeyAlias = config.getSigningKeyAlias();
-      if (signingKeyAlias != null) {
-        // ensure that the signing key alias exists in the configured keystore
-        KeyStore ks;
-        try {
-          ks = getSigningKeystore();
-          if (ks != null) {
-            if (!ks.containsAlias(signingKeyAlias)) {
-              throw new ServiceLifecycleException("Configured signing key alias does not exist.");
-            }
-          }
-        } catch (KeystoreServiceException e) {
-          throw new ServiceLifecycleException("Unable to get the configured signing keystore.", e);
-        } catch (KeyStoreException e) {
-          throw new ServiceLifecycleException("Signing keystore has not been loaded.", e);
-        }
       }
     }
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -17,9 +17,14 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
+import java.security.Key;
+import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import java.security.PublicKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Map;
@@ -30,7 +35,9 @@ import java.util.HashSet;
 
 import javax.security.auth.Subject;
 
+import org.apache.knox.gateway.GatewayResources;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -48,11 +55,12 @@ import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 
 public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
+  private static final GatewayResources RESOURCES = ResourcesFactory.get(GatewayResources.class);
 
   private static final Set<String> SUPPORTED_SIG_ALGS = new HashSet<>();
   private AliasService as;
   private KeystoreService ks;
-  String signingKeyAlias;
+  private GatewayConfig config;
 
   static {
       // Only standard RSA signature algorithms are accepted
@@ -165,10 +173,9 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
     if(signingKeystoreAlias != null) {
      return signingKeystoreAlias;
     }
-    if(signingKeyAlias != null) {
-      return signingKeyAlias;
-    }
-    return GatewayConfig.DEFAULT_SIGNING_KEY_ALIAS;
+
+    String alias = config.getSigningKeyAlias();
+    return (alias == null) ? GatewayConfig.DEFAULT_SIGNING_KEY_ALIAS : alias;
   }
 
   @Override
@@ -184,7 +191,7 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
     PublicKey key;
     try {
       if (publicKey == null) {
-        key = ks.getSigningKeystore().getCertificate(getSigningKeyAlias(signingKeyAlias)).getPublicKey();
+        key = ks.getSigningKeystore().getCertificate(getSigningKeyAlias(null)).getPublicKey();
       }
       else {
         key = publicKey;
@@ -205,26 +212,64 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
     if (as == null || ks == null) {
       throw new ServiceLifecycleException("Alias or Keystore service is not set");
     }
-    signingKeyAlias = config.getSigningKeyAlias();
-
-    RSAPrivateKey key;
-    char[] passphrase;
-    try {
-      passphrase = as.getSigningKeyPassphrase();
-      if (passphrase != null) {
-        key = (RSAPrivateKey) ks.getSigningKey(getSigningKeyAlias(signingKeyAlias),
-            passphrase);
-        if (key == null) {
-          throw new ServiceLifecycleException("Provisioned passphrase cannot be used to acquire signing key.");
-        }
-      }
-    } catch (AliasServiceException | KeystoreServiceException e) {
-      throw new ServiceLifecycleException("Provisioned signing key passphrase cannot be acquired.", e);
-    }
+    this.config = config;
   }
 
   @Override
   public void start() throws ServiceLifecycleException {
+    // Ensure that the default signing keystore is available
+    KeyStore keystore;
+    try {
+      keystore = ks.getSigningKeystore();
+      if (keystore == null) {
+        throw new ServiceLifecycleException(RESOURCES.signingKeystoreNotAvailable(config.getSigningKeystorePath()));
+      }
+    } catch (KeystoreServiceException e) {
+      throw new ServiceLifecycleException(RESOURCES.signingKeystoreNotAvailable(config.getSigningKeystorePath()), e);
+    }
+
+    // Ensure that the password for the signing key is available
+    char[] passphrase;
+    try {
+      passphrase = as.getSigningKeyPassphrase();
+      if (passphrase == null) {
+        throw new ServiceLifecycleException(RESOURCES.signingKeyPassphraseNotAvailable(config.getSigningKeyAlias()));
+      }
+    } catch (AliasServiceException e) {
+      throw new ServiceLifecycleException(RESOURCES.signingKeyPassphraseNotAvailable(config.getSigningKeyAlias()), e);
+    }
+
+    String defaultAliasName = getSigningKeyAlias(null);
+
+    // Ensure that the public signing keys is available
+    try {
+      Certificate certificate = keystore.getCertificate(defaultAliasName);
+      if(certificate == null) {
+        throw new ServiceLifecycleException(RESOURCES.publicSigningKeyNotFound(defaultAliasName));
+      }
+      PublicKey publicKey = certificate.getPublicKey();
+      if (publicKey == null) {
+        throw new ServiceLifecycleException(RESOURCES.publicSigningKeyNotFound(defaultAliasName));
+      }
+      else if (! (publicKey instanceof  RSAPublicKey)) {
+        throw new ServiceLifecycleException(RESOURCES.publicSigningKeyWrongType(defaultAliasName));
+      }
+    } catch (KeyStoreException e) {
+      throw new ServiceLifecycleException(RESOURCES.publicSigningKeyNotFound(defaultAliasName), e);
+    }
+
+    // Ensure that the private signing keys is available
+    try {
+      Key key = keystore.getKey(defaultAliasName, passphrase);
+      if (key == null) {
+        throw new ServiceLifecycleException(RESOURCES.privateSigningKeyNotFound(defaultAliasName));
+      }
+      else if (! (key instanceof  RSAPrivateKey)) {
+        throw new ServiceLifecycleException(RESOURCES.privateSigningKeyWrongType(defaultAliasName));
+      }
+    } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
+      throw new ServiceLifecycleException(RESOURCES.privateSigningKeyNotFound(defaultAliasName), e);
+    }
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
@@ -369,6 +369,10 @@ public class DefaultTokenAuthorityServiceTest {
     ta.init(config, new HashMap<>());
     ta.start();
 
+    // Stop the started services...
+    ta.stop();
+    ks.stop();
+
     EasyMock.verify(config, ms, as);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.MasterService;
 import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
@@ -301,7 +302,6 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
-    EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
 
     AliasService as = EasyMock.createNiceMock(AliasService.class);
     EasyMock.expect(as.getSigningKeyPassphrase()).andReturn("horton".toCharArray()).anyTimes();
@@ -326,5 +326,216 @@ public class DefaultTokenAuthorityServiceTest {
                                                      .getCertificate(customSigningKeyAlias).getPublicKey();
     assertFalse(ta.verifyToken(token));
     assertTrue(ta.verifyToken(token, customPublicKey));
+  }
+
+  @Test
+  public void testServiceStart() throws Exception {
+    /*
+     Generated testSigningKeyName.jks with the following commands:
+     cd gateway-server/src/test/resources/keystores/
+     keytool -genkey -alias testSigningKeyAlias -keyalg RSA -keystore testSigningKeyName.jks \
+         -storepass testSigningKeyPassphrase -keypass testSigningKeyPassphrase -keysize 2048 \
+         -dname 'CN=testSigningKey,OU=example,O=Apache,L=US,ST=CA,C=US' -noprompt
+     */
+
+    String basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+
+    GatewayConfig config = EasyMock.createMock(GatewayConfig.class);
+    EasyMock.expect(config.getGatewayKeystoreDir()).andReturn(basedir + "/target/test-classes/keystores").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePath()).andReturn(basedir + "/target/test-classes/keystores/server-keystore.jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystoreType()).andReturn("jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePasswordAlias()).andReturn(GatewayConfig.DEFAULT_SIGNING_KEYSTORE_PASSWORD_ALIAS).anyTimes();
+    EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
+
+    MasterService ms = EasyMock.createMock(MasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    AliasService as = EasyMock.createMock(AliasService.class);
+    EasyMock.expect(as.getSigningKeyPassphrase()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    EasyMock.replay(config, ms, as);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(config, new HashMap<>());
+    ks.start();
+
+    DefaultTokenAuthorityService ta = new DefaultTokenAuthorityService();
+    ta.setAliasService(as);
+    ta.setKeystoreService(ks);
+    ta.init(config, new HashMap<>());
+    ta.start();
+
+    EasyMock.verify(config, ms, as);
+  }
+
+  @Test(expected = ServiceLifecycleException.class)
+  public void testServiceStartMissingKeystore() throws Exception {
+    String basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+
+    GatewayConfig config = EasyMock.createMock(GatewayConfig.class);
+    EasyMock.expect(config.getGatewayKeystoreDir()).andReturn(basedir + "/target/test-classes/keystores").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePath()).andReturn(basedir + "/target/test-classes/keystores/missing-server-keystore.jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystoreType()).andReturn("jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePasswordAlias()).andReturn(GatewayConfig.DEFAULT_SIGNING_KEYSTORE_PASSWORD_ALIAS).anyTimes();
+
+    MasterService ms = EasyMock.createMock(MasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    AliasService as = EasyMock.createMock(AliasService.class);
+    EasyMock.expect(as.getSigningKeyPassphrase()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    EasyMock.replay(config, ms, as);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(config, new HashMap<>());
+    ks.start();
+
+    DefaultTokenAuthorityService ta = new DefaultTokenAuthorityService();
+    ta.setAliasService(as);
+    ta.setKeystoreService(ks);
+    ta.init(config, new HashMap<>());
+    ta.start();
+
+    EasyMock.verify(config, ms, as);
+  }
+
+  @Test(expected = ServiceLifecycleException.class)
+  public void testServiceStartInvalidKeystorePassword() throws Exception {
+    /*
+     Generated testSigningKeyName.jks with the following commands:
+     cd gateway-server/src/test/resources/keystores/
+     keytool -genkey -alias testSigningKeyAlias -keyalg RSA -keystore testSigningKeyName.jks \
+         -storepass testSigningKeyPassphrase -keypass testSigningKeyPassphrase -keysize 2048 \
+         -dname 'CN=testSigningKey,OU=example,O=Apache,L=US,ST=CA,C=US' -noprompt
+     */
+
+    String basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+
+    GatewayConfig config = EasyMock.createMock(GatewayConfig.class);
+    EasyMock.expect(config.getGatewayKeystoreDir()).andReturn(basedir + "/target/test-classes/keystores").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePath()).andReturn(basedir + "/target/test-classes/keystores/server-keystore.jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystoreType()).andReturn("jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePasswordAlias()).andReturn(GatewayConfig.DEFAULT_SIGNING_KEYSTORE_PASSWORD_ALIAS).anyTimes();
+    EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
+
+    MasterService ms = EasyMock.createMock(MasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("invalid_password".toCharArray()).atLeastOnce();
+
+    AliasService as = EasyMock.createMock(AliasService.class);
+    EasyMock.expect(as.getSigningKeyPassphrase()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    EasyMock.replay(config, ms, as);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(config, new HashMap<>());
+    ks.start();
+
+    DefaultTokenAuthorityService ta = new DefaultTokenAuthorityService();
+    ta.setAliasService(as);
+    ta.setKeystoreService(ks);
+    ta.init(config, new HashMap<>());
+    ta.start();
+
+    EasyMock.verify(config, ms, as);
+  }
+
+  @Test(expected = ServiceLifecycleException.class)
+  public void testServiceStartMissingKey() throws Exception {
+    /*
+     Generated testSigningKeyName.jks with the following commands:
+     cd gateway-server/src/test/resources/keystores/
+     keytool -genkey -alias testSigningKeyAlias -keyalg RSA -keystore testSigningKeyName.jks \
+         -storepass testSigningKeyPassphrase -keypass testSigningKeyPassphrase -keysize 2048 \
+         -dname 'CN=testSigningKey,OU=example,O=Apache,L=US,ST=CA,C=US' -noprompt
+     */
+
+    String basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+
+    GatewayConfig config = EasyMock.createMock(GatewayConfig.class);
+    EasyMock.expect(config.getGatewayKeystoreDir()).andReturn(basedir + "/target/test-classes/keystores").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePath()).andReturn(basedir + "/target/test-classes/keystores/server-keystore.jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystoreType()).andReturn("jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePasswordAlias()).andReturn(GatewayConfig.DEFAULT_SIGNING_KEYSTORE_PASSWORD_ALIAS).anyTimes();
+    EasyMock.expect(config.getSigningKeyAlias()).andReturn("invalid_key").anyTimes();
+
+    MasterService ms = EasyMock.createMock(MasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    AliasService as = EasyMock.createMock(AliasService.class);
+    EasyMock.expect(as.getSigningKeyPassphrase()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    EasyMock.replay(config, ms, as);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(config, new HashMap<>());
+    ks.start();
+
+    DefaultTokenAuthorityService ta = new DefaultTokenAuthorityService();
+    ta.setAliasService(as);
+    ta.setKeystoreService(ks);
+    ta.init(config, new HashMap<>());
+    ta.start();
+
+    EasyMock.verify(config, ms, as);
+  }
+
+  @Test(expected = ServiceLifecycleException.class)
+  public void testServiceInvalidKeyPassword() throws Exception {
+    /*
+     Generated testSigningKeyName.jks with the following commands:
+     cd gateway-server/src/test/resources/keystores/
+     keytool -genkey -alias testSigningKeyAlias -keyalg RSA -keystore testSigningKeyName.jks \
+         -storepass testSigningKeyPassphrase -keypass testSigningKeyPassphrase -keysize 2048 \
+         -dname 'CN=testSigningKey,OU=example,O=Apache,L=US,ST=CA,C=US' -noprompt
+     */
+
+    String basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+
+    GatewayConfig config = EasyMock.createMock(GatewayConfig.class);
+    EasyMock.expect(config.getGatewayKeystoreDir()).andReturn(basedir + "/target/test-classes/keystores").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePath()).andReturn(basedir + "/target/test-classes/keystores/server-keystore.jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystoreType()).andReturn("jks").atLeastOnce();
+    EasyMock.expect(config.getSigningKeystorePasswordAlias()).andReturn(GatewayConfig.DEFAULT_SIGNING_KEYSTORE_PASSWORD_ALIAS).anyTimes();
+    EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
+
+    MasterService ms = EasyMock.createMock(MasterService.class);
+    EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
+
+    AliasService as = EasyMock.createMock(AliasService.class);
+    EasyMock.expect(as.getSigningKeyPassphrase()).andReturn("invalid".toCharArray()).atLeastOnce();
+
+    EasyMock.replay(config, ms, as);
+
+    DefaultKeystoreService ks = new DefaultKeystoreService();
+    ks.setMasterService(ms);
+    ks.init(config, new HashMap<>());
+    ks.start();
+
+    DefaultTokenAuthorityService ta = new DefaultTokenAuthorityService();
+    ta.setAliasService(as);
+    ta.setKeystoreService(ks);
+    ta.init(config, new HashMap<>());
+    ta.start();
+
+    EasyMock.verify(config, ms, as);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moved validation to `org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService#start`.   

Added call to `org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService#start` in `org.apache.knox.gateway.services.DefaultGatewayServices#start`.

Created message resource values in `org.apache.knox.gateway.GatewayResources` to help manage error messages. 

Added new unit tests.


## How was this patch tested?

Ran unit tested

Tested the following scenarios:
* Existing Default signing keystore (gateway.jks) and aliases
* Existing Custom signing keystore and aliaes
* Missing default signing keystore - keystore created on start
* Invalid master key (negative test)
* Missing custom signing keystore (negative test)
* Existing custom signing keystore with invalid password (negative test)
* Existing custom signing keystore with invalid key alias (negative test)
* Existing custom signing keystore with invalid key password (negative test)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
