### PR TITLE
KNOX-1827 - Knox Fails to Rewrite WebFonts for Zeppelin

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.0/rewrite.xml
@@ -24,8 +24,8 @@
     <rewrite template="{$serviceUrl[ZEPPELINUI]}/"/>
   </rule>
 
-  <rule dir="IN" name="ZEPPELINUI/zeppelin/inbound/rootAppScript" pattern="*://*:*/**/zeppelin/{path=app**}">
-    <rewrite template="{$serviceUrl[ZEPPELINUI]}/{path=app**}"/>
+  <rule dir="IN" name="ZEPPELINUI/zeppelin/inbound/rootAppScript" pattern="*://*:*/**/zeppelin/{path=**}">
+    <rewrite template="{$serviceUrl[ZEPPELINUI]}/{path=**}"/>
   </rule>
 
 


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

Update rewrite rule for ZeppelinUI. Current service.xml is sending all the js and webfont files to the rule ZEPPELINUI/zeppelin/inbound/rootAppScript which is looking for a file pattern starting with app. This removes that restriction allow the webfonts to work again.

(Please fill in changes proposed in this fix)

Setup Zeppelin 0.8.0 and Knox and watch the Knox logs for failure to rewrite errors for *.woff files.

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
