### PR TITLE
KNOX-1918 - Atlas API - prevent global HDFS rules from triggering

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/atlas-api/0.1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas-api/0.1.2.0/rewrite.xml
@@ -14,9 +14,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
-
 <rules>
+    <!-- KNOX-1918 prevent global HDFS rules from triggering -->
+    <rule dir="OUT" name="ATLAS-API/atlas/outbound" pattern="hdfs://{host}/{path=**}?{**}">
+        <rewrite template="hdfs://{host}/{path=**}?{**}"/>
+    </rule>
     <rule dir="IN" name="ATLAS-API/atlas/inbound" pattern="*://*:*/**/atlas/api/{path=**}?{**}">
         <rewrite template="{$serviceUrl[ATLAS-API]}/api/{path=**}?{**}"/>
     </rule>

--- a/gateway-service-definitions/src/main/resources/services/atlas-api/0.8.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas-api/0.8.0/rewrite.xml
@@ -14,9 +14,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
-
 <rules>
+    <!-- KNOX-1918 prevent global HDFS rules from triggering -->
+    <rule dir="OUT" name="ATLAS-API/atlas/outbound" pattern="hdfs://{host}/{path=**}?{**}">
+        <rewrite template="hdfs://{host}/{path=**}?{**}"/>
+    </rule>
     <rule dir="IN" name="ATLAS-API/atlas/inbound" pattern="*://*:*/**/atlas/api/{path=**}?{**}">
         <rewrite template="{$serviceUrl[ATLAS-API]}/api/{path=**}?{**}"/>
     </rule>

--- a/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/rewrite.xml
@@ -15,6 +15,10 @@
    limitations under the License.
 -->
 <rules>
+    <!-- KNOX-1918 prevent global HDFS rules from triggering -->
+    <rule dir="OUT" name="ATLAS-API/atlas/outbound" pattern="hdfs://{host}/{path=**}?{**}">
+        <rewrite template="hdfs://{host}/{path=**}?{**}"/>
+    </rule>
     <rule dir="IN" name="ATLAS-API/atlas/inbound" pattern="*://*:*/**/atlas/api/{path=**}?{**}">
         <rewrite template="{$serviceUrl[ATLAS-API]}/api/{path=**}?{**}"/>
     </rule>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prevent global HDFS rules from triggering when using Atlas API

## How was this patch tested?

* `mvn -T.5C clean verify -Ppackage,release`
* Checked that hdfs urls are not changed when using Atlas API
