### PR TITLE
KNOX-1814 - Moving conf/data folder checking to Java layer from bash

### DIFF
--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -284,8 +284,7 @@ function checkEnv {
         echo "This command $0 must not be run as root."
         exit 1
     fi
-    checkReadDir $APP_CONF_DIR
-    checkWriteDir $APP_DATA_DIR
+
     checkWriteDir $APP_LOG_DIR
     checkWriteDir $APP_PID_DIR
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -98,6 +98,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -253,8 +254,8 @@ public class GatewayServer {
 
   private static void validateConfigurableGatewayDirectories(GatewayConfig config) throws GatewayConfigurationException {
     final Set<String> errors = new HashSet<>();
-    checkIfDirectoryExistsAndCanBeRead(Paths.get(config.getGatewayConfDir()).toFile(), GatewayConfig.GATEWAY_CONF_HOME_VAR, errors);
-    checkIfDirectoryExistsAndCanBeWritten(Paths.get(config.getGatewayDataDir()).toFile(), GatewayConfig.GATEWAY_DATA_HOME_VAR, errors);
+    checkIfDirectoryExistsAndCanBeRead(Paths.get(config.getGatewayConfDir()), GatewayConfig.GATEWAY_CONF_HOME_VAR, errors);
+    checkIfDirectoryExistsAndCanBeWritten(Paths.get(config.getGatewayDataDir()), GatewayConfig.GATEWAY_DATA_HOME_VAR, errors);
 
     if (!errors.isEmpty()) {
       throw new GatewayConfigurationException(errors);
@@ -265,13 +266,11 @@ public class GatewayServer {
     final Set<String> errors = new HashSet<>();
     if (config.isHadoopKerberosSecured()) {
       if (config.getKerberosConfig() != null) {
-        final File krb5ConfFile = Paths.get(config.getKerberosConfig()).toFile();
-        checkIfFileExistsAndCanBeRead(krb5ConfFile, GatewayConfig.KRB5_CONFIG, errors);
+        checkIfFileExistsAndCanBeRead(Paths.get(config.getKerberosConfig()), GatewayConfig.KRB5_CONFIG, errors);
       }
 
       if (config.getKerberosLoginConfig() != null) {
-        final File loginConfigFile = Paths.get(config.getKerberosLoginConfig()).toFile();
-        checkIfFileExistsAndCanBeRead(loginConfigFile, GatewayConfig.KRB5_LOGIN_CONFIG, errors);
+        checkIfFileExistsAndCanBeRead(Paths.get(config.getKerberosLoginConfig()), GatewayConfig.KRB5_LOGIN_CONFIG, errors);
       }
     }
     if (!errors.isEmpty()) {
@@ -279,29 +278,32 @@ public class GatewayServer {
     }
   }
 
-  private static void checkIfFileExistsAndCanBeRead(File fileToBeChecked, String propertyName, Set<String> errors) {
-    checkIfFileExistsAndCanBeRead(fileToBeChecked, propertyName, errors, false);
+  private static void checkIfFileExistsAndCanBeRead(Path toBeChecked, String propertyName, Set<String> errors) {
+    checkIfFileExistsAndCanBeReadOrWrite(toBeChecked, propertyName, errors, false, false);
   }
 
-  private static void checkIfDirectoryExistsAndCanBeRead(File fileToBeChecked, String propertyName, Set<String> errors) {
-    checkIfFileExistsAndCanBeRead(fileToBeChecked, propertyName, errors, true);
+  private static void checkIfDirectoryExistsAndCanBeRead(Path toBeChecked, String propertyName, Set<String> errors) {
+    checkIfFileExistsAndCanBeReadOrWrite(toBeChecked, propertyName, errors, false, true);
   }
 
-  private static void checkIfFileExistsAndCanBeRead(File fileToBeChecked, String propertyName, Set<String> errors, boolean directory) {
+  private static void checkIfDirectoryExistsAndCanBeWritten(Path toBeChecked, String propertyName, Set<String> errors) {
+    checkIfFileExistsAndCanBeReadOrWrite(toBeChecked, propertyName, errors, true, true);
+  }
+
+  private static void checkIfFileExistsAndCanBeReadOrWrite(Path toBeChecked, String propertyName, Set<String> errors, boolean checkForWritePermission, boolean directory) {
+    final File fileToBeChecked = toBeChecked.toFile();
     if (!fileToBeChecked.exists()) {
       errors.add(propertyName + " is set to a non-existing " + (directory ? "directory: " : "file: ") + fileToBeChecked);
-    } else if (!fileToBeChecked.canRead()) {
-      errors.add(propertyName + " is set to a non-readable " + (directory ? "directory: " : "file: ") + fileToBeChecked);
-    } else if (directory && !fileToBeChecked.isDirectory()) {
-      errors.add(propertyName + " is not a directory: " + fileToBeChecked);
-    }
-  }
-
-  private static void checkIfDirectoryExistsAndCanBeWritten(File fileToBeChecked, String propertyName, Set<String> errors) {
-    if (!fileToBeChecked.exists()) {
-      errors.add(propertyName + " is set to a non-existing directory: " + fileToBeChecked);
-    } else if (!fileToBeChecked.canWrite()) {
-      errors.add(propertyName + " is set to a non-writeable directory: " + fileToBeChecked);
+    } else {
+      if (!fileToBeChecked.canRead()) {
+        errors.add(propertyName + " is set to a non-readable " + (directory ? "directory: " : "file: ") + fileToBeChecked);
+      }
+      if (checkForWritePermission && !fileToBeChecked.canWrite()) {
+        errors.add(propertyName + " is set to a non-writeable " + (directory ? "directory: " : "file: ") + fileToBeChecked);
+      }
+      if (directory && !fileToBeChecked.isDirectory()) {
+        errors.add(propertyName + " is not a directory: " + fileToBeChecked);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`conf` and `data` directories are configurable using GATEWAY_HOME (or newly introduced env variable) in the Java layer, therefore those checks should either be removed from the `bash` layer, so they take those variables into account within the Java code.

## How was this patch tested?

Running JUnit tests:
```
$ mvn -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:13 min (Wall Clock)
[INFO] Finished at: 2019-03-11T11:04:32+01:00
[INFO] Final Memory: 272M/1965M
[INFO] ------------------------------------------------------------------------
```

Additionally, the following manual test steps were executed:

1. Using non-existing `conf` and `data` folders:
```
$ ls -al $GATEWAY_CONF_HOME
ls: cannot access /home/knox/nonExistingFolder: No such file or directory
$ ls -al $GATEWAY_DATA_HOME
ls: cannot access /home/knox/nonExistingFolder: No such file or directory

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh start
Starting Gateway succeeded with PID 32349.

// wait 10 seconds

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh status
Gateway is not running. No PID file found.

This error found in gateway.log:
2019-03-11 10:37:13,405 FATAL knox.gateway (GatewayServer.java:main(175)) - Failed to start gateway: org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_DATA_HOME is set to a non-existing directory: /home/knox/nonExistingFolder
GATEWAY_CONF_HOME is set to a non-existing directory: /home/knox/nonExistingFolder
org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_DATA_HOME is set to a non-existing directory: /home/knox/nonExistingFolder
GATEWAY_CONF_HOME is set to a non-existing directory: /home/knox/nonExistingFolder
        at org.apache.knox.gateway.GatewayServer.validateConfigurableGatewayDirectories(GatewayServer.java:260)
        at org.apache.knox.gateway.GatewayServer.main(GatewayServer.java:159)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
        at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
        at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
        at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
        at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)        
```

2. Using non-readable `conf` folder:
```
$ export GATEWAY_CONF_HOME=/home/knox/testFolder
$ mkdir /home/knox/testFolder
$ chmod -r /home/knox/testFolder

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh start
Starting Gateway succeeded with PID 11511.

// wait 10 seconds

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh status
Gateway is not running. No PID file found.

The following error found in gateway.log:
2019-03-11 10:40:19,813 FATAL knox.gateway (GatewayServer.java:main(175)) - Failed to start gateway: org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_CONF_HOME is set to a non-readable directory: /home/knox/testFolder
org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_CONF_HOME is set to a non-readable directory: /home/knox/testFolder
        at org.apache.knox.gateway.GatewayServer.validateConfigurableGatewayDirectories(GatewayServer.java:260)
        at org.apache.knox.gateway.GatewayServer.main(GatewayServer.java:159)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
        at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
        at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
        at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
        at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)
```

3. Using non-writeable `data` folder:
```
$ export GATEWAY_DATA_HOME=/home/knox/testFolder
$ chmod +r /home/knox/testFolder/
$ chmod -w /home/knox/testFolder/
$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh start
Starting Gateway failed.

This error found in gateway.log:
2019-03-11 10:42:51,596 FATAL knox.gateway (GatewayServer.java:main(175)) - Failed to start gateway: org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_DATA_HOME is set to a non-writeable directory: /home/knox/testFolder
org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_DATA_HOME is set to a non-writeable directory: /home/knox/testFolder
        at org.apache.knox.gateway.GatewayServer.validateConfigurableGatewayDirectories(GatewayServer.java:260)
        at org.apache.knox.gateway.GatewayServer.main(GatewayServer.java:159)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
        at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
        at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
        at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
        at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)
```