### PR TITLE
KNOX-1917 - DefaultKeystoreService should use a shared read lock

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -472,8 +472,11 @@ public class DefaultKeystoreService implements KeystoreService, Service {
 
       // If the file does not exist, create an empty keystore
       if (Files.exists(keyStoreFilePath)) {
-        try (InputStream input = Files.newInputStream(keyStoreFilePath)) {
-          keyStore.load(input, password);
+        try (FileChannel fileChannel = FileChannel.open(keyStoreFilePath, StandardOpenOption.READ)) {
+          fileChannel.lock(0L, Long.MAX_VALUE, true);
+          try (InputStream input = Channels.newInputStream(fileChannel)) {
+            keyStore.load(input, password);
+          }
         }
       } else {
         keyStore.load(null, password);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use a shared read lock to ensure that multiple processes won't read/write at the same time.

## How was this patch tested?

`mvn -T.5C clean verify -Ppackage,release`
