### PR TITLE
KNOX-1859 - Improve alias lookup for HadoopAuthProvider

### DIFF
--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-spi</artifactId>
         </dependency>
         <dependency>
@@ -60,11 +64,6 @@
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.knox</groupId>
-            <artifactId>gateway-server</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -20,16 +20,9 @@ package org.apache.knox.gateway.hadoopauth;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
-import org.apache.knox.gateway.i18n.messages.StackTrace;
 
 @Messages(logger="org.apache.knox.gateway.provider.global.hadoopauth")
 public interface HadoopAuthMessages {
   @Message( level = MessageLevel.DEBUG, text = "Hadoop Authentication Asserted Principal: {0}" )
   void hadoopAuthAssertedPrincipal(String name);
-
-  @Message( level = MessageLevel.ERROR, text = "Alias service exception: {0}" )
-  void aliasServiceException(@StackTrace( level = MessageLevel.DEBUG ) Exception e);
-
-  @Message( level = MessageLevel.ERROR, text = "Unable to get password for {0}: {1}" )
-  void unableToGetPassword(String name, @StackTrace( level = MessageLevel.DEBUG ) Exception e);
 }

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/HadoopAuthDeploymentContributorTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/HadoopAuthDeploymentContributorTest.java
@@ -25,10 +25,6 @@ import org.apache.knox.gateway.descriptor.GatewayDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
 import org.apache.knox.gateway.descriptor.impl.GatewayDescriptorImpl;
 import org.apache.knox.gateway.hadoopauth.deploy.HadoopAuthDeploymentContributor;
-import org.apache.knox.gateway.services.ServiceType;
-import org.apache.knox.gateway.services.GatewayServices;
-import org.apache.knox.gateway.services.security.AliasService;
-import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
 import org.apache.knox.gateway.topology.Provider;
 import org.apache.knox.gateway.topology.Topology;
 import org.easymock.EasyMock;
@@ -36,7 +32,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -67,20 +62,20 @@ public class HadoopAuthDeploymentContributorTest {
   }
 
   @Test
-  public void testDeployment() throws Exception {
+  public void testDeployment() {
     String aliasKey = "signature.secret";
-    String aliasValue = "password";
+    String aliasValue = "${ALIAS=signature.secret}";
     String normalKey = "type";
     String normalValue = "simple";
 
-    WebArchive webArchive = ShrinkWrap.create( WebArchive.class, "test-acrhive" );
+    WebArchive webArchive = ShrinkWrap.create( WebArchive.class, "test-archive" );
 
     Provider provider = new Provider();
     provider.setEnabled( true );
     provider.setName( HadoopAuthDeploymentContributor.NAME );
     // Keep order of params in map for testing
     Map<String, String> params = new TreeMap<>();
-    params.put(aliasKey, aliasKey);
+    params.put(aliasKey, aliasValue);
     params.put(normalKey, normalValue);
     provider.setParams(params);
 
@@ -95,30 +90,13 @@ public class HadoopAuthDeploymentContributorTest {
     GatewayDescriptor gatewayDescriptor = new GatewayDescriptorImpl();
     ResourceDescriptor resource = gatewayDescriptor.createResource();
 
-    AliasService as = EasyMock.createNiceMock( AliasService.class );
-    EasyMock.expect(as.getAliasesForCluster(context.getTopology().getName()))
-        .andReturn(Collections.singletonList(aliasKey)).anyTimes();
-    EasyMock.expect(as.getPasswordFromAliasForCluster(context.getTopology().getName(), aliasKey))
-        .andReturn(aliasValue.toCharArray()).anyTimes();
-    EasyMock.replay( as );
-    DefaultCryptoService cryptoService = new DefaultCryptoService();
-    cryptoService.setAliasService( as );
-
-    GatewayServices gatewayServices = EasyMock.createNiceMock( GatewayServices.class );
-    EasyMock.expect( gatewayServices.getService( ServiceType.CRYPTO_SERVICE ) ).andReturn( cryptoService ).anyTimes();
-
     HadoopAuthDeploymentContributor contributor = new HadoopAuthDeploymentContributor();
-    contributor.setAliasService(as);
 
     assertThat( contributor.getRole(), is( HadoopAuthDeploymentContributor.ROLE ) );
     assertThat( contributor.getName(), is( HadoopAuthDeploymentContributor.NAME ) );
 
-    // Just make sure it doesn't blow up.
     contributor.initializeContribution( context );
-
     contributor.contributeFilter(context, provider, null, resource, null);
-
-    // Just make sure it doesn't blow up.
     contributor.finalizeContribution( context );
 
     // Check that the params are properly setup
@@ -126,7 +104,7 @@ public class HadoopAuthDeploymentContributorTest {
     assertNotNull(hadoopAuthFilterDescriptor);
     assertEquals(HadoopAuthDeploymentContributor.NAME, hadoopAuthFilterDescriptor.name());
     List<FilterParamDescriptor> hadoopAuthFilterParams = hadoopAuthFilterDescriptor.params();
-    assertEquals(2, hadoopAuthFilterParams.size());
+    assertEquals(3, hadoopAuthFilterParams.size());
 
     FilterParamDescriptor paramDescriptor = hadoopAuthFilterParams.get(0);
     assertEquals(aliasKey, paramDescriptor.name());

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.hadoopauth.filter;
+
+import org.apache.knox.gateway.deploy.DeploymentContext;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
+import org.apache.knox.gateway.topology.Topology;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class HadoopAuthFilterTest {
+  @Test
+  public void testHadoopAuthFilterAliases() throws Exception {
+    String aliasKey = "signature.secret";
+    String aliasConfigKey = "${ALIAS=" + aliasKey + "}";
+    String aliasValue = "password";
+
+    Topology topology = new Topology();
+    topology.setName("Sample");
+
+    DeploymentContext context = EasyMock.createNiceMock(DeploymentContext.class);
+    EasyMock.expect(context.getTopology()).andReturn(topology).anyTimes();
+    EasyMock.replay(context);
+
+    String clusterName = context.getTopology().getName();
+
+    AliasService as = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(as.getPasswordFromAliasForCluster(clusterName, aliasKey))
+        .andReturn(aliasValue.toCharArray()).anyTimes();
+    EasyMock.replay(as);
+    DefaultCryptoService cryptoService = new DefaultCryptoService();
+    cryptoService.setAliasService(as);
+
+    GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
+    EasyMock.expect(gatewayServices.getService(ServiceType.CRYPTO_SERVICE)).andReturn(cryptoService).anyTimes();
+
+    HadoopAuthFilter hadoopAuthFilter = new HadoopAuthFilter();
+
+    String configPrefix = "hadoop.auth.config.";
+
+    Properties props = new Properties();
+    props.put("clusterName", clusterName);
+    props.put(configPrefix + "signature.secret", aliasConfigKey);
+    props.put(configPrefix + "test", "abc");
+
+    FilterConfig filterConfig = new HadoopAuthTestFilterConfig(props);
+    Properties configuration = hadoopAuthFilter.getConfiguration(as, configPrefix, filterConfig);
+    assertEquals(aliasValue, configuration.getProperty(aliasKey));
+    assertEquals("abc", configuration.getProperty("test"));
+  }
+
+  private static class HadoopAuthTestFilterConfig implements FilterConfig {
+    Properties props;
+
+    HadoopAuthTestFilterConfig(Properties props) {
+      this.props = props;
+    }
+
+    @Override
+    public String getFilterName() {
+      return null;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+      return null;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+      return props.getProperty(name, null);
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+      return (Enumeration<String>)props.propertyNames();
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

KNOX-1522 added the initial ability to resolve property names to aliases. This was implemented in a way that wasn't optimal. We should improve this so aliases are resolved within the auth filter config itself instead of in the contributor.

This also makes sure we use follow the existing "${ALIAS=...}" convention when resolving the aliases. This is a behavior change but makes it much more readable to know what is an alias vs a plain text value.

## How was this patch tested?

`mvn -T.5C clean verify -Ppackage,release`