### PR TITLE
KNOX-1804 - Moving copy-pasted bash functions to knox-function.sh

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -17,6 +17,27 @@
 #  limitations under the License.
 #
 
+############################
+##### common variables #####
+############################
+
+# The app's home dir
+APP_HOME_DIR=`dirname $APP_BIN_DIR`
+
+# The app's PID
+APP_PID=0
+
+# The start wait time
+APP_START_WAIT_TIME=2
+
+# The kill wait time limit
+APP_KILL_WAIT_TIME=10
+
+
+############################
+##### common functions #####
+############################
+
 JAVA_VERSION_PATTERNS=( "1.6.0_31/bin/java$" "1.6.0_.*/bin/java$" "1.6.0.*/bin/java$" "1.6\..*/bin/java$" "/bin/java$" )
 
 function findJava() {
@@ -104,3 +125,157 @@ function printEnv() {
     fi
 }
 
+function appIsRunning {
+   if [ $1 -eq 0 ]; then return 0; fi
+
+   ps -p $1 > /dev/null
+
+   if [ $? -eq 1 ]; then
+     return 0
+   else
+     return 1
+   fi
+}
+
+# Returns 0 if the app is running and sets the $PID variable
+# TODO: this may be a false indication: it may happen the process started but it'll return with a <>0 exit code due to validation errors; this should be fixed ASAP
+function getPID {
+   if [ ! -d $APP_PID_DIR ]; then
+      printf "Can't find PID dir.\n"
+      exit 1
+   fi
+   if [ ! -f $APP_PID_FILE ]; then
+     APP_PID=0
+     return 1
+   fi
+
+   APP_PID="$(<$APP_PID_FILE)"
+
+   ps -p $APP_PID > /dev/null
+   # if the exit code was 1 then it isn't running
+   if [ "$?" -eq "1" ];
+   then
+     return 1
+   fi
+
+   return 0
+}
+
+function appStart {
+   if [ "$APP_RUNNING_IN_FOREGROUND" == true ]; then
+      $JAVA $APP_JAVA_OPTS -jar $APP_JAR $@
+   else
+      getPID
+      if [ $? -eq 0 ]; then
+         printf "$APP_LABEL is already running with PID $APP_PID.\n"
+         exit 0
+      fi
+
+      printf "Starting $APP_LABEL "
+
+      rm -f $APP_PID_FILE
+
+      nohup $JAVA $APP_JAVA_OPTS -jar $APP_JAR $@ >>$APP_OUT_FILE 2>>$APP_ERR_FILE & printf $!>$APP_PID_FILE || exit 1
+
+      ##give a second to the JVM to start and run validation
+      sleep 1
+
+      getPID
+      for ((i=0; i<APP_START_WAIT_TIME*10; i++)); do
+         appIsRunning $APP_PID
+         if [ $? -eq 0 ]; then break; fi
+         sleep 0.1
+      done
+      appIsRunning $APP_PID
+      if [ $? -ne 1 ]; then
+         printf "failed.\n"
+         rm -f $APP_PID_FILE
+         exit 1
+      fi
+      printf "succeeded with PID $APP_PID.\n"
+      return 0
+   fi
+}
+
+function appStop {
+   getPID
+   appIsRunning $APP_PID
+   if [ "$?" -eq "0" ]; then
+     printf "$APP_LABEL is not running.\n"
+     rm -f $APP_PID_FILE
+     return 0
+   fi
+
+   printf "Stopping $APP_LABEL with PID $APP_PID "
+   appKill $APP_PID >>$APP_OUT_FILE 2>>$APP_ERR_FILE
+
+   if [ "$?" -ne "0" ]; then
+     printf "failed. \n"
+     exit 1
+   else
+     rm -f $APP_PID_FILE
+     printf "succeeded.\n"
+     return 0
+   fi
+}
+
+function appStatus {
+   printf "$APP_LABEL "
+   getPID
+   if [ "$?" -eq "1" ]; then
+     printf "is not running. No PID file found.\n"
+     return 0
+   fi
+
+   appIsRunning $APP_PID
+   if [ "$?" -eq "1" ]; then
+     printf "is running with PID $APP_PID.\n"
+     exit 1
+   else
+     printf "is not running.\n"
+     return 0
+   fi
+}
+
+# Removing the app's PID/ERR/OUT files if app is not running
+function appClean {
+   getPID
+   appIsRunning $APP_PID
+   if [ "$?" -eq "0" ]; then
+     deleteLogFiles
+     return 0
+   else
+     printf "Can't clean files.  $APP_LABEL is running with PID $APP_PID.\n"
+     exit 1
+   fi
+}
+
+function appKill {
+   local localPID=$1
+   kill $localPID || return 1
+   for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
+      appIsRunning $localPID
+      if [ "$?" -eq "0" ]; then return 0; fi
+      sleep 0.1
+   done
+
+   kill -s KILL $localPID || return 1
+   for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
+      appIsRunning $localPID
+      if [ "$?" -eq "0" ]; then return 0; fi
+      sleep 0.1
+   done
+
+   return 1
+}
+
+function deleteLogFiles {
+     rm -f $APP_PID_FILE
+     printf "Removed the $APP_LABEL PID file: $APP_PID_FILE.\n"
+
+     rm -f $APP_OUT_FILE
+     printf "Removed the $APP_LABEL OUT file: $APP_OUT_FILE.\n"
+
+     rm -f $APP_ERR_FILE
+     printf "Removed the $APP_LABEL ERR file: $APP_ERR_FILE.\n"
+}

--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -35,9 +35,6 @@ APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # The app's jar name
 APP_JAR="$APP_BIN_DIR/gateway.jar"
 
-# The app's home dir
-APP_HOME_DIR=`dirname $APP_BIN_DIR`
-
 # The app's conf dir
 DEFAULT_APP_CONF_DIR="$APP_HOME_DIR/conf"
 APP_CONF_DIR=${KNOX_GATEWAY_CONF_DIR:-$DEFAULT_APP_CONF_DIR}
@@ -59,9 +56,6 @@ APP_MEM_OPTS="$KNOX_GATEWAY_MEM_OPTS"
 # The app's debugging options
 APP_DBG_OPTS="$KNOX_GATEWAY_DBG_OPTS"
 
-# The app's PID
-APP_PID=0
-
 #dynamic library path
 DEFAULT_JAVA_LIB_PATH="-Djava.library.path=$APP_HOME_DIR/ext/native"
 APP_JAVA_LIB_PATH=${KNOX_GATEWAY_JAVA_LIB_PATH:-$DEFAULT_JAVA_LIB_PATH}
@@ -75,11 +69,10 @@ APP_PID_FILE="$APP_PID_DIR/$APP_NAME.pid"
 APP_OUT_FILE="$APP_LOG_DIR/$APP_NAME.out"
 APP_ERR_FILE="$APP_LOG_DIR/$APP_NAME.err"
 
-# The start wait time
-APP_START_WAIT_TIME=2
+DEFAULT_APP_RUNNING_IN_FOREGROUND="$GATEWAY_SERVER_RUN_IN_FOREGROUND"
+APP_RUNNING_IN_FOREGROUND=${KNOX_GATEWAY_RUNNING_IN_FOREGROUND:-DEFAULT_APP_RUNNING_IN_FOREGROUND}
 
-# The kill wait time limit
-APP_KILL_WAIT_TIME=10
+APP_JAVA_OPTS="$APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
 
 function main {
    checkJava
@@ -92,6 +85,7 @@ function main {
          if [ "$2" = "--printEnv" ]; then
            printEnv
          fi
+         checkEnv
          appStart
          ;;
       stop)   
@@ -116,149 +110,6 @@ function setupEnv {
    checkEnv
    $JAVA -jar $APP_JAR -persist-master -nostart
    return 0
-}
-
-function appStart {
-   checkEnv
-
-   if [ "$GATEWAY_SERVER_RUN_IN_FOREGROUND" == true ]; then
-      $JAVA $APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR
-   else
-      getPID
-      if [ "$?" -eq "0" ]; then
-         printf "$APP_LABEL is already running with PID $APP_PID.\n"
-         exit 0
-      fi
-  
-      printf "Starting $APP_LABEL "
-   
-      rm -f $APP_PID_FILE
-
-      nohup $JAVA $APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR >>$APP_OUT_FILE 2>>$APP_ERR_FILE & printf $!>$APP_PID_FILE || exit 1
-
-      getPID
-      for ((i=0; i<APP_START_WAIT_TIME*10; i++)); do
-         appIsRunning $APP_PID
-         if [ "$?" -eq "0" ]; then break; fi
-         sleep 0.1
-      done
-      appIsRunning $APP_PID
-      if [ "$?" -ne "1" ]; then
-         printf "failed.\n"
-         rm -f $APP_PID_FILE
-         exit 1
-      fi
-      printf "succeeded with PID $APP_PID.\n"
-      return 0
-   fi
-}
-
-function appStop {
-   getPID
-   appIsRunning $APP_PID
-   if [ "$?" -eq "0" ]; then
-     printf "$APP_LABEL is not running.\n"
-     rm -f $APP_PID_FILE
-     return 0
-   fi
-  
-   printf "Stopping $APP_LABEL with PID $APP_PID "
-   appKill $APP_PID >>$APP_OUT_FILE 2>>$APP_ERR_FILE
-
-   if [ "$?" -ne "0" ]; then
-     printf "failed. \n"
-     exit 1
-   else
-     rm -f $APP_PID_FILE
-     printf "succeeded.\n"
-     return 0
-   fi
-}
-
-function appStatus {
-   printf "$APP_LABEL "
-   getPID
-   if [ "$?" -eq "1" ]; then
-     printf "is not running. No PID file found.\n"
-     return 0
-   fi
-
-   appIsRunning $APP_PID
-   if [ "$?" -eq "1" ]; then
-     printf "is running with PID $APP_PID.\n"
-     exit 1
-   else
-     printf "is not running.\n"
-     return 0
-   fi
-}
-
-# Removed the app PID file if app is not run
-function appClean {
-   getPID
-   appIsRunning $APP_PID
-   if [ "$?" -eq "0" ]; then
-     deleteLogFiles
-     return 0
-   else
-     printf "Can't clean files.  $APP_LABEL is running with PID $APP_PID.\n"
-     exit 1
-   fi
-}
-
-function appKill {
-   local localPID=$1
-   kill $localPID || return 1
-   for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
-      appIsRunning $localPID
-      if [ "$?" -eq "0" ]; then return 0; fi
-      sleep 0.1
-   done
-
-   kill -s KILL $localPID || return 1
-   for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
-      appIsRunning $localPID
-      if [ "$?" -eq "0" ]; then return 0; fi
-      sleep 0.1
-   done
-
-   return 1
-}
-
-# Returns 0 if the app is running and sets the $PID variable.
-function getPID {
-   if [ ! -d $APP_PID_DIR ]; then
-      printf "Can't find PID dir.\n"
-      exit 1
-   fi
-   if [ ! -f $APP_PID_FILE ]; then
-     APP_PID=0
-     return 1
-   fi
-   
-   APP_PID="$(<$APP_PID_FILE)"
-
-   ps -p $APP_PID > /dev/null
-   # if the exit code was 1 then it isn't running
-   # and it is safe to start
-   if [ "$?" -eq "1" ];
-   then
-     return 1
-   fi
-
-   return 0
-}
-
-function appIsRunning {
-   if [ "$1" -eq "0" ]; then return 0; fi
-
-   ps -p $1 > /dev/null
-
-   if [ "$?" -eq "1" ]; then
-     return 0
-   else
-     return 1
-   fi
 }
 
 function checkReadDir {
@@ -297,17 +148,6 @@ function checkEnv {
 
     checkWriteDir $APP_LOG_DIR
     checkWriteDir $APP_PID_DIR
-}
-
-function deleteLogFiles {
-     rm -f $APP_PID_FILE
-     printf "Removed the $APP_LABEL PID file: $APP_PID_FILE.\n"
-     
-     rm -f $APP_OUT_FILE
-     printf "Removed the $APP_LABEL OUT file: $APP_OUT_FILE.\n"
-     
-     rm -f $APP_ERR_FILE
-     printf "Removed the $APP_LABEL ERR file: $APP_ERR_FILE.\n"
 }
 
 function printHelp {

--- a/gateway-release/home/bin/ldap.sh
+++ b/gateway-release/home/bin/ldap.sh
@@ -35,9 +35,6 @@ APP_JAR="$APP_BIN_DIR/ldap.jar"
 # Source common functions
 . $APP_BIN_DIR/knox-functions.sh
 
-# The app's home dir
-APP_HOME_DIR=`dirname $APP_BIN_DIR`
-
 # The app's conf dir
 DEFAULT_APP_CONF_DIR="$APP_HOME_DIR/conf"
 APP_CONF_DIR=${KNOX_LDAP_CONF_DIR:-$DEFAULT_APP_CONF_DIR}
@@ -55,9 +52,6 @@ APP_MEM_OPTS="$KNOX_LDAP_MEM_OPTS"
 # The app's debugging options
 APP_DBG_OPTS="$KNOX_LDAP_DBG_OPTS"
 
-# The app's PID
-APP_PID=0
-
 # The name of the PID file
 DEFAULT_APP_PID_DIR="$APP_HOME_DIR/pids"
 APP_PID_DIR=${KNOX_LDAP_PID_DIR:-$DEFAULT_APP_PID_DIR}
@@ -67,11 +61,11 @@ APP_PID_FILE="$APP_PID_DIR/$APP_NAME.pid"
 APP_OUT_FILE="$APP_LOG_DIR/$APP_NAME.out"
 APP_ERR_FILE="$APP_LOG_DIR/$APP_NAME.err"
 
-# The start wait time
-APP_START_WAIT_TIME=2
+DEFAULT_APP_RUNNING_IN_FOREGROUND="$LDAP_SERVER_RUN_IN_FOREGROUND"
+APP_RUNNING_IN_FOREGROUND=${KNOX_LDAP_RUNNING_IN_FOREGROUND:-DEFAULT_APP_RUNNING_IN_FOREGROUND}
 
-# The kill wait time limit
-APP_KILL_WAIT_TIME=10
+# JAVA options used by the JVM
+APP_JAVA_OPTS="$APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
 
 function main {
    checkJava
@@ -81,7 +75,8 @@ function main {
          if [ "$2" = "--printEnv" ]; then
            printEnv
          fi
-         appStart
+         createLogFiles
+         appStart $APP_CONF_DIR
          ;;
       stop)   
          appStop
@@ -98,149 +93,6 @@ function main {
    esac
 }
 
-function appStart {
-   createLogFiles
-
-   if [ "$LDAP_SERVER_RUN_IN_FOREGROUND" == true ]; then
-      $JAVA $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR $APP_CONF_DIR
-   else
-      getPID
-      if [ $? -eq 0 ]; then
-         printf "$APP_LABEL is already running with PID $APP_PID.\n"
-         exit 0
-      fi
-  
-      printf "Starting $APP_LABEL "
-   
-      rm -f $APP_PID_FILE
-
-      nohup $JAVA $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR $APP_CONF_DIR >>$APP_OUT_FILE 2>>$APP_ERR_FILE & printf $!>$APP_PID_FILE || exit 1
-
-      getPID
-      for ((i=0; i<APP_START_WAIT_TIME*10; i++)); do
-         appIsRunning $APP_PID
-         if [ $? -eq 0 ]; then break; fi
-         sleep 0.1
-      done
-      appIsRunning $APP_PID
-      if [ $? -ne 1 ]; then
-         printf "failed.\n"
-         rm -f $APP_PID_FILE
-         exit 1
-      fi
-      printf "succeeded with PID $APP_PID.\n"
-      return 0
-   fi
-}
-
-function appStop {
-   getPID
-   appIsRunning $APP_PID
-   if [ $? -eq 0 ]; then
-     printf "$APP_LABEL is not running.\n"
-     rm -f $APP_PID_FILE
-     return 0
-   fi
-  
-   printf "Stopping $APP_LABEL with PID $APP_PID "
-   appKill $APP_PID >>$APP_OUT_FILE 2>>$APP_ERR_FILE
-
-   if [ $? -ne 0 ]; then 
-     printf "failed. \n"
-     exit 1
-   else
-     rm -f $APP_PID_FILE
-     printf "succeeded.\n"
-     return 0
-   fi
-}
-
-function appStatus {
-   printf "$APP_LABEL "
-   getPID
-   if [ $? -eq 1 ]; then
-     printf "is not running. No PID file found.\n"
-     return 0
-   fi
-
-   appIsRunning $APP_PID
-   if [ $? -eq 1 ]; then
-     printf "is running with PID $APP_PID.\n"
-     exit 1
-   else
-     printf "is not running.\n"
-     return 0
-   fi
-}
-
-# Removed the PID file if app is not run
-function appClean {
-   getPID
-   appIsRunning $APP_PID
-   if [ $? -eq 0 ]; then 
-     deleteLogFiles
-     return 0
-   else
-     printf "Can't clean files.  $APP_LABEL is running with PID $APP_PID.\n"
-     exit 1
-   fi
-}
-
-function appKill {
-   local localPID=$1
-   kill $localPID || return 1
-   for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
-      appIsRunning $localPID
-      if [ $? -eq 0 ]; then return 0; fi
-      sleep 0.1
-   done
-
-   kill -s KILL $localPID || return 1
-   for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
-      appIsRunning $localPID
-      if [ $? -eq 0 ]; then return 0; fi
-      sleep 0.1
-   done
-
-   return 1
-}
-
-# Returns 0 if the app is running and sets the $APP_PID variable.
-function getPID {
-   if [ ! -d $APP_PID_DIR ]; then
-      printf "Can't find pid dir.\n"
-      exit 1
-   fi
-   if [ ! -f $APP_PID_FILE ]; then
-     APP_PID=0
-     return 1
-   fi
-   
-   APP_PID="$(<$APP_PID_FILE)"
-
-   ps -p $APP_PID > /dev/null
-   # if the exit code was 1 then it isn't running
-   # and it is safe to start
-   if [ "$?" -eq "1" ];
-   then
-     return 1
-   fi
-      
-   return 0
-}
-
-function appIsRunning {
-   if [ $1 -eq 0 ]; then return 0; fi
-
-   ps -p $1 > /dev/null
-
-   if [ $? -eq 1 ]; then
-     return 0
-   else
-     return 1
-   fi
-}
-
 function createLogFiles {
    if [ ! -d "$APP_LOG_DIR" ]; then
       printf "Can't find log dir.\n"
@@ -248,17 +100,6 @@ function createLogFiles {
    fi
    if [ ! -f "$APP_OUT_FILE" ]; then touch $APP_OUT_FILE; fi
    if [ ! -f "$APP_ERR_FILE" ]; then touch $APP_ERR_FILE; fi   
-}
-
-function deleteLogFiles {
-     rm -f $APP_PID_FILE
-     printf "Removed the $APP_LABEL PID file: $APP_PID_FILE.\n"
-     
-     rm -f $APP_OUT_FILE
-     printf "Removed the $APP_LABEL OUT file: $APP_OUT_FILE.\n"
-     
-     rm -f $APP_ERR_FILE
-     printf "Removed the $APP_LABEL ERR file: $APP_ERR_FILE.\n"
 }
 
 function printHelp {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removing code duplication in `gateway.sh` and `ldap.sh` files.

## How was this patch tested?

Executing the following manual test steps:
```
-- Gateway test --

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh status
Gateway is not running. No PID file found.

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh clean
Removed the Gateway PID file: /home/knox/knox-1.3.0-SNAPSHOT/pids/gateway.pid.
Removed the Gateway OUT file: /home/knox/knox-1.3.0-SNAPSHOT/logs/gateway.out.
Removed the Gateway ERR file: /home/knox/knox-1.3.0-SNAPSHOT/logs/gateway.err.
 
$ export KNOX_GATEWAY_CONF_DIR=~knox/nonExistingFolder

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh start --printEnv
APP_CONF_DIR = /home/knox/nonExistingFolder
APP_LOG_DIR = /home/knox/knox-1.3.0-SNAPSHOT/logs
APP_DATA_DIR = /home/knox/knox-1.3.0-SNAPSHOT/data
APP_PID_DIR = /home/knox/knox-1.3.0-SNAPSHOT/pids
APP_JAVA_LIB_PATH = -Djava.library.path=/home/knox/knox-1.3.0-SNAPSHOT/ext/native
APP_JAR = /home/knox/knox-1.3.0-SNAPSHOT/bin/gateway.jar
Starting Gateway failed.

$ tail -20 knox-1.3.0-SNAPSHOT/logs/gateway.log
2019-03-13 13:23:18,473 INFO  knox.gateway (GatewayServer.java:logSysProp(218)) - System Property: java.home=/usr/jdk64/jdk1.8.0_112/jre
2019-03-13 13:23:18,910 INFO  knox.gateway (GatewayConfigImpl.java:loadConfigResource(398)) - Loading configuration resource jar:file:/home/knox/knox-1.3.0-SNAPSHOT/bin/../lib/gateway-server-1.3.0-SNAPSHOT.jar!/conf/gateway-default.xml
2019-03-13 13:23:19,176 INFO  knox.gateway (GatewayConfigImpl.java:loadConfigFile(386)) - Loading configuration file /home/knox/knox-1.3.0-SNAPSHOT/bin/../conf/gateway-site.xml
2019-03-13 13:23:19,274 INFO  knox.gateway (GatewayConfigImpl.java:initGatewayHomeDir(326)) - Using /home/knox/knox-1.3.0-SNAPSHOT/bin/.. as GATEWAY_HOME via system property.
2019-03-13 13:23:19,274 INFO  knox.gateway (GatewayConfigImpl.java:init(319)) - Cookie scoping feature enabled: false
2019-03-13 13:23:19,278 FATAL knox.gateway (GatewayServer.java:main(176)) - Failed to start gateway: org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_CONF_HOME is set to a non-existing directory: /home/knox/nonExistingFolder
org.apache.knox.gateway.config.GatewayConfigurationException: Found configurations errors:
GATEWAY_CONF_HOME is set to a non-existing directory: /home/knox/nonExistingFolder
	at org.apache.knox.gateway.GatewayServer.validateConfigurableGatewayDirectories(GatewayServer.java:261)
	at org.apache.knox.gateway.GatewayServer.main(GatewayServer.java:160)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
	at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
	at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
	at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
	at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)
    
$ unset KNOX_GATEWAY_CONF_DIR
$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh start --printEnv
APP_CONF_DIR = /home/knox/knox-1.3.0-SNAPSHOT/conf
APP_LOG_DIR = /home/knox/knox-1.3.0-SNAPSHOT/logs
APP_DATA_DIR = /home/knox/knox-1.3.0-SNAPSHOT/data
APP_PID_DIR = /home/knox/knox-1.3.0-SNAPSHOT/pids
APP_JAVA_LIB_PATH = -Djava.library.path=/home/knox/knox-1.3.0-SNAPSHOT/ext/native
APP_JAR = /home/knox/knox-1.3.0-SNAPSHOT/bin/gateway.jar
Starting Gateway succeeded with PID 22783.

$ tail knox-1.3.0-SNAPSHOT/logs/gateway.log
2019-03-13 13:24:35,165 INFO  knox.gateway (DefaultGatewayServices.java:initializeContribution(240)) - Credential store found for the cluster: admin - no need to create one.
2019-03-13 13:24:35,230 INFO  knox.gateway (GatewayServer.java:internalActivateTopology(828)) - Activating topology admin
2019-03-13 13:24:35,231 INFO  knox.gateway (GatewayServer.java:internalActivateArchive(838)) - Activating topology admin archive %2F
2019-03-13 13:24:35,232 INFO  knox.gateway (GatewayServer.java:handleCreateDeployment(943)) - Deploying topology default to /home/knox/knox-1.3.0-SNAPSHOT/data/deployments/default.topo.168dc3b4f48
2019-03-13 13:24:35,232 INFO  knox.gateway (GatewayServer.java:internalDeactivateTopology(862)) - Deactivating topology default
2019-03-13 13:24:35,382 INFO  knox.gateway (DefaultGatewayServices.java:initializeContribution(240)) - Credential store found for the cluster: default - no need to create one.
2019-03-13 13:24:35,417 ERROR knox.gateway (GatewayServer.java:handleCreateDeployment(967)) - Failed to deploy topology default: org.apache.knox.gateway.deploy.DeploymentException: Failed to contribute provider. Role: authorization Name: XASecurePDPKnox. Please check the topology for errors in name and role and that the provider is on the classpath.
2019-03-13 13:24:35,633 INFO  knox.gateway (GatewayServer.java:start(626)) - Topology port mapping feature enabled: true
2019-03-13 13:24:40,054 INFO  knox.gateway (GatewayServer.java:start(661)) - Monitoring topologies in directory: /home/knox/knox-1.3.0-SNAPSHOT/conf/topologies
2019-03-13 13:24:40,077 INFO  knox.gateway (GatewayServer.java:startGateway(384)) - Started gateway on port 8,443.

$ ps -ef | grep gateway.jar
knox      1679     1 47 13:24 pts/0    00:00:09 /bin/java -Djava.library.path=/home/knox/knox-1.3.0-SNAPSHOT/ext/native -jar /home/knox/knox-1.3.0-SNAPSHOT/bin/gateway.jar
knox      1929 20240  0 13:24 pts/0    00:00:00 grep --color=auto gateway.jar

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh status
Gateway is running with PID 22783.

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh stop
Stopping Gateway with PID 22783 succeeded.

$ ./knox-1.3.0-SNAPSHOT/bin/gateway.sh status
Gateway is not running. No PID file found.

$ ps -ef | grep gateway.jar
knox      3108 20240  0 13:25 pts/0    00:00:00 grep --color=auto gateway.jar


-- LDAP test --

$ ./knox-1.3.0-SNAPSHOT/bin/ldap.sh clean
Removed the LDAP PID file: /home/knox/knox-1.3.0-SNAPSHOT/pids/ldap.pid.
Removed the LDAP OUT file: /home/knox/knox-1.3.0-SNAPSHOT/logs/ldap.out.
Removed the LDAP ERR file: /home/knox/knox-1.3.0-SNAPSHOT/logs/ldap.err.

$ ./knox-1.3.0-SNAPSHOT/bin/ldap.sh status
LDAP is not running. No PID file found.

$ ./knox-1.3.0-SNAPSHOT/bin/ldap.sh start --printEnv
APP_CONF_DIR = /home/knox/knox-1.3.0-SNAPSHOT/conf
APP_LOG_DIR = /home/knox/knox-1.3.0-SNAPSHOT/logs
APP_PID_DIR = /home/knox/knox-1.3.0-SNAPSHOT/pids
APP_JAR = /home/knox/knox-1.3.0-SNAPSHOT/bin/ldap.jar
Starting LDAP succeeded with PID 28458.

$ tail knox-1.3.0-SNAPSHOT/logs/ldap.log 
2019-03-13 13:29:48,691 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: homeurl
2019-03-13 13:29:48,692 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: workurl
2019-03-13 13:29:48,692 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: custom1
2019-03-13 13:29:48,692 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: custom2
2019-03-13 13:29:48,692 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: custom3
2019-03-13 13:29:48,692 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: custom4
2019-03-13 13:29:48,692 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: nsAIMid
2019-03-13 13:29:48,699 ERROR entry.Value (Value.java:<init>(273)) - ERR_13725_CANNOT_HANDLE_NAME_AND_OPTIONAL_UID_NORM I do not know how to handle NameAndOptionalUID normalization with objects of class: automountInformation
2019-03-13 13:29:50,844 INFO  ldap.LdapServer (LdapServer.java:startNetwork(722)) - Successful bind of an LDAP Service (33389) is completed.
2019-03-13 13:29:50,845 INFO  ldap.LdapServer (LdapServer.java:start(589)) - Ldap service started.

$ ps -ef | grep ldap.jar
knox     30767     1 33 13:31 pts/0    00:00:07 /bin/java -jar /home/knox/knox-1.3.0-SNAPSHOT/bin/ldap.jar /home/knox/knox-1.3.0-SNAPSHOT/conf
knox     30988 20240  0 13:32 pts/0    00:00:00 grep --color=auto ldap.jar

$ ./knox-1.3.0-SNAPSHOT/bin/ldap.sh status
LDAP is running with PID 28458.

$ ./knox-1.3.0-SNAPSHOT/bin/ldap.sh stop
Stopping LDAP with PID 28458 succeeded.

$ ./knox-1.3.0-SNAPSHOT/bin/ldap.sh status
LDAP is not running. No PID file found.

$ ps -ef | grep ldap.jar
knox     30698 20240  0 13:31 pts/0    00:00:00 grep --color=auto ldap.jar
```

After both the Gateway server and the test LDAP instance were up&running I was able to login to admin UI.

I also tested these applications running in the foreground (by setting `KNOX_GATEWAY_RUNNING_IN_FOREGROUND` and `KNOX_LDAP_RUNNING_IN_FOREGROUND` to `true`).