### PR TITLE
KNOX-1922 - Processing a DNSName only if the hostname starts with a letter

### DIFF
--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -83,10 +83,10 @@ public abstract class AbstractJWTFilterTest  {
   protected abstract String getVerificationPemProperty();
 
   private static String buildDistinguishedName(String hostname) {
-    MessageFormat headerFormatter = new MessageFormat(dnTemplate, Locale.ROOT);
+    final String cn = Character.isAlphabetic(hostname.charAt(0)) ? hostname : "localhost";
     String[] paramArray = new String[1];
-    paramArray[0] = hostname;
-    return headerFormatter.format(paramArray);
+    paramArray[0] = cn;
+    return new MessageFormat(dnTemplate, Locale.ROOT).format(paramArray);
   }
 
   @BeforeClass

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -181,31 +181,36 @@ public class X509CertificateUtil {
       if("localhost".equals(hostname)) {
         // Add short hostname
         String detectedHostname = InetAddress.getLocalHost().getHostName();
-        // DNSName dnsName = new DNSName(detectedHostname);
-        Object dnsNameObject = dnsNameConstr.newInstance(detectedHostname);
+        if (Character.isAlphabetic(detectedHostname.charAt(0))) {
+          // DNSName dnsName = new DNSName(detectedHostname);
+          Object dnsNameObject = dnsNameConstr.newInstance(detectedHostname);
+          // GeneralName generalName = new GeneralName(dnsName);
+          Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
+          // generalNames.add(generalName);
+          generalNamesAdd.invoke(generalNamesObject, generalNameObject);
+        }
+
+        // Add fully qualified hostname
+        String detectedFullyQualifiedHostname = InetAddress.getLocalHost().getCanonicalHostName();
+        if (Character.isAlphabetic(detectedFullyQualifiedHostname.charAt(0))) {
+          // DNSName dnsName = new DNSName(detectedFullyQualifiedHostname);
+          Object fullyQualifiedDnsNameObject = dnsNameConstr.newInstance(detectedFullyQualifiedHostname);
+          // GeneralName generalName = new GeneralName(fullyQualifiedDnsNameObject);
+          Object fullyQualifiedGeneralNameObject = generalNameConstr.newInstance(
+              fullyQualifiedDnsNameObject);
+          // generalNames.add(fullyQualifiedGeneralNameObject);
+          generalNamesAdd.invoke(generalNamesObject, fullyQualifiedGeneralNameObject);
+        }
+      }
+
+      if (Character.isAlphabetic(hostname.charAt(0))) {
+        // DNSName dnsName = new DNSName(hostname);
+        Object dnsNameObject = dnsNameConstr.newInstance(hostname);
         // GeneralName generalName = new GeneralName(dnsName);
         Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
         // generalNames.add(generalName);
         generalNamesAdd.invoke(generalNamesObject, generalNameObject);
-
-        // Add fully qualified hostname
-        String detectedFullyQualifiedHostname = InetAddress.getLocalHost().getCanonicalHostName();
-        // DNSName dnsName = new DNSName(detectedFullyQualifiedHostname);
-        Object fullyQualifiedDnsNameObject = dnsNameConstr.newInstance(
-            detectedFullyQualifiedHostname);
-        // GeneralName generalName = new GeneralName(fullyQualifiedDnsNameObject);
-        Object fullyQualifiedGeneralNameObject = generalNameConstr.newInstance(
-            fullyQualifiedDnsNameObject);
-        // generalNames.add(fullyQualifiedGeneralNameObject);
-        generalNamesAdd.invoke(generalNamesObject, fullyQualifiedGeneralNameObject);
       }
-
-      // DNSName dnsName = new DNSName(hostname);
-      Object dnsNameObject = dnsNameConstr.newInstance(hostname);
-      // GeneralName generalName = new GeneralName(dnsName);
-      Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
-      // generalNames.add(generalName);
-      generalNamesAdd.invoke(generalNamesObject, generalNameObject);
 
       // SubjectAlternativeNameExtension san = new SubjectAlternativeNameExtension(generalNames);
       Class<?> subjectAlternativeNameExtensionClass = Class.forName(

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -176,6 +176,7 @@ public class X509CertificateUtil {
       Class<?> dnsNameClass = Class.forName(getDNSNameModuleName());
       Constructor<?> dnsNameConstr = dnsNameClass.getConstructor(String.class);
 
+      boolean generalNameAdded = false;
       // Pull the hostname out of the DN
       String hostname = dn.split(",", 2)[0].split("=", 2)[1];
       if("localhost".equals(hostname)) {
@@ -188,6 +189,7 @@ public class X509CertificateUtil {
           Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
           // generalNames.add(generalName);
           generalNamesAdd.invoke(generalNamesObject, generalNameObject);
+          generalNameAdded = true;
         }
 
         // Add fully qualified hostname
@@ -196,10 +198,10 @@ public class X509CertificateUtil {
           // DNSName dnsName = new DNSName(detectedFullyQualifiedHostname);
           Object fullyQualifiedDnsNameObject = dnsNameConstr.newInstance(detectedFullyQualifiedHostname);
           // GeneralName generalName = new GeneralName(fullyQualifiedDnsNameObject);
-          Object fullyQualifiedGeneralNameObject = generalNameConstr.newInstance(
-              fullyQualifiedDnsNameObject);
+          Object fullyQualifiedGeneralNameObject = generalNameConstr.newInstance(fullyQualifiedDnsNameObject);
           // generalNames.add(fullyQualifiedGeneralNameObject);
           generalNamesAdd.invoke(generalNamesObject, fullyQualifiedGeneralNameObject);
+          generalNameAdded = true;
         }
       }
 
@@ -210,34 +212,29 @@ public class X509CertificateUtil {
         Object generalNameObject = generalNameConstr.newInstance(dnsNameObject);
         // generalNames.add(generalName);
         generalNamesAdd.invoke(generalNamesObject, generalNameObject);
+        generalNameAdded = true;
       }
 
-      // SubjectAlternativeNameExtension san = new SubjectAlternativeNameExtension(generalNames);
-      Class<?> subjectAlternativeNameExtensionClass = Class.forName(
-          getSubjectAlternativeNameExtensionModuleName());
-      Constructor<?> subjectAlternativeNameExtensionConstr =
-          subjectAlternativeNameExtensionClass.getConstructor(generalNamesClass);
-      Object subjectAlternativeNameExtensionObject = subjectAlternativeNameExtensionConstr
-                                                         .newInstance(generalNamesObject);
+      if (generalNameAdded) {
+        // SubjectAlternativeNameExtension san = new SubjectAlternativeNameExtension(generalNames);
+        Class<?> subjectAlternativeNameExtensionClass = Class.forName(getSubjectAlternativeNameExtensionModuleName());
+        Constructor<?> subjectAlternativeNameExtensionConstr = subjectAlternativeNameExtensionClass.getConstructor(generalNamesClass);
+        Object subjectAlternativeNameExtensionObject = subjectAlternativeNameExtensionConstr.newInstance(generalNamesObject);
 
-      // CertificateExtensions certificateExtensions = new CertificateExtensions();
-      Class<?> certificateExtensionsClass = Class.forName(getCertificateExtensionsModuleName());
-      Constructor<?> certificateExtensionsConstr = certificateExtensionsClass.getConstructor();
-      Object certificateExtensionsObject = certificateExtensionsConstr.newInstance();
+        // CertificateExtensions certificateExtensions = new CertificateExtensions();
+        Class<?> certificateExtensionsClass = Class.forName(getCertificateExtensionsModuleName());
+        Constructor<?> certificateExtensionsConstr = certificateExtensionsClass.getConstructor();
+        Object certificateExtensionsObject = certificateExtensionsConstr.newInstance();
 
-      // certificateExtensions.set(san.getExtensionId().toString(), san);
-      Method getExtensionIdMethod = subjectAlternativeNameExtensionObject.getClass()
-                                        .getMethod("getExtensionId");
-      String sanExtensionId = getExtensionIdMethod.invoke(subjectAlternativeNameExtensionObject)
-                                  .toString();
-      Method certificateExtensionsSet = certificateExtensionsObject.getClass().getMethod("set",
-          String.class, Object.class);
-      certificateExtensionsSet.invoke(certificateExtensionsObject, sanExtensionId,
-          subjectAlternativeNameExtensionObject);
+        // certificateExtensions.set(san.getExtensionId().toString(), san);
+        Method getExtensionIdMethod = subjectAlternativeNameExtensionObject.getClass().getMethod("getExtensionId");
+        String sanExtensionId = getExtensionIdMethod.invoke(subjectAlternativeNameExtensionObject).toString();
+        Method certificateExtensionsSet = certificateExtensionsObject.getClass().getMethod("set", String.class, Object.class);
+        certificateExtensionsSet.invoke(certificateExtensionsObject, sanExtensionId, subjectAlternativeNameExtensionObject);
 
-      // info.set(X509CertInfo.EXTENSIONS, certificateExtensions);
-      methodSET.invoke(certInfoObject, getSetField(certInfoObject, "EXTENSIONS"),
-          certificateExtensionsObject);
+        // info.set(X509CertInfo.EXTENSIONS, certificateExtensions);
+        methodSET.invoke(certInfoObject, getSetField(certInfoObject, "EXTENSIONS"), certificateExtensionsObject);
+      }
 
       // Sign the cert to identify the algorithm that's used.
       // X509CertImpl cert = new X509CertImpl(info);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Checking if hostname starts with a letter before generating a `DNSName` with it.

## How was this patch tested?

Running JUnit test with Oracle JDK u151 (I was able to reproduce this issue with that JDK):
```
$ export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_151.jdk/Contents/Home/jre/

$ java -version
java version "1.8.0_151"
Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.151-b12, mixed mode)

$ mvn clean -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 27:04 min (Wall Clock)
[INFO] Finished at: 2019-07-16T11:08:16+02:00
[INFO] Final Memory: 380M/2163M
[INFO] ------------------------------------------------------------------------
```
Started the Knox Gateway using the same JDK (u151); previously it did not start due to the `DNSName components must begin with a letter` issue):
```
$ export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_151.jdk/Contents/Home/jre/

$ bin/gateway.sh start
Starting Gateway succeeded with PID 13456.

ps -ef | grep gateway
  502 13456     1   0  1:05PM ttys001    0:16.58 /Library/Java/JavaVirtualMachines/jdk1.8.0_151.jdk/Contents/Home/jre//bin/java -Djava.library.path=/Users/smolnar/test/knoxGateway/ext/native    -jar /Users/smolnar/test/knoxGateway/bin/gateway.jar
```
I was able to login to admin UI and edit the sandbox topology.
```