### PR TITLE
KNOX-1816 - Optionally added shellcheck validation to our build and fixed issues shellcheck already found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ before_install:
 script:
   # argLine to work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925
   - $DOCKERRUN $IMAGE mvn -T1C verify -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -DargLine="-Djdk.net.URLClassPath.disableClassPathURLCheck=true" -B -V
+  - shellcheck gateway-shell-release/home/bin/*.sh
+  - shellcheck gateway-release/home/bin/*.sh
+  - shellcheck gateway-release-common/home/bin/*.sh
 git:
   depth: 1000
 cache:

--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -22,7 +22,8 @@
 ############################
 
 # The app's home dir
-APP_HOME_DIR=`dirname $APP_BIN_DIR`
+APP_HOME_DIR=$(dirname "$APP_BIN_DIR")
+export APP_HOME_DIR
 
 # The app's PID
 APP_PID=0
@@ -32,6 +33,10 @@ APP_START_WAIT_TIME=2
 
 # The kill wait time limit
 APP_KILL_WAIT_TIME=10
+
+#dynamic library path
+DEFAULT_JAVA_LIB_PATH="-Djava.library.path=$APP_HOME_DIR/ext/native"
+APP_JAVA_LIB_PATH=${KNOX_GATEWAY_JAVA_LIB_PATH:-$DEFAULT_JAVA_LIB_PATH}
 
 
 ############################
@@ -60,7 +65,7 @@ function findJava() {
 
   # Try to find java on PATH.
   if [ "$JAVA" == "" ]; then
-    JAVA=`which java 2>/dev/null`
+    JAVA=$(command -v java 2>/dev/null)
     if [ ! -x "$JAVA" ]; then
       JAVA=""
     fi
@@ -69,8 +74,10 @@ function findJava() {
   # Use the search patterns to find java.
   if [ "$JAVA" == "" ]; then
     for pattern in "${JAVA_VERSION_PATTERNS[@]}"; do
-      JAVA=( $(find /usr -executable -name java -print 2> /dev/null | grep "$pattern" | head -n 1 ) )
+      # shellcheck disable=SC2207
+      JAVAS=( $(find /usr -executable -name java -print 2> /dev/null | grep "$pattern" | head -n 1 ) )
       if [ -x "$JAVA" ]; then
+        JAVA=${JAVAS[1]}
         break
       else
         JAVA=""
@@ -88,47 +95,47 @@ function checkJava() {
 }
 
 function printEnv() {
-    if [ ! -z "$APP_CONF_DIR" ]; then
+    if [ -n "$APP_CONF_DIR" ]; then
       echo "APP_CONF_DIR = $APP_CONF_DIR"
     fi
     
-    if [ ! -z "$APP_LOG_DIR" ]; then
+    if [ -n "$APP_LOG_DIR" ]; then
       echo "APP_LOG_DIR = $APP_LOG_DIR"
     fi
 
-    if [ ! -z "$APP_DATA_DIR" ]; then
+    if [ -n "$APP_DATA_DIR" ]; then
       echo "APP_DATA_DIR = $APP_DATA_DIR"
     fi
 
-    if [ ! -z "$APP_MEM_OPTS" ]; then
+    if [ -n "$APP_MEM_OPTS" ]; then
       echo "APP_MEM_OPTS = $APP_MEM_OPTS"
     fi
 
-    if [ ! -z "$APP_LOG_OPTS" ]; then
+    if [ -n "$APP_LOG_OPTS" ]; then
       echo "APP_LOG_OPTS = $APP_LOG_OPTS"
     fi
 
-    if [ ! -z "$APP_DBG_OPTS" ]; then
+    if [ -n "$APP_DBG_OPTS" ]; then
       echo "APP_DBG_OPTS = $APP_DBG_OPTS"
     fi
 
-    if [ ! -z "$APP_PID_DIR" ]; then
+    if [ -n "$APP_PID_DIR" ]; then
       echo "APP_PID_DIR = $APP_PID_DIR"
     fi
 
-    if [ ! -z "$APP_JAVA_LIB_PATH" ]; then
+    if [ -n "$APP_JAVA_LIB_PATH" ]; then
       echo "APP_JAVA_LIB_PATH = $APP_JAVA_LIB_PATH"
     fi
 
-    if [ ! -z "$APP_JAR" ]; then
+    if [ -n "$APP_JAR" ]; then
       echo "APP_JAR = $APP_JAR"
     fi
 }
 
 function appIsRunning {
-   if [ $1 -eq 0 ]; then return 0; fi
+   if [ "$1" -eq 0 ]; then return 0; fi
 
-   ps -p $1 > /dev/null
+   ps -p "$1" > /dev/null
 
    if [ $? -eq 1 ]; then
      return 0
@@ -140,18 +147,18 @@ function appIsRunning {
 # Returns 0 if the app is running and sets the $PID variable
 # TODO: this may be a false indication: it may happen the process started but it'll return with a <>0 exit code due to validation errors; this should be fixed ASAP
 function getPID {
-   if [ ! -d $APP_PID_DIR ]; then
+   if [ ! -d "$APP_PID_DIR" ]; then
       printf "Can't find PID dir.\n"
       exit 1
    fi
-   if [ ! -f $APP_PID_FILE ]; then
+   if [ ! -f "$APP_PID_FILE" ]; then
      APP_PID=0
      return 1
    fi
 
-   APP_PID="$(<$APP_PID_FILE)"
+   APP_PID="$(<"$APP_PID_FILE")"
 
-   ps -p $APP_PID > /dev/null
+   ps -p "$APP_PID" > /dev/null
    # if the exit code was 1 then it isn't running
    if [ "$?" -eq "1" ];
    then
@@ -163,73 +170,69 @@ function getPID {
 
 function appStart {
    if [ "$APP_RUNNING_IN_FOREGROUND" == true ]; then
-      exec $JAVA $APP_JAVA_OPTS -jar $APP_JAR $@
+      exec "$JAVA" "$APP_JAVA_OPTS" -jar "$APP_JAR" "$@"
    else
-      getPID
-      if [ $? -eq 0 ]; then
-         printf "$APP_LABEL is already running with PID $APP_PID.\n"
+      if getPID; then
+         printf "%s is already running with PID %d.\n" "$APP_LABEL" "$APP_PID"
          exit 0
       fi
 
-      printf "Starting $APP_LABEL "
+      printf "Starting %s " "$APP_LABEL"
 
-      rm -f $APP_PID_FILE
+      rm -f "$APP_PID_FILE"
 
-      nohup $JAVA $APP_JAVA_OPTS -jar $APP_JAR $@ >>$APP_OUT_FILE 2>>$APP_ERR_FILE & printf $!>$APP_PID_FILE || exit 1
+      nohup "$JAVA" "$APP_JAVA_OPTS" -jar "$APP_JAR" "$@" >>"$APP_OUT_FILE" 2>>"$APP_ERR_FILE" & printf %s $!>"$APP_PID_FILE" || exit 1
 
       ##give a second to the JVM to start and run validation
       sleep 1
 
       getPID
       for ((i=0; i<APP_START_WAIT_TIME*10; i++)); do
-         appIsRunning $APP_PID
-         if [ $? -eq 0 ]; then break; fi
+         if appIsRunning "$APP_PID"; then break; fi
          sleep 0.1
       done
-      appIsRunning $APP_PID
+      appIsRunning "$APP_PID"
       if [ $? -ne 1 ]; then
          printf "failed.\n"
-         rm -f $APP_PID_FILE
+         rm -f "$APP_PID_FILE"
          exit 1
       fi
-      printf "succeeded with PID $APP_PID.\n"
+      printf "succeeded with PID %s.\n" "$APP_PID"
       return 0
    fi
 }
 
 function appStop {
    getPID
-   appIsRunning $APP_PID
-   if [ "$?" -eq "0" ]; then
-     printf "$APP_LABEL is not running.\n"
-     rm -f $APP_PID_FILE
+   if appIsRunning "$APP_PID"; then
+     printf "%s is not running.\n" "$APP_LABEL"
+     rm -f "$APP_PID_FILE"
      return 0
    fi
 
-   printf "Stopping $APP_LABEL with PID $APP_PID "
-   appKill $APP_PID >>$APP_OUT_FILE 2>>$APP_ERR_FILE
+   printf "Stopping %s with PID %d " "$APP_LABEL" "$APP_PID"
 
-   if [ "$?" -ne "0" ]; then
+   if ! appKill "$APP_PID" >>"$APP_OUT_FILE" 2>>"$APP_ERR_FILE"; then
      printf "failed. \n"
      exit 1
    else
-     rm -f $APP_PID_FILE
+     rm -f "$APP_PID_FILE"
      printf "succeeded.\n"
      return 0
    fi
 }
 
 function appStatus {
-   printf "$APP_LABEL "
+   printf "%s " "$APP_LABEL"
    getPID
    if [ "$?" -eq "1" ]; then
      printf "is not running. No PID file found.\n"
      return 0
    fi
 
-   appIsRunning $APP_PID
+   appIsRunning "$APP_PID"
    if [ "$?" -eq "1" ]; then
-     printf "is running with PID $APP_PID.\n"
+     printf "is running with PID %d.\n" "$APP_PID"
      exit 1
    else
      printf "is not running.\n"
@@ -240,29 +243,26 @@ function appStatus {
 # Removing the app's PID/ERR/OUT files if app is not running
 function appClean {
    getPID
-   appIsRunning $APP_PID
-   if [ "$?" -eq "0" ]; then
+   if appIsRunning "$APP_PID"; then
      deleteLogFiles
      return 0
    else
-     printf "Can't clean files.  $APP_LABEL is running with PID $APP_PID.\n"
+     printf "Can't clean files.  %s is running with PID %d.\n" "$APP_LABEL" "$APP_PID"
      exit 1
    fi
 }
 
 function appKill {
    local localPID=$1
-   kill $localPID || return 1
+   kill "$localPID" || return 1
    for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
-      appIsRunning $localPID
-      if [ "$?" -eq "0" ]; then return 0; fi
+      if appIsRunning "$localPID"; then return 0; fi
       sleep 0.1
    done
 
-   kill -s KILL $localPID || return 1
+   kill -s KILL "$localPID" || return 1
    for ((i=0; i<APP_KILL_WAIT_TIME*10; i++)); do
-      appIsRunning $localPID
-      if [ "$?" -eq "0" ]; then return 0; fi
+      if appIsRunning "$localPID"; then return 0; fi
       sleep 0.1
    done
 
@@ -270,12 +270,12 @@ function appKill {
 }
 
 function deleteLogFiles {
-     rm -f $APP_PID_FILE
-     printf "Removed the $APP_LABEL PID file: $APP_PID_FILE.\n"
+     rm -f "$APP_PID_FILE"
+     printf "Removed the %s PID file.\n" "$APP_LABEL"
 
-     rm -f $APP_OUT_FILE
-     printf "Removed the $APP_LABEL OUT file: $APP_OUT_FILE.\n"
+     rm -f "$APP_OUT_FILE"
+     printf "Removed the %s OUT file.\n" "$APP_LABEL"
 
-     rm -f $APP_ERR_FILE
-     printf "Removed the $APP_LABEL ERR file: $APP_ERR_FILE.\n"
+     rm -f "$APP_ERR_FILE"
+     printf "Removed the %s ERR file.\n" "$APP_LABEL"
 }

--- a/gateway-release-common/pom.xml
+++ b/gateway-release-common/pom.xml
@@ -29,4 +29,43 @@
 
   <name>gateway-release-common</name>
   <description>Contains common resources to be used by released artifacts</description>
+  
+  <profiles>
+        <profile>
+           <!-- Running this profile require you to have the 'shellcheck' tool installed on your DEV environment. Check out https://github.com/koalaman/shellcheck#installing for more information -->
+           <activation>
+               <property>
+                   <name>shellcheck</name>
+                   <value>true</value>
+               </property>
+           </activation>
+           <build>
+               <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>shellcheck_verification</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>shellcheck</executable>
+                            <arguments>
+                                <argument>-x</argument>
+                                <!-- for any reason *.sh does not work if I run it from Maven; it's ok to do it in the command line -->
+                                <argument>${project.basedir}/home/bin/knox-functions.sh</argument>
+                                <argument>${project.basedir}/home/bin/knox-env.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+               </plugins>
+           </build>
+        </profile>
+  </profiles>
 </project>

--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# shellcheck disable=SC1090
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +18,7 @@
 #
 
 # The app's label
-APP_LABEL=Gateway
+export APP_LABEL=Gateway
 
 # The app's name
 APP_NAME=gateway
@@ -27,21 +27,21 @@ APP_NAME=gateway
 APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Setup the common environment
-. $APP_BIN_DIR/knox-env.sh
+. "$APP_BIN_DIR"/knox-env.sh
 
 # Source common functions
-. $APP_BIN_DIR/knox-functions.sh
+. "$APP_BIN_DIR"/knox-functions.sh
 
 # The app's jar name
 APP_JAR="$APP_BIN_DIR/gateway.jar"
 
 # The app's conf dir
 DEFAULT_APP_CONF_DIR="$APP_HOME_DIR/conf"
-APP_CONF_DIR=${KNOX_GATEWAY_CONF_DIR:-$DEFAULT_APP_CONF_DIR}
+export APP_CONF_DIR=${KNOX_GATEWAY_CONF_DIR:-$DEFAULT_APP_CONF_DIR}
 
 # The app's data dir
 DEFAULT_APP_DATA_DIR="$APP_HOME_DIR/data"
-APP_DATA_DIR=${KNOX_GATEWAY_DATA_DIR:-$DEFAULT_APP_DATA_DIR}
+export APP_DATA_DIR=${KNOX_GATEWAY_DATA_DIR:-$DEFAULT_APP_DATA_DIR}
 
 # The app's log dir
 DEFAULT_APP_LOG_DIR="$APP_HOME_DIR/logs"
@@ -56,23 +56,19 @@ APP_MEM_OPTS="$KNOX_GATEWAY_MEM_OPTS"
 # The app's debugging options
 APP_DBG_OPTS="$KNOX_GATEWAY_DBG_OPTS"
 
-#dynamic library path
-DEFAULT_JAVA_LIB_PATH="-Djava.library.path=$APP_HOME_DIR/ext/native"
-APP_JAVA_LIB_PATH=${KNOX_GATEWAY_JAVA_LIB_PATH:-$DEFAULT_JAVA_LIB_PATH}
-
 # Name of PID file
 DEFAULT_APP_PID_DIR="$APP_HOME_DIR/pids"
 APP_PID_DIR=${KNOX_GATEWAY_PID_DIR:-$DEFAULT_APP_PID_DIR}
-APP_PID_FILE="$APP_PID_DIR/$APP_NAME.pid"
+export APP_PID_FILE="$APP_PID_DIR/$APP_NAME.pid"
 
 # Name of LOG/OUT/ERR file
-APP_OUT_FILE="$APP_LOG_DIR/$APP_NAME.out"
-APP_ERR_FILE="$APP_LOG_DIR/$APP_NAME.err"
+export APP_OUT_FILE="$APP_LOG_DIR/$APP_NAME.out"
+export APP_ERR_FILE="$APP_LOG_DIR/$APP_NAME.err"
 
 DEFAULT_APP_RUNNING_IN_FOREGROUND="$GATEWAY_SERVER_RUN_IN_FOREGROUND"
-APP_RUNNING_IN_FOREGROUND=${KNOX_GATEWAY_RUNNING_IN_FOREGROUND:-$DEFAULT_APP_RUNNING_IN_FOREGROUND}
+export APP_RUNNING_IN_FOREGROUND=${KNOX_GATEWAY_RUNNING_IN_FOREGROUND:-$DEFAULT_APP_RUNNING_IN_FOREGROUND}
 
-APP_JAVA_OPTS="$APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
+export APP_JAVA_OPTS="$APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
 
 function main {
    checkJava
@@ -101,59 +97,59 @@ function main {
          printHelp
          ;;
       *)
-         printf "Usage: $0 {start|stop|status|clean}\n"
+         printf "Usage: %s {start|stop|status|clean}\n" "$0"
          ;;
    esac
 }
 
 function setupEnv {
    checkEnv
-   $JAVA -jar $APP_JAR -persist-master -nostart
+   "$JAVA" -jar "$APP_JAR" -persist-master -nostart
    return 0
 }
 
 function checkReadDir {
     if [ ! -e "$1" ]; then
-        printf "Directory $1 does not exist.\n"
+        printf "Directory %s does not exist.\n" "$1"
         exit 1
     fi
     if [ ! -d "$1" ]; then
-        printf "File $1 is not a directory.\n"
+        printf "File %s is not a directory.\n" "$1"
         exit 1
     fi
     if [ ! -r "$1" ]; then
-        printf "Directory $1 is not readable by current user $USER.\n"
+        printf "Directory %s is not readable by current user %s.\n" "$1" "$USER"
         exit 1
     fi
     if [ ! -x "$1" ]; then
-        printf "Directory $1 is not executable by current user $USER.\n"
+        printf "Directory %s is not executable by current user %s.\n" "$1" "$USER"
         exit 1
     fi
 }
 
 function checkWriteDir {
-    checkReadDir $1
+    checkReadDir "$1"
     if [ ! -w "$1" ]; then
-        printf "Directory $1 is not writable by current user $USER.\n"
+        printf "Directory %s is not writable by current user %s.\n" "$1" "$USER"
         exit 1
     fi
 }
 
 function checkEnv {
     # Make sure not running as root
-    if [ "`id -u`" -eq "0" ]; then
+    if [ "$(id -u)" -eq "0" ]; then
         echo "This command $0 must not be run as root."
         exit 1
     fi
 
-    checkWriteDir $APP_LOG_DIR
-    checkWriteDir $APP_PID_DIR
+    checkWriteDir "$APP_LOG_DIR"
+    checkWriteDir "$APP_PID_DIR"
 }
 
 function printHelp {
-   $JAVA -jar $APP_JAR -help
+   "$JAVA" -jar "$APP_JAR" -help
    return 0
 }
 
 #Starting main
-main $@
+main "$@"

--- a/gateway-release/home/bin/knoxcli.sh
+++ b/gateway-release/home/bin/knoxcli.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# shellcheck disable=SC1090
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -18,10 +18,7 @@
 #
 
 # The app's label
-APP_LABEL=KnoxCLI
-
-# The app's name
-APP_NAME=knoxcli
+export APP_LABEL=KnoxCLI
 
 # Start/stop script location
 APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -30,10 +27,12 @@ APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_JAR="$APP_BIN_DIR/knoxcli.jar"
 
 # Setup the common environment
-. $APP_BIN_DIR/knox-env.sh
+. "$APP_BIN_DIR"/knox-env.sh
 
 # Source common functions
-. $APP_BIN_DIR/knox-functions.sh
+. "$APP_BIN_DIR"/knox-functions.sh
+
+APP_JAVA_OPTS="$APP_JAVA_LIB_PATH $KNOX_CLI_MEM_OPTS $KNOX_CLI_DBG_OPTS $KNOX_CLI_LOG_OPTS"
 
 function main {
    checkJava
@@ -41,10 +40,10 @@ function main {
    #printf "Starting $APP_LABEL \n"
    #printf "$@"
 
-   $JAVA $KNOX_CLI_MEM_OPTS $KNOX_CLI_DBG_OPTS $KNOX_CLI_LOG_OPTS -jar $APP_JAR $@ || exit 1
+   $JAVA "$APP_JAVA_OPTS" -jar "$APP_JAR" "$@" || exit 1
 
    return 0
 }
 
 #Starting main
-main $@
+main "$@"

--- a/gateway-release/home/bin/ldap.sh
+++ b/gateway-release/home/bin/ldap.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# shellcheck disable=SC1090
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -18,7 +18,7 @@
 #
 
 # The app's label
-APP_LABEL=LDAP
+export APP_LABEL=LDAP
 
 # The app's name
 APP_NAME=ldap
@@ -27,13 +27,13 @@ APP_NAME=ldap
 APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # The app's JAR name
-APP_JAR="$APP_BIN_DIR/ldap.jar"
+export APP_JAR="$APP_BIN_DIR/ldap.jar"
 
 # Setup the common environment
-. $APP_BIN_DIR/knox-env.sh
+. "$APP_BIN_DIR"/knox-env.sh
 
 # Source common functions
-. $APP_BIN_DIR/knox-functions.sh
+. "${APP_BIN_DIR}"/knox-functions.sh
 
 # The app's conf dir
 DEFAULT_APP_CONF_DIR="$APP_HOME_DIR/conf"
@@ -55,17 +55,17 @@ APP_DBG_OPTS="$KNOX_LDAP_DBG_OPTS"
 # The name of the PID file
 DEFAULT_APP_PID_DIR="$APP_HOME_DIR/pids"
 APP_PID_DIR=${KNOX_LDAP_PID_DIR:-$DEFAULT_APP_PID_DIR}
-APP_PID_FILE="$APP_PID_DIR/$APP_NAME.pid"
+export APP_PID_FILE="$APP_PID_DIR/$APP_NAME.pid"
 
 #Name of LOG/OUT/ERR file
 APP_OUT_FILE="$APP_LOG_DIR/$APP_NAME.out"
 APP_ERR_FILE="$APP_LOG_DIR/$APP_NAME.err"
 
 DEFAULT_APP_RUNNING_IN_FOREGROUND="$LDAP_SERVER_RUN_IN_FOREGROUND"
-APP_RUNNING_IN_FOREGROUND=${KNOX_LDAP_RUNNING_IN_FOREGROUND:-$DEFAULT_APP_RUNNING_IN_FOREGROUND}
+export APP_RUNNING_IN_FOREGROUND=${KNOX_LDAP_RUNNING_IN_FOREGROUND:-$DEFAULT_APP_RUNNING_IN_FOREGROUND}
 
 # JAVA options used by the JVM
-APP_JAVA_OPTS="$APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
+export APP_JAVA_OPTS="$APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
 
 function main {
    checkJava
@@ -76,7 +76,7 @@ function main {
            printEnv
          fi
          createLogFiles
-         appStart $APP_CONF_DIR
+         appStart "$APP_CONF_DIR"
          ;;
       stop)   
          appStop
@@ -98,14 +98,14 @@ function createLogFiles {
       printf "Can't find log dir.\n"
       exit 1
    fi
-   if [ ! -f "$APP_OUT_FILE" ]; then touch $APP_OUT_FILE; fi
-   if [ ! -f "$APP_ERR_FILE" ]; then touch $APP_ERR_FILE; fi   
+   if [ ! -f "$APP_OUT_FILE" ]; then touch "$APP_OUT_FILE"; fi
+   if [ ! -f "$APP_ERR_FILE" ]; then touch "$APP_ERR_FILE"; fi
 }
 
 function printHelp {
-   printf "Usage: $0 {start|stop|status|clean}\n"
+   printf "Usage: %s {start|stop|status|clean}\n" "$0"
    return 0
 }
 
 # Starting main
-main $@
+main "$@"

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -160,6 +160,43 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+           <!-- Running this profile require you to have the 'shellcheck' tool installed on your DEV environment. Check out https://github.com/koalaman/shellcheck#installing for more information -->
+           <activation>
+               <property>
+                   <name>shellcheck</name>
+                   <value>true</value>
+               </property>
+           </activation>
+           <build>
+               <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>shellcheck_verification</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>shellcheck</executable>
+                            <arguments>
+                                <argument>-x</argument>
+                                <!-- for any reason *.sh does not work if I run it from Maven; it's ok to do it in the command line -->
+                                <argument>${project.basedir}/home/bin/ldap.sh</argument>
+                                <argument>${project.basedir}/home/bin/gateway.sh</argument>
+                                <argument>${project.basedir}/home/bin/knoxcli.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+               </plugins>
+           </build>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/gateway-shell-release/home/bin/knoxshell.sh
+++ b/gateway-shell-release/home/bin/knoxshell.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# shellcheck disable=SC1090
 #
 #  Licensed to the Apache Software Foundation (ASF) under one or more
 #  contributor license agreements.  See the NOTICE file distributed with
@@ -18,25 +18,19 @@
 #
 
 # The app's label
-APP_LABEL=KnoxShell
-
-# The app's name
-APP_NAME=knoxshell
+export APP_LABEL=KnoxShell
 
 # Start/stop script location
 APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Setup the common environment
-. $APP_BIN_DIR/knox-env.sh
+. "$APP_BIN_DIR"/knox-env.sh
 
 # Source common functions
-. $APP_BIN_DIR/knox-functions.sh
+. "$APP_BIN_DIR"/knox-functions.sh
 
 # The app's jar name
 APP_JAR="$APP_BIN_DIR/knoxshell.jar"
-
-# The apps home dir
-APP_HOME_DIR=`dirname $APP_BIN_DIR`
 
 # The app's logging options
 APP_LOG_OPTS="$KNOX_SHELL_LOG_OPTS"
@@ -47,6 +41,8 @@ APP_MEM_OPTS="$KNOX_SHELL_MEM_OPTS"
 # The app's debugging options
 APP_DBG_OPTS="$KNOX_SHELL_DBG_OPTS"
 
+# JAVA options used by the JVM
+export APP_JAVA_OPTS="$APP_JAVA_LIB_PATH $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS"
 
 function main {
    checkJava
@@ -59,17 +55,17 @@ function main {
             echo "Illegal number of parameters."
             printHelp
         else
-          $JAVA -cp $APP_JAR org.apache.knox.gateway.shell.KnoxSh $1 --gateway $2 || exit 1
+          $JAVA -cp "$APP_JAR" org.apache.knox.gateway.shell.KnoxSh "$1" --gateway "$2" || exit 1
         fi
          ;;
       list|destroy)
-        $JAVA -cp $APP_JAR org.apache.knox.gateway.shell.KnoxSh $1 || exit 1
+        "$JAVA" -cp "$APP_JAR" org.apache.knox.gateway.shell.KnoxSh "$1" || exit 1
          ;;
       help)
          printHelp
          ;;
       *)
-          $JAVA $APP_MEM_OPTS $APP_DBG_OPTS $APP_LOG_OPTS -jar $APP_JAR $@ || exit 1
+         $JAVA "$APP_JAVA_OPTS" -jar "$APP_JAR" "$@" || exit 1
          ;;
    esac
    
@@ -101,4 +97,4 @@ function printHelp {
 }
 
 #Starting main
-main $@
+main "$@"

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -168,6 +168,41 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+           <!-- Running this profile require you to have the 'shellcheck' tool installed on your DEV environment. Check out https://github.com/koalaman/shellcheck#installing for more information -->
+           <activation>
+               <property>
+                   <name>shellcheck</name>
+                   <value>true</value>
+               </property>
+           </activation>
+           <build>
+               <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>shellcheck_verification</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>shellcheck</executable>
+                            <arguments>
+                                <argument>-x</argument>
+                                <!-- for any reason *.sh does not work if I run it from Maven; it's ok to do it in the command line -->
+                                <argument>${project.basedir}/home/bin/knoxshell.sh</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+               </plugins>
+           </build>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
         <easymock.version>4.0.2</easymock.version>
         <eclipselink.version>2.7.4</eclipselink.version>
         <ehcache.version>2.6.11</ehcache.version>
+        <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <findsecbugs-plugin.version>1.9.0</findsecbugs-plugin.version>
         <forbiddenapis.version>2.6</forbiddenapis.version>
         <groovy.version>2.5.7</groovy.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Shellcheck](https://www.shellcheck.net/) is a very useful tool that helps developers to avoid common pitfalls with their bash scripts. The following changes were made:
1. optionally added shellcheck validation to knox build in these sub-projects:

- gateway-release
- gateway-release-common
- gateway-shell-release

To activate this feature the command should include `-Dshellcheck=true` (by default this is turned off).
**Note:** since there is no official Maven plugin for shellcheck you need to install the tool manually first. According to its [Github readme](https://github.com/koalaman/shellcheck#travis-ci) Travis CI comes with built-in shellcheck so it should be safe to include that flag in our TravisCI build.

2. I fixed our shell scripts to conform shellcheck

## How was this patch tested?

Built the project with and without the new flag (I made an error on purpose in some of the scripts to see if the build actually fails):
```
$ mvn -DskipTests -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dpmd.skip=true -Drat.skip -Dshellcheck=true -Ppackage,release package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 02:29 min
[INFO] Finished at: 2019-07-12T10:30:46+02:00
[INFO] Final Memory: 146M/1618M
[INFO] ------------------------------------------------------------------------
```

Additionally, I deployed Knox locally and tested if the scripts are working as expected:
```
################
## gateway.sh ##
################

$ bin/gateway.sh
Usage: bin/gateway.sh {start|stop|status|clean}

$ bin/gateway.sh status
Gateway is running with PID 24139.

$ bin/gateway.sh stop
Stopping Gateway with PID 24139 succeeded.

$ bin/gateway.sh stop
Gateway is not running.

$ bin/gateway.sh clean
Removed the Gateway PID file.
Removed the Gateway OUT file.
Removed the Gateway ERR file.

$ bin/gateway.sh start
Starting Gateway succeeded with PID 24841.

$ bin/gateway.sh start
Gateway is already running with PID 24841.

$ bin/gateway.sh clean
Can't clean files.  Gateway is running with PID 24841.

$ bin/gateway.sh status
Gateway is running with PID 24841.

$ bin/gateway.sh stop
Stopping Gateway with PID 24841 succeeded.
```
```
#############
## ldap.sh ##
#############

$ bin/ldap.sh
Usage: bin/ldap.sh {start|stop|status|clean}

$ bin/ldap.sh status
LDAP is not running. No PID file found.

$ bin/ldap.sh stop
LDAP is not running.

$ bin/ldap.sh clean
Removed the LDAP PID file.
Removed the LDAP OUT file.
Removed the LDAP ERR file.

$ bin/ldap.sh start
Starting LDAP succeeded with PID 25045.

$ bin/ldap.sh start
LDAP is already running with PID 25045.

$ bin/ldap.sh clean
Can't clean files.  LDAP is running with PID 25045.

$ bin/ldap.sh status
LDAP is running with PID 25045.

$ bin/ldap.sh stop
Stopping LDAP with PID 25045 succeeded.

$ bin/ldap.sh stop
LDAP is not running.
```
```
##################
## knoxshell.sh ##
##################  
  
$ bin/knoxshell.sh help

Apache Knox Client Shell
The client shell facility provide a CLI for establishing and managing Apache Knox Sessions
and executing the Apache Knox groovy-based DSL scripts. It may also be used to enter an
interactive shell where groovy-based DSL and groovy code may be entered and executed in realtime.

knoxshell usage: 
   knoxshell.sh [[buildTrustStore <knox-gateway-url>|init <topology-url>|list|destroy|help] | [<script-file-name>]]
   ----------------------------------------------------------
   buildTrustStore <knox-gateway-url> - downloads the given gateway server's public certificate and builds a trust store to be used by KnoxShell
        example: knoxshell.sh buildTrustStore https://localhost:8443/
   init <topology-url> - requests a session from the knox token service at the url
        example: knoxshell.sh init https://localhost:8443/gateway/sandbox
   list - lists the details of the cached knox session token
        example: knoxshell.sh list
   destroy - removes the cached knox session token
        example: knoxshell.sh destroy
   <script-file-name> - executes the groovy script file
        example: knoxshell.sh ~/bin/ls.groovy  


$ bin/knoxshell.sh buildTrustStore https://localhost:8443
Opening connection to localhost:8443...
Starting SSL handshake...
Gateway server's certificate is exported into /Users/smolnar/gateway-client-trust.jks
```
```
################
## knoxcli.sh ##
################

$ bin/knoxcli.sh 
KnoxCLI {cmd} [options]
   [--help]
   [version]
   [create-master [--force] [--master mastersecret] [--generate]]
   [create-cert [--force] [--hostname h]]
   [export-cert [--type PEM|JKS|JCEKS|PKCS12]]
   [create-alias aliasname [--cluster clustername] [ (--value v) | (--generate) ]]
   [delete-alias aliasname [--cluster clustername]]
   [list-alias [--cluster clustername]]
   [redeploy [--cluster clustername]]
   [list-topologies]
   [validate-topology [--cluster clustername] | [--path "path/to/file"]]
   [user-auth-test [--cluster clustername] [--u username] [--p password] [--g]]
   [system-user-auth-test [--cluster clustername] [--d]]
   [service-test [--u username] [--p password] [--cluster clustername] [--hostname name] [--port port]]
   [list-registry-clients]
   [list-provider-configs --registry-client name]
   [upload-provider-config providerConfigFile --registry-client name [--entry-name entryName]]
   [list-descriptors --registry-client name]
   [upload-descriptor descriptorFile --registry-client name [--entry-name entryName]]
   [delete-provider-config providerConfig --registry-client name]
   [delete-descriptor descriptor --registry-client name]
   [get-registry-acl entry --registry-client name]

===============================================================================
version

Displays Knox version information.

===============================================================================
create-master [--force] [--master mastersecret] [--generate]

...
===============================================================================
delete-descriptor descriptor --registry-client name

Deletes a simple descriptor from the specified remote registry.


===============================================================================

$ bin/knoxcli.sh version
Apache Knox: 1.4.0-SNAPSHOT (77f0c515a9948b860668b6efea16d6879e166a78)
```