### PR TITLE
KNOX-1812 - The Knox Gateway truststore should be configurable

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -626,4 +626,13 @@ public interface GatewayMessages {
            text = "Remote Alias Service enabled")
   void remoteAliasServiceEnabled();
 
+  @Message( level = MessageLevel.ERROR, text = "The path to the keystore file does not exist: {0}" )
+  void keystoreFileDoesNotExist(String path);
+
+  @Message( level = MessageLevel.ERROR, text = "The path to the keystore file is not a file: {0}" )
+  void keystoreFileIsNotAFile(String path);
+
+  @Message( level = MessageLevel.ERROR, text = "The path to the keystore is not accessible: {0}" )
+  void keystoreFileIsNotAccessible(String path);
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -105,8 +105,6 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String TRUST_ALL_CERTS = GATEWAY_CONFIG_FILE_PREFIX + ".trust.all.certs";
   private static final String CLIENT_AUTH_NEEDED = GATEWAY_CONFIG_FILE_PREFIX + ".client.auth.needed";
   private static final String CLIENT_AUTH_WANTED = GATEWAY_CONFIG_FILE_PREFIX + ".client.auth.wanted";
-  private static final String TRUSTSTORE_PATH = GATEWAY_CONFIG_FILE_PREFIX + ".truststore.path";
-  private static final String TRUSTSTORE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".truststore.type";
   private static final String KEYSTORE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".keystore.type";
   private static final String XFORWARDED_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".xforwarded.enabled";
   private static final String EPHEMERAL_DH_KEY_SIZE = GATEWAY_CONFIG_FILE_PREFIX + ".jdk.tls.ephemeralDHKeySize";
@@ -543,7 +541,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public String getTruststorePath() {
-    return get( TRUSTSTORE_PATH, null);
+    return get( GATEWAY_TRUSTSTORE_PATH, null);
   }
 
   @Override
@@ -553,7 +551,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public String getTruststoreType() {
-    return get( TRUSTSTORE_TYPE, "JKS");
+    return get( GATEWAY_TRUSTSTORE_TYPE, DEFAULT_GATEWAY_TRUSTSTORE_TYPE);
+  }
+
+  @Override
+  public String getTruststorePasswordAlias() {
+    return get( GATEWAY_TRUSTSTORE_PASSWORD_ALIAS, DEFAULT_GATEWAY_TRUSTSTORE_PASSWORD_ALIAS);
   }
 
   @Override
@@ -602,6 +605,21 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
       }
     }
     return t;
+  }
+
+  @Override
+  public String getHttpClientTruststorePath() {
+    return get(HTTP_CLIENT_TRUSTSTORE_PATH);
+  }
+
+  @Override
+  public String getHttpClientTruststoreType() {
+    return get(HTTP_CLIENT_TRUSTSTORE_TYPE, DEFAULT_HTTP_CLIENT_TRUSTSTORE_TYPE);
+  }
+
+  @Override
+  public String getHttpClientTruststorePasswordAlias() {
+    return get(HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS, DEFAULT_HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -64,8 +64,8 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
   private static final String CERT_GEN_MODE = "hadoop.gateway.cert.gen.mode";
   private static final String CERT_GEN_MODE_LOCALHOST = "localhost";
   private static final String CERT_GEN_MODE_HOSTNAME = "hostname";
-  private static GatewayMessages LOG = MessagesFactory.get( GatewayMessages.class );
-  private static GatewayResources RES = ResourcesFactory.get( GatewayResources.class );
+  private static GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+  private static GatewayResources RES = ResourcesFactory.get(GatewayResources.class);
 
   private GatewayConfig config;
   private Map<String, Map<String, String>> cache = new ConcurrentHashMap<>();
@@ -111,13 +111,17 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
 
   @Override
   public KeyStore getKeystoreForGateway() throws KeystoreServiceException {
-    final File  keyStoreFile = new File( config.getIdentityKeystorePath() );
-    readLock.lock();
-    try {
-      return getKeystore(keyStoreFile, config.getIdentityKeystoreType(), getKeystorePassword(config.getIdentityKeystorePasswordAlias()));
-    }
-    finally {
-      readLock.unlock();
+    return getKeystore(config.getIdentityKeystorePath(), config.getIdentityKeystoreType(), config.getIdentityKeystorePasswordAlias(), true);
+  }
+
+  @Override
+  public KeyStore getTruststoreForHttpClient() throws KeystoreServiceException {
+    String trustStorePath = config.getHttpClientTruststorePath();
+    if (trustStorePath == null) {
+      // If the trustStorePath is null, fallback to behavior before KNOX-1812
+      return getKeystoreForGateway();
+    } else {
+      return getKeystore(trustStorePath, config.getHttpClientTruststoreType(), config.getHttpClientTruststorePasswordAlias(), true);
     }
   }
 
@@ -128,30 +132,19 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
 
   @Override
   public KeyStore getSigningKeystore(String keystoreName) throws KeystoreServiceException {
-    File keyStoreFile;
+    String keyStoreFile;
     String keyStoreType;
-    char[] password;
+    String passwordAlias;
     if(keystoreName != null) {
-      keyStoreFile = new File(keyStoreDir, keystoreName + ".jks");
+      keyStoreFile = Paths.get(keyStoreDir, keystoreName + ".jks").toString();
       keyStoreType = "jks";
-      password = masterService.getMasterSecret();
+      passwordAlias = null;
     } else {
-      keyStoreFile = new File(config.getSigningKeystorePath());
+      keyStoreFile = config.getSigningKeystorePath();
       keyStoreType = config.getSigningKeystoreType();
-      password = getKeystorePassword(config.getSigningKeystorePasswordAlias());
+      passwordAlias = config.getSigningKeystorePasswordAlias();
     }
-
-    // make sure the keystore exists
-    if (!keyStoreFile.exists()) {
-      throw new KeystoreServiceException("Configured signing keystore does not exist.");
-    }
-    readLock.lock();
-    try {
-      return getKeystore(keyStoreFile, keyStoreType, password);
-    }
-    finally {
-      readLock.unlock();
-    }
+    return getKeystore(keyStoreFile, keyStoreType, passwordAlias, true);
   }
 
   @Override
@@ -327,14 +320,10 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
   @Override
   public KeyStore getCredentialStoreForCluster(String clusterName)
       throws KeystoreServiceException {
-    final File  keyStoreFile = new File( keyStoreDir, clusterName + CREDENTIALS_SUFFIX  );
-    readLock.lock();
-    try {
-      return getKeystore(keyStoreFile, "JCEKS", masterService.getMasterSecret());
-    }
-    finally {
-      readLock.unlock();
-    }
+    String filename = Paths.get(keyStoreDir, clusterName + CREDENTIALS_SUFFIX).toString();
+    // Do not fail getting the credential store if the keystore file does not exist.  The returned
+    // KeyStore will be empty.  This seems like a potential bug, but is the behavior before KNOX-1812
+    return getKeystore(filename, "JCEKS", null, false);
   }
 
   @Override
@@ -446,6 +435,48 @@ public class DefaultKeystoreService extends BaseKeystoreService implements
   @Override
   public String getKeystorePath() {
     return config.getIdentityKeystorePath();
+  }
+
+  /**
+   * Loads a keystore file.
+   * <p>
+   * if <code>failIfNotAccessible</code> is <code>true</code>, then the path to the keystore file
+   * (keystorePath) is validated such that it exists, is a file and can be read by the process. If
+   * any of these checks fail, a {@link KeystoreServiceException} is thrown in dicatating the exact
+   * reason.
+   * <p>
+   * Before the keystore file is loaded, the service's read lock is locked to prevent concurrent
+   * reads on the file.
+   *
+   * @param keystorePath        the path to the keystore file
+   * @param keystoreType        the type of keystore file
+   * @param alias               the alias for the password to the keystore file (see {@link #getKeystorePassword(String)})
+   * @param failIfNotAccessible <code>true</code> to ensure the keystore file exists and is readable; <code>false</code> to not check
+   * @return a {@link KeyStore}, or <code>null</code> if the requested keystore cannot be created
+   * @throws KeystoreServiceException if an error occurs loading the keystore file
+   */
+  private KeyStore getKeystore(String keystorePath, String keystoreType, String alias, boolean failIfNotAccessible) throws KeystoreServiceException {
+    File keystoreFile = new File(keystorePath);
+
+    if (failIfNotAccessible) {
+      if (!keystoreFile.exists()) {
+        LOG.keystoreFileDoesNotExist(keystorePath);
+        throw new KeystoreServiceException("The keystore file does not exist: " + keystoreFile.getAbsolutePath());
+      } else if (!keystoreFile.isFile()) {
+        LOG.keystoreFileIsNotAFile(keystorePath);
+        throw new KeystoreServiceException("The keystore file is not a file: " + keystoreFile.getAbsolutePath());
+      } else if (!keystoreFile.canRead()) {
+        LOG.keystoreFileIsNotAccessible(keystorePath);
+        throw new KeystoreServiceException("The keystore file cannot be read: " + keystoreFile.getAbsolutePath());
+      }
+    }
+
+    readLock.lock();
+    try {
+      return getKeystore(keystoreFile, keystoreType, getKeystorePassword(alias));
+    } finally {
+      readLock.unlock();
+    }
   }
 
   private char[] getKeystorePassword(String alias) throws KeystoreServiceException {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
@@ -40,7 +40,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public class JettySSLService implements SSLService {
   private static final String EPHEMERAL_DH_KEY_SIZE_PROPERTY = "jdk.tls.ephemeralDHKeySize";
-  private static final String GATEWAY_TRUSTSTORE_PASSWORD = "gateway-truststore-password";
   private static final String GATEWAY_CREDENTIAL_STORE_NAME = "__gateway";
   private static GatewayMessages log = MessagesFactory.get( GatewayMessages.class );
 
@@ -171,12 +170,13 @@ public class JettySSLService implements SSLService {
       char[] truststorePassword;
 
       if (truststorePath != null) {
+        String trustStorePasswordAlias = config.getTruststorePasswordAlias();
         trustStoreType = config.getTruststoreType();
 
         try {
-          truststorePassword = as.getPasswordFromAliasForGateway(GATEWAY_TRUSTSTORE_PASSWORD);
+          truststorePassword = as.getPasswordFromAliasForGateway(trustStorePasswordAlias);
         } catch (AliasServiceException e) {
-          log.failedToGetPasswordForGatewayTruststore(GATEWAY_TRUSTSTORE_PASSWORD, e);
+          log.failedToGetPasswordForGatewayTruststore(trustStorePasswordAlias, e);
           throw e;
         }
       }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -348,4 +348,43 @@ public class GatewayConfigImplTest {
     assertEquals("custom_keystore_password_alias", config.getSigningKeystorePasswordAlias());
   }
 
+  @Test
+  public void testHttpClientTruststoreOptions() {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    // Validate default options (backwards compatibility)
+    assertEquals("gateway-httpclient-truststore-password", config.getHttpClientTruststorePasswordAlias());
+    assertEquals("JKS", config.getHttpClientTruststoreType());
+    assertNull(config.getHttpClientTruststorePath());
+
+    // Validate changed options
+    config.set("gateway.httpclient.truststore.password.alias", "custom_password_alias");
+    config.set("gateway.httpclient.truststore.path", "custom_path");
+    config.set("gateway.httpclient.truststore.type", "custom_type");
+
+    assertEquals("custom_password_alias", config.getHttpClientTruststorePasswordAlias());
+    assertEquals("custom_path", config.getHttpClientTruststorePath());
+    assertEquals("custom_type", config.getHttpClientTruststoreType());
+  }
+
+  @Test
+  public void testGatewayTruststoreOptions() {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    // Validate default options (backwards compatibility)
+    assertEquals("gateway-truststore-password", config.getTruststorePasswordAlias());
+    assertEquals("JKS", config.getTruststoreType());
+    assertNull(config.getTruststorePath());
+
+    // Validate changed options
+    config.set("gateway.truststore.password.alias", "custom_password_alias");
+    config.set("gateway.truststore.path", "custom_path");
+    config.set("gateway.truststore.type", "custom_type");
+
+    assertEquals("custom_password_alias", config.getTruststorePasswordAlias());
+    assertEquals("custom_path", config.getTruststorePath());
+    assertEquals("custom_type", config.getTruststoreType());
+  }
+
+
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package org.apache.knox.gateway.services.security.impl;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createMockBuilder;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreServiceException;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.util.Collections;
+
+public class DefaultKeystoreServiceTest {
+  @Rule
+  public final TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void testGetTruststoreForHttpClientDefaults() throws Exception {
+    final File dataDir = testFolder.newFolder();
+
+    GatewayConfigImpl config = new GatewayConfigImpl();
+    config.set("gateway.data.dir", dataDir.getAbsolutePath());
+
+    KeyStore keystore = createNiceMock(KeyStore.class);
+
+    DefaultKeystoreService keystoreService = createMockBuilder(DefaultKeystoreService.class)
+        .addMockedMethod("getKeystoreForGateway")
+        .createMock();
+    expect(keystoreService.getKeystoreForGateway()).andReturn(keystore).once();
+
+    replay(keystore, keystoreService);
+
+    keystoreService.init(config, Collections.emptyMap());
+
+    assertEquals(keystore, keystoreService.getTruststoreForHttpClient());
+
+    verify(keystore, keystoreService);
+  }
+
+  @Test
+  public void testGetTruststoreForHttpClientCustomTrustStore() throws Exception {
+    final File dataDir = testFolder.newFolder();
+    final File truststoreFile = testFolder.newFile();
+    final String truststoreType = "jks";
+    final String truststorePasswordAlias = "password-alias";
+    final char[] truststorePassword = "truststore_password".toCharArray();
+
+    GatewayConfigImpl config = new GatewayConfigImpl();
+    config.set("gateway.data.dir", dataDir.getAbsolutePath());
+    config.set("gateway.httpclient.truststore.path", truststoreFile.getAbsolutePath());
+    config.set("gateway.httpclient.truststore.type", truststoreType);
+    config.set("gateway.httpclient.truststore.password.alias", truststorePasswordAlias);
+
+    KeyStore keystore = createNiceMock(KeyStore.class);
+
+    DefaultKeystoreService keystoreService = createMockBuilder(DefaultKeystoreService.class)
+        .addMockedMethod("getKeystore", File.class, String.class, char[].class)
+        .addMockedMethod("getCredentialForCluster", String.class, String.class)
+        .createMock();
+    expect(keystoreService.getKeystore(eq(truststoreFile), eq(truststoreType), eq(truststorePassword)))
+        .andReturn(keystore)
+        .once();
+    expect(keystoreService.getCredentialForCluster(eq(AliasService.NO_CLUSTER_NAME), eq(truststorePasswordAlias)))
+        .andReturn(truststorePassword)
+        .once();
+
+    replay(keystore, keystoreService);
+
+    keystoreService.init(config, Collections.emptyMap());
+
+    assertEquals(keystore, keystoreService.getTruststoreForHttpClient());
+
+    verify(keystore, keystoreService);
+  }
+
+  @Test(expected = KeystoreServiceException.class)
+  public void testGetTruststoreForHttpClientMissingCustomTrustStore() throws Exception {
+    final File dataDir = testFolder.newFolder();
+    final String truststoreType = "jks";
+    final String truststorePasswordAlias = "password-alias";
+    final char[] truststorePassword = "truststore_password".toCharArray();
+
+    GatewayConfigImpl config = new GatewayConfigImpl();
+    config.set("gateway.data.dir", dataDir.getAbsolutePath());
+    config.set("gateway.httpclient.truststore.path", Paths.get(dataDir.getAbsolutePath(), "missing_file.jks").toString());
+    config.set("gateway.httpclient.truststore.type", truststoreType);
+    config.set("gateway.httpclient.truststore.password.alias", truststorePasswordAlias);
+
+    DefaultKeystoreService keystoreService = createMockBuilder(DefaultKeystoreService.class)
+        .addMockedMethod("getKeystore", File.class, String.class, char[].class)
+        .addMockedMethod("getCredentialForCluster", String.class, String.class)
+        .createMock();
+    expect(keystoreService.getCredentialForCluster(eq(AliasService.NO_CLUSTER_NAME), eq(truststorePasswordAlias)))
+        .andReturn(truststorePassword)
+        .once();
+
+    replay(keystoreService);
+
+    keystoreService.init(config, Collections.emptyMap());
+
+    keystoreService.getTruststoreForHttpClient();
+
+    verify(keystoreService);
+  }
+
+  @Test
+  public void testGetTruststoreForHttpClientCustomTrustStoreMissingPasswordAlias() throws Exception {
+    final File dataDir = testFolder.newFolder();
+    final File truststoreFile = testFolder.newFile();
+    final String truststoreType = "jks";
+    final char[] masterSecret = "master_secret".toCharArray();
+
+    GatewayConfigImpl config = new GatewayConfigImpl();
+    config.set("gateway.data.dir", dataDir.getAbsolutePath());
+    config.set("gateway.httpclient.truststore.path", truststoreFile.getAbsolutePath());
+    config.set("gateway.httpclient.truststore.type", truststoreType);
+
+    KeyStore keystore = createNiceMock(KeyStore.class);
+
+    DefaultKeystoreService keystoreService = createMockBuilder(DefaultKeystoreService.class)
+        .addMockedMethod("getKeystore", File.class, String.class, char[].class)
+        .addMockedMethod("getCredentialForCluster", String.class, String.class)
+        .withConstructor()
+        .createMock();
+    expect(keystoreService.getKeystore(eq(truststoreFile), eq(truststoreType), eq(masterSecret)))
+        .andReturn(keystore)
+        .once();
+    expect(keystoreService.getCredentialForCluster(eq(AliasService.NO_CLUSTER_NAME), eq(GatewayConfig.DEFAULT_HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS)))
+        .andReturn(null)
+        .once();
+
+    MasterService masterService = createMock(MasterService.class);
+    expect(masterService.getMasterSecret()).andReturn(masterSecret);
+
+    replay(keystore, keystoreService, masterService);
+
+    keystoreService.init(config, Collections.emptyMap());
+    keystoreService.setMasterService(masterService);
+
+    assertEquals(keystore, keystoreService.getTruststoreForHttpClient());
+
+    verify(keystore, keystoreService, masterService);
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
@@ -293,7 +293,7 @@ public class JettySSLServiceTest {
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(identityKeyPassphrase).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andReturn(truststorePassword).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq(truststorePasswordAlias))).andReturn(truststorePassword).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -346,7 +346,7 @@ public class JettySSLServiceTest {
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(identityKeyPassphrase).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andThrow(new AliasServiceException(null)).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq(truststorePasswordAlias))).andThrow(new AliasServiceException(null)).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -382,7 +382,7 @@ public class JettySSLServiceTest {
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(identityKeyPassphrase).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andReturn(null).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq(truststorePasswordAlias))).andReturn(null).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -435,7 +435,7 @@ public class JettySSLServiceTest {
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(null).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(null).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andReturn(null).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq(truststorePasswordAlias))).andReturn(null).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
@@ -59,8 +59,9 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
@@ -108,8 +109,9 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andThrow(new AliasServiceException(null)).atLeastOnce();
@@ -141,8 +143,9 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(null).atLeastOnce();
@@ -191,8 +194,9 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(false, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(null).atLeastOnce();
@@ -230,8 +234,9 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(true, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(true, false, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
@@ -281,13 +286,14 @@ public class JettySSLServiceTest {
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
     char[] truststorePassword = "horton".toCharArray();
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(identityKeyPassphrase).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("gateway-truststore-password"))).andReturn(truststorePassword).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andReturn(truststorePassword).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -333,13 +339,14 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(identityKeyPassphrase).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("gateway-truststore-password"))).andThrow(new AliasServiceException(null)).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andThrow(new AliasServiceException(null)).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -368,13 +375,14 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(identityKeystorePassword).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(identityKeyPassphrase).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("gateway-truststore-password"))).andReturn(null).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andReturn(null).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -420,13 +428,14 @@ public class JettySSLServiceTest {
     String identityKeyAlias = "server";
     Path truststorePath = Paths.get(basedir, "target", "test-classes", "keystores", "server-truststore.jks");
     String truststoreType = "jks";
+    String truststorePasswordAlias = "trust_store_password";
 
-    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType);
+    GatewayConfig config = createGatewayConfig(true, true, identityKeystorePath, identityKeystoreType, identityKeyAlias, truststorePath, truststoreType, truststorePasswordAlias);
 
     AliasService aliasService = createMock(AliasService.class);
     expect(aliasService.getGatewayIdentityKeystorePassword()).andReturn(null).atLeastOnce();
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn(null).atLeastOnce();
-    expect(aliasService.getPasswordFromAliasForGateway(eq("gateway-truststore-password"))).andReturn(null).atLeastOnce();
+    expect(aliasService.getPasswordFromAliasForGateway(eq("trust_store_password"))).andReturn(null).atLeastOnce();
 
     KeystoreService keystoreService = createMock(KeystoreService.class);
 
@@ -448,7 +457,8 @@ public class JettySSLServiceTest {
 
   private GatewayConfig createGatewayConfig(boolean isClientAuthNeeded, boolean isExplicitTruststore,
                                             Path identityKeystorePath, String identityKeystoreType,
-                                            String identityKeyAlias, Path truststorePath, String truststoreType) {
+                                            String identityKeyAlias, Path truststorePath,
+                                            String truststoreType, String trustStorePasswordAlias) {
     GatewayConfig config = createMock(GatewayConfig.class);
     expect(config.getIdentityKeystorePath()).andReturn(identityKeystorePath.toString()).atLeastOnce();
     expect(config.getIdentityKeystoreType()).andReturn(identityKeystoreType).atLeastOnce();
@@ -460,6 +470,7 @@ public class JettySSLServiceTest {
       if (isExplicitTruststore) {
         expect(config.getTruststorePath()).andReturn(truststorePath.toString()).atLeastOnce();
         expect(config.getTruststoreType()).andReturn(truststoreType).atLeastOnce();
+        expect(config.getTruststorePasswordAlias()).andReturn(trustStorePasswordAlias).atLeastOnce();
       } else {
         expect(config.getTruststorePath()).andReturn(null).atLeastOnce();
       }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -73,6 +73,18 @@ public interface GatewayConfig {
   String DEFAULT_SIGNING_KEY_ALIAS = "gateway-identity";
   String DEFAULT_SIGNING_KEY_PASSPHRASE_ALIAS = "signing.key.passphrase";
 
+  String GATEWAY_TRUSTSTORE_PASSWORD_ALIAS = "gateway.truststore.password.alias";
+  String GATEWAY_TRUSTSTORE_PATH = "gateway.truststore.path";
+  String GATEWAY_TRUSTSTORE_TYPE = "gateway.truststore.type";
+  String DEFAULT_GATEWAY_TRUSTSTORE_TYPE = "JKS";
+  String DEFAULT_GATEWAY_TRUSTSTORE_PASSWORD_ALIAS = "gateway-truststore-password";
+
+  String HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS = "gateway.httpclient.truststore.password.alias";
+  String HTTP_CLIENT_TRUSTSTORE_PATH = "gateway.httpclient.truststore.path";
+  String HTTP_CLIENT_TRUSTSTORE_TYPE = "gateway.httpclient.truststore.type";
+  String DEFAULT_HTTP_CLIENT_TRUSTSTORE_TYPE = "JKS";
+  String DEFAULT_HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS = "gateway-httpclient-truststore-password";
+
   String REMOTE_CONFIG_REGISTRY_TYPE = "type";
   String REMOTE_CONFIG_REGISTRY_ADDRESS = "address";
   String REMOTE_CONFIG_REGISTRY_NAMESPACE = "namespace";
@@ -173,6 +185,14 @@ public interface GatewayConfig {
 
   String getTruststoreType();
 
+  /**
+   * Returns the configured value for the alias name to use when to looking up the Gateway's
+   * truststore password.
+   *
+   * @return an alias name
+   */
+  String getTruststorePasswordAlias();
+
   boolean isXForwardedEnabled();
 
   String getEphemeralDHKeySize();
@@ -182,6 +202,29 @@ public interface GatewayConfig {
   int getHttpClientConnectionTimeout();
 
   int getHttpClientSocketTimeout();
+
+  /**
+   * Returns the configured value for the path to the truststore to be used by the HTTP client instance
+   * connecting to a service from the Gateway.
+   *
+   * @return a path to the trust file; or <code>null</code> if not set
+   */
+  String getHttpClientTruststorePath();
+
+  /**
+   * Returns the configured value for the type of the truststore specified by {@link #getHttpClientTruststorePath()}.
+   *
+   * @return a truststore type
+   */
+  String getHttpClientTruststoreType();
+
+  /**
+   * Returns the configured value for the alias name to use when to looking up the HTTP client's
+   * truststore password.
+   *
+   * @return an alias name
+   */
+  String getHttpClientTruststorePasswordAlias();
 
   int getThreadPoolMax();
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/KeystoreService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/KeystoreService.java
@@ -32,6 +32,15 @@ public interface KeystoreService {
 
   KeyStore getKeystoreForGateway() throws KeystoreServiceException;
 
+  /**
+   * Gets the configured keystore instance that contains trust data.
+   * <p>
+   * If not configured, the Gateway's identity keystore should be returned. See {@link #getKeystoreForGateway()}
+   *
+   * @return a {@link KeyStore}
+   */
+  KeyStore getTruststoreForHttpClient() throws KeystoreServiceException;
+
   KeyStore getSigningKeystore() throws KeystoreServiceException;
 
   KeyStore getSigningKeystore(String keystoreName) throws KeystoreServiceException;

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -316,6 +316,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return truststoreType;
   }
 
+  @Override
+  public String getTruststorePasswordAlias() {
+    return null;
+  }
+
   public void setTruststoreType( String truststoreType ) {
     this.truststoreType = truststoreType;
   }
@@ -386,6 +391,21 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   @Override
   public int getHttpClientSocketTimeout() {
     return -1;
+  }
+
+  @Override
+  public String getHttpClientTruststorePath() {
+    return null;
+  }
+
+  @Override
+  public String getHttpClientTruststoreType() {
+    return null;
+  }
+
+  @Override
+  public String getHttpClientTruststorePasswordAlias() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Knox Gateway truststore should be configurable

Knox relies on a trust store for various purposes
- The *KnoxCLI* (via a KnoxSession) uses a truststore to trust the connection to the Knox Gateway server
  - The truststore is determined by the Java system properties (`javax.net.ssl.trustStore`, `javax.net.ssl.trustStorePassword`) or the JVM's cacerts file

- The *Knox Gateway* server uses a truststore to trust the connections going out to the services (if connecting via TLS/SSL)
 - The truststore is set to be the same keystore as the Gateway's identitiy keystore.
 - See `org.apache.knox.gateway.dispatch.DefaultHttpClientFactory#createHttpClient`.

- The *Knox Gateway* server uses a truststore to trust the user/client connecting to it when clientauth is enabled
  - The truststore is set to be the same keystore as the Gateway's identity keystore unless one is explicitly specified in the gateway-site.xml file (`gateway.truststore.path`, `gateway.truststore.type`). If a truststore is explicitly set, the password for the truststore is looked up, using alias name "`gateway-truststore-password`", from the alias service.
  - See `org.apache.knox.gateway.services.security.impl.JettySSLService#buildSslContextFactory`.

By making the outgoing connection truststore (#2, from above) configurable, it will be possible to use the same truststore for both incoming and outgoing connections, which will be convenient when services communicate with each other via the Knox Gateway. 

To make sure the truststore configuration is flexible and backwards compatible with older versions of Knox,  new properties should be introduced in the gateway-site.xml file:
- `gateway.httpclient.truststore.path`
- `gateway.httpclient.truststore.type`
- `gateway.httpclient.truststore.password.alias`

Note: This naming convention goes along with the following properties used to configure the Gateway's HTTPClient instance: 
- `gateway.httpclient.maxConnections`
- `gateway.httpclient.connectionTimeout`
- `gateway.httpclient.socketTimeout`

If `gateway.httpclient.truststore.path` is not set in the configuration, then Gateway's identity keystore will be used (which is the current implementation); else, the configured truststore details will be used. 
 
Also, to keep things consistent, the password alias name for the _clientauth_ truststore should be configurable using the property name:

- `gateway.truststore.password.alias` (default: "`gateway-truststore-password`")

## How was this patch tested?

Manually tested using various scenarios
- defaults, backwards compatibility
- custom identity keystore, unset truststore
- default identity keystore, custom truststore
- custom identity keystore, custom truststore

Updated and created new unit test cases:
```
mvn -T.5C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 15:35 min (Wall Clock)
[INFO] Finished at: 2019-03-10T11:28:24-04:00
[INFO] Final Memory: 319M/1930M
[INFO] ------------------------------------------------------------------------
```

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
