### PR TITLE
KNOX-1851 - remove the unnecessary instanceof check

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasServiceProvider.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasServiceProvider.java
@@ -45,12 +45,7 @@ public class ZookeeperRemoteAliasServiceProvider implements RemoteAliasServicePr
       final RemoteConfigurationRegistryClientService registryClientService = services
           .getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE);
 
-      /* Check to see if we already have ZooKeeperClientService instance, if so use it */
-      if (registryClientService instanceof ZooKeeperClientService) {
-        return new ZookeeperRemoteAliasService(localAliasService, ms,
-            registryClientService);
-
-      }
+      return new ZookeeperRemoteAliasService(localAliasService, ms, registryClientService);
     }
 
     throw new ConfigurationException(String.format(Locale.ROOT,"%s service not configured", ZooKeeperClientService.TYPE));


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is just a cleanup for the previous patch. Removing the unnecessary `registryClientService instanceof ZooKeeperClientService` check so that the ZookeeperRemoteAliasServiceProvider can be generic and not dependent on the ZooKeeperClientService.

## How was this patch tested?
Tested locally on my machine with local ZK instance.

