### PR TITLE
KNOX-1858 - Add service name to X-Forwarded-Context header

### DIFF
--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -139,5 +139,10 @@ limitations under the License.
         <description>The whitelist to be applied for dispatches associated with the service roles specified by gateway.dispatch.whitelist.services.
         If the value is DEFAULT, a domain-based whitelist will be derived from the Knox host.</description>
     </property>
+    <property>
+        <name>gateway.header.x-forward-context.append.servicename</name>
+        <value>LIVYSERVER</value>
+        <description>Add service name to x-forward-context header for the list of services defined above.</description>
+    </property>
 
 </configuration>

--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -140,7 +140,7 @@ limitations under the License.
         If the value is DEFAULT, a domain-based whitelist will be derived from the Knox host.</description>
     </property>
     <property>
-        <name>gateway.header.x-forward-context.append.servicename</name>
+        <name>gateway.xforwarded.header.context.append.servicename</name>
         <value>LIVYSERVER</value>
         <description>Add service name to x-forward-context header for the list of services defined above.</description>
     </property>

--- a/gateway-server-xforwarded-filter/src/main/java/org/apache/knox/gateway/filter/XForwardedHeaderFilter.java
+++ b/gateway-server-xforwarded-filter/src/main/java/org/apache/knox/gateway/filter/XForwardedHeaderFilter.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.filter;
 
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -25,8 +26,27 @@ import java.io.IOException;
 
 public class XForwardedHeaderFilter extends AbstractGatewayFilter {
 
+  private static final String APPEND_SERVICE_NAME_PARAM = "isAppendServiceName";
+  /**
+   * There could be a case where a service might use double context paths
+   * e.g. "/livy/v1" instead of "livy".
+   * This parameter can be used to add such context (/livy/v1) to the
+   * X-Forward-Context header.
+   */
+  private static final String SERVICE_CONTEXT = "serviceContext";
+
+  private boolean isAppendServiceName;
+  private String serviceContext;
+
+  @Override
+  public void init( FilterConfig filterConfig ) throws ServletException {
+    super.init( filterConfig );
+    isAppendServiceName = Boolean.parseBoolean(filterConfig.getInitParameter(APPEND_SERVICE_NAME_PARAM));
+    serviceContext = filterConfig.getInitParameter(SERVICE_CONTEXT);
+  }
+
   @Override
   protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
-    chain.doFilter( new XForwardedHeaderRequestWrapper( request ), response );
+    chain.doFilter( new XForwardedHeaderRequestWrapper( request ,  isAppendServiceName, serviceContext), response );
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -231,7 +231,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
       "OOZIE", "WEBHBASE", "HIVE", "RESOURCEMANAGER");
 
   /* property that specifies list of services for which we need to append service name to the X-Forward-Context header */
-  public static final String X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".header.x-forward-context.append.servicename";
+  public static final String X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".xforwarded.header.context.append.servicename";
 
   public GatewayConfigImpl() {
     init();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -230,6 +230,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
       "NAMENODE", "JOBTRACKER", "WEBHDFS", "WEBHCAT",
       "OOZIE", "WEBHBASE", "HIVE", "RESOURCEMANAGER");
 
+  /* property that specifies list of services for which we need to append service name to the X-Forward-Context header */
+  public static final String X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".header.x-forward-context.append.servicename";
+
   public GatewayConfigImpl() {
     init();
   }
@@ -1050,5 +1053,23 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public boolean isTopologyValidationEnabled() {
     final String result = get(STRICT_TOPOLOGY_VALIDATION, Boolean.toString(DEFAULT_STRICT_TOPOLOGY_VALIDATION));
     return Boolean.parseBoolean(result);
+  }
+
+  /**
+   * Returns a list of services that need service name appended to
+   * X-Forward-Context header as a result of which the new header would look
+   * /{gateway}/{sandbox}/{serviceName}
+   *
+   * @return
+   * @since 1.3.0
+   */
+  @Override
+  public List<String> getXForwardContextAppendServices() {
+    String value = get( X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES );
+    if ( value != null && !value.isEmpty() && !"none".equalsIgnoreCase(value.trim()) ) {
+      return Arrays.asList( value.trim().split("\\s*,\\s*") );
+    } else {
+      return new ArrayList<>();
+    }
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/deploy/impl/ApplicationDeploymentContributor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/deploy/impl/ApplicationDeploymentContributor.java
@@ -64,6 +64,7 @@ public class ApplicationDeploymentContributor extends ServiceDeploymentContribut
   private static final String XFORWARDED_FILTER_ROLE = "xforwardedheaders";
   private static final String COOKIE_SCOPING_FILTER_NAME = "CookieScopeServletFilter";
   private static final String COOKIE_SCOPING_FILTER_ROLE = "cookiescopef";
+  private static final String APPEND_SERVICE_NAME_PARAM = "isAppendServiceName";
 
   private ServiceDefinition serviceDefinition;
 
@@ -185,7 +186,16 @@ public class ApplicationDeploymentContributor extends ServiceDeploymentContribut
     resource.pattern(binding.getPath());
     //add x-forwarded filter if enabled in config
     if (context.getGatewayConfig().isXForwardedEnabled()) {
-      resource.addFilter().name(XFORWARDED_FILTER_NAME).role(XFORWARDED_FILTER_ROLE).impl(XForwardedHeaderFilter.class);
+      final FilterDescriptor filter = resource.addFilter()
+          .name(XFORWARDED_FILTER_NAME).role(XFORWARDED_FILTER_ROLE)
+          .impl(XForwardedHeaderFilter.class);
+      /* check if we need to add service name to the context */
+      if (context.getGatewayConfig().getXForwardContextAppendServices() != null
+          && !context.getGatewayConfig().getXForwardContextAppendServices()
+          .isEmpty() && context.getGatewayConfig()
+          .getXForwardContextAppendServices().contains(service.getRole())) {
+        filter.param().name(APPEND_SERVICE_NAME_PARAM).value("true");
+      }
     }
     if (context.getGatewayConfig().isCookieScopingToPathEnabled()) {
       FilterDescriptor filter = resource.addFilter().name(COOKIE_SCOPING_FILTER_NAME).role(COOKIE_SCOPING_FILTER_ROLE).impl(CookieScopeServletFilter.class);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -606,5 +606,16 @@ public interface GatewayConfig {
    */
   boolean isTopologyValidationEnabled();
 
+  /**
+   * Returns a list of services that need service name appended to
+   * X-Forward-Context header as a result of which the new header would look
+   * /{gateway}/{sandbox}/{serviceName}
+   *
+   * @return List of service names for which service name needs to be appended
+   * to X-Forward-Context header, can be empty list.
+   * @since 1.3.0
+   */
+  List<String> getXForwardContextAppendServices();
+
 
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -746,4 +746,17 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public boolean isTopologyValidationEnabled() {
     return false;
   }
+
+  /**
+   * Returns a list of services that need service name appended to
+   * X-Forward-Context header as a result of which the new header would look
+   * /{gateway}/{sandbox}/{serviceName}
+   *
+   * @return
+   * @since 1.3.0
+   */
+  @Override
+  public List<String> getXForwardContextAppendServices() {
+    return null;
+  }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?
Add a configurable way to append service name to the X-Forward-Context header

## How was this patch tested?
Manually  tested using netcat to check headers.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
