### PR TITLE
KNOX-1819 - Ensure services are started and stopped in the correct order

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
@@ -20,6 +20,7 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
@@ -165,7 +166,7 @@ class AmbariServiceDiscovery implements ServiceDiscovery {
                     Object obj = m.invoke(null);
                     if (GatewayServices.class.isAssignableFrom(obj.getClass())) {
                         ClusterConfigurationMonitorService clusterMonitorService =
-                              ((GatewayServices) obj).getService(GatewayServices.CLUSTER_CONFIGURATION_MONITOR_SERVICE);
+                              ((GatewayServices) obj).getService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE);
                         ClusterConfigurationMonitor monitor =
                                                  clusterMonitorService.getMonitor(AmbariConfigurationMonitor.getType());
                         if (monitor != null) {

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServletContextListener.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServletContextListener.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.ha.provider;
 
 import org.apache.knox.gateway.ha.provider.impl.DefaultHaProvider;
 import org.apache.knox.gateway.ha.provider.impl.HaDescriptorManager;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 
@@ -62,7 +63,7 @@ public class HaServletContextListener implements ServletContextListener {
    private void setupHaProvider(HaDescriptor descriptor, ServletContext servletContext) {
       GatewayServices services = (GatewayServices) servletContext.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
       String clusterName = (String) servletContext.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE);
-      ServiceRegistry serviceRegistry = services.getService(GatewayServices.SERVICE_REGISTRY_SERVICE);
+      ServiceRegistry serviceRegistry = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
       HaProvider provider = new DefaultHaProvider(descriptor);
       List<String> serviceNames = descriptor.getEnabledServiceNames();
       for (String serviceName : serviceNames) {

--- a/gateway-provider-rewrite-func-hostmap-static/src/main/java/org/apache/knox/gateway/hostmap/impl/HostmapFunctionProcessor.java
+++ b/gateway-provider-rewrite-func-hostmap-static/src/main/java/org/apache/knox/gateway/hostmap/impl/HostmapFunctionProcessor.java
@@ -21,6 +21,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.hostmap.api.HostmapFunctionDescriptor;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.hostmap.FileBasedHostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
@@ -52,7 +53,7 @@ public class HostmapFunctionProcessor
     clusterName = environment.getAttribute(  GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE );
     GatewayServices services = environment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE );
     if( clusterName != null && services != null ) {
-      hostMapperService = services.getService( GatewayServices.HOST_MAPPING_SERVICE );
+      hostMapperService = services.getService( ServiceType.HOST_MAPPING_SERVICE );
       if( hostMapperService != null ) {
         hostMapperService.registerHostMapperForCluster( clusterName, hostMapper );
       }

--- a/gateway-provider-rewrite-func-hostmap-static/src/test/java/org/apache/knox/gateway/hostmap/impl/HostmapFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-hostmap-static/src/test/java/org/apache/knox/gateway/hostmap/impl/HostmapFunctionProcessorTest.java
@@ -25,6 +25,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteRulesDescriptorFacto
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriter;
 import org.apache.knox.gateway.filter.rewrite.ext.UrlRewriteActionRewriteDescriptorExt;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
@@ -71,7 +72,7 @@ public class HostmapFunctionProcessorTest {
     HostMapperService hms = EasyMock.createNiceMock( HostMapperService.class );
 
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
+    EasyMock.expect( gatewayServices.getService( ServiceType.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
 
     UrlRewriteEnvironment environment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( environment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedAddressFunctionProcessor.java
+++ b/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedAddressFunctionProcessor.java
@@ -20,7 +20,7 @@ package org.apache.knox.gateway.svcregfunc.impl;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
 import org.apache.knox.gateway.svcregfunc.api.ServiceMappedAddressFunctionDescriptor;
@@ -47,7 +47,7 @@ public class ServiceMappedAddressFunctionProcessor
   @Override
   public void initialize( UrlRewriteEnvironment environment, ServiceMappedAddressFunctionDescriptor descriptor ) throws Exception {
     super.initialize( environment, descriptor );
-    HostMapperService hostmapService = services().getService( GatewayServices.HOST_MAPPING_SERVICE );
+    HostMapperService hostmapService = services().getService( ServiceType.HOST_MAPPING_SERVICE );
     if( hostmapService != null ) {
       hostmap = hostmapService.getHostMapper( cluster() );
     }

--- a/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedHostFunctionProcessor.java
+++ b/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedHostFunctionProcessor.java
@@ -20,7 +20,7 @@ package org.apache.knox.gateway.svcregfunc.impl;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
 import org.apache.knox.gateway.svcregfunc.api.ServiceMappedHostFunctionDescriptor;
@@ -45,7 +45,7 @@ public class ServiceMappedHostFunctionProcessor
   @Override
   public void initialize( UrlRewriteEnvironment environment, ServiceMappedHostFunctionDescriptor descriptor ) throws Exception {
     super.initialize( environment, descriptor );
-    HostMapperService hostmapService = services().getService( GatewayServices.HOST_MAPPING_SERVICE );
+    HostMapperService hostmapService = services().getService( ServiceType.HOST_MAPPING_SERVICE );
     if( hostmapService != null ) {
       hostmap = hostmapService.getHostMapper( cluster() );
     }

--- a/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedUrlFunctionProcessor.java
+++ b/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedUrlFunctionProcessor.java
@@ -21,7 +21,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriter;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
 import org.apache.knox.gateway.svcregfunc.api.ServiceMappedUrlFunctionDescriptor;
@@ -44,7 +44,7 @@ public class ServiceMappedUrlFunctionProcessor
   @Override
   public void initialize( UrlRewriteEnvironment environment, ServiceMappedUrlFunctionDescriptor descriptor ) throws Exception {
     super.initialize( environment, descriptor );
-    HostMapperService hostmapService = services().getService( GatewayServices.HOST_MAPPING_SERVICE );
+    HostMapperService hostmapService = services().getService( ServiceType.HOST_MAPPING_SERVICE );
     if( hostmapService != null ) {
       hostmap = hostmapService.getHostMapper( cluster() );
     }

--- a/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceRegistryFunctionProcessorBase.java
+++ b/gateway-provider-rewrite-func-service-registry/src/main/java/org/apache/knox/gateway/svcregfunc/impl/ServiceRegistryFunctionProcessorBase.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteFunctionDescriptor;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 
@@ -45,7 +46,7 @@ abstract class ServiceRegistryFunctionProcessorBase<T extends UrlRewriteFunction
     if( services == null ) {
       throw new IllegalArgumentException( "services==null" );
     }
-    registry = services.getService( GatewayServices.SERVICE_REGISTRY_SERVICE );
+    registry = services.getService( ServiceType.SERVICE_REGISTRY_SERVICE );
     if( registry == null ) {
       throw new IllegalArgumentException( "registry==null" );
     }

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceAddressFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceAddressFunctionProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.svcregfunc.api.ServiceAddressFunctionDescriptor;
@@ -55,7 +56,7 @@ public class ServiceAddressFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceHostFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceHostFunctionProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.svcregfunc.api.ServiceHostFunctionDescriptor;
@@ -55,7 +56,7 @@ public class ServiceHostFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedAddressFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedAddressFunctionProcessorTest.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
@@ -66,8 +67,8 @@ public class ServiceMappedAddressFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
-    EasyMock.expect( svc.getService( GatewayServices.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedHostFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedHostFunctionProcessorTest.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
@@ -66,8 +67,8 @@ public class ServiceMappedHostFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
-    EasyMock.expect( svc.getService( GatewayServices.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedUrlFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceMappedUrlFunctionProcessorTest.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
@@ -66,8 +67,8 @@ public class ServiceMappedUrlFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
-    EasyMock.expect( svc.getService( GatewayServices.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServicePathFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServicePathFunctionProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.svcregfunc.api.ServicePathFunctionDescriptor;
@@ -55,7 +56,7 @@ public class ServicePathFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServicePortFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServicePortFunctionProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.svcregfunc.api.ServicePortFunctionDescriptor;
@@ -55,7 +56,7 @@ public class ServicePortFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceRegistryFunctionsTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceRegistryFunctionsTest.java
@@ -21,6 +21,7 @@ import org.apache.http.auth.BasicUserPrincipal;
 import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletContextListener;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletFilter;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.util.urltemplate.Parser;
@@ -78,7 +79,7 @@ public class ServiceRegistryFunctionsTest {
     EasyMock.expect( mockServiceRegistry.lookupServiceURL( "test-cluster", "JOBTRACKER" ) ).andReturn( "test-jt-scheme://test-jt-host:511" ).anyTimes();
 
     GatewayServices mockGatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( mockGatewayServices.getService(GatewayServices.SERVICE_REGISTRY_SERVICE) ).andReturn( mockServiceRegistry ).anyTimes();
+    EasyMock.expect( mockGatewayServices.getService(ServiceType.SERVICE_REGISTRY_SERVICE) ).andReturn( mockServiceRegistry ).anyTimes();
 
     EasyMock.replay( mockServiceRegistry, mockGatewayServices );
 

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceSchemeFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceSchemeFunctionProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.svcregfunc.api.ServiceSchemeFunctionDescriptor;
@@ -55,7 +56,7 @@ public class ServiceSchemeFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceUrlFunctionProcessorTest.java
+++ b/gateway-provider-rewrite-func-service-registry/src/test/java/org/apache/knox/gateway/svcregfunc/impl/ServiceUrlFunctionProcessorTest.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
 import org.apache.knox.gateway.ha.provider.HaProvider;
 import org.apache.knox.gateway.ha.provider.HaServletContextListener;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.hostmap.HostMapper;
 import org.apache.knox.gateway.services.hostmap.HostMapperService;
@@ -66,8 +67,8 @@ public class ServiceUrlFunctionProcessorTest {
     EasyMock.expect( reg.lookupServiceURL( "test-cluster", "test-service" ) ).andReturn( "test-scheme://test-host:777/test-path" ).anyTimes();
 
     svc = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( svc.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
-    EasyMock.expect( svc.getService( GatewayServices.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( reg ).anyTimes();
+    EasyMock.expect( svc.getService( ServiceType.HOST_MAPPING_SERVICE ) ).andReturn( hms ).anyTimes();
 
     env = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( env.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( svc ).anyTimes();

--- a/gateway-provider-rewrite-step-encrypt-uri/src/main/java/org/apache/knox/gateway/encrypturi/impl/DecryptUriProcessor.java
+++ b/gateway-provider-rewrite-step-encrypt-uri/src/main/java/org/apache/knox/gateway/encrypturi/impl/DecryptUriProcessor.java
@@ -25,6 +25,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteStepProcessor;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteStepStatus;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.CryptoService;
 import org.apache.knox.gateway.services.security.EncryptionResult;
@@ -52,7 +53,7 @@ public class DecryptUriProcessor
   public void initialize( UrlRewriteEnvironment environment, DecryptUriDescriptor descriptor ) throws Exception {
     clusterName = environment.getAttribute( GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE );
     GatewayServices services = environment.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-    cryptoService = services.getService(GatewayServices.CRYPTO_SERVICE);
+    cryptoService = services.getService(ServiceType.CRYPTO_SERVICE);
     param = descriptor.getParam();
   }
 

--- a/gateway-provider-rewrite-step-encrypt-uri/src/main/java/org/apache/knox/gateway/encrypturi/impl/EncryptUriProcessor.java
+++ b/gateway-provider-rewrite-step-encrypt-uri/src/main/java/org/apache/knox/gateway/encrypturi/impl/EncryptUriProcessor.java
@@ -28,6 +28,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteStepProcessor;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteStepStatus;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.CryptoService;
 import org.apache.knox.gateway.services.security.EncryptionResult;
@@ -52,7 +53,7 @@ public class EncryptUriProcessor
   public void initialize( UrlRewriteEnvironment environment, EncryptUriDescriptor descriptor ) throws Exception {
     clusterName = environment.getAttribute( GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE );
     GatewayServices services = environment.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-    cryptoService = services.getService(GatewayServices.CRYPTO_SERVICE);
+    cryptoService = services.getService(ServiceType.CRYPTO_SERVICE);
     template = descriptor.getTemplate();
     param = descriptor.getParam();
   }

--- a/gateway-provider-rewrite-step-encrypt-uri/src/test/java/org/apache/knox/gateway/encrypturi/impl/EncryptDecryptUriProcessorTest.java
+++ b/gateway-provider-rewrite-step-encrypt-uri/src/test/java/org/apache/knox/gateway/encrypturi/impl/EncryptDecryptUriProcessorTest.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteStepProcessor;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteStepStatus;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -85,7 +86,7 @@ public class EncryptDecryptUriProcessorTest {
     DefaultCryptoService cryptoService = new DefaultCryptoService();
     cryptoService.setAliasService( as );
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
 
     UrlRewriteEnvironment encEnvironment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( encEnvironment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();
@@ -121,7 +122,7 @@ public class EncryptDecryptUriProcessorTest {
     // Test decryption.  Result is in dectryptedAdrress.
     String decParam = "foo";
     gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
     as = EasyMock.createNiceMock( AliasService.class );
     EasyMock.expect( as.getPasswordFromAliasForCluster( clusterName, passwordAlias ) ).andReturn( secret.toCharArray() ).anyTimes();
 

--- a/gateway-provider-rewrite-step-encrypt-uri/src/test/java/org/apache/knox/gateway/encrypturi/impl/EncryptUriDeploymentContributorTest.java
+++ b/gateway-provider-rewrite-step-encrypt-uri/src/test/java/org/apache/knox/gateway/encrypturi/impl/EncryptUriDeploymentContributorTest.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.encrypturi.impl;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.deploy.ProviderDeploymentContributor;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -77,7 +78,7 @@ public class EncryptUriDeploymentContributorTest {
     cryptoService.setAliasService( as );
 
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
 
     UrlRewriteEnvironment encEnvironment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( encEnvironment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();

--- a/gateway-provider-rewrite-step-secure-query/src/test/java/org/apache/knox/gateway/securequery/SecureQueryDeploymentContributorTest.java
+++ b/gateway-provider-rewrite-step-secure-query/src/test/java/org/apache/knox/gateway/securequery/SecureQueryDeploymentContributorTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.securequery;
 
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -65,7 +66,7 @@ public class SecureQueryDeploymentContributorTest {
     cryptoService.setAliasService(as);
 
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
 
     UrlRewriteEnvironment encEnvironment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( encEnvironment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();

--- a/gateway-provider-rewrite-step-secure-query/src/test/java/org/apache/knox/gateway/securequery/SecureQueryEncodeProcessorTest.java
+++ b/gateway-provider-rewrite-step-secure-query/src/test/java/org/apache/knox/gateway/securequery/SecureQueryEncodeProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.securequery;
 
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -45,7 +46,7 @@ public class SecureQueryEncodeProcessorTest {
     DefaultCryptoService cryptoService = new DefaultCryptoService();
     cryptoService.setAliasService(as);
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
 
     UrlRewriteEnvironment environment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( environment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();

--- a/gateway-provider-rewrite-step-secure-query/src/test/java/org/apache/knox/gateway/securequery/SecureQueryEncryptDecryptProcessorTest.java
+++ b/gateway-provider-rewrite-step-secure-query/src/test/java/org/apache/knox/gateway/securequery/SecureQueryEncryptDecryptProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.securequery;
 
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteContext;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -55,7 +56,7 @@ public class SecureQueryEncryptDecryptProcessorTest {
     DefaultCryptoService cryptoService = new DefaultCryptoService();
     cryptoService.setAliasService(as);
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
 
     UrlRewriteEnvironment encEnvironment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( encEnvironment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();
@@ -80,7 +81,7 @@ public class SecureQueryEncryptDecryptProcessorTest {
     // Test decryption.  Results are left in decTemplate.
 
     gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
     as = EasyMock.createNiceMock( AliasService.class );
     EasyMock.expect( as.getPasswordFromAliasForCluster("test-cluster-name", "encryptQueryString")).andReturn( secret.toCharArray() ).anyTimes();
 
@@ -122,7 +123,7 @@ public class SecureQueryEncryptDecryptProcessorTest {
     DefaultCryptoService cryptoService = new DefaultCryptoService();
     cryptoService.setAliasService(as);
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
 
     UrlRewriteEnvironment encEnvironment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
     EasyMock.expect( encEnvironment.getAttribute( GatewayServices.GATEWAY_SERVICES_ATTRIBUTE ) ).andReturn( gatewayServices ).anyTimes();
@@ -147,7 +148,7 @@ public class SecureQueryEncryptDecryptProcessorTest {
     // Test decryption with decode returning null
 
     gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService );
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService );
     as = EasyMock.createNiceMock( AliasService.class );
     EasyMock.expect( as.getPasswordFromAliasForCluster("test-cluster-name", "encryptQueryString")).andReturn( secret.toCharArray() ).anyTimes();
 

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/FrontendFunctionProcessorTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/FrontendFunctionProcessorTest.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteEnvironment;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletContextListener;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletFilter;
 import org.apache.knox.gateway.filter.rewrite.spi.UrlRewriteFunctionProcessor;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.util.urltemplate.Parser;
@@ -129,7 +130,7 @@ public class FrontendFunctionProcessorTest {
     EasyMock.expect( mockServiceRegistry.lookupServiceURL( "test-cluster", "JOBTRACKER" ) ).andReturn( "test-jt-scheme://test-jt-host:511" ).anyTimes();
 
     GatewayServices mockGatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( mockGatewayServices.getService(GatewayServices.SERVICE_REGISTRY_SERVICE) ).andReturn( mockServiceRegistry ).anyTimes();
+    EasyMock.expect( mockGatewayServices.getService(ServiceType.SERVICE_REGISTRY_SERVICE) ).andReturn( mockServiceRegistry ).anyTimes();
 
     EasyMock.replay( mockServiceRegistry, mockGatewayServices );
 

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/HadoopAuthDeploymentContributorTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/HadoopAuthDeploymentContributorTest.java
@@ -25,6 +25,7 @@ import org.apache.knox.gateway.descriptor.GatewayDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
 import org.apache.knox.gateway.descriptor.impl.GatewayDescriptorImpl;
 import org.apache.knox.gateway.hadoopauth.deploy.HadoopAuthDeploymentContributor;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -104,7 +105,7 @@ public class HadoopAuthDeploymentContributorTest {
     cryptoService.setAliasService( as );
 
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
 
     HadoopAuthDeploymentContributor contributor = new HadoopAuthDeploymentContributor();
     contributor.setAliasService(as);

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -52,6 +52,7 @@ import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
@@ -103,7 +104,7 @@ public abstract class AbstractJWTFilter implements Filter {
     if (context != null) {
       GatewayServices services = (GatewayServices) context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
       if (services != null) {
-        authority = services.getService(GatewayServices.TOKEN_SERVICE);
+        authority = services.getService(ServiceType.TOKEN_SERVICE);
       }
     }
   }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AccessTokenFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AccessTokenFederationFilter.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.provider.federation.jwt.filter;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
@@ -52,7 +53,7 @@ public class AccessTokenFederationFilter implements Filter {
   @Override
   public void init( FilterConfig filterConfig ) throws ServletException {
     GatewayServices services = (GatewayServices) filterConfig.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-    authority = services.getService(GatewayServices.TOKEN_SERVICE);
+    authority = services.getService(ServiceType.TOKEN_SERVICE);
   }
 
   @Override

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.knox.gateway.filter.security.AbstractIdentityAssertionFilter;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
@@ -64,8 +65,8 @@ public class JWTAccessTokenAssertionFilter extends AbstractIdentityAssertionFilt
     validity = Long.parseLong(validityStr);
 
     GatewayServices services = (GatewayServices) filterConfig.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-    authority = services.getService(GatewayServices.TOKEN_SERVICE);
-    sr = services.getService(GatewayServices.SERVICE_REGISTRY_SERVICE);
+    authority = services.getService(ServiceType.TOKEN_SERVICE);
+    sr = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
   }
 
   @Override

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
 import org.apache.knox.gateway.filter.security.AbstractIdentityAssertionFilter;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
@@ -51,8 +52,8 @@ public class JWTAuthCodeAssertionFilter extends AbstractIdentityAssertionFilter 
 //    validity = Long.parseLong(validityStr);
 
     GatewayServices services = (GatewayServices) filterConfig.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-    authority = services.getService(GatewayServices.TOKEN_SERVICE);
-    sr = services.getService(GatewayServices.SERVICE_REGISTRY_SERVICE);
+    authority = services.getService(ServiceType.TOKEN_SERVICE);
+    sr = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
   }
 
   @Override

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.pac4j.Pac4jMessages;
 import org.apache.knox.gateway.pac4j.session.KnoxSessionStore;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -109,10 +110,10 @@ public class Pac4jDispatcherFilter implements Filter {
       GatewayServices services = (GatewayServices) context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
       clusterName = (String) context.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE);
       if (services != null) {
-        keystoreService = services.getService(GatewayServices.KEYSTORE_SERVICE);
-        cryptoService = services.getService(GatewayServices.CRYPTO_SERVICE);
-        aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
-        masterService = services.getService(GatewayServices.MASTER_SERVICE);
+        keystoreService = services.getService(ServiceType.KEYSTORE_SERVICE);
+        cryptoService = services.getService(ServiceType.CRYPTO_SERVICE);
+        aliasService = services.getService(ServiceType.ALIAS_SERVICE);
+        masterService = services.getService(ServiceType.MASTER_SERVICE);
       }
     }
     // crypto service, alias service and cluster name are mandatory

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/Pac4jProviderTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/Pac4jProviderTest.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.audit.api.Auditor;
 import org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter;
 import org.apache.knox.gateway.pac4j.filter.Pac4jIdentityAdapter;
 import org.apache.knox.gateway.pac4j.session.KnoxSessionStore;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -71,8 +72,8 @@ public class Pac4jProviderTest {
         cryptoService.setAliasService(aliasService);
 
         final GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
-        EasyMock.expect(services.getService(GatewayServices.CRYPTO_SERVICE)).andReturn(cryptoService);
-        EasyMock.expect(services.getService(GatewayServices.ALIAS_SERVICE)).andReturn(aliasService);
+        EasyMock.expect(services.getService(ServiceType.CRYPTO_SERVICE)).andReturn(cryptoService);
+        EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService);
         EasyMock.replay(services);
 
         final ServletContext context = EasyMock.createNiceMock(ServletContext.class);
@@ -169,8 +170,8 @@ public class Pac4jProviderTest {
         cryptoService.setAliasService(aliasService);
 
         final GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
-        EasyMock.expect(services.getService(GatewayServices.CRYPTO_SERVICE)).andReturn(cryptoService);
-        EasyMock.expect(services.getService(GatewayServices.ALIAS_SERVICE)).andReturn(aliasService);
+        EasyMock.expect(services.getService(ServiceType.CRYPTO_SERVICE)).andReturn(cryptoService);
+        EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService);
         EasyMock.replay(services);
 
         final ServletContext context = EasyMock.createNiceMock(ServletContext.class);
@@ -267,8 +268,8 @@ public class Pac4jProviderTest {
         cryptoService.setAliasService(aliasService);
 
         final GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
-        EasyMock.expect(services.getService(GatewayServices.CRYPTO_SERVICE)).andReturn(cryptoService);
-        EasyMock.expect(services.getService(GatewayServices.ALIAS_SERVICE)).andReturn(aliasService);
+        EasyMock.expect(services.getService(ServiceType.CRYPTO_SERVICE)).andReturn(cryptoService);
+        EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService);
         EasyMock.replay(services);
 
         final ServletContext context = EasyMock.createNiceMock(ServletContext.class);

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapContextFactory.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapContextFactory.java
@@ -27,6 +27,7 @@ import javax.naming.ldap.LdapContext;
 import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -88,7 +89,7 @@ public class KnoxLdapContextFactory extends JndiLdapContextFactory {
       String aliasName = systemPass;
 
       GatewayServices services = GatewayServer.getGatewayServices();
-      AliasService aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
+      AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
 
       String clusterName = getClusterName();
       //System.err.println("FACTORY systempass 30: " + systemPass);

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/deploy/impl/ShiroDeploymentContributorTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/deploy/impl/ShiroDeploymentContributorTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.deploy.impl;
 
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.deploy.ProviderDeploymentContributor;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
@@ -81,7 +82,7 @@ public class ShiroDeploymentContributorTest {
     cryptoService.setAliasService( as );
 
     GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( GatewayServices.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
+    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
 
     ShiroDeploymentContributor contributor = new ShiroDeploymentContributor();
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -641,7 +641,7 @@ public interface GatewayMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to remove credential: {1}")
   void failedToRemoveCredential(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 
-  @Message(level = MessageLevel.INFO, text = "Staring service: {0}")
+  @Message(level = MessageLevel.INFO, text = "Starting service: {0}")
   void startingService(String serviceTypeName);
 
   @Message(level = MessageLevel.INFO, text = "Stopping service: {0}")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -640,4 +640,10 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Failed to remove credential: {1}")
   void failedToRemoveCredential(@StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.INFO, text = "Staring service: {0}")
+  void startingService(String serviceTypeName);
+
+  @Message(level = MessageLevel.INFO, text = "Stopping service: {0}")
+  void stoppingService(String serviceTypeName);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -37,6 +37,7 @@ import org.apache.knox.gateway.filter.PortMappingHelperHandler;
 import org.apache.knox.gateway.filter.RequestUpdateHandler;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -323,14 +324,14 @@ public class GatewayServer {
   }
 
   public static void redeployTopologies( String topologyName  ) {
-    TopologyService ts = getGatewayServices().getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = getGatewayServices().getService(ServiceType.TOPOLOGY_SERVICE);
     ts.reloadTopologies();
     ts.redeployTopologies(topologyName);
   }
 
   private void cleanupTopologyDeployments() {
     File deployDir = new File( config.getGatewayDeploymentDir() );
-    TopologyService ts = getGatewayServices().getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = getGatewayServices().getService(ServiceType.TOPOLOGY_SERVICE);
     for( Topology topology : ts.getTopologies() ) {
       cleanupTopologyDeployments( deployDir, topology );
     }
@@ -432,7 +433,7 @@ public class GatewayServer {
       httpsConfig.setSecureScheme( "https" );
       httpsConfig.setSecurePort( connectorPort );
       httpsConfig.addCustomizer( new SecureRequestCustomizer() );
-      SSLService ssl = services.getService(GatewayServices.SSL_SERVICE);
+      SSLService ssl = services.getService(ServiceType.SSL_SERVICE);
       SslContextFactory sslContextFactory = (SslContextFactory)ssl.buildSslContextFactory( config );
       connector = new ServerConnector( server, sslContextFactory, new HttpConnectionFactory( httpsConfig ) );
     } else {
@@ -593,7 +594,7 @@ public class GatewayServer {
     // Redeploy autodeploy topologies.
     File topologiesDir = calculateAbsoluteTopologiesDir();
     log.loadingTopologiesFromDirectory(topologiesDir.getAbsolutePath());
-    monitor = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    monitor = services.getService(ServiceType.TOPOLOGY_SERVICE);
     monitor.addTopologyChangeListener(listener);
     monitor.reloadTopologies();
     List<String> autoDeploys = config.getAutoDeployTopologyNames();
@@ -865,7 +866,7 @@ public class GatewayServer {
     String topoPath = "/" + Urls.trimLeadingAndTrailingSlashJoin( config.getGatewayPath(), topoName );
     String topoPathSlash = topoPath + "/";
 
-    ServiceRegistry sr = getGatewayServices().getService(GatewayServices.SERVICE_REGISTRY_SERVICE);
+    ServiceRegistry sr = getGatewayServices().getService(ServiceType.SERVICE_REGISTRY_SERVICE);
     if (sr != null) {
       sr.removeClusterServices( topoName );
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServlet.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServlet.java
@@ -30,6 +30,7 @@ import org.apache.knox.gateway.descriptor.GatewayDescriptorFactory;
 import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.metrics.MetricsService;
 
@@ -204,7 +205,7 @@ public class GatewayServlet implements Servlet, Filter {
       GatewayConfig gatewayConfig = (GatewayConfig) servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
       if (gatewayConfig.isMetricsEnabled()) {
         GatewayServices gatewayServices = (GatewayServices) servletContext.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-        MetricsService metricsService = gatewayServices.getService(GatewayServices.METRICS_SERVICE);
+        MetricsService metricsService = gatewayServices.getService(ServiceType.METRICS_SERVICE);
         if (metricsService != null) {
           GatewayFilter instrumentedFilter = metricsService.getInstrumented(filter);
           if (instrumentedFilter != null) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/deploy/DeploymentFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/deploy/DeploymentFactory.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.deploy.impl.ApplicationDeploymentContributor;
 import org.apache.knox.gateway.descriptor.GatewayDescriptor;
 import org.apache.knox.gateway.descriptor.GatewayDescriptorFactory;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.topology.Application;
@@ -449,19 +450,19 @@ public abstract class DeploymentFactory {
   private static void injectServices(Object contributor) {
     if (gatewayServices != null) {
       Statement stmt;
-      for(String serviceName : gatewayServices.getServiceNames()) {
+      for(ServiceType serviceType : gatewayServices.getServiceTypes()) {
 
         try {
           // TODO: this is just a temporary injection solution
           // TODO: test for the existence of the setter before attempting it
           // TODO: avoid exception throwing when there is no setter
-          stmt = new Statement(contributor, "set" + serviceName, new Object[]{gatewayServices.getService(serviceName)});
+          stmt = new Statement(contributor, "set" + serviceType.getServiceTypeName(), new Object[]{gatewayServices.getService(serviceType)});
           stmt.execute();
         } catch (NoSuchMethodException e) {
           // TODO: eliminate the possibility of this being thrown up front
         } catch (Exception e) {
           // Maybe it makes sense to throw exception
-          log.failedToInjectService( serviceName, e );
+          log.failedToInjectService( serviceType.getServiceTypeName(), e );
           throw new DeploymentException("Failed to inject service.", e);
         }
       }
@@ -504,7 +505,7 @@ public abstract class DeploymentFactory {
             log.contributeService( service.getName(), service.getRole() );
             contributor.contributeService( context, service );
             if( gatewayServices != null ) {
-              ServiceRegistry sr = gatewayServices.getService( GatewayServices.SERVICE_REGISTRY_SERVICE );
+              ServiceRegistry sr = gatewayServices.getService( ServiceType.SERVICE_REGISTRY_SERVICE );
               if( sr != null ) {
                 String regCode = sr.getRegistrationCode( topology.getName() );
                 sr.registerService( regCode, topology.getName(), service.getRole(), service.getUrls() );

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/AbstractGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/AbstractGatewayServices.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+package org.apache.knox.gateway.services;
+
+import static org.apache.knox.gateway.services.ServiceType.PREFERRED_START_ORDER;
+
+import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * AbstractGatewayServices is an abstract implementation of {@link GatewayServices} that manages the
+ * contained/registered services. See {@link ServiceType} for the different types of services that may
+ * be registered.
+ * <p>
+ * This implementation ensures the proper ordering of registered services when starting and stopping
+ * them.
+ * <p>
+ * {@link GatewayServices} implementations should extend this class and register relevant services
+ * during the initialization process ({@link GatewayServices#init(GatewayConfig, Map)} using
+ * {@link #addService(ServiceType, Service)}.
+ * <p>
+ */
+public abstract class AbstractGatewayServices implements GatewayServices {
+
+  private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+
+  private final Map<ServiceType, Service> services = new EnumMap<>(ServiceType.class);
+  private final String role;
+  private final String name;
+
+  AbstractGatewayServices(String role, String name) {
+    this.role = role;
+    this.name = name;
+  }
+
+  @Override
+  public void start() throws ServiceLifecycleException {
+    for (ServiceType serviceType : PREFERRED_START_ORDER) {
+      Service service = services.get(serviceType);
+      // If the the service has not been registered, skip it.
+      if (service != null) {
+        LOG.startingService(serviceType.getServiceTypeName());
+        service.start();
+      }
+    }
+  }
+
+  @Override
+  public void stop() throws ServiceLifecycleException {
+    // Reverse the preferred startup order
+    ArrayList<ServiceType> copy = new ArrayList<>(Arrays.asList(PREFERRED_START_ORDER));
+    Collections.reverse(copy);
+
+    for (ServiceType serviceType : copy) {
+      Service service = services.get(serviceType);
+      // If the the service has not been registered, skip it.
+      if (service != null) {
+        LOG.stoppingService(serviceType.getServiceTypeName());
+        service.stop();
+      }
+    }
+  }
+
+  @Override
+  public String getRole() {
+    return role;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Set<ServiceType> getServiceTypes() {
+    return services.keySet();
+  }
+
+  @Override
+  public <T> T getService(ServiceType serviceType) {
+    return (T) services.get(serviceType);
+  }
+
+  /**
+   * Add/register a service with this container.
+   * <p>
+   * An implementation for a service type may be added/registered only once.  Adding a service
+   * implementation for a service type that was previously added overwrites the previously added
+   * implementation.
+   *
+   * @param serviceType the {@link ServiceType} type to add
+   * @param service     the {@link Service} implementation
+   */
+  protected void addService(ServiceType serviceType, Service service) {
+    services.put(serviceType, service);
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/AbstractGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/AbstractGatewayServices.java
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 package org.apache.knox.gateway.services;
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -34,7 +34,6 @@ import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
 import org.apache.knox.gateway.services.hostmap.impl.DefaultHostMapperService;
 import org.apache.knox.gateway.services.registry.impl.DefaultServiceRegistryService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
-import org.apache.knox.gateway.services.security.SSLService;
 import org.apache.knox.gateway.services.security.impl.DefaultAliasService;
 import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
 import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
@@ -43,26 +42,26 @@ import org.apache.knox.gateway.services.security.impl.JettySSLService;
 import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
 import org.apache.knox.gateway.topology.Provider;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class DefaultGatewayServices implements GatewayServices {
+public class DefaultGatewayServices extends AbstractGatewayServices {
   private static GatewayMessages log = MessagesFactory.get( GatewayMessages.class );
 
-  private Map<String,Service> services = new HashMap<>();
+  public DefaultGatewayServices() {
+    super("Services", "GatewayServices");
+  }
 
   @Override
   public void init(GatewayConfig config, Map<String,String> options) throws ServiceLifecycleException {
     DefaultMasterService ms = new DefaultMasterService();
     ms.init(config, options);
-    services.put(MASTER_SERVICE, ms);
+    addService(ServiceType.MASTER_SERVICE, ms);
 
     DefaultKeystoreService ks = new DefaultKeystoreService();
     ks.setMasterService(ms);
     ks.init(config, options);
-    services.put(KEYSTORE_SERVICE, ks);
+    addService(ServiceType.KEYSTORE_SERVICE, ks);
 
     final DefaultAliasService defaultAlias = new DefaultAliasService();
     defaultAlias.setKeystoreService(ks);
@@ -79,7 +78,7 @@ public class DefaultGatewayServices implements GatewayServices {
         RemoteConfigurationRegistryClientServiceFactory.newInstance(config);
     registryClientService.setAliasService(defaultAlias);
     registryClientService.init(config, options);
-    services.put(REMOTE_REGISTRY_CLIENT_SERVICE, registryClientService);
+    addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, registryClientService);
 
 
     /* create an instance so that it can be passed to other services */
@@ -90,19 +89,19 @@ public class DefaultGatewayServices implements GatewayServices {
      * be called before alias.start();
      */
     alias.init(config, options);
-    services.put(ALIAS_SERVICE, alias);
+    addService(ServiceType.ALIAS_SERVICE, alias);
 
     DefaultCryptoService crypto = new DefaultCryptoService();
     crypto.setKeystoreService(ks);
     crypto.setAliasService(alias);
     crypto.init(config, options);
-    services.put(CRYPTO_SERVICE, crypto);
+    addService(ServiceType.CRYPTO_SERVICE, crypto);
 
     JettySSLService ssl = new JettySSLService();
     ssl.setAliasService(alias);
     ssl.setKeystoreService(ks);
     ssl.init(config, options);
-    services.put(SSL_SERVICE, ssl);
+    addService(ServiceType.SSL_SERVICE, ssl);
 
     // The DefaultTokenAuthorityService needs to be initialized after the JettySSLService to ensure
     // that the signing keystore is available for it.
@@ -111,119 +110,39 @@ public class DefaultGatewayServices implements GatewayServices {
     ts.setKeystoreService(ks);
     ts.init(config, options);
     // prolly should not allow the token service to be looked up?
-    services.put(TOKEN_SERVICE, ts);
+    addService(ServiceType.TOKEN_SERVICE, ts);
 
     DefaultServiceRegistryService sr = new DefaultServiceRegistryService();
     sr.setCryptoService( crypto );
     sr.init( config, options );
-    services.put( SERVICE_REGISTRY_SERVICE, sr );
+    addService(ServiceType.SERVICE_REGISTRY_SERVICE, sr);
 
     DefaultHostMapperService hm = new DefaultHostMapperService();
     hm.init( config, options );
-    services.put( HOST_MAPPING_SERVICE, hm );
+    addService(ServiceType.HOST_MAPPING_SERVICE, hm );
 
     DefaultServerInfoService sis = new DefaultServerInfoService();
     sis.init( config, options );
-    services.put( SERVER_INFO_SERVICE, sis );
+    addService(ServiceType.SERVER_INFO_SERVICE, sis );
 
 
     DefaultClusterConfigurationMonitorService ccs = new DefaultClusterConfigurationMonitorService();
     ccs.setAliasService(alias);
     ccs.init(config, options);
-    services.put(CLUSTER_CONFIGURATION_MONITOR_SERVICE, ccs);
+    addService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, ccs);
 
     DefaultTopologyService tops = new DefaultTopologyService();
     tops.setAliasService(alias);
     tops.init(  config, options  );
-    services.put(  TOPOLOGY_SERVICE, tops  );
+    addService(ServiceType.TOPOLOGY_SERVICE, tops  );
 
     DefaultServiceDefinitionRegistry sdr = new DefaultServiceDefinitionRegistry();
     sdr.init( config, options );
-    services.put( SERVICE_DEFINITION_REGISTRY, sdr );
+    addService(ServiceType.SERVICE_DEFINITION_REGISTRY, sdr );
 
     DefaultMetricsService metricsService = new DefaultMetricsService();
     metricsService.init( config, options );
-    services.put( METRICS_SERVICE, metricsService );
-  }
-
-  @Override
-  public void start() throws ServiceLifecycleException {
-    Service ms = services.get(MASTER_SERVICE);
-    ms.start();
-
-    Service ks = services.get(KEYSTORE_SERVICE);
-    ks.start();
-
-    Service alias = services.get(ALIAS_SERVICE);
-    alias.start();
-
-    SSLService ssl = (SSLService) services.get(SSL_SERVICE);
-    ssl.start();
-
-    (services.get(TOKEN_SERVICE)).start();
-
-    ServerInfoService sis = (ServerInfoService) services.get(SERVER_INFO_SERVICE);
-    sis.start();
-
-    RemoteConfigurationRegistryClientService clientService =
-                            (RemoteConfigurationRegistryClientService)services.get(REMOTE_REGISTRY_CLIENT_SERVICE);
-    clientService.start();
-
-    (services.get(CLUSTER_CONFIGURATION_MONITOR_SERVICE)).start();
-
-    DefaultTopologyService tops = (DefaultTopologyService)services.get(TOPOLOGY_SERVICE);
-    tops.start();
-
-    DefaultMetricsService metricsService = (DefaultMetricsService) services.get(METRICS_SERVICE);
-    metricsService.start();
-  }
-
-  @Override
-  public void stop() throws ServiceLifecycleException {
-    Service ms = services.get(MASTER_SERVICE);
-    ms.stop();
-
-    Service ks = services.get(KEYSTORE_SERVICE);
-    ks.stop();
-
-    (services.get(CLUSTER_CONFIGURATION_MONITOR_SERVICE)).stop();
-
-    Service alias = services.get(ALIAS_SERVICE);
-    alias.stop();
-
-    SSLService ssl = (SSLService) services.get(SSL_SERVICE);
-    ssl.stop();
-
-    (services.get(TOKEN_SERVICE)).stop();
-
-    ServerInfoService sis = (ServerInfoService) services.get(SERVER_INFO_SERVICE);
-    sis.stop();
-
-    DefaultTopologyService tops = (DefaultTopologyService)services.get(TOPOLOGY_SERVICE);
-    tops.stop();
-
-    DefaultMetricsService metricsService = (DefaultMetricsService) services.get(METRICS_SERVICE);
-    metricsService.stop();
-  }
-
-  @Override
-  public Collection<String> getServiceNames() {
-    return services.keySet();
-  }
-
-  @Override
-  public <T> T getService(String serviceName) {
-    return (T)services.get(serviceName);
-  }
-
-  @Override
-  public String getRole() {
-    return "Services";
-  }
-
-  @Override
-  public String getName() {
-    return "GatewayServices";
+    addService(ServiceType.METRICS_SERVICE, metricsService );
   }
 
   @Override
@@ -231,7 +150,7 @@ public class DefaultGatewayServices implements GatewayServices {
     // setup credential store as appropriate
     String clusterName = context.getTopology().getName();
     try {
-      KeystoreService ks = getService(KEYSTORE_SERVICE);
+      KeystoreService ks = getService(ServiceType.KEYSTORE_SERVICE);
       if (!ks.isCredentialStoreForClusterAvailable(clusterName)) {
         log.creatingCredentialStoreForCluster(clusterName);
         ks.createCredentialStoreForCluster(clusterName);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/GatewayServicesContextListener.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/GatewayServicesContextListener.java
@@ -31,7 +31,7 @@ public class GatewayServicesContextListener implements ServletContextListener {
     GatewayServices gs = GatewayServer.getGatewayServices();
     sce.getServletContext().setAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE, gs);
     String topologyName = (String) sce.getServletContext().getAttribute("org.apache.knox.gateway.gateway.cluster");
-    TopologyService ts = gs.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = gs.getService(ServiceType.TOPOLOGY_SERVICE);
     Topology topology = getTopology(ts, topologyName);
     sce.getServletContext().setAttribute("org.apache.knox.gateway.topology", topology);
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -36,7 +36,7 @@ import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.service.definition.ServiceDefinition;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClient;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -596,7 +596,7 @@ public class DefaultTopologyService
   public void start() {
     // Register a cluster configuration monitor listener for change notifications
     ClusterConfigurationMonitorService ccms =
-                  GatewayServer.getGatewayServices().getService(GatewayServices.CLUSTER_CONFIGURATION_MONITOR_SERVICE);
+                  GatewayServer.getGatewayServices().getService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE);
     ccms.addListener(new TopologyDiscoveryTrigger(this, ccms));
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorFactory.java
@@ -20,6 +20,7 @@ import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
 
@@ -38,7 +39,7 @@ public class RemoteConfigurationMonitorFactory {
         if (remoteConfigRegistryClientService == null) {
             GatewayServices services = GatewayServer.getGatewayServices();
             if (services != null) {
-                remoteConfigRegistryClientService = services.getService(GatewayServices.REMOTE_REGISTRY_CLIENT_SERVICE);
+                remoteConfigRegistryClientService = services.getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE);
             }
         }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.topology.simple;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -253,9 +254,9 @@ public class SimpleDescriptorHandler {
         try {
             GatewayServices services = GatewayServer.getGatewayServices();
             if (services != null) {
-                MasterService ms = services.getService(GatewayServices.MASTER_SERVICE);
+                MasterService ms = services.getService(ServiceType.MASTER_SERVICE);
                 if (ms != null) {
-                    KeystoreService ks = services.getService(GatewayServices.KEYSTORE_SERVICE);
+                    KeystoreService ks = services.getService(ServiceType.KEYSTORE_SERVICE);
                     if (ks != null) {
                         if (!ks.isCredentialStoreForClusterAvailable(topologyName)) {
                             ks.createCredentialStoreForCluster(topologyName);
@@ -263,7 +264,7 @@ public class SimpleDescriptorHandler {
 
                         // If the credential store existed, or it was just successfully created
                         if (ks.getCredentialStoreForCluster(topologyName) != null) {
-                            AliasService aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
+                            AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
                             if (aliasService != null) {
                                 // Derive and set the query param encryption password
                                 String queryEncryptionPass = new String(ms.getMasterSecret()) + topologyName;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -35,6 +35,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
 import org.apache.knox.gateway.services.CLIGatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -510,19 +511,19 @@ public class KnoxCLI extends Configured implements Tool {
     public abstract String getUsage();
 
     protected AliasService getAliasService() {
-      return services.getService(GatewayServices.ALIAS_SERVICE);
+      return services.getService(ServiceType.ALIAS_SERVICE);
     }
 
     protected KeystoreService getKeystoreService() {
-      return services.getService(GatewayServices.KEYSTORE_SERVICE);
+      return services.getService(ServiceType.KEYSTORE_SERVICE);
     }
 
     protected TopologyService getTopologyService()  {
-      return services.getService(GatewayServices.TOPOLOGY_SERVICE);
+      return services.getService(ServiceType.TOPOLOGY_SERVICE);
     }
 
     protected RemoteConfigurationRegistryClientService getRemoteConfigRegistryClientService() {
-      return services.getService(GatewayServices.REMOTE_REGISTRY_CLIENT_SERVICE);
+      return services.getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE);
     }
 
   }
@@ -683,7 +684,7 @@ public class KnoxCLI extends Configured implements Tool {
          if ( !isForceRequired(config, ks) || force) {
            char[] passphrase = as.getGatewayIdentityPassphrase();
            if (passphrase == null) {
-             MasterService ms = services.getService(GatewayServices.MASTER_SERVICE);
+             MasterService ms = services.getService(ServiceType.MASTER_SERVICE);
              passphrase = ms.getMasterSecret();
            }
            ks.addSelfSignedCertForGateway(config.getIdentityKeyAlias(), passphrase, hostname);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandler.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.websockets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceDefEntry;
 import org.apache.knox.gateway.services.registry.ServiceDefinitionRegistry;
@@ -151,10 +152,10 @@ public class GatewayWebsocketHandler extends WebSocketHandler
   private synchronized String getMatchedBackendURL(final String path) {
 
     final ServiceRegistry serviceRegistryService = services
-        .getService(GatewayServices.SERVICE_REGISTRY_SERVICE);
+        .getService(ServiceType.SERVICE_REGISTRY_SERVICE);
 
     final ServiceDefinitionRegistry serviceDefinitionService = services
-        .getService(GatewayServices.SERVICE_DEFINITION_REGISTRY);
+        .getService(ServiceType.SERVICE_DEFINITION_REGISTRY);
 
     /* Filter out the /cluster/topology to get the context we want */
     String[] pathInfo = path.split(REGEX_SPLIT_CONTEXT);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/AbstractGatewayServicesTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/AbstractGatewayServicesTest.java
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 
 package org.apache.knox.gateway.services;

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/AbstractGatewayServicesTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/AbstractGatewayServicesTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package org.apache.knox.gateway.services;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createMockBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.junit.Test;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+public class AbstractGatewayServicesTest {
+
+  @Test
+  public void testAddStartAndStop() throws ServiceLifecycleException {
+    AbstractGatewayServices gatewayServices = createMockBuilder(AbstractGatewayServices.class)
+        .withConstructor("role", "name")
+        .createMock();
+
+    Map<ServiceType, Service> serviceMap = new EnumMap<>(ServiceType.class);
+    TestService lastService = null;
+
+    for (ServiceType serviceType : ServiceType.PREFERRED_START_ORDER) {
+      TestService testService = new TestService();
+      testService.setPreviousService(lastService);
+
+      if (lastService != null) {
+        lastService.setNextService(testService);
+      }
+
+      lastService = testService;
+      serviceMap.put(serviceType, testService);
+    }
+
+    for (ServiceType serviceType : ServiceType.values()) {
+      gatewayServices.addService(serviceType, serviceMap.get(serviceType));
+    }
+
+    gatewayServices.start();
+    gatewayServices.stop();
+
+    assertEquals(EnumSet.allOf(ServiceType.class), gatewayServices.getServiceTypes());
+  }
+
+  @Test
+  public void testGetRoleAndGetName() {
+    AbstractGatewayServices gatewayServices = createMockBuilder(AbstractGatewayServices.class)
+        .withConstructor("role", "name")
+        .createMock();
+
+    assertEquals("role", gatewayServices.getRole());
+    assertEquals("name", gatewayServices.getName());
+  }
+
+  @Test
+  public void testGetServiceAndGetServiceTypes() {
+    AbstractGatewayServices gatewayServices = createMockBuilder(AbstractGatewayServices.class)
+        .withConstructor("role", "name")
+        .createMock();
+
+    Set<ServiceType> expected = EnumSet.of(ServiceType.ALIAS_SERVICE, ServiceType.CRYPTO_SERVICE, ServiceType.MASTER_SERVICE);
+
+    for (ServiceType serviceType : expected) {
+      gatewayServices.addService(serviceType, createMock(Service.class));
+    }
+
+    assertEquals(expected, gatewayServices.getServiceTypes());
+    assertNotEquals(EnumSet.allOf(ServiceType.class), gatewayServices.getServiceTypes());
+
+    for (ServiceType serviceType : ServiceType.values()) {
+      if (expected.contains(serviceType)) {
+        assertNotNull(gatewayServices.getService(serviceType));
+      } else {
+        assertNull(gatewayServices.getService(serviceType));
+      }
+    }
+  }
+
+  private class TestService implements Service {
+    private TestService previousService;
+    private TestService nextService;
+    private boolean started;
+
+    @Override
+    public void init(GatewayConfig config, Map<String, String> options) {
+      assertFalse(started);
+      if (previousService != null) {
+        assertFalse(previousService.isStarted());
+      }
+      if (nextService != null) {
+        assertFalse(nextService.isStarted());
+      }
+    }
+
+    @Override
+    public void start() {
+      assertFalse(started);
+      if (previousService != null) {
+        assertTrue(previousService.isStarted());
+      }
+      if (nextService != null) {
+        assertFalse(nextService.isStarted());
+      }
+      started = true;
+    }
+
+    @Override
+    public void stop() {
+      assertTrue(started);
+      if (previousService != null) {
+        assertTrue(previousService.isStarted());
+      }
+      if (nextService != null) {
+        assertFalse(nextService.isStarted());
+      }
+      started = false;
+    }
+
+    public boolean isStarted() {
+      return started;
+    }
+
+    void setPreviousService(TestService previousService) {
+      this.previousService = previousService;
+    }
+
+    void setNextService(TestService nextService) {
+      this.nextService = nextService;
+    }
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/AbstractGatewayServicesTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/AbstractGatewayServicesTest.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 public class AbstractGatewayServicesTest {
 
+
   @Test
   public void testAddStartAndStop() throws ServiceLifecycleException {
     AbstractGatewayServices gatewayServices = createMockBuilder(AbstractGatewayServices.class)
@@ -46,7 +47,28 @@ public class AbstractGatewayServicesTest {
     Map<ServiceType, Service> serviceMap = new EnumMap<>(ServiceType.class);
     TestService lastService = null;
 
-    for (ServiceType serviceType : ServiceType.PREFERRED_START_ORDER) {
+    ServiceType[] orderedServiceTypes = {
+        ServiceType.MASTER_SERVICE,
+        ServiceType.KEYSTORE_SERVICE,
+        ServiceType.ALIAS_SERVICE,
+        ServiceType.SSL_SERVICE,
+        ServiceType.TOKEN_SERVICE,
+        ServiceType.SERVER_INFO_SERVICE,
+        ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE,
+        ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE,
+        ServiceType.TOPOLOGY_SERVICE,
+        ServiceType.METRICS_SERVICE,
+        ServiceType.CRYPTO_SERVICE,
+        ServiceType.HOST_MAPPING_SERVICE,
+        ServiceType.SERVICE_DEFINITION_REGISTRY,
+        ServiceType.SERVICE_REGISTRY_SERVICE
+    };
+
+    assertNotEquals(ServiceType.values(), orderedServiceTypes);
+
+    // Services should be started in the order they were added.. and stopped in the reverse order.
+    // For testing let's use an order different than what is defined in the ServiceType enum.
+    for (ServiceType serviceType : orderedServiceTypes) {
       TestService testService = new TestService();
       testService.setPreviousService(lastService);
 
@@ -56,9 +78,7 @@ public class AbstractGatewayServicesTest {
 
       lastService = testService;
       serviceMap.put(serviceType, testService);
-    }
 
-    for (ServiceType serviceType : ServiceType.values()) {
       gatewayServices.addService(serviceType, serviceMap.get(serviceType));
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 
 package org.apache.knox.gateway.services.security.impl;

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 
 package org.apache.knox.gateway.services.security.impl;

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -22,7 +22,7 @@ import com.mycila.xmltool.XMLTag;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClient;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -80,7 +80,7 @@ public class KnoxCLITest {
     cli.run(new String[]{"version"});
 
     RemoteConfigurationRegistryClientService service =
-                                   cli.getGatewayServices().getService(GatewayServices.REMOTE_REGISTRY_CLIENT_SERVICE);
+                                   cli.getGatewayServices().getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE);
     assertNotNull(service);
     RemoteConfigurationRegistryClient client = service.get("test_client");
     assertNotNull(client);
@@ -615,7 +615,7 @@ public class KnoxCLITest {
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("alias1 has been successfully " +
         "created."));
 
-    AliasService as = cli.getGatewayServices().getService(GatewayServices.ALIAS_SERVICE);
+    AliasService as = cli.getGatewayServices().getService(ServiceType.ALIAS_SERVICE);
 
     outContent.reset();
     String[] clusterCreateArgs = {"create-alias", "alias2", "--value", "testvalue1", "--cluster", "test",
@@ -670,7 +670,7 @@ public class KnoxCLITest {
     KnoxCLI cli = new KnoxCLI();
     int rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    MasterService ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
+    MasterService ms = cli.getGatewayServices().getService(ServiceType.MASTER_SERVICE);
     String master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master, is( "master" ) );
     assertThat( outContent.toString(StandardCharsets.UTF_8.name()), containsString( "Master secret has been persisted to disk." ) );
@@ -770,7 +770,7 @@ public class KnoxCLITest {
     cli.setConf( config );
     rc = cli.run(args);
     assertEquals(0, rc);
-    MasterService ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
+    MasterService ms = cli.getGatewayServices().getService(ServiceType.MASTER_SERVICE);
     // assertTrue(ms.getClass().getName(), ms.getClass().getName().equals("kjdfhgjkhfdgjkh"));
     assertEquals(new String(ms.getMasterSecret()), "master", new String(ms.getMasterSecret()));
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("Master secret has been persisted to disk."));
@@ -792,7 +792,7 @@ public class KnoxCLITest {
     cli.setConf(config);
     rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    MasterService ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
+    MasterService ms = cli.getGatewayServices().getService(ServiceType.MASTER_SERVICE);
     String master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master.length(), is( 36 ) );
     assertThat( master.indexOf( '-' ), is( 8 ) );
@@ -809,7 +809,7 @@ public class KnoxCLITest {
     outContent.reset();
     cli = new KnoxCLI();
     rc = cli.run(args);
-    ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
+    ms = cli.getGatewayServices().getService(ServiceType.MASTER_SERVICE);
     String master2 = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master2.length(), is( 36 ) );
     assertThat( UUID.fromString( master2 ), notNullValue() );
@@ -838,7 +838,7 @@ public class KnoxCLITest {
 
     rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
+    ms = cli.getGatewayServices().getService(ServiceType.MASTER_SERVICE);
     String master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master, is( "test-master-1" ) );
     assertThat( outContent.toString(StandardCharsets.UTF_8.name()), containsString( "Master secret has been persisted to disk." ) );
@@ -852,7 +852,7 @@ public class KnoxCLITest {
     args = new String[]{ "create-master", "--master", "test-master-2", "--force" };
     rc = cli.run(args);
     assertThat( rc, is( 0 ) );
-    ms = cli.getGatewayServices().getService(GatewayServices.MASTER_SERVICE);
+    ms = cli.getGatewayServices().getService(ServiceType.MASTER_SERVICE);
     master = String.copyValueOf( ms.getMasterSecret() );
     assertThat( master, is( "test-master-2" ) );
     assertThat( outContent.toString(StandardCharsets.UTF_8.name()), containsString( "Master secret has been persisted to disk." ) );

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -31,6 +31,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
@@ -319,7 +320,7 @@ public class BadUrlTest {
 
     DeploymentFactory.setGatewayServices(services);
     final TopologyService monitor = services
-        .getService(GatewayServices.TOPOLOGY_SERVICE);
+        .getService(ServiceType.TOPOLOGY_SERVICE);
     monitor.addTopologyChangeListener(topoListener);
     monitor.reloadTopologies();
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTest.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
@@ -403,7 +404,7 @@ public class WebsocketEchoTest {
 
     DeploymentFactory.setGatewayServices(services);
     final TopologyService monitor = services
-        .getService(GatewayServices.TOPOLOGY_SERVICE);
+        .getService(ServiceType.TOPOLOGY_SERVICE);
     monitor.addTopologyChangeListener(topoListener);
     monitor.reloadTopologies();
   }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
@@ -31,6 +31,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
@@ -379,7 +380,7 @@ public class WebsocketMultipleConnectionTest {
 
     DeploymentFactory.setGatewayServices(services);
     final TopologyService monitor = services
-        .getService(GatewayServices.TOPOLOGY_SERVICE);
+        .getService(ServiceType.TOPOLOGY_SERVICE);
     monitor.addTopologyChangeListener(topoListener);
     monitor.reloadTopologies();
   }

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/AliasResource.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/AliasResource.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.service.admin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -182,7 +183,7 @@ public class AliasResource {
         .getServletContext()
         .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    return services.getService(GatewayServices.ALIAS_SERVICE);
+    return services.getService(ServiceType.ALIAS_SERVICE);
   }
 
   public static class TopologyAliases {

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/TopologiesResource.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/TopologiesResource.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.i18n.GatewaySpiMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.service.admin.beans.BeanConverter;
 import org.apache.knox.gateway.service.admin.beans.Topology;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.topology.TopologyService;
@@ -106,7 +107,7 @@ public class TopologiesResource {
     GatewayServices services =
               (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     if (services != null) {
-      TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+      TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
       GatewayConfig config =
                 (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
@@ -140,7 +141,7 @@ public class TopologiesResource {
     GatewayConfig config =
         (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
 
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     ArrayList<SimpleTopology> st = new ArrayList<>();
     for (org.apache.knox.gateway.topology.Topology t : ts.getTopologies()) {
@@ -176,7 +177,7 @@ public class TopologiesResource {
                 (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
     t.setName(id);
-    TopologyService ts = gs.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = gs.getService(ServiceType.TOPOLOGY_SERVICE);
 
     // Check for existing topology with the same name, to see if it had been generated
     boolean existingGenerated = false;
@@ -208,7 +209,7 @@ public class TopologiesResource {
       GatewayServices services = (GatewayServices) request.getServletContext()
           .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-      TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+      TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
       for (org.apache.knox.gateway.topology.Topology t : ts.getTopologies()) {
         if(t.getName().equals(id)) {
@@ -233,7 +234,7 @@ public class TopologiesResource {
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
     List<HrefListItem> configs = new ArrayList<>();
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
     // Get all the simple descriptor file names
     for (File providerConfig : ts.getProviderConfigurations()){
       String id = FilenameUtils.getBaseName(providerConfig.getName());
@@ -253,7 +254,7 @@ public class TopologiesResource {
     GatewayServices services =
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     File providerConfigFile = null;
 
@@ -289,7 +290,7 @@ public class TopologiesResource {
     GatewayServices services =
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
     if (ts.deleteProviderConfiguration(name, Boolean.valueOf(force))) {
       response = ok().entity("{ \"deleted\" : \"provider config " + name + "\" }").build();
     } else {
@@ -308,7 +309,7 @@ public class TopologiesResource {
       GatewayServices services =
               (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-      TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+      TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
       if (ts.deleteDescriptor(name)) {
         response = ok().entity("{ \"deleted\" : \"descriptor " + name + "\" }").build();
       }
@@ -342,7 +343,7 @@ public class TopologiesResource {
     GatewayServices gs =
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    TopologyService ts = gs.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = gs.getService(ServiceType.TOPOLOGY_SERVICE);
 
     File existing = getExistingConfigFile(ts.getProviderConfigurations(), name);
     boolean isUpdate = (existing != null);
@@ -389,7 +390,7 @@ public class TopologiesResource {
     GatewayServices gs =
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    TopologyService ts = gs.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = gs.getService(ServiceType.TOPOLOGY_SERVICE);
 
     File existing = getExistingConfigFile(ts.getDescriptors(), name);
     boolean isUpdate = (existing != null);
@@ -426,7 +427,7 @@ public class TopologiesResource {
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
     List<HrefListItem> descriptors = new ArrayList<>();
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
     for (File descriptor : ts.getDescriptors()){
       String id = FilenameUtils.getBaseName(descriptor.getName());
       descriptors.add(new HrefListItem(buildHref(id, request), descriptor.getName()));
@@ -446,7 +447,7 @@ public class TopologiesResource {
     GatewayServices services =
             (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     File descriptorFile = null;
 

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/VersionResource.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/VersionResource.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServerInfoService;
 
@@ -50,7 +51,7 @@ public class VersionResource {
     GatewayServices services = (GatewayServices)request.getServletContext().
         getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    ServerInfoService sis = services.getService(GatewayServices.SERVER_INFO_SERVICE);
+    ServerInfoService sis = services.getService(ServiceType.SERVER_INFO_SERVICE);
 
     return new ServerVersion(sis.getBuildVersion(), sis.getBuildHash());
   }

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -46,6 +46,7 @@ import javax.ws.rs.WebApplicationException;
 
 import org.apache.knox.gateway.audit.log4j.audit.Log4jAuditor;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -228,8 +229,8 @@ public class WebSSOResource {
       }
     }
 
-    AliasService as = services.getService(GatewayServices.ALIAS_SERVICE);
-    JWTokenAuthority ts = services.getService(GatewayServices.TOKEN_SERVICE);
+    AliasService as = services.getService(ServiceType.ALIAS_SERVICE);
+    JWTokenAuthority ts = services.getService(ServiceType.TOKEN_SERVICE);
     Principal p = request.getUserPrincipal();
 
     try {

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.service.knoxsso;
 import org.apache.http.HttpStatus;
 import org.apache.knox.gateway.audit.log4j.audit.Log4jAuditor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.util.RegExUtils;
 
@@ -157,7 +158,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -209,7 +210,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -267,7 +268,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -326,7 +327,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -379,7 +380,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -435,7 +436,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -493,7 +494,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -550,7 +551,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -615,7 +616,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -673,7 +674,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -725,7 +726,7 @@ public class WebSSOResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services).anyTimes();
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority).anyTimes();
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
@@ -837,12 +838,12 @@ public class WebSSOResourceTest {
     TestJWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
     authority.addCustomSigningKey(customSigningKeyName, customSigningKeyAlias, customSigningKeyPassphrase.toCharArray(),
         customPrivateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     EasyMock.expect(aliasService.getPasswordFromAliasForCluster(topologyName, customSigningKeyPassphraseAlias))
         .andReturn(customSigningKeyPassphrase.toCharArray());
-    EasyMock.expect(services.getService(GatewayServices.ALIAS_SERVICE)).andReturn(aliasService);
+    EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService);
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
@@ -173,13 +174,13 @@ public class TokenResource {
     GatewayServices services = (GatewayServices) request.getServletContext()
         .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
 
-    JWTokenAuthority ts = services.getService(GatewayServices.TOKEN_SERVICE);
+    JWTokenAuthority ts = services.getService(ServiceType.TOKEN_SERVICE);
     Principal p = request.getUserPrincipal();
     long expires = getExpiry();
 
     if (endpointPublicCert == null) {
       // acquire PEM for gateway identity of this gateway instance
-      KeystoreService ks = services.getService(GatewayServices.KEYSTORE_SERVICE);
+      KeystoreService ks = services.getService(ServiceType.KEYSTORE_SERVICE);
       if (ks != null) {
         try {
           Certificate cert = ks.getCertificateForGateway();

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -22,6 +22,7 @@ import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
@@ -108,7 +109,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -152,7 +153,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -204,7 +205,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -261,7 +262,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request, trustedCertMock);
 
@@ -312,7 +313,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request, trustedCertMock);
 
@@ -346,7 +347,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -380,7 +381,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -426,7 +427,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -476,7 +477,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -527,7 +528,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 
@@ -577,7 +578,7 @@ public class TokenServiceResourceTest {
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
 
     JWTokenAuthority authority = new TestJWTokenAuthority(publicKey, privateKey);
-    EasyMock.expect(services.getService(GatewayServices.TOKEN_SERVICE)).andReturn(authority);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
 
     EasyMock.replay(principal, services, context, request);
 

--- a/gateway-service-test/src/main/java/org/apache/knox/gateway/service/test/ServiceTestResource.java
+++ b/gateway-service-test/src/main/java/org/apache/knox/gateway/service/test/ServiceTestResource.java
@@ -25,6 +25,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.topology.Service;
@@ -176,7 +177,7 @@ public class ServiceTestResource {
         .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
 
-    TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     for (Topology t : ts.getTopologies()) {
       if(t.getName().equals(id)) {
@@ -196,7 +197,7 @@ public class ServiceTestResource {
         .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     List<String> fullURLs = new ArrayList<>();
     if(services != null) {
-      TopologyService ts = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+      TopologyService ts = services.getService(ServiceType.TOPOLOGY_SERVICE);
       Map<String, List<String>> urls = ts.getServiceTestURLs(topology, conf);
       List<String> urlPaths = urls.get(role);
 

--- a/gateway-service-vault/src/main/java/org/apache/knox/gateway/service/vault/CredentialResource.java
+++ b/gateway-service-vault/src/main/java/org/apache/knox/gateway/service/vault/CredentialResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -77,7 +78,7 @@ public class CredentialResource {
     GatewayServices services = (GatewayServices)request.getServletContext().
         getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     String clusterName = (String) request.getServletContext().getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE);
-    AliasService as = services.getService(GatewayServices.ALIAS_SERVICE);
+    AliasService as = services.getService(ServiceType.ALIAS_SERVICE);
     List<String> aliases = null;
     try {
       aliases = as.getAliasesForCluster(clusterName);
@@ -91,7 +92,7 @@ public class CredentialResource {
     GatewayServices services = (GatewayServices)request.getServletContext().
         getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     String clusterName = (String) request.getServletContext().getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE);
-    AliasService as = services.getService(GatewayServices.ALIAS_SERVICE);
+    AliasService as = services.getService(ServiceType.ALIAS_SERVICE);
     char[] credential = null;
     try {
       credential = as.getPasswordFromAliasForCluster(clusterName, alias);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -28,6 +28,7 @@ import javax.net.ssl.SSLContext;
 import javax.servlet.FilterConfig;
 
 import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -73,7 +74,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     GatewayServices services = (GatewayServices) filterConfig.getServletContext()
         .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     if (gatewayConfig != null && gatewayConfig.isMetricsEnabled()) {
-      MetricsService metricsService = services.getService(GatewayServices.METRICS_SERVICE);
+      MetricsService metricsService = services.getService(ServiceType.METRICS_SERVICE);
       builder = metricsService.getInstrumented(HttpClientBuilder.class);
     } else {
       builder = HttpClients.custom();
@@ -141,10 +142,10 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     char[] identityKeyPassphrase;
     KeyStore trustKeystore;
 
-    KeystoreService ks = services.getService(GatewayServices.KEYSTORE_SERVICE);
+    KeystoreService ks = services.getService(ServiceType.KEYSTORE_SERVICE);
     try {
       if (Boolean.parseBoolean(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL))) {
-        AliasService as = services.getService(GatewayServices.ALIAS_SERVICE);
+        AliasService as = services.getService(ServiceType.ALIAS_SERVICE);
 
         // Get the Gateway's configured identity keystore and key passphrase
         identityKeystore = ks.getKeystoreForGateway();

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/GatewayServices.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/GatewayServices.java
@@ -27,25 +27,7 @@ public interface GatewayServices extends Service,
   String GATEWAY_CLUSTER_ATTRIBUTE = "org.apache.knox.gateway.gateway.cluster";
   String GATEWAY_SERVICES_ATTRIBUTE = "org.apache.knox.gateway.gateway.services";
 
-  /* ************************************************************************************
-   * Service Name Constants
-   * ************************************************************************************ */
-  String ALIAS_SERVICE = "AliasService";
-  String CLUSTER_CONFIGURATION_MONITOR_SERVICE = "ClusterConfigurationMonitorService";
-  String CRYPTO_SERVICE = "CryptoService";
-  String HOST_MAPPING_SERVICE = "HostMappingService";
-  String KEYSTORE_SERVICE = "KeystoreService";
-  String MASTER_SERVICE = "MasterService";
-  String METRICS_SERVICE = "MetricsService";
-  String REMOTE_REGISTRY_CLIENT_SERVICE = "RemoteConfigRegistryClientService";
-  String SERVER_INFO_SERVICE = "ServerInfoService";
-  String SERVICE_DEFINITION_REGISTRY = "ServiceDefinitionRegistry";
-  String SERVICE_REGISTRY_SERVICE = "ServiceRegistryService";
-  String SSL_SERVICE = "SSLService";
-  String TOKEN_SERVICE = "TokenService";
-  String TOPOLOGY_SERVICE = "TopologyService";
+  Collection<ServiceType> getServiceTypes();
 
-  Collection<String> getServiceNames();
-
-  <T> T getService( String serviceName );
+  <T> T getService(ServiceType serviceName);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 
 package org.apache.knox.gateway.services;

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package org.apache.knox.gateway.services;
+
+public enum ServiceType {
+  ALIAS_SERVICE("AliasService"),
+  CLUSTER_CONFIGURATION_MONITOR_SERVICE("ClusterConfigurationMonitorService"),
+  CRYPTO_SERVICE("CryptoService"),
+  HOST_MAPPING_SERVICE("HostMappingService"),
+  KEYSTORE_SERVICE("KeystoreService"),
+  MASTER_SERVICE("MasterService"),
+  METRICS_SERVICE("MetricsService"),
+  REMOTE_REGISTRY_CLIENT_SERVICE("RemoteConfigRegistryClientService"),
+  SERVER_INFO_SERVICE("ServerInfoService"),
+  SERVICE_DEFINITION_REGISTRY("ServiceDefinitionRegistry"),
+  SERVICE_REGISTRY_SERVICE("ServiceRegistryService"),
+  SSL_SERVICE("SSLService"),
+  TOKEN_SERVICE("TokenService"),
+  TOPOLOGY_SERVICE("TopologyService");
+
+  public static final ServiceType[] PREFERRED_START_ORDER = {
+      MASTER_SERVICE,
+      KEYSTORE_SERVICE,
+      ALIAS_SERVICE,
+      SSL_SERVICE,
+      TOKEN_SERVICE,
+      SERVER_INFO_SERVICE,
+      REMOTE_REGISTRY_CLIENT_SERVICE,
+      CLUSTER_CONFIGURATION_MONITOR_SERVICE,
+      TOPOLOGY_SERVICE,
+      METRICS_SERVICE,
+      CRYPTO_SERVICE,
+      HOST_MAPPING_SERVICE,
+      SERVICE_DEFINITION_REGISTRY,
+      SERVICE_REGISTRY_SERVICE
+  };
+
+  private final String serviceTypeName;
+
+  ServiceType(String serviceTypeName) {
+    this.serviceTypeName = serviceTypeName;
+  }
+
+  public String getServiceTypeName() {
+    return serviceTypeName;
+  }
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
@@ -34,23 +34,6 @@ public enum ServiceType {
   TOKEN_SERVICE("TokenService"),
   TOPOLOGY_SERVICE("TopologyService");
 
-  public static final ServiceType[] PREFERRED_START_ORDER = {
-      MASTER_SERVICE,
-      KEYSTORE_SERVICE,
-      ALIAS_SERVICE,
-      SSL_SERVICE,
-      TOKEN_SERVICE,
-      SERVER_INFO_SERVICE,
-      REMOTE_REGISTRY_CLIENT_SERVICE,
-      CLUSTER_CONFIGURATION_MONITOR_SERVICE,
-      TOPOLOGY_SERVICE,
-      METRICS_SERVICE,
-      CRYPTO_SERVICE,
-      HOST_MAPPING_SERVICE,
-      SERVICE_DEFINITION_REGISTRY,
-      SERVICE_REGISTRY_SERVICE
-  };
-
   private final String serviceTypeName;
 
   ServiceType(String serviceTypeName) {

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- *
  */
 
 package org.apache.knox.gateway.dispatch;

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNull;
 
 import org.apache.http.client.HttpClient;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
@@ -62,7 +63,7 @@ public class DefaultHttpClientFactoryTest {
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).once();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
-    expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
 
     ServletContext servletContext = createMock(ServletContext.class);
     expect(servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gatewayConfig).atLeastOnce();
@@ -90,7 +91,7 @@ public class DefaultHttpClientFactoryTest {
     expect(keystoreService.getTruststoreForHttpClient()).andReturn(null).once();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
-    expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
 
     FilterConfig filterConfig = createMock(FilterConfig.class);
     expect(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL)).andReturn("false").once();
@@ -116,8 +117,8 @@ public class DefaultHttpClientFactoryTest {
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn("horton".toCharArray()).once();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
-    expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
-    expect(gatewayServices.getService(GatewayServices.ALIAS_SERVICE)).andReturn(aliasService).once();
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
+    expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).once();
 
     FilterConfig filterConfig = createMock(FilterConfig.class);
     expect(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL)).andReturn("true").once();
@@ -144,8 +145,8 @@ public class DefaultHttpClientFactoryTest {
     expect(aliasService.getGatewayIdentityPassphrase()).andReturn("horton".toCharArray()).once();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
-    expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
-    expect(gatewayServices.getService(GatewayServices.ALIAS_SERVICE)).andReturn(aliasService).once();
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
+    expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).once();
 
     FilterConfig filterConfig = createMock(FilterConfig.class);
     expect(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL)).andReturn("true").once();
@@ -165,7 +166,7 @@ public class DefaultHttpClientFactoryTest {
     expect(keystoreService.getTruststoreForHttpClient()).andReturn(null).once();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
-    expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
 
     FilterConfig filterConfig = createMock(FilterConfig.class);
     expect(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL)).andReturn("false").once();
@@ -187,7 +188,7 @@ public class DefaultHttpClientFactoryTest {
     expect(keystoreService.getTruststoreForHttpClient()).andReturn(trustStore).once();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
-    expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
 
     FilterConfig filterConfig = createMock(FilterConfig.class);
     expect(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL)).andReturn("false").once();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/AmbariServiceDefinitionTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/AmbariServiceDefinitionTest.java
@@ -20,7 +20,7 @@ package org.apache.knox.gateway;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.test.TestUtils;
@@ -132,7 +132,7 @@ public class AmbariServiceDefinitionTest {
     } catch ( ServiceLifecycleException e ) {
       e.printStackTrace(); // I18N not required.
     }
-    topos = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    topos = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     gateway = GatewayServer.startGateway( config, services );
     MatcherAssert.assertThat( "Failed to start gateway.", gateway, notNullValue() );

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
@@ -38,6 +38,7 @@ import com.mycila.xmltool.XMLTag;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
@@ -607,7 +608,7 @@ public class GatewayAdminTopologyFuncTest {
 
     GatewayServices srvs = GatewayServer.getGatewayServices();
 
-    TopologyService ts = srvs.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = srvs.getService(ServiceType.TOPOLOGY_SERVICE);
     try {
       ts.stopMonitor();
 
@@ -660,7 +661,7 @@ public class GatewayAdminTopologyFuncTest {
 
     GatewayServices gs = GatewayServer.getGatewayServices();
 
-    TopologyService ts = gs.getService(GatewayServices.TOPOLOGY_SERVICE);
+    TopologyService ts = gs.getService(ServiceType.TOPOLOGY_SERVICE);
 
     ts.deployTopology(test);
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.test.TestUtils;
@@ -136,7 +136,7 @@ public class GatewayAppFuncTest {
     } catch ( ServiceLifecycleException e ) {
       e.printStackTrace(); // I18N not required.
     }
-    topos = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    topos = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     gateway = GatewayServer.startGateway( config, services );
     assertThat( "Failed to start gateway.", gateway, notNullValue() );

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapDynamicGroupFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapDynamicGroupFuncTest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.test.TestUtils;
@@ -76,7 +77,7 @@ public class GatewayLdapDynamicGroupFuncTest {
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
 
     GatewayServices services = GatewayServer.getGatewayServices();
-    AliasService aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
+    AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
     aliasService.addAliasForCluster(cluster, "ldcSystemPassword", "guest-password");
 
     driver.stop();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapGroupFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapGroupFuncTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.net.URL;
 
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.test.TestUtils;
@@ -69,7 +70,7 @@ public class GatewayLdapGroupFuncTest {
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
 
     GatewayServices services = GatewayServer.getGatewayServices();
-    AliasService aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
+    AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
     aliasService.addAliasForCluster(cluster, "ldcSystemPassword", "guest-password");
 
     driver.stop();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapPosixGroupFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapPosixGroupFuncTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway;
 
 import com.mycila.xmltool.XMLDoc;
 import com.mycila.xmltool.XMLTag;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.test.TestUtils;
@@ -73,7 +74,7 @@ public class GatewayLdapPosixGroupFuncTest {
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
 
     GatewayServices services = GatewayServer.getGatewayServices();
-    AliasService aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
+    AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
     aliasService.addAliasForCluster(cluster, "ldcSystemPassword", "guest-password");
 
     driver.stop();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayMultiFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayMultiFuncTest.java
@@ -34,7 +34,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
-import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.test.TestUtils;
@@ -134,7 +134,7 @@ public class GatewayMultiFuncTest {
     } catch ( ServiceLifecycleException e ) {
       e.printStackTrace(); // I18N not required.
     }
-    topos = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    topos = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     gateway = GatewayServer.startGateway( config, services );
     assertThat( "Failed to start gateway.", gateway, notNullValue() );

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewaySslFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewaySslFuncTest.java
@@ -41,6 +41,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.knox.gateway.services.DefaultGatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.topology.TopologyService;
@@ -165,7 +166,7 @@ public class GatewaySslFuncTest {
     } catch ( ServiceLifecycleException e ) {
       e.printStackTrace(); // I18N not required.
     }
-    topos = services.getService(GatewayServices.TOPOLOGY_SERVICE);
+    topos = services.getService(ServiceType.TOPOLOGY_SERVICE);
 
     gateway = GatewayServer.startGateway( config, services );
     assertThat( "Failed to start gateway.", gateway, notNullValue() );

--- a/gateway-test/src/test/java/org/apache/knox/gateway/Knox242FuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/Knox242FuncTest.java
@@ -28,6 +28,7 @@ import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.test.TestUtils;
@@ -78,7 +79,7 @@ public class Knox242FuncTest {
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
 
     GatewayServices services = GatewayServer.getGatewayServices();
-    AliasService aliasService = services.getService(GatewayServices.ALIAS_SERVICE);
+    AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
     aliasService.addAliasForCluster(cluster, "ldcSystemPassword", "guest-password");
 
     driver.stop();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/OozieServiceDefinitionTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/OozieServiceDefinitionTest.java
@@ -25,6 +25,7 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletContextListen
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletEnvironment;
 import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletFilter;
 import org.apache.knox.gateway.filter.rewrite.impl.UrlRewriteRequest;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
 import org.apache.knox.gateway.util.XmlUtils;
@@ -62,7 +63,7 @@ public class OozieServiceDefinitionTest {
 
     // Mock out the gateway services registry which is required for several url rewrite functions to work.
     GatewayServices services = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( services.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( registry ).anyTimes();
+    EasyMock.expect( services.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( registry ).anyTimes();
 
     UrlRewriteProcessor rewriteProcessor = new UrlRewriteProcessor();
 
@@ -116,7 +117,7 @@ public class OozieServiceDefinitionTest {
 
     // Mock out the gateway services registry which is required for several url rewrite functions to work.
     GatewayServices services = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( services.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( registry ).anyTimes();
+    EasyMock.expect( services.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( registry ).anyTimes();
 
     UrlRewriteProcessor rewriteProcessor = new UrlRewriteProcessor();
 
@@ -169,7 +170,7 @@ public class OozieServiceDefinitionTest {
 
     // Mock out the gateway services registry which is required for several url rewrite functions to work.
     GatewayServices services = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( services.getService( GatewayServices.SERVICE_REGISTRY_SERVICE ) ).andReturn( registry ).anyTimes();
+    EasyMock.expect( services.getService( ServiceType.SERVICE_REGISTRY_SERVICE ) ).andReturn( registry ).anyTimes();
 
     UrlRewriteProcessor rewriteProcessor = new UrlRewriteProcessor();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -18,6 +18,7 @@ package org.apache.knox.gateway;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
@@ -174,7 +175,7 @@ public class SimpleDescriptorHandlerFuncTest {
       MasterService ms = EasyMock.createNiceMock(MasterService.class);
       EasyMock.expect(ms.getMasterSecret()).andReturn(testMasterSecret.toCharArray()).anyTimes();
       EasyMock.replay(ms);
-      EasyMock.expect(gatewayServices.getService(GatewayServices.MASTER_SERVICE)).andReturn(ms).anyTimes();
+      EasyMock.expect(gatewayServices.getService(ServiceType.MASTER_SERVICE)).andReturn(ms).anyTimes();
 
       // Keystore Service
       KeystoreService ks = EasyMock.createNiceMock(KeystoreService.class);
@@ -184,7 +185,7 @@ public class SimpleDescriptorHandlerFuncTest {
       KeyStore credStore = EasyMock.createNiceMock(KeyStore.class);
       EasyMock.expect(ks.getCredentialStoreForCluster(testDescriptor.getName())).andReturn(credStore).anyTimes();
       EasyMock.replay(ks);
-      EasyMock.expect(gatewayServices.getService(GatewayServices.KEYSTORE_SERVICE)).andReturn(ks).anyTimes();
+      EasyMock.expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(ks).anyTimes();
 
       // Alias Service
       AliasService as = EasyMock.createNiceMock(AliasService.class);
@@ -195,7 +196,7 @@ public class SimpleDescriptorHandlerFuncTest {
       as.addAliasForCluster(capture(capturedCluster), capture(capturedAlias), capture(capturedPwd));
       EasyMock.expectLastCall().anyTimes();
       EasyMock.replay(as);
-      EasyMock.expect(gatewayServices.getService(GatewayServices.ALIAS_SERVICE)).andReturn(as).anyTimes();
+      EasyMock.expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(as).anyTimes();
 
       // Topology Service
       TopologyService ts = EasyMock.createNiceMock(TopologyService.class);
@@ -205,7 +206,7 @@ public class SimpleDescriptorHandlerFuncTest {
       EasyMock.expectLastCall().anyTimes();
       EasyMock.expect(ts.getTopologies()).andReturn(Collections.emptyList()).anyTimes();
       EasyMock.replay(ts);
-      EasyMock.expect(gatewayServices.getService(GatewayServices.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
+      EasyMock.expect(gatewayServices.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
 
       EasyMock.replay(gatewayServices);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ensure services are started and stopped in the correct order in `org.apache.knox.gateway.services.DefaultGatewayServices` and `org.apache.knox.gateway.services.CLIGatewayServices`.

The following order is being enforced for starting services:

1. MasterService
1. KeystoreService
1. AliasService
1. SslService
1. TokenService
1. ServerInfoService
1. RemoteRegistryClientService
1. ClusterConfigurationMonitorervice
1. TopologyService
1. MetricsService
1. CryptoService
1. HostMappingService
1. ServiceDefinitionRegistry
1. ServiceRegistryService

The order is reversed for stopping. 

A new class, `org.apache.knox.gateway.services.ServiceType`, was added to enumerate the different service types.

A new class, `org.apache.knox.gateway.services.AbstractGatewayServices`, was added to implement the starting and stopping order listed above. Only _registered_ services will be started and stopped. An associated unit test class was added as well -  `org.apache.knox.gateway.services.AbstractGatewayServicesTest`

The rest of the changes are basically converting `GatewayServices` constants to `ServiceType` enums... for example, `GatewayServices.MASTER_SERVICE` to `ServiceType.MASTER_SERVICE`

## How was this patch tested?

Added new unit tests and executed them:
```
mvn -T.5C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 16:22 min (Wall Clock)
[INFO] Finished at: 2019-04-01T11:19:15-04:00
[INFO] Final Memory: 274M/1472M
[INFO] ------------------------------------------------------------------------
```

Started server to see new logged messages:
```
2019-04-01 12:14:52,720 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: MasterService
2019-04-01 12:14:52,720 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: KeystoreService
2019-04-01 12:14:52,720 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: AliasService
2019-04-01 12:14:52,720 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: SSLService
2019-04-01 12:14:52,720 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: TokenService
2019-04-01 12:14:52,722 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: ServerInfoService
2019-04-01 12:14:52,722 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: RemoteConfigRegistryClientService
2019-04-01 12:14:52,722 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: ClusterConfigurationMonitorService
2019-04-01 12:14:52,723 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: TopologyService
2019-04-01 12:14:52,723 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: MetricsService
2019-04-01 12:14:52,723 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: CryptoService
2019-04-01 12:14:52,723 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: HostMappingService
2019-04-01 12:14:52,723 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: ServiceDefinitionRegistry
2019-04-01 12:14:52,723 INFO  knox.gateway (AbstractGatewayServices.java:start(67)) - Starting service: ServiceRegistryService
```

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
