### PR TITLE
KNOX-1851 - Fix NPE in Zookeeper Remote Alias Service

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -354,6 +354,10 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-configinjector</artifactId>
+        </dependency>
 
         <!-- ********** ********** ********** ********** ********** ********** -->
         <!-- ********** Test Dependencies                           ********** -->

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -171,7 +171,7 @@ public class KnoxCLI extends Configured implements Tool {
     return exitCode;
   }
 
-  GatewayServices getGatewayServices() {
+  public static synchronized GatewayServices getGatewayServices() {
     return services;
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?
This PR fixes issue with gateway starting up (due to NPE) when zookeeper remote alias service is configured.

## How was this patch tested?
Manual testing with local Zookeeper instance.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
