### PR TITLE
KNOX-1856 - Using the appropriate error messages when throwing exception in case there is no public cert for the gateway or the cert is not an X509Certificate

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
@@ -99,8 +99,9 @@ public class JettySSLService implements SSLService {
   private void logAndValidateCertificate(GatewayConfig config) throws ServiceLifecycleException {
     // let's log the hostname (CN) and cert expiry from the gateway's public cert to aid in SSL debugging
     Certificate cert;
+    final String identityKeyAlias = config.getIdentityKeyAlias();
     try {
-      cert = as.getCertificateForGateway(config.getIdentityKeyAlias());
+      cert = as.getCertificateForGateway(identityKeyAlias);
     } catch (AliasServiceException e) {
       throw new ServiceLifecycleException("Cannot Retreive Gateway SSL Certificate. Server will not start.", e);
     }
@@ -122,10 +123,10 @@ public class JettySSLService implements SSLService {
           throw new ServiceLifecycleException("Gateway SSL Certificate is not yet valid. Server will not start.", e);
         }
       } else {
-        throw new ServiceLifecycleException("Public certificate for the gateway cannot be found with the alias gateway-identity. Plase check the identity certificate alias.");
+        throw new ServiceLifecycleException("Public certificate for the gateway is not of the expected type of  . Something is wrong with the gateway keystore.");
       }
     } else {
-      throw new ServiceLifecycleException("Public certificate for the gateway is not of the expected type of X509Certificate. Something is wrong with the gateway keystore.");
+      throw new ServiceLifecycleException("Public certificate for the gateway cannot be found with the alias " + identityKeyAlias + ". Please check the identity certificate alias.");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Until now Knox threw exceptions with misleading error messages in case:
- there was no public cert for the gateway or the cert
- the cert is not an X509Certificate

## How was this patch tested?

Running JUnit tests