### PR TITLE
KNOX-1870 - Zeppelin UI service definition service.xml has wrong version

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.0/service.xml
@@ -15,7 +15,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<service role="ZEPPELINUI" name="zeppelinui" version="0.6.0">
+<service role="ZEPPELINUI" name="zeppelinui" version="0.8.0">
   <policies>
     <policy role="webappsec"/>
     <policy role="authentication" name="Anonymous"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set service.xml version to 0.8.0 to match folder structure.

## How was this patch tested?

`mvn -T.5C clean verify -Ppackage,release`
