### PR TITLE
KNOX-1848 - Default to 'zookeeper' as remote alias configuration type in case it is not set in gateway-site.xml

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -24,9 +24,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
+
+import static org.apache.knox.gateway.services.security.impl.RemoteAliasService.REMOTE_ALIAS_SERVICE_TYPE;
 
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -989,7 +992,13 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public Map<String, String> getRemoteAliasServiceConfiguration() {
-    return getPropsWithPrefix(getRemoteAliasServiceConfigurationPrefix());
+    final Map<String, String> remoteAliasServiceConfiguration = getPropsWithPrefix(getRemoteAliasServiceConfigurationPrefix());
+
+    //in case the remote alias service configuration type is not set we default to zookeeper
+    if (!remoteAliasServiceConfiguration.containsKey(REMOTE_ALIAS_SERVICE_TYPE)) {
+      remoteAliasServiceConfiguration.put(REMOTE_ALIAS_SERVICE_TYPE, ZookeeperRemoteAliasService.TYPE);
+    }
+    return remoteAliasServiceConfiguration;
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -17,14 +17,17 @@
 package org.apache.knox.gateway.config.impl;
 
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
 import org.apache.knox.test.TestUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.knox.gateway.services.security.impl.RemoteAliasService.REMOTE_ALIAS_SERVICE_TYPE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +39,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 
 public class GatewayConfigImplTest {
 
@@ -386,5 +388,21 @@ public class GatewayConfigImplTest {
     assertEquals("custom_type", config.getTruststoreType());
   }
 
+  @Test
+  public void shouldReturnUserConfiguredRemoteAliasConfigType() throws Exception {
+    final String remoteAliasServiceType = "testServiceType";
+    GatewayConfigImpl config = new GatewayConfigImpl();
+    config.set(config.getRemoteAliasServiceConfigurationPrefix() + REMOTE_ALIAS_SERVICE_TYPE, "testServiceType");
+    final Map<String, String> remoteAliasServiceConfiguration = config.getRemoteAliasServiceConfiguration();
+    assertTrue(remoteAliasServiceConfiguration.containsKey(REMOTE_ALIAS_SERVICE_TYPE));
+    assertEquals(remoteAliasServiceType, remoteAliasServiceConfiguration.get(REMOTE_ALIAS_SERVICE_TYPE));
+  }
+
+  @Test
+  public void shouldReturnZookeeperAsRemoteAliasConfigTypeIfItIsUnset() throws Exception {
+    final Map<String, String> remoteAliasServiceConfiguration = new GatewayConfigImpl().getRemoteAliasServiceConfiguration();
+    assertTrue(remoteAliasServiceConfiguration.containsKey(REMOTE_ALIAS_SERVICE_TYPE));
+    assertEquals(ZookeeperRemoteAliasService.TYPE, remoteAliasServiceConfiguration.get(REMOTE_ALIAS_SERVICE_TYPE));
+  }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure to default `gateway.remote.alias.service.config.type` to `zookeeper` in case it was not set in `gateway-site.xml`

## How was this patch tested?

Running JUnit tests.