### PR TITLE
KNOX-1959 - HadoopAuthCookieStore should not read krb5 login config each time

### DIFF
--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/HadoopAuthCookieStoreTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/HadoopAuthCookieStoreTest.java
@@ -167,6 +167,7 @@ public class HadoopAuthCookieStoreTest {
     File result = null;
     try {
       File f = File.createTempFile(filename, ".conf");
+      f.deleteOnExit();
       try(OutputStream out = Files.newOutputStream(f.toPath())) {
         out.write(contents.getBytes(StandardCharsets.UTF_8));
         out.flush();
@@ -194,5 +195,4 @@ public class HadoopAuthCookieStoreTest {
            "storeKey=true\n" +
            "useTicketCache=false;";
   }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move knox principal to constructor and use that each time to check cookie

## How was this patch tested?

`mvn -T.5C clean verify -Ppackage,release -Dshellcheck`