### PR TITLE
KNOX-1872 - Update Ranger service definitions to support trusted proxy

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/rewrite.xml
@@ -1,0 +1,27 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="RANGER/ranger/inbound/public" pattern="*://*:*/**/ranger/service/public/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/public/{path=**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/plugins/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/plugins/{path=**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/healthcheck" pattern="*://*:*/**/ranger">
+        <rewrite template="{$serviceUrl[RANGER]}"/>
+    </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
@@ -1,0 +1,25 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="RANGER" name="ranger" version="1.0.0">
+    <routes>
+        <route path="/ranger/service/public/**"/>
+        <route path="/ranger/service/plugins/**"/>
+        <route path="/ranger"/>
+    </routes>
+    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch"/>
+</service>
+

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
@@ -1,0 +1,69 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="RANGERUI/rangerui/inbound/root" pattern="*://*:*/**/ranger/">
+        <rewrite template="{$serviceUrl[RANGERUI]}/"/>
+    </rule>
+    <rule dir="IN" name="RANGERUI/rangerui/inbound/path" pattern="*://*:*/**/ranger/{**}">
+        <rewrite template="{$serviceUrl[RANGERUI]}/{**}"/>
+    </rule>
+    <rule dir="IN" name="RANGERUI/rangerui/inbound/query" pattern="*://*:*/**/ranger/{**}?{**}">
+        <rewrite template="{$serviceUrl[RANGERUI]}/{**}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/extrapath">
+        <rewrite template="{$frontend[topology]}/ranger/j_spring_security_check"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/index">
+        <rewrite template="{$frontend[path]}/ranger/index.html"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/links" pattern="libs/{**}">
+        <rewrite template="{$frontend[path]}/ranger/libs/{**}"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/styles" pattern="styles/{**}">
+        <rewrite template="{$frontend[path]}/ranger/styles/{**}"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/styles" pattern="images/{**}">
+        <rewrite template="{$frontend[path]}/ranger/images/{**}"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/init" pattern="scripts/Init.js?ver=build.version">
+        <rewrite template="{$frontend[path]}/ranger/scripts/Init.js?ver=build.version"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/links" pattern="scripts/{**}">
+        <rewrite template="{$frontend[path]}/ranger/scripts/{**}"/>
+    </rule>
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/login/headers/location">
+        <match pattern="*://*:*/login.jsp"/>
+        <rewrite template="{$frontend[url]}/ranger/login.jsp"/>
+    </rule>
+
+    <filter name="RANGERUI/rangerui/outbound/links">
+        <content type="application/javascript">
+            <apply path="j_spring_security_check" rule="RANGERUI/rangerui/outbound/extrapath"/>
+            <apply path="index.html" rule="RANGERUI/rangerui/outbound/index"/>
+        </content>
+        <content type="*/html">
+        </content>
+    </filter>
+
+    <filter name="RANGERUI/rangerui/outbound/headers">
+        <content type="application/x-http-headers">
+            <apply path="Location" rule="RANGERUI/rangerui/outbound/login/headers/location"/>
+        </content>
+    </filter>
+
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
@@ -1,0 +1,36 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="RANGERUI" name="rangerui" version="1.0.0">
+    <routes>
+        <route path="/ranger">
+            <rewrite apply="RANGERUI/rangerui/inbound/root" to="request.url"/>
+            <rewrite apply="RANGERUI/rangerui/outbound/links" to="response.body"/>
+            <rewrite apply="RANGERUI/rangerui/outbound/headers" to="response.headers"/>
+        </route>
+        <route path="/ranger/**">
+            <rewrite apply="RANGERUI/rangerui/inbound/path" to="request.url"/>
+            <rewrite apply="RANGERUI/rangerui/outbound/links" to="response.body"/>
+            <rewrite apply="RANGERUI/rangerui/outbound/headers" to="response.headers"/>
+        </route>
+        <route path="/ranger/**?**">
+            <rewrite apply="RANGERUI/rangerui/inbound/query" to="request.url"/>
+            <rewrite apply="RANGERUI/rangerui/outbound/links" to="response.body"/>
+            <rewrite apply="RANGERUI/rangerui/outbound/headers" to="response.headers"/>
+        </route>
+    </routes>
+    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch"/>
+</service>

--- a/gateway-test/src/test/java/org/apache/knox/gateway/deploy/DeploymentFactoryFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/deploy/DeploymentFactoryFuncTest.java
@@ -661,7 +661,7 @@ public class DeploymentFactoryFuncTest {
     authenticationTopology.setName( "test-cluster" );
 
     final Service service = new Service();
-    service.setRole( "RANGER" );
+    service.setRole( "AMBARIUI" );
     service.addUrl( "http://localhost:50070/" );
     federationTopology.addService( service );
     authenticationTopology.addService( service );
@@ -712,31 +712,27 @@ public class DeploymentFactoryFuncTest {
     /* Make sure AnonymousAuthFilter is added to the chain */
     final Document gateway = XmlUtils.readXml( war.get( "%2F/WEB-INF/gateway.xml" ).getAsset().openStream() );
 
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/pattern", equalTo( "/ranger/service/public/**" ) ) );
+    assertThat( gateway, hasXPath( "/gateway/resource[1]/pattern", equalTo( "/ambari" ) ) );
     assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[1]/role", equalTo( "authentication" ) ) );
     assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[1]/class", equalTo( "org.apache.knox.gateway.filter.AnonymousAuthFilter" ) ) );
     assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[2]/role", equalTo( "rewrite" ) ) );
     assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[2]/class", equalTo( "org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletFilter" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[3]/role", equalTo( "identity-assertion" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[3]/class", equalTo( "org.apache.knox.gateway.identityasserter.filter.IdentityAsserterFilter" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[4]/role", equalTo( "authorization" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[4]/class", equalTo( "org.apache.knox.gateway.filter.AclsAuthorizationFilter" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[5]/role", equalTo( "dispatch" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[5]/class", equalTo( "org.apache.knox.gateway.dispatch.GatewayDispatchFilter" ) ) );
+    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[3]/role", equalTo( "authorization" ) ) );
+    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[3]/class", equalTo( "org.apache.knox.gateway.filter.AclsAuthorizationFilter" ) ) );
+    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[4]/role", equalTo( "dispatch" ) ) );
+    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[4]/class", equalTo( "org.apache.knox.gateway.dispatch.GatewayDispatchFilter" ) ) );
 
     final Document gateway2 = XmlUtils.readXml( war.get( "%2F/WEB-INF/gateway.xml" ).getAsset().openStream() );
 
-    assertThat( gateway2, hasXPath( "/gateway/resource[1]/pattern", equalTo( "/ranger/service/public/**" ) ) );
+    assertThat( gateway2, hasXPath( "/gateway/resource[1]/pattern", equalTo( "/ambari" ) ) );
     assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[1]/role", equalTo( "authentication" ) ) );
     assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[1]/class", equalTo( "org.apache.knox.gateway.filter.AnonymousAuthFilter" ) ) );
     assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[2]/role", equalTo( "rewrite" ) ) );
     assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[2]/class", equalTo( "org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletFilter" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[3]/role", equalTo( "identity-assertion" ) ) );
-    assertThat( gateway, hasXPath( "/gateway/resource[1]/filter[3]/class", equalTo( "org.apache.knox.gateway.identityasserter.filter.IdentityAsserterFilter" ) ) );
-    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[4]/role", equalTo( "authorization" ) ) );
-    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[4]/class", equalTo( "org.apache.knox.gateway.filter.AclsAuthorizationFilter" ) ) );
-    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[5]/role", equalTo( "dispatch" ) ) );
-    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[5]/class", equalTo( "org.apache.knox.gateway.dispatch.GatewayDispatchFilter" ) ) );
+    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[3]/role", equalTo( "authorization" ) ) );
+    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[3]/class", equalTo( "org.apache.knox.gateway.filter.AclsAuthorizationFilter" ) ) );
+    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[4]/role", equalTo( "dispatch" ) ) );
+    assertThat( gateway2, hasXPath( "/gateway/resource[1]/filter[4]/class", equalTo( "org.apache.knox.gateway.dispatch.GatewayDispatchFilter" ) ) );
 
     LOG_EXIT();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make Ranger service definitions support trusted proxy by default

## How was this patch tested?

* `mvn -T.5C clean verify -Ppackage,release`
* Tested proxying Ranger UI and API with updated service definitions on Kerberized cluster