### PR TITLE
KNOX-1879 - HDFSUI service definition doesn't work with DefaultHaDispatch

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/service.xml
@@ -51,5 +51,5 @@
             <rewrite apply="DATANODE/outbound/datanode/static" to="response.body"/>
         </route>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
 </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add ha-classname to HDFSUI service definition

## How was this patch tested?

* `mvn clean verify -Ppackage,release`
* Checked that HDFSUI service definition works with HaProvider on cluster
