### PR TITLE
KNOX-1912 - X509CertificateUtil should set CN and SAN

### DIFF
--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.security.KeyPair;
@@ -57,149 +58,196 @@ public class X509CertificateUtil {
    * @return self-signed X.509 certificate
    */
   public static X509Certificate generateCertificate(String dn, KeyPair pair, int days, String algorithm) {
-
-  PrivateKey privkey = pair.getPrivate();
-  Object x509CertImplObject = null;
-  try {
-    Date from = new Date();
-    Date to = new Date(from.getTime() + days * 86400000L);
-
-    Class<?> certInfoClass = Class.forName(getX509CertInfoModuleName());
-    Constructor<?> certInfoConstr = certInfoClass.getConstructor();
-    Object certInfoObject = certInfoConstr.newInstance();
-
-    // CertificateValidity interval = new CertificateValidity(from, to);
-    Class<?> certValidityClass = Class.forName(getX509CertifValidityModuleName());
-    Constructor<?> certValidityConstr = certValidityClass
-        .getConstructor(new Class[] { Date.class, Date.class });
-    Object certValidityObject = certValidityConstr.newInstance(from, to);
-
-    BigInteger sn = new BigInteger(64, new SecureRandom());
-
-    // X500Name owner = new X500Name(dn);
-    Class<?> x500NameClass = Class.forName(getX509X500NameModuleName());
-    Constructor<?> x500NameConstr = x500NameClass
-        .getConstructor(new Class[] { String.class });
-    Object x500NameObject = x500NameConstr.newInstance(dn);
-
-    Method methodSET = certInfoObject.getClass().getMethod("set", String.class, Object.class);
-
-    // info.set(X509CertInfo.VALIDITY, interval);
-    methodSET.invoke(certInfoObject, getSetField(certInfoObject, "VALIDITY"),certValidityObject);
-
-    // info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(sn));
-    Class<?> certificateSerialNumberClass = Class.forName(getCertificateSerialNumberModuleName());
-    Constructor<?> certificateSerialNumberConstr = certificateSerialNumberClass
-        .getConstructor(new Class[] { BigInteger.class });
-    Object certificateSerialNumberObject = certificateSerialNumberConstr
-        .newInstance(sn);
-    methodSET.invoke(certInfoObject, getSetField(certInfoObject, "SERIAL_NUMBER"),
-        certificateSerialNumberObject);
-
-    // info.set(X509CertInfo.SUBJECT, new CertificateSubjectName(owner));
+    PrivateKey privkey = pair.getPrivate();
+    Object x509CertImplObject = null;
     try {
-      Class<?> certificateSubjectNameClass = Class.forName(getCertificateSubjectNameModuleName());
-      Constructor<?> certificateSubjectNameConstr = certificateSubjectNameClass
-          .getConstructor(new Class[] { x500NameClass });
-      Object certificateSubjectNameObject = certificateSubjectNameConstr
-          .newInstance(x500NameObject);
-      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "SUBJECT"),
-          certificateSubjectNameObject);
-    }
-    catch (InvocationTargetException ite) {
-      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "SUBJECT"),
-          x500NameObject);
-    }
+      Date from = new Date();
+      Date to = new Date(from.getTime() + days * 86400000L);
 
-    // info.set(X509CertInfo.ISSUER, new CertificateIssuerName(owner));
-    try {
-      Class<?> certificateIssuerNameClass = Class.forName(getCertificateIssuerNameModuleName());
-      Constructor<?> certificateIssuerNameConstr = certificateIssuerNameClass
-          .getConstructor(new Class[] { x500NameClass });
-      Object certificateIssuerNameObject = certificateIssuerNameConstr
-          .newInstance(x500NameObject);
-      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "ISSUER"),
-          certificateIssuerNameObject);
-    }
-    catch (InvocationTargetException ite) {
-      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "ISSUER"),
-          x500NameObject);
-    }
+      Class<?> certInfoClass = Class.forName(getX509CertInfoModuleName());
+      Constructor<?> certInfoConstr = certInfoClass.getConstructor();
+      Object certInfoObject = certInfoConstr.newInstance();
 
-    // info.set(X509CertInfo.KEY, new CertificateX509Key(pair.getPublic()));
-    Class<?> certificateX509KeyClass = Class.forName(getCertificateX509KeyModuleName());
-    Constructor<?> certificateX509KeyConstr = certificateX509KeyClass
-        .getConstructor(new Class[] { PublicKey.class });
-    Object certificateX509KeyObject = certificateX509KeyConstr
-        .newInstance(pair.getPublic());
-    methodSET.invoke(certInfoObject, getSetField(certInfoObject, "KEY"),
-        certificateX509KeyObject);
-    // info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
-    Class<?> certificateVersionClass = Class.forName(getCertificateVersionModuleName());
-    Constructor<?> certificateVersionConstr = certificateVersionClass
-        .getConstructor(new Class[] { int.class });
-    Constructor<?> certificateVersionConstr0 = certificateVersionClass
-        .getConstructor();
-    Object certInfoObject0 = certificateVersionConstr0.newInstance();
-    Field v3IntField = certInfoObject0.getClass()
-        .getDeclaredField("V3");
-    v3IntField.setAccessible(true);
-    int fValue = v3IntField.getInt(certInfoObject0);
-    Object certificateVersionObject = certificateVersionConstr
-        .newInstance(fValue);
-    methodSET.invoke(certInfoObject, getSetField(certInfoObject, "VERSION"),
-        certificateVersionObject);
+      // CertificateValidity interval = new CertificateValidity(from, to);
+      Class<?> certValidityClass = Class.forName(getX509CertifValidityModuleName());
+      Constructor<?> certValidityConstr = certValidityClass.getConstructor(Date.class, Date.class);
+      Object certValidityObject = certValidityConstr.newInstance(from, to);
 
-    // AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
-    Class<?> algorithmIdClass = Class.forName(getAlgorithmIdModuleName());
-    Field md5WithRSAField = algorithmIdClass
-        .getDeclaredField("md5WithRSAEncryption_oid");
-    md5WithRSAField.setAccessible(true);
-    Class<?> objectIdentifierClass = Class.forName(getObjectIdentifierModuleName());
+      BigInteger sn = new BigInteger(64, new SecureRandom());
 
-    Object md5WithRSAValue = md5WithRSAField.get(algorithmIdClass);
+      // X500Name owner = new X500Name(dn);
+      Class<?> x500NameClass = Class.forName(getX509X500NameModuleName());
+      Constructor<?> x500NameConstr = x500NameClass.getConstructor(String.class);
+      Object x500NameObject = x500NameConstr.newInstance(dn);
 
-    Constructor<?> algorithmIdConstr = algorithmIdClass
-        .getConstructor(new Class[] { objectIdentifierClass });
-    Object algorithmIdObject = algorithmIdConstr.newInstance(md5WithRSAValue);
+      Method methodSET = certInfoObject.getClass().getMethod("set", String.class, Object.class);
 
-    // info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algo));
-    Class<?> certificateAlgorithmIdClass = Class.forName(getCertificateAlgorithmIdModuleName());
-    Constructor<?> certificateAlgorithmIdConstr = certificateAlgorithmIdClass
-        .getConstructor(new Class[] { algorithmIdClass });
-    Object certificateAlgorithmIdObject = certificateAlgorithmIdConstr
-        .newInstance(algorithmIdObject);
-    methodSET.invoke(certInfoObject, getSetField(certInfoObject, "ALGORITHM_ID"),
-        certificateAlgorithmIdObject);
+      // info.set(X509CertInfo.VALIDITY, interval);
+      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "VALIDITY"),certValidityObject);
 
-    // Sign the cert to identify the algorithm that's used.
-    // X509CertImpl cert = new X509CertImpl(info);
-    Class<?> x509CertImplClass = Class.forName(getX509CertImplModuleName());
-    Constructor<?> x509CertImplConstr = x509CertImplClass
-        .getConstructor(new Class[] { certInfoClass });
-    x509CertImplObject = x509CertImplConstr.newInstance(certInfoObject);
+      // info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(sn));
+      Class<?> certificateSerialNumberClass = Class.forName(getCertificateSerialNumberModuleName());
+      Constructor<?> certificateSerialNumberConstr = certificateSerialNumberClass
+                                                         .getConstructor(BigInteger.class);
+      Object certificateSerialNumberObject = certificateSerialNumberConstr.newInstance(sn);
+      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "SERIAL_NUMBER"),
+          certificateSerialNumberObject);
 
-    // cert.sign(privkey, algorithm);
-    Method methoSIGN = x509CertImplObject.getClass().getMethod("sign",
-        PrivateKey.class, String.class);
-    methoSIGN.invoke(x509CertImplObject, privkey, algorithm);
+      // info.set(X509CertInfo.SUBJECT, new CertificateSubjectName(owner));
+      try {
+        Class<?> certificateSubjectNameClass = Class.forName(getCertificateSubjectNameModuleName());
+        Constructor<?> certificateSubjectNameConstr = certificateSubjectNameClass
+                                                          .getConstructor(x500NameClass);
+        Object certificateSubjectNameObject = certificateSubjectNameConstr
+                                                  .newInstance(x500NameObject);
+        methodSET.invoke(certInfoObject, getSetField(certInfoObject, "SUBJECT"),
+            certificateSubjectNameObject);
+      }
+      catch (InvocationTargetException ite) {
+        methodSET.invoke(certInfoObject, getSetField(certInfoObject, "SUBJECT"),
+            x500NameObject);
+      }
 
-    // Update the algorith, and resign.
-    // algo = (AlgorithmId)cert.get(X509CertImpl.SIG_ALG);
-    Method methoGET = x509CertImplObject.getClass().getMethod("get", String.class);
-    String sig_alg = getSetField(x509CertImplObject, "SIG_ALG");
+      // info.set(X509CertInfo.ISSUER, new CertificateIssuerName(owner));
+      try {
+        Class<?> certificateIssuerNameClass = Class.forName(getCertificateIssuerNameModuleName());
+        Constructor<?> certificateIssuerNameConstr = certificateIssuerNameClass
+                                                         .getConstructor(x500NameClass);
+        Object certificateIssuerNameObject = certificateIssuerNameConstr.newInstance(x500NameObject);
+        methodSET.invoke(certInfoObject, getSetField(certInfoObject, "ISSUER"),
+            certificateIssuerNameObject);
+      }
+      catch (InvocationTargetException ite) {
+        methodSET.invoke(certInfoObject, getSetField(certInfoObject, "ISSUER"),
+            x500NameObject);
+      }
 
-    String certAlgoIdNameValue = getSetField(certificateAlgorithmIdObject, "NAME");
-    String certAlgoIdAlgoValue = getSetField(certificateAlgorithmIdObject, "ALGORITHM");
-    // info.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, algo);
-    methodSET.invoke(certInfoObject, certAlgoIdNameValue + "."
-        + certAlgoIdAlgoValue,
-        methoGET.invoke(x509CertImplObject, sig_alg));
+      // info.set(X509CertInfo.KEY, new CertificateX509Key(pair.getPublic()));
+      Class<?> certificateX509KeyClass = Class.forName(getCertificateX509KeyModuleName());
+      Constructor<?> certificateX509KeyConstr = certificateX509KeyClass
+                                                    .getConstructor(PublicKey.class);
+      Object certificateX509KeyObject = certificateX509KeyConstr.newInstance(pair.getPublic());
+      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "KEY"),
+          certificateX509KeyObject);
+      // info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+      Class<?> certificateVersionClass = Class.forName(getCertificateVersionModuleName());
+      Constructor<?> certificateVersionConstr = certificateVersionClass.getConstructor(int.class);
+      Constructor<?> certificateVersionConstr0 = certificateVersionClass.getConstructor();
+      Object certInfoObject0 = certificateVersionConstr0.newInstance();
+      Field v3IntField = certInfoObject0.getClass().getDeclaredField("V3");
+      v3IntField.setAccessible(true);
+      int fValue = v3IntField.getInt(certInfoObject0);
+      Object certificateVersionObject = certificateVersionConstr.newInstance(fValue);
+      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "VERSION"),
+          certificateVersionObject);
 
-    // cert = new X509CertImpl(info);
-    x509CertImplObject = x509CertImplConstr.newInstance(certInfoObject);
-    // cert.sign(privkey, algorithm);
-    methoSIGN.invoke(x509CertImplObject, privkey, algorithm);
+      // AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
+      Class<?> algorithmIdClass = Class.forName(getAlgorithmIdModuleName());
+      Field md5WithRSAField = algorithmIdClass.getDeclaredField("md5WithRSAEncryption_oid");
+      md5WithRSAField.setAccessible(true);
+      Class<?> objectIdentifierClass = Class.forName(getObjectIdentifierModuleName());
+
+      Object md5WithRSAValue = md5WithRSAField.get(algorithmIdClass);
+
+      Constructor<?> algorithmIdConstr = algorithmIdClass.getConstructor(objectIdentifierClass);
+      Object algorithmIdObject = algorithmIdConstr.newInstance(md5WithRSAValue);
+
+      // info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algo));
+      Class<?> certificateAlgorithmIdClass = Class.forName(getCertificateAlgorithmIdModuleName());
+      Constructor<?> certificateAlgorithmIdConstr = certificateAlgorithmIdClass
+                                                        .getConstructor(algorithmIdClass);
+      Object certificateAlgorithmIdObject = certificateAlgorithmIdConstr
+                                                .newInstance(algorithmIdObject);
+      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "ALGORITHM_ID"),
+          certificateAlgorithmIdObject);
+
+      // Set the SAN extension
+      Class<?> generalNameInterfaceClass = Class.forName(getGeneralNameInterfaceModuleName());
+
+      Class<?> generalNameClass = Class.forName(getGeneralNameModuleName());
+      Constructor<?> generalNameConstr = generalNameClass.getConstructor(generalNameInterfaceClass);
+
+      // GeneralNames generalNames = new GeneralNames();
+      Class<?> generalNamesClass = Class.forName(getGeneralNamesModuleName());
+      Constructor<?> generalNamesConstr = generalNamesClass.getConstructor();
+      Object generalNamesObject = generalNamesConstr.newInstance();
+      Method generalNamesAdd = generalNamesObject.getClass().getMethod("add", generalNameClass);
+
+      Class<?> dnsNameClass = Class.forName(getDNSNameModuleName());
+      Constructor<?> dnsNameConstr = dnsNameClass.getConstructor(String.class);
+
+      // Pull the hostname out of the DN
+      String hostname = dn.split(",", 2)[0].split("=", 2)[1];
+      if("localhost".equals(hostname)) {
+        String detectedHostname = InetAddress.getLocalHost().getHostName();
+        // DNSName dnsName = new DNSName(detectedHostname);
+        Object dnsNameObject = dnsNameConstr.newInstance(detectedHostname);
+        // GeneralName generalName = new GeneralName(dnsName);
+        Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
+        // generalNames.add(generalName);
+        generalNamesAdd.invoke(generalNamesObject, generalNameObject);
+      }
+
+      // DNSName dnsName = new DNSName(hostname);
+      Object dnsNameObject = dnsNameConstr.newInstance(hostname);
+      // GeneralName generalName = new GeneralName(dnsName);
+      Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
+      // generalNames.add(generalName);
+      generalNamesAdd.invoke(generalNamesObject, generalNameObject);
+
+      // SubjectAlternativeNameExtension san = new SubjectAlternativeNameExtension(generalNames);
+      Class<?> subjectAlternativeNameExtensionClass = Class.forName(
+          getSubjectAlternativeNameExtensionModuleName());
+      Constructor<?> subjectAlternativeNameExtensionConstr =
+          subjectAlternativeNameExtensionClass.getConstructor(generalNamesClass);
+      Object subjectAlternativeNameExtensionObject = subjectAlternativeNameExtensionConstr
+                                                         .newInstance(generalNamesObject);
+
+      // CertificateExtensions certificateExtensions = new CertificateExtensions();
+      Class<?> certificateExtensionsClass = Class.forName(getCertificateExtensionsModuleName());
+      Constructor<?> certificateExtensionsConstr = certificateExtensionsClass.getConstructor();
+      Object certificateExtensionsObject = certificateExtensionsConstr.newInstance();
+
+      // certificateExtensions.set(san.getExtensionId().toString(), san);
+      Method getExtensionIdMethod = subjectAlternativeNameExtensionObject.getClass()
+                                        .getMethod("getExtensionId");
+      String sanExtensionId = getExtensionIdMethod.invoke(subjectAlternativeNameExtensionObject)
+                                  .toString();
+      Method certificateExtensionsSet = certificateExtensionsObject.getClass().getMethod("set",
+          String.class, Object.class);
+      certificateExtensionsSet.invoke(certificateExtensionsObject, sanExtensionId,
+          subjectAlternativeNameExtensionObject);
+
+      // info.set(X509CertInfo.EXTENSIONS, certificateExtensions);
+      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "EXTENSIONS"),
+          certificateExtensionsObject);
+
+      // Sign the cert to identify the algorithm that's used.
+      // X509CertImpl cert = new X509CertImpl(info);
+      Class<?> x509CertImplClass = Class.forName(getX509CertImplModuleName());
+      Constructor<?> x509CertImplConstr = x509CertImplClass.getConstructor(certInfoClass);
+      x509CertImplObject = x509CertImplConstr.newInstance(certInfoObject);
+
+      // cert.sign(privkey, algorithm);
+      Method methoSIGN = x509CertImplObject.getClass().getMethod("sign",
+          PrivateKey.class, String.class);
+      methoSIGN.invoke(x509CertImplObject, privkey, algorithm);
+
+      // Update the algorith, and resign.
+      // algo = (AlgorithmId)cert.get(X509CertImpl.SIG_ALG);
+      Method methoGET = x509CertImplObject.getClass().getMethod("get", String.class);
+      String sig_alg = getSetField(x509CertImplObject, "SIG_ALG");
+
+      String certAlgoIdNameValue = getSetField(certificateAlgorithmIdObject, "NAME");
+      String certAlgoIdAlgoValue = getSetField(certificateAlgorithmIdObject, "ALGORITHM");
+      // info.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, algo);
+      methodSET.invoke(certInfoObject, certAlgoIdNameValue + "." + certAlgoIdAlgoValue,
+          methoGET.invoke(x509CertImplObject, sig_alg));
+
+      // cert = new X509CertImpl(info);
+      x509CertImplObject = x509CertImplConstr.newInstance(certInfoObject);
+      // cert.sign(privkey, algorithm);
+      methoSIGN.invoke(x509CertImplObject, privkey, algorithm);
     } catch (Exception e) {
       LOG.failedToGenerateCertificate(e);
     }
@@ -208,62 +256,109 @@ public class X509CertificateUtil {
 
   private static String getX509CertInfoModuleName() {
     return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.X509CertInfo"
-        : "sun.security.x509.X509CertInfo";
+               : "sun.security.x509.X509CertInfo";
   }
 
   private static String getX509CertifValidityModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateValidity"
-        : "sun.security.x509.CertificateValidity";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateValidity" :
+               "sun.security.x509.CertificateValidity";
   }
 
   private static String getX509X500NameModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.X500Name"
-        : "sun.security.x509.X500Name";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.X500Name" :
+               "sun.security.x509.X500Name";
   }
 
   private static String getCertificateSerialNumberModuleName() {
-   return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateSerialNumber"
-        : "sun.security.x509.CertificateSerialNumber";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateSerialNumber" :
+               "sun.security.x509.CertificateSerialNumber";
   }
 
   private static String getCertificateSubjectNameModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateSubjectName"
-        : "sun.security.x509.CertificateSubjectName";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateSubjectName" :
+               "sun.security.x509.CertificateSubjectName";
   }
 
   private static String getCertificateIssuerNameModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateIssuerName"
-        : "sun.security.x509.CertificateIssuerName";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateIssuerName" :
+               "sun.security.x509.CertificateIssuerName";
   }
 
   private static String getCertificateX509KeyModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateX509Key"
-        : "sun.security.x509.CertificateX509Key";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateX509Key" :
+               "sun.security.x509.CertificateX509Key";
   }
 
   private static String getCertificateVersionModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateVersion"
-        : "sun.security.x509.CertificateVersion";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateVersion" :
+               "sun.security.x509.CertificateVersion";
   }
 
   private static String getAlgorithmIdModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.AlgorithmId"
-        : "sun.security.x509.AlgorithmId";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.AlgorithmId" :
+               "sun.security.x509.AlgorithmId";
   }
 
   private static String getObjectIdentifierModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.util.ObjectIdentifier"
-        : "sun.security.util.ObjectIdentifier";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.util.ObjectIdentifier" :
+               "sun.security.util.ObjectIdentifier";
   }
 
   private static String getCertificateAlgorithmIdModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.CertificateAlgorithmId"
-        : "sun.security.x509.CertificateAlgorithmId";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateAlgorithmId" :
+               "sun.security.x509.CertificateAlgorithmId";
+  }
+
+  private static String getGeneralNameInterfaceModuleName() {
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.GeneralNameInterface" :// TODO
+               "sun.security.x509.GeneralNameInterface";
+  }
+
+  private static String getGeneralNameModuleName() {
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.GeneralName" : // TODO
+               "sun.security.x509.GeneralName";
+  }
+
+  private static String getGeneralNamesModuleName() {
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.GeneralNames" : // TODO
+               "sun.security.x509.GeneralNames";
+  }
+
+  private static String getDNSNameModuleName() {
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.DNSName" : // TODO
+               "sun.security.x509.DNSName";
+  }
+
+  private static String getSubjectAlternativeNameExtensionModuleName() {
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.SubjectAlternativeNameExtension" : // TODO
+               "sun.security.x509.SubjectAlternativeNameExtension";
+  }
+
+  private static String getCertificateExtensionsModuleName() {
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.CertificateExtensions" : // TODO
+               "sun.security.x509.CertificateExtensions";
   }
 
   private static String getX509CertImplModuleName() {
-    return System.getProperty("java.vendor").contains("IBM") ? "com.ibm.security.x509.X509CertImpl"
-        : "sun.security.x509.X509CertImpl";
+    return System.getProperty("java.vendor").contains("IBM") ?
+               "com.ibm.security.x509.X509CertImpl" :
+               "sun.security.x509.X509CertImpl";
   }
 
   private static String getSetField(Object obj, String setString)
@@ -274,7 +369,7 @@ public class X509CertificateUtil {
   }
 
   public static void writeCertificateToFile(Certificate cert, final File file)
-       throws CertificateEncodingException, IOException {
+      throws CertificateEncodingException, IOException {
     byte[] bytes = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     try(OutputStream out = Files.newOutputStream(file.toPath()) ) {
@@ -363,4 +458,3 @@ public class X509CertificateUtil {
     }
   }
 }
-


### PR DESCRIPTION
## What changes were proposed in this pull request?

`X509CertificateUtil` should set both CN and SAN when creating a certificate.

## How was this patch tested?

* `mvn -T.5C clean verify -Ppackage,release`
* Knox doesn't compile with IBM so moving forward there.
* Tested with building and running Knox. Checked that OOTB there are 2 SAN cert entries one for `localhost` and the other for the hostname of the machine.
