### PR TITLE
KNOX-1919 - Taking gateway.path into consideration when processing redirectToUrl provider param with the OOTB knoxsso.xml sample

### DIFF
--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/filter/RedirectToUrlFilterTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/filter/RedirectToUrlFilterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class RedirectToUrlFilterTest {
+
+  private static final String OUT_OF_THE_BOX_REDIRECT_TO_URL = "/${GATEWAY_PATH}/knoxsso/knoxauth/login.html";
+  private static final String CUSTOM_REDIRECT_URL = "/route/to/my/web/app/login/page";
+
+  @Test
+  public void shouldReplaceGatewayPathInRedirectUrl() throws Exception {
+    final String customGatewayPath = "customGatewayPath";
+    final RedirectToUrlFilter filter = new RedirectToUrlFilter();
+    filter.init(buildFilterConfigAndSetOtherMockExpectations(OUT_OF_THE_BOX_REDIRECT_TO_URL, customGatewayPath));
+    assertEquals("/" + customGatewayPath + "/knoxsso/knoxauth/login.html", filter.getRedirectUrl());
+  }
+
+  @Test
+  public void shouldNotTouchAlreadyCustomizedRedirectUrl() throws Exception {
+    final RedirectToUrlFilter filter = new RedirectToUrlFilter();
+    filter.init(buildFilterConfigAndSetOtherMockExpectations(CUSTOM_REDIRECT_URL, ""));
+    assertEquals(CUSTOM_REDIRECT_URL, filter.getRedirectUrl());
+  }
+
+  private FilterConfig buildFilterConfigAndSetOtherMockExpectations(String redirectUrl, String customGatewayPath) {
+    final FilterConfig filterConfig = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(filterConfig.getInitParameter(RedirectToUrlFilter.REDIRECT_TO_URL)).andReturn(redirectUrl);
+    final ServletContext servletContext = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(filterConfig.getServletContext()).andReturn(servletContext);
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gatewayConfig);
+    EasyMock.expect(gatewayConfig.getGatewayPath()).andReturn(customGatewayPath);
+
+    EasyMock.replay(filterConfig, servletContext, gatewayConfig);
+    return filterConfig;
+  }
+}

--- a/gateway-release/home/conf/topologies/knoxsso.xml
+++ b/gateway-release/home/conf/topologies/knoxsso.xml
@@ -39,7 +39,7 @@
             </param>
             <param>
                 <name>redirectToUrl</name>
-                <value>/gateway/knoxsso/knoxauth/login.html</value>
+                <value>/${GATEWAY_PATH}/knoxsso/knoxauth/login.html</value>
             </param>
             <param>
                 <name>restrictedCookies</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before my change, the `redirectToUrl` parameter in the OOTB `knoxsso.xml` topology was hardcoded to `/gateway/knoxsso/knoxauth/login.html`. In case we changed the `gateway.path` configuration element the admin UI became unreachable. If you knew where to find the root cause it was easy to fix it, but we can do this smarter.
I changed the sample URL to `/${GATEWAY_PATH}/knoxsso/knoxauth/login.html` and made sure to replace the `${GATEWAY_PATH}` placeholder with the actual value of `gateway.path`.

## How was this patch tested?

Tested manually as follows: 

1. changed `gateway.path` to `smolnar_test` in `gateway-site.xml`
2. restarted the server
3. hit the following URL: `https://localhost:8443/smolnar_test/manager/admin-ui/`
4. as expected I got redirected to the proper URL

<img width="1674" alt="Screen Shot 2019-07-10 at 3 36 09 PM" src="https://user-images.githubusercontent.com/34065904/60976271-ab0b2180-a32d-11e9-981f-6ceb7eab0237.png">
