### PR TITLE
KNOX-1839 - Fix Spark History UI incomplete applications links

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/1.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/1.4.0/rewrite.xml
@@ -77,8 +77,8 @@
   <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/static/graphlib" pattern="/static/graphlib-dot.min.js">
     <rewrite template="{$frontend[url]}/sparkhistory/static/graphlib-dot.min.js"/>
   </rule>
-  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/apps" pattern="/?{page}?{showIncomplete}">
-    <rewrite template="{$frontend[url]}/sparkhistory/?{page}?{showIncomplete}"/>
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/apps" pattern="/?{showIncomplete}?{**}">
+    <rewrite template="{$frontend[url]}/sparkhistory/?{showIncomplete}?{**}"/>
   </rule>
 
   <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/headers/location">

--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
@@ -42,8 +42,8 @@
     <rewrite template="{$frontend[url]}/sparkhistory/history/{**}?{**}"/>
   </rule>
 
-  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/apps" pattern="/?{page}?{showIncomplete}">
-    <rewrite template="{$frontend[url]}/sparkhistory/?{page}?{showIncomplete}"/>
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/apps" pattern="/?{showIncomplete}?{**}">
+    <rewrite template="{$frontend[url]}/sparkhistory/?{showIncomplete}?{**}"/>
   </rule>
 
   <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/headers/location">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change rewrite rules for incomplete application link in Spark History UI to fix broken link.
The link to show incomplete applications in the Spark History UI is not rewritten correctly. It should link to '/gateway/<topology>/sparkhistory?showIncomplete=true' but instead links to '?showIncomplete=true'

## How was this patch tested?

Manually verified that Spark History UI link is rewritten correctly after this rewrite change is applied.

