### PR TITLE
KNOX-1955 - Admin UI should handle gateway.path change

### DIFF
--- a/gateway-admin-ui/admin-ui/app/gateway-version.service.ts
+++ b/gateway-admin-ui/admin-ui/app/gateway-version.service.ts
@@ -23,8 +23,8 @@ import {GatewayVersion} from './gateway-version';
 
 @Injectable()
 export class GatewayVersionService {
-
-    private apiUrl = '/gateway/manager/api/v1/version';
+    private apiUrl = window.location.pathname.replace(new RegExp('admin-ui/.*'), 'api/v1/');
+    private versionUrl = this.apiUrl + 'version';
 
     constructor(private http: HttpClient) {
     }
@@ -32,7 +32,7 @@ export class GatewayVersionService {
     getVersion(): Promise<GatewayVersion> {
         let headers = new HttpHeaders();
         headers = this.addHeaders(headers);
-        return this.http.get(this.apiUrl, {headers: headers})
+        return this.http.get(this.versionUrl, {headers: headers})
             .toPromise()
             .then(response => {
                 return response['ServerVersion'] as GatewayVersion;

--- a/gateway-admin-ui/admin-ui/app/resource/resource.service.ts
+++ b/gateway-admin-ui/admin-ui/app/resource/resource.service.ts
@@ -22,14 +22,12 @@ import {Resource} from './resource';
 import {ProviderConfig} from '../resource-detail/provider-config';
 import {Descriptor} from '../resource-detail/descriptor';
 
-
 @Injectable()
 export class ResourceService {
-
     // TODO: PJZ: Get this list dynamically?
     private static discoveryTypes: Array<string> = ['ClouderaManager', 'Ambari'];
 
-    apiUrl = '/gateway/manager/api/v1/';
+    apiUrl = window.location.pathname.replace(new RegExp('admin-ui/.*'), 'api/v1/');
     providersUrl = this.apiUrl + 'providerconfig';
     descriptorsUrl = this.apiUrl + 'descriptors';
     topologiesUrl = this.apiUrl + 'topologies';

--- a/gateway-admin-ui/admin-ui/app/topology.service.ts
+++ b/gateway-admin-ui/admin-ui/app/topology.service.ts
@@ -23,8 +23,7 @@ import {Topology} from './topology';
 
 @Injectable()
 export class TopologyService {
-
-    apiUrl = '/gateway/manager/api/v1/';
+    apiUrl = window.location.pathname.replace(new RegExp('admin-ui/.*'), 'api/v1/');
     topologiesUrl = this.apiUrl + 'topologies';
     selectedTopologySource = new Subject<Topology>();
     selectedTopology$ = this.selectedTopologySource.asObservable();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `window.location` instead of hardcoding the API endpoints

## How was this patch tested?

* `mvn -T.5C clean verify -Ppackage,release -Dshellcheck`
* Ran built Knox and updated `gateway.path` in `gateway-site.xml` and checked the AdminUI
