### PR TITLE
KNOX-1828 Fix Websocket Message Size

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/websockets/ProxyInboundClient.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/websockets/ProxyInboundClient.java
@@ -55,10 +55,6 @@ public class ProxyInboundClient extends Endpoint {
     this.session = backendSession;
     this.config = config;
 
-    /* Set the max message size */
-    session.setMaxBinaryMessageBufferSize(Integer.MAX_VALUE);
-    session.setMaxTextMessageBufferSize(Integer.MAX_VALUE);
-
     /* Add message handler for binary data */
     session.addMessageHandler(new MessageHandler.Whole<byte[]>() {
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/websockets/ProxyWebSocketAdapter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/websockets/ProxyWebSocketAdapter.java
@@ -81,6 +81,10 @@ public class ProxyWebSocketAdapter extends WebSocketAdapter {
      * plumbing takes place
      */
     container = ContainerProvider.getWebSocketContainer();
+    container.setDefaultMaxTextMessageBufferSize(frontEndSession.getPolicy().getMaxTextMessageBufferSize());
+    container.setDefaultMaxBinaryMessageBufferSize(frontEndSession.getPolicy().getMaxBinaryMessageBufferSize());
+    container.setAsyncSendTimeout(frontEndSession.getPolicy().getAsyncWriteTimeout());
+    container.setDefaultMaxSessionIdleTimeout(frontEndSession.getPolicy().getIdleTimeout());
 
     final ProxyInboundClient backendSocket = new ProxyInboundClient(getMessageCallback());
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BigEchoSocketHandler.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BigEchoSocketHandler.java
@@ -36,8 +36,8 @@ class BigEchoSocketHandler extends WebSocketHandler implements WebSocketCreator 
 
   @Override
   public void configure(WebSocketServletFactory factory) {
-    factory.getPolicy().setMaxTextMessageSize(10);
-    factory.getPolicy().setMaxBinaryMessageSize(10);
+    factory.getPolicy().setMaxTextMessageSize(66000);
+    factory.getPolicy().setMaxTextMessageBufferSize(66000);
     factory.setCreator(this);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/MessageFailureTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/MessageFailureTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.websockets;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -69,7 +70,7 @@ public class MessageFailureTest {
    */
   @Test(timeout = 8000)
   public void testMessageTooBig() throws Exception {
-    final String bigMessage = "Echooooooooooooo";
+    final String bigMessage = RandomStringUtils.randomAscii(66001);
 
     WebSocketContainer container = ContainerProvider.getWebSocketContainer();
 
@@ -82,6 +83,28 @@ public class MessageFailureTest {
         TimeUnit.MILLISECONDS);
 
     Assert.assertThat(client.close.getCloseCode().getCode(), CoreMatchers.is(CloseReason.CloseCodes.TOO_BIG.getCode()));
+  }
+
+  /**
+   * Test for a message that bigger than Jetty default but smaller than limit
+   * @throws Exception
+   */
+  @Test(timeout = 8000)
+  public void testMessageBiggerThanDefault() throws Exception {
+    final String bigMessage = RandomStringUtils.randomAscii(66000);
+
+    WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+
+    WebsocketClient client = new WebsocketClient();
+    javax.websocket.Session session = container.connectToServer(client,
+            proxyUri);
+    session.getBasicRemote().sendText(bigMessage);
+
+    client.awaitClose(CloseReason.CloseCodes.TOO_BIG.getCode(), 1000,
+            TimeUnit.MILLISECONDS);
+
+    Assert.assertThat(client.close.getCloseCode().getCode(), CoreMatchers.is(CloseReason.CloseCodes.TOO_BIG.getCode()));
+
   }
 
   /*

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/ProxyInboundClientTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/ProxyInboundClientTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.knox.gateway.websockets;
 
-import org.apache.commons.lang.RandomStringUtils;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -192,53 +191,4 @@ public class ProxyInboundClientTest {
     Assert.assertEquals("Binary message does not match", textMessage, new String(receivedBinaryMessage, StandardCharsets.UTF_8));
   }
 
-  @Test(timeout = 3000)
-  public void testTextMaxBufferLimit() throws IOException, DeploymentException {
-    final String longMessage = RandomStringUtils.random(100000);
-
-    final AtomicBoolean isTestComplete = new AtomicBoolean(false);
-
-    final WebSocketContainer container = ContainerProvider.getWebSocketContainer();
-    final ProxyInboundClient client = new ProxyInboundClient( new MessageEventCallback() {
-      @Override
-      public void doCallback(String message) {
-      }
-
-      @Override
-      public void onConnectionOpen(Object session) {
-      }
-
-      @Override
-      public void onConnectionClose(CloseReason reason) {
-        isTestComplete.set(true);
-      }
-
-      @Override
-      public void onError(Throwable cause) {
-        isTestComplete.set(true);
-      }
-
-      @Override
-      public void onMessageText(String message, Object session) {
-        receivedMessage = message;
-        isTestComplete.set(true);
-      }
-
-      @Override
-      public void onMessageBinary(byte[] message, boolean last, Object session) {
-      }
-    });
-
-    Assert.assertThat(client, instanceOf(javax.websocket.Endpoint.class));
-
-    Session session = container.connectToServer(client, serverUri);
-
-    session.getBasicRemote().sendText(longMessage);
-
-    while(!isTestComplete.get()) { // NOPMD
-      /* just wait for the test to finish */
-    }
-
-    Assert.assertEquals(longMessage, receivedMessage);
-  }
 }


### PR DESCRIPTION
Resolves issue with Zeppelin and websocket messages being capped at 65,536 bytes.

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Set websocket container max text and binary message sizes to Integer.MAX_VALUE.

## How was this patch tested?

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)
Create workbook in zeppelin that returns more than 65,536 bytes of data. I used a sql query from Phoenix but anything that makes a big message should work.
After proxying through Knox page never completes loading and Knox spams error logs with message too large.
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
