### PR TITLE
KNOX-1837 - Remove ServiceTestResource glassfish Base64 dependency

### DIFF
--- a/gateway-service-test/pom.xml
+++ b/gateway-service-test/pom.xml
@@ -74,11 +74,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>

--- a/gateway-service-test/src/main/java/org/apache/knox/gateway/service/test/ServiceTestResource.java
+++ b/gateway-service-test/src/main/java/org/apache/knox/gateway/service/test/ServiceTestResource.java
@@ -29,7 +29,6 @@ import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.topology.Service;
 import org.apache.knox.gateway.topology.Topology;
-import org.glassfish.jersey.internal.util.Base64;
 
 import javax.net.ssl.SSLContext;
 import javax.servlet.http.HttpServletRequest;
@@ -49,6 +48,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -77,7 +77,9 @@ public class ServiceTestResource {
 
 //    Create Authorization String
     if( username != null && password != null) {
-      authString = "Basic " + Base64.encodeAsString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+      String base64EncodedUserPass = Base64.getEncoder().encodeToString(
+          (username + ":" + password).getBytes(StandardCharsets.UTF_8));
+      authString = "Basic " + base64EncodedUserPass;
     } else if (request.getHeader("Authorization") != null) {
       authString = request.getHeader("Authorization");
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove glassfish dependency used for Base64 and replace with JDK 8+ Base64

## How was this patch tested?

`mvn -T.5C verify -Ppackage,release`