### PR TITLE
KNOX-1933 - Add rewrite rules to fix Yarn RM application and logs URL

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/rewrite.xml
@@ -32,4 +32,17 @@
   <rule dir="IN" name="LIVYSERVER/livy/path/inbound" pattern="*://*:*/**/livy/{path=**}?{**}">
     <rewrite template="{$serviceUrl[LIVYSERVER]}/{path=**}?{**}"/>
   </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/sparkurl" pattern="*://*:*/proxy/{**}">
+    <rewrite template="{$frontend[url]}/yarn/proxy/{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/logs" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
+    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{**}?{scheme}?host={$hostmap(host)}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/logs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}">
+    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{scheme}?host={$hostmap(host)}?{port}"/>
+  </rule>
+
 </rules>


### PR DESCRIPTION
Testing Done:
Deployed on a cluster with Knox and made sure these links worked