### PR TITLE
KNOX-1877 - Atlas service definitions should default to trusted proxy

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/rewrite.xml
@@ -1,0 +1,21 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="ATLAS-API/atlas/inbound" pattern="*://*:*/**/atlas/api/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[ATLAS-API]}/api/{path=**}?{**}"/>
+    </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/service.xml
@@ -1,0 +1,23 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="ATLAS-API" name="atlas-api" version="2.0.0">
+    <routes>
+        <route path="/atlas/api/**"/>
+    </routes>
+
+    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch" ha-classname="org.apache.knox.gateway.ha.dispatch.AtlasApiTrustedProxyHaDispatch"/>
+</service>

--- a/gateway-service-definitions/src/main/resources/services/atlas/2.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/2.0.0/rewrite.xml
@@ -1,0 +1,78 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <!-- inbound rules -->
+    <rule dir="IN" name="ATLAS/atlas/inbound/root" pattern="*://*:*/**/atlas/">
+        <rewrite template="{$serviceUrl[ATLAS]}/"/>
+    </rule>
+
+    <rule dir="IN" name="ATLAS/atlas/inbound/path" pattern="*://*:*/**/atlas/{**}">
+        <rewrite template="{$serviceUrl[ATLAS]}/{**}"/>
+    </rule>
+
+    <rule dir="IN" name="ATLAS/atlas/inbound/query" pattern="*://*:*/**/atlas/{**}?{**}">
+        <rewrite template="{$serviceUrl[ATLAS]}/{**}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/links" pattern="css/{**}">
+        <rewrite template="{$frontend[path]}/atlas/css/{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/links" pattern="js/{**}">
+        <rewrite template="{$frontend[path]}/atlas/js/{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/styles" pattern="img/{**}">
+        <rewrite template="{$frontend[path]}/atlas/img/{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/contextpath">
+        <rewrite template="{$frontend[path]}/atlas/"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/extrapath">
+        <rewrite template="{$frontend[topology]}/atlas/j_spring_security_check"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/index">
+        <rewrite template="{$frontend[path]}/atlas/index.html"/>
+    </rule>
+
+    <rule dir="OUT" name="ATLAS/atlas/outbound/login/headers/location">
+        <match pattern="*://*:*/login.jsp"/>
+        <rewrite template="{$frontend[url]}/atlas/login.jsp"/>
+    </rule>
+
+    <filter name="ATLAS/atlas/outbound/links">
+        <content type="*/x-javascript">
+            <apply path="j_spring_security_check" rule="ATLAS/atlas/outbound/extrapath"/>
+            <apply path="index.html" rule="ATLAS/atlas/outbound/index"/>
+        </content>
+        <content type="application/javascript">
+            <apply path="j_spring_security_check" rule="ATLAS/atlas/outbound/extrapath"/>
+            <apply path="index.html" rule="ATLAS/atlas/outbound/index"/>
+        </content>
+        <content type="*/html">
+        </content>
+    </filter>
+
+    <filter name="ATLAS/atlas/outbound/headers">
+        <content type="application/x-http-headers">
+            <apply path="Location" rule="ATLAS/atlas/outbound/login/headers/location"/>
+        </content>
+    </filter>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/atlas/2.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/2.0.0/service.xml
@@ -1,0 +1,39 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="ATLAS" name="atlas" version="2.0.0">
+    <routes>
+        <route path="/atlas">
+            <rewrite apply="ATLAS/atlas/inbound/root" to="request.url"/>
+            <rewrite apply="ATLAS/atlas/outbound/links" to="response.body"/>
+            <rewrite apply="ATLAS/atlas/outbound/headers" to="response.headers"/>
+        </route>
+
+        <route path="/atlas/**">
+            <rewrite apply="ATLAS/atlas/inbound/path" to="request.url"/>
+            <rewrite apply="ATLAS/atlas/outbound/links" to="response.body"/>
+            <rewrite apply="ATLAS/atlas/outbound/headers" to="response.headers"/>
+        </route>
+
+        <route path="/atlas/**?**">
+            <rewrite apply="ATLAS/atlas/inbound/query" to="request.url"/>
+            <rewrite apply="ATLAS/atlas/outbound/links" to="response.body"/>
+            <rewrite apply="ATLAS/atlas/outbound/headers" to="response.headers"/>
+        </route>
+    </routes>
+
+    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch" ha-classname="org.apache.knox.gateway.ha.dispatch.AtlasTrustedProxyHaDispatch" />
+</service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add new atlas and atlas-api 2.0.0 service definitions that default to trusted proxy.

## How was this patch tested?

* `mvn clean verify -Ppackage,release`
* Manually tested updated service definitions with Kerberized Atlas and Knox