### PR TITLE
KNOX-1963 - Ranger API service should proxy xusers/users and and xusers/groups

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/rewrite.xml
@@ -21,6 +21,12 @@
     <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/plugins/{path=**}?{**}">
         <rewrite template="{$serviceUrl[RANGER]}/service/plugins/{path=**}?{**}"/>
     </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/xusers/users/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/xusers/users/{path=**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/xusers/groups/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/xusers/groups/{path=**}?{**}"/>
+    </rule>
     <rule dir="IN" name="RANGER/ranger/inbound/healthcheck" pattern="*://*:*/**/ranger">
         <rewrite template="{$serviceUrl[RANGER]}"/>
     </rule>

--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
@@ -18,6 +18,8 @@
     <routes>
         <route path="/ranger/service/public/**"/>
         <route path="/ranger/service/plugins/**"/>
+        <route path="/ranger/service/xusers/users/**"/>
+        <route path="/ranger/service/xusers/groups/**"/>
         <route path="/ranger"/>
     </routes>
     <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added Request paths in the Knox Ranger service definition allowed paths and rewrite rules.

## How was this patch tested?

Verified that the calls to the allowed path are accessible through proxy.