### PR TITLE
KNOX-1817 - Fix XSS issues with Alias API

### DIFF
--- a/gateway-service-admin/pom.xml
+++ b/gateway-service-admin/pom.xml
@@ -94,6 +94,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.knox</groupId>

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/TopologiesResource.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/TopologiesResource.java
@@ -27,6 +27,7 @@ import org.apache.knox.gateway.service.admin.beans.Topology;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.topology.TopologyService;
+import org.owasp.encoder.Encode;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
@@ -360,7 +361,8 @@ public class TopologiesResource {
         }
       } catch (URISyntaxException e) {
         log.invalidResourceURI(e.getInput(), e.getReason(), e);
-        response = status(Response.Status.BAD_REQUEST).entity("{ \"error\" : \"Failed to deploy provider configuration " + name + "\" }").build();
+        response = status(Response.Status.BAD_REQUEST).entity("{ \"error\" : \"Failed to deploy provider configuration " + Encode
+            .forHtml(name) + "\" }").build();
       }
     }
 
@@ -407,7 +409,7 @@ public class TopologiesResource {
         }
       } catch (URISyntaxException e) {
         log.invalidResourceURI(e.getInput(), e.getReason(), e);
-        response = status(Response.Status.BAD_REQUEST).entity("{ \"error\" : \"Failed to deploy descriptor " + name + "\" }").build();
+        response = status(Response.Status.BAD_REQUEST).entity("{ \"error\" : \"Failed to deploy descriptor " + Encode.forHtml(name) + "\" }").build();
       }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
         <xml-matchers.version>0.10</xml-matchers.version>
         <zip4j.version>1.3.2</zip4j.version>
         <zookeeper.version>3.4.13</zookeeper.version>
+        <owasp-java-encoder>1.2.2</owasp-java-encoder>
     </properties>
 
     <profiles>
@@ -1959,6 +1960,12 @@
                 <groupId>de.thetaphi</groupId>
                 <artifactId>forbiddenapis</artifactId>
                 <version>${forbiddenapis.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.owasp.encoder</groupId>
+                <artifactId>encoder</artifactId>
+                <version>${owasp-java-encoder}</version>
             </dependency>
 
             <!-- ********** ********** ********** ********** ********** ********** -->


### PR DESCRIPTION
## What changes were proposed in this pull request?
The Alias API was passing user input back in some cases as response without encoding, this was when an error was thrown or when a response message saying 'alias' for a 'topology' was created. This opens up the API for XSS attacks. The PR:

1. Adds encoding to the data that is going out as response. 
2. Decodes the user inputs - since the api uses application/x-www-form-urlencoded

## How was this patch tested?
The patch was tested manually e.g.

`curl -iku admin:admin-password -H "Content-Type: application/json"  -d "value=mysecret" -X PUT  'https://localhost:8443/gateway/admin/api/v1/aliases/sandbox/somelongreallylongalias<>'
HTTP/1.1 201 Created
Date: Tue, 12 Mar 2019 19:54:00 GMT
Set-Cookie: KNOXSESSIONID=node0tb9bz05vhh6k1xpp0ti2p0vqh2.node0;Path=/gateway/admin;Secure;HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/admin; Max-Age=0; Expires=Mon, 11-Mar-2019 19:54:00 GMT
Content-Type: application/json
Content-Length: 85
Server: Jetty(9.4.15.v20190215)

{ "created" : { "topology": "sandbox", "alias": "somelongreallylongalias&lt;&gt;" } }`
