### PR TITLE
KNOX-1744 - Add rewrite rules to fix executor stdout/stderr links in Spark History Server UI

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
@@ -89,4 +89,13 @@
       <apply path="Location" rule="SPARKHISTORYUI/sparkhistory/outbound/headers/location/sso"/>
     </content>
   </filter>
+
+  <!-- re-write rules for yarn container logs -->
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}">
+    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{scheme}?{host}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
+    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
+  </rule>
 </rules>


### PR DESCRIPTION
Testing Done:
Deployed on a cluster with Knox and ensured that the URLs are rewritten