### PR TITLE
KNOX-1803 - Stop redirecting stderr & stdout to a file when the server runs in the foreground

### DIFF
--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -112,7 +112,7 @@ function appStart {
    checkEnv
 
    if [ "$GATEWAY_SERVER_RUN_IN_FOREGROUND" == true ]; then
-      $JAVA $APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR >>$APP_OUT_FILE 2>>$APP_ERR_FILE
+      $JAVA $APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR
    else
       getPID
       if [ "$?" -eq "0" ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Gateway's output (both standard output and error) is being redirected even if the `GATEWAY_SERVER_RUN_IN_FOREGROUND` environment variable is set to `true`. This should be stopped so that end-users get immediate feedback in case of any error upon startup (without browsing error/output files).

## How was this patch tested?

Manual testing:
```
$ export GATEWAY_SERVER_RUN_IN_FOREGROUND=true

$ echo $GATEWAY_SERVER_RUN_IN_FOREGROUND
true

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh start
log4j:WARN No such property [maxBackupIndex] in org.apache.log4j.DailyRollingFileAppender.
log4j:WARN No such property [maxFileSize] in org.apache.log4j.DailyRollingFileAppender.
ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...
```