### PR TITLE
KNOX-1864: Implement PATCH method

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/AbstractGatewayDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/AbstractGatewayDispatch.java
@@ -95,6 +95,12 @@ public abstract class AbstractGatewayDispatch implements Dispatch {
   }
 
   @Override
+  public void doPatch(URI url, HttpServletRequest request, HttpServletResponse response )
+      throws IOException, URISyntaxException {
+    response.sendError( HttpServletResponse.SC_METHOD_NOT_ALLOWED );
+  }
+
+  @Override
   public void doDelete(URI url, HttpServletRequest request, HttpServletResponse response )
       throws IOException, URISyntaxException {
     response.sendError( HttpServletResponse.SC_METHOD_NOT_ALLOWED );

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -26,6 +26,7 @@ import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
 import org.apache.knox.gateway.SpiGatewayMessages;
@@ -266,6 +267,16 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
    public void doPut(URI url, HttpServletRequest request, HttpServletResponse response)
          throws IOException, URISyntaxException {
       HttpPut method = new HttpPut(url);
+      HttpEntity entity = createRequestEntity(request);
+      method.setEntity(entity);
+      copyRequestHeaderFields(method, request);
+      executeRequest(method, request, response);
+   }
+
+   @Override
+   public void doPatch(URI url, HttpServletRequest request, HttpServletResponse response)
+         throws IOException, URISyntaxException {
+      HttpPatch method = new HttpPatch(url);
       HttpEntity entity = createRequestEntity(request);
       method.setEntity(entity);
       copyRequestHeaderFields(method, request);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/Dispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/Dispatch.java
@@ -47,6 +47,9 @@ public interface Dispatch {
   void doPut( URI url, HttpServletRequest request, HttpServletResponse response )
       throws IOException, ServletException, URISyntaxException;
 
+  void doPatch( URI url, HttpServletRequest request, HttpServletResponse response )
+      throws IOException, ServletException, URISyntaxException;
+
   void doDelete( URI url, HttpServletRequest request, HttpServletResponse response )
       throws IOException, ServletException, URISyntaxException;
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/GatewayDispatchFilter.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/GatewayDispatchFilter.java
@@ -60,6 +60,7 @@ public class GatewayDispatchFilter extends AbstractGatewayFilter {
     map.put("GET", new GetAdapter());
     map.put("POST", new PostAdapter());
     map.put("PUT", new PutAdapter());
+    map.put("PATCH", new PutAdapter());
     map.put("DELETE", new DeleteAdapter());
     map.put("OPTIONS", new OptionsAdapter());
     map.put("HEAD", new HeadAdapter());
@@ -187,6 +188,14 @@ public class GatewayDispatchFilter extends AbstractGatewayFilter {
     public void doMethod(Dispatch dispatch, HttpServletRequest request, HttpServletResponse response)
         throws IOException, ServletException, URISyntaxException {
       dispatch.doPut( dispatch.getDispatchUrl(request), request, response);
+    }
+  }
+
+  private static class PatchAdapter implements Adapter {
+    @Override
+    public void doMethod(Dispatch dispatch, HttpServletRequest request, HttpServletResponse response)
+        throws IOException, ServletException, URISyntaxException {
+      dispatch.doPatch( dispatch.getDispatchUrl(request), request, response);
     }
   }
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/GatewayDispatchFilter.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/GatewayDispatchFilter.java
@@ -60,7 +60,7 @@ public class GatewayDispatchFilter extends AbstractGatewayFilter {
     map.put("GET", new GetAdapter());
     map.put("POST", new PostAdapter());
     map.put("PUT", new PutAdapter());
-    map.put("PATCH", new PutAdapter());
+    map.put("PATCH", new PatchAdapter());
     map.put("DELETE", new DeleteAdapter());
     map.put("OPTIONS", new OptionsAdapter());
     map.put("HEAD", new HeadAdapter());


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

the PATCH http method was not implemented and is necessary for certain REST api's (e.g. Apache Metron) to function.

## How was this patch tested?

It was tested by manually replacing the gateway-spi jar by the newly built one and validating if the expected functionality works properly.

Before the patch, Knox would return a 405 http error when a patch request was submitted. After the patch, a 200 OK is returned as expected.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
