### PR TITLE
KNOX-1849 - Start the Java process with 'exec' when running the app in the foreground

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -163,7 +163,7 @@ function getPID {
 
 function appStart {
    if [ "$APP_RUNNING_IN_FOREGROUND" == true ]; then
-      $JAVA $APP_JAVA_OPTS -jar $APP_JAR $@
+      exec $JAVA $APP_JAVA_OPTS -jar $APP_JAR $@
    else
       getPID
       if [ $? -eq 0 ]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Running the Knox Gateway and the LDAP server using exec in the foreground gives us the opportunity to execute the underlying Java command that completely replaces the current bash process (there won't be any parent process which makes graceful stops easier by clients).

Note: without this change CM will consider the Gateway stopped even if the JAva process is still running in the background.

## How was this patch tested?

Running Knox Gateway and the LDAP server in the foreground after I built the project.