### PR TITLE
KNOX-1948 - If no rules are defined don't rewrite

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/i18n/UrlRewriteMessages.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/i18n/UrlRewriteMessages.java
@@ -84,4 +84,7 @@ public interface UrlRewriteMessages {
 
   @Message( level = MessageLevel.TRACE, text = "Failed to decode query string: {0}" )
   void failedToDecodeQueryString( String queryString, @StackTrace(level = MessageLevel.TRACE) Exception exception );
+
+  @Message( level = MessageLevel.INFO, text = "No rewrite rule was found, skipping rewriting JSON request body" )
+  void skippingRewritingJsonRequestBody();
 }

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteServletFilterTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteServletFilterTest.java
@@ -234,18 +234,23 @@ public class UrlRewriteServletFilterTest {
 //    fail( "TODO" );
 //  }
 
+  /**
+   * If no rewrite rule is defined for inbound request skip rewriting
+   * JSON Body.
+   * @throws Exception
+   */
   @Test
   public void testInboundJsonBodyRewrite() throws Exception {
     testSetUp( null );
 
     String inputJson = "{\"url\":\"http://mock-host:1/test-input-path\"}";
-    String outputJson = "{\"url\":\"http://mock-host:1/test-output-path-1\"}";
 
     // Setup the server side request/response interaction.
     interaction.expect()
         .method( "PUT" )
         .requestUrl( "http://mock-host:1/test-output-path-1" )
-        .content( outputJson, StandardCharsets.UTF_8 );
+        // Make sure nothing changed in the payload since no rule for payload was specified
+        .content( inputJson, StandardCharsets.UTF_8 );
     interaction.respond()
         .status( 200 );
     interactions.add( interaction );
@@ -258,7 +263,6 @@ public class UrlRewriteServletFilterTest {
 
     // Execute the request.
     response = TestUtils.execute( server, request );
-
     // Test the results.
     assertThat( response.getStatus(), is( 200 ) );
   }
@@ -457,6 +461,11 @@ public class UrlRewriteServletFilterTest {
 //    fail( "TODO" );
 //  }
 
+  /**
+   * Example test case where inbound rule is specified to rewrite
+   * request body.
+   * @throws Exception
+   */
   @Test
   public void testRequestJsonBodyRewriteWithFilterInitParam() throws Exception {
     Map<String,String> initParams = new HashMap<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change affects inbound requests with JSON payloads that do not have any rewrite rules defined. Currently Knox will try to apply the *best match* from all the inbound rules which in most cases is problematic. This patch will prevent rewriting inbound JSON payloads unless there a rewrite rule is explicitly defined for that request payload. 

This change will not affect other rewrite functionality.

## How was this patch tested?

This patch was manually tested and unit tests provided.

