### PR TITLE
KNOX-1584 - YARN v2 UI - Application - History link fix

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -171,12 +171,34 @@
     </content>
   </filter>
    
-  <rule dir="IN" name="YARNUIV2/yarnuiv2/inbound/proxy" pattern="*://*:*/**/yarnuiv2/proxy/{**}?{**}">
-      <rewrite template="{$serviceUrl[YARNUIV2]}/proxy/{**}?{**}"/>
+  <filter name="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job/location"/>
+    </content>
+   </filter>
+
+  <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/proxy" pattern="*://*:*/proxy/{**}">
+      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}"/>
    </rule>
 
-   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/proxy" pattern="*://*:*/proxy/{**}">
-      <rewrite template="{gateway.scheme}://{gateway.host}:{gateway.port}/gateway/default/sparkhistory/history/{**}?{**}"/>
-   </rule>
+
+   <rule flow="OR" dir="OUT" name="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job/location">
+      <match pattern="{scheme}://{host}:{port}/jobhistory/job/{**}">
+          <rewrite template="{$frontend[url]}/jobhistory/job/{**}?{scheme}?{host}?{port}"/>
+      </match>
+      <match pattern="{scheme}://{host}:{port}/jobhistory/logs/{**}?{**}">
+          <rewrite template="{$frontend[url]}/jobhistory/logs/{**}"/>
+      </match>        
+      <match pattern="*://*:*/history/{**}?{**}">
+          <rewrite template="{$frontend[url]}/sparkhistory/history/{**}?{**}"/>
+      </match>
+      <match pattern="*://*:*/cluster/app/{**}">
+          <rewrite template="{$frontend[url]}/yarnuiv2/cluster/app/{**}"/>
+      </match>
+      <match pattern="*://*:*/cluster/apps/{**}">
+          <rewrite template="{$frontend[url]}/yarnuiv2/cluster/apps/{**}"/>
+      </match>
+    </rule>
+   
  </rules>
   

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -170,5 +170,13 @@
       <apply path="Location" rule="YARNUIV2/yarnuiv2/outbound/headers/index/location"/>
     </content>
   </filter>
+   
+  <rule dir="IN" name="YARNUIV2/yarnuiv2/inbound/proxy" pattern="*://*:*/**/yarnuiv2/proxy/{**}?{**}">
+      <rewrite template="{$serviceUrl[YARNUIV2]}/proxy/{**}?{**}"/>
+   </rule>
+
+   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/proxy" pattern="*://*:*/proxy/{**}">
+      <rewrite template="{gateway.scheme}://{gateway.host}:{gateway.port}/gateway/default/sparkhistory/history/{**}?{**}"/>
+   </rule>
  </rules>
   

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -175,30 +175,30 @@
     <content type="application/x-http-headers">
       <apply path="Location" rule="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job/location"/>
     </content>
-   </filter>
+  </filter>
 
   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/proxy" pattern="*://*:*/proxy/{**}">
-      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}"/>
-   </rule>
+    <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}"/>
+  </rule>
 
 
-   <rule flow="OR" dir="OUT" name="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job/location">
-      <match pattern="{scheme}://{host}:{port}/jobhistory/job/{**}">
-          <rewrite template="{$frontend[url]}/jobhistory/job/{**}?{scheme}?{host}?{port}"/>
-      </match>
-      <match pattern="{scheme}://{host}:{port}/jobhistory/logs/{**}?{**}">
-          <rewrite template="{$frontend[url]}/jobhistory/logs/{**}"/>
-      </match>        
-      <match pattern="*://*:*/history/{**}?{**}">
-          <rewrite template="{$frontend[url]}/sparkhistory/history/{**}?{**}"/>
-      </match>
-      <match pattern="*://*:*/cluster/app/{**}">
-          <rewrite template="{$frontend[url]}/yarnuiv2/cluster/app/{**}"/>
-      </match>
-      <match pattern="*://*:*/cluster/apps/{**}">
-          <rewrite template="{$frontend[url]}/yarnuiv2/cluster/apps/{**}"/>
-      </match>
-    </rule>
+  <rule flow="OR" dir="OUT" name="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job/location">
+    <match pattern="{scheme}://{host}:{port}/jobhistory/job/{**}">
+      <rewrite template="{$frontend[url]}/jobhistory/job/{**}?{scheme}?{host}?{port}"/>
+    </match>
+    <match pattern="{scheme}://{host}:{port}/jobhistory/logs/{**}?{**}">
+      <rewrite template="{$frontend[url]}/jobhistory/logs/{**}"/>
+    </match>        
+    <match pattern="*://*:*/history/{**}?{**}">
+      <rewrite template="{$frontend[url]}/sparkhistory/history/{**}?{**}"/>
+    </match>
+    <match pattern="*://*:*/cluster/app/{**}">
+      <rewrite template="{$frontend[url]}/yarnuiv2/cluster/app/{**}"/>
+    </match>
+    <match pattern="*://*:*/cluster/apps/{**}">
+      <rewrite template="{$frontend[url]}/yarnuiv2/cluster/apps/{**}"/>
+    </match>
+  </rule>
    
  </rules>
   

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -187,7 +187,7 @@
       <rewrite template="{$frontend[url]}/jobhistory/job/{**}?{scheme}?{host}?{port}"/>
     </match>
     <match pattern="{scheme}://{host}:{port}/jobhistory/logs/{**}?{**}">
-      <rewrite template="{$frontend[url]}/jobhistory/logs/{**}"/>
+      <rewrite template="{$frontend[url]}/jobhistory/logs/{**}?{**}"/>
     </match>        
     <match pattern="*://*:*/history/{**}?{**}">
       <rewrite template="{$frontend[url]}/sparkhistory/history/{**}?{**}"/>

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -199,6 +199,26 @@
       <rewrite template="{$frontend[url]}/yarnuiv2/cluster/apps/{**}"/>
     </match>
   </rule>
+  
+  <!-- Yarn application containerlog outbound routing -->
+  <!--
+         This is the reference to the log button on application page
+   Rule changes
+   href='//${yarn.nodemanager}:{yarn.nodemanager.port}/node/containerlogs/container_xxx/user' into'
+   https://knox_host:knox_port/gateway/default/yarn/nodemanager/node/containerlogs/container_XXX/user?host=${yarn.nodemanager.host}&port=${yarn.nodemanager.port}
+
+   This is match by inbound "YARNUIV2/yarnuiv2/inbound/jobhistory/logs" rewrite which is a client content rewrite
+   by adding META refresh. So we need to rewrite META refresh to jobstory.
+  -->
+  <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/node/containerlogs">
+    <match pattern="{scheme}://{host}:{port}/node/containerlogs/{**}"/>
+      <rewrite template="{$frontend[url]}/yarnuiv2/nodemanager/node/containerlogs/{**}?{scheme}?host={$hostmap(host)}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/apps/history1">
+      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}?{**}"/>
+  </rule>  
+  
    
  </rules>
   

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/service.xml
@@ -89,6 +89,14 @@
       <rewrite apply="YARNUIV2/yarnuiv2/inbound/config" to="request.url"/>
     </route>
 
+    <route path="/yarnuiv2/proxy/**">
+      <rewrite apply="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job" to="response.headers"/>
+    </route>
+
+    <route path="/yarnuiv2/jobhistory/**">
+      <rewrite apply="YARNUIV2/yarnuiv2/outbound/headers/jobhistory/job" to="response.headers"/>
+    </route>
+
   </routes>
   <dispatch classname="org.apache.knox.gateway.dispatch.PassAllHeadersDispatch" ha-classname="org.apache.knox.gateway.rm.dispatch.RMUI2HaDispatch"/>
 </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Updated the rewrite.xml file to have the Application Master/History link which comes under YARN UI's application url.

## How was this patch tested?
I have created a HDP 3.1 cluster and enabled knox rewrite rules for YARN and below is the snapshot of the same.
<img width="1251" alt="Fixed_Link_Snapshot" src="https://user-images.githubusercontent.com/8832194/54689562-cca98880-4b45-11e9-953c-659cdf44ad5f.png">
