### PR TITLE
KNOX-1694 - Prevent port mapped topologies from being exposed to gateway port

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -449,6 +449,14 @@ public interface GatewayMessages {
            text = "Topology port mapping feature enabled: {0}")
   void gatewayTopologyPortMappingEnabled(boolean enabled);
 
+  @Message(level = MessageLevel.ERROR,
+           text = "No topology mapped to port: {0}")
+  void noTopologyMappedToPort(int port);
+
+  @Message(level = MessageLevel.ERROR,
+           text = "Could not find topology {0} specified in port mapping config")
+  void noMappedTopologyFound(String topology);
+
   @Message(level = MessageLevel.DEBUG,
            text = "Creating a connector for topology {0} listening on port {1}.")
   void createJettyConnector(String topology, int port);
@@ -489,6 +497,10 @@ public interface GatewayMessages {
                    + "This invalid topology mapping will be ignored by the gateway. "
                    + "Gateway restart will be required if in the future \"{0}\" topology is added.")
   void topologyPortMappingCannotFindTopology(String topology, int port);
+
+  @Message(level = MessageLevel.ERROR,
+           text = "Port mapped topology {0} cannot be configured as default topology")
+  void defaultTopologyInPortmappedTopology(String topology);
 
 
   @Message( level = MessageLevel.WARN, text = "There is no registry client defined for remote configuration monitoring." )

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayDefaultTopologyTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayDefaultTopologyTest.java
@@ -18,45 +18,34 @@ package org.apache.knox.gateway;
 
 import org.apache.knox.test.TestUtils;
 import org.apache.knox.test.category.ReleaseTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.net.ConnectException;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.knox.test.TestUtils.LOG_ENTER;
 import static org.apache.knox.test.TestUtils.LOG_EXIT;
 
 /**
- * Test that the Gateway Topology Port Mapping feature is disabled properly.
- *
+ * Test default topology feature
  */
 @Category(ReleaseTest.class)
-public class GatewayPortMappingDisableFeatureTest extends PortMappingHelper {
+public class GatewayDefaultTopologyTest extends PortMappingHelper {
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  public GatewayPortMappingDisableFeatureTest() {
+  public GatewayDefaultTopologyTest() {
     super();
   }
 
-  @Before
-  public void setup() throws Exception {
-    eeriePort = getAvailablePort(1240, 49151);
-    ConcurrentHashMap<String, Integer> topologyPortMapping = new ConcurrentHashMap<>();
-    topologyPortMapping.put("eerie", eeriePort);
-    /* define port mappings but feature disabled */
-    init(null, topologyPortMapping, false);
+  @BeforeClass
+  public static void setup() throws Exception {
+    /* setup test with eerie as a default topology */
+    init("eerie",false);
   }
 
-  @After
-  public void cleanup() throws Exception {
+  @AfterClass
+  public static void cleanup() throws Exception {
     LOG_ENTER();
     driver.cleanup();
     driver.reset();
@@ -65,20 +54,22 @@ public class GatewayPortMappingDisableFeatureTest extends PortMappingHelper {
   }
 
   /*
-   * Test the standard case
+   * Test the standard case:
+   * http://localhost:{topologyPort}/gateway/eerie/webhdfs/v1
    */
   @Test(timeout = TestUtils.MEDIUM_TIMEOUT )
   public void testBasicListOperation() throws IOException {
-    test(driver.getUrl("WEBHDFS") );
+    test("http://localhost:" + driver.getGatewayPort() + "/gateway/eerie" + "/webhdfs" );
   }
 
   /*
-   * Test the multi port fail scenario when the feature is disabled.
+   * Test the Default Topology Feature, activated by property
+   * "default.app.topology.name"
+   *
+   * http://localhost:{eeriePort}/gateway/eerie/webhdfs/v1
    */
   @Test(timeout = TestUtils.MEDIUM_TIMEOUT )
-  public void testMultiPortFailOperation() throws IOException {
-    exception.expect(ConnectException.class);
-    exception.expectMessage("Connection refused");
-    test("http://localhost:" + eeriePort + "/webhdfs" );
+  public void testDefaultTopologyFeature() throws IOException {
+    test("http://localhost:" + driver.getGatewayPort() + "/webhdfs" );
   }
 }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayPortMappingFailTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayPortMappingFailTest.java
@@ -16,10 +16,9 @@
  */
 package org.apache.knox.gateway;
 
+import org.apache.http.HttpStatus;
 import org.apache.knox.test.TestUtils;
 import org.apache.knox.test.category.ReleaseTest;
-import org.apache.knox.test.mock.MockServer;
-import org.apache.http.HttpStatus;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,21 +35,7 @@ import static org.apache.knox.test.TestUtils.LOG_EXIT;
  * Test the fail cases for the Port Mapping Feature
  */
 @Category(ReleaseTest.class)
-public class GatewayPortMappingFailTest {
-
-  // Specifies if the test requests should go through the gateway or directly to the services.
-  // This is frequently used to verify the behavior of the test both with and without the gateway.
-  private static final boolean USE_GATEWAY = true;
-
-  // Specifies if the test requests should be sent to mock services or the real services.
-  // This is frequently used to verify the behavior of the test both with and without mock services.
-  private static final boolean USE_MOCK_SERVICES = true;
-
-  private static GatewayTestDriver driver = new GatewayTestDriver();
-
-  private static MockServer masterServer;
-
-  private static int eeriePort;
+public class GatewayPortMappingFailTest extends PortMappingHelper {
 
   /**
    * Create an instance
@@ -59,39 +44,12 @@ public class GatewayPortMappingFailTest {
     super();
   }
 
-  /**
-   * Creates a deployment of a gateway instance that all test methods will share.  This method also creates a
-   * registry of sorts for all of the services that will be used by the test methods.
-   * The createTopology method is used to create the topology file that would normally be read from disk.
-   * The driver.setupGateway invocation is where the creation of GATEWAY_HOME occurs.
-   * <p>
-   * This would normally be done once for this suite but the failure tests start affecting each other depending
-   * on the state the last 'active' url
-   *
-   * @throws Exception Thrown if any failure occurs.
-   */
   @BeforeClass
   public static void setup() throws Exception {
-    LOG_ENTER();
-
-    eeriePort = GatewayPortMappingFuncTest.getAvailablePort(1240, 49151);
-
+    eeriePort = getAvailablePort(1240, 49151);
     ConcurrentHashMap<String, Integer> topologyPortMapping = new ConcurrentHashMap<>();
     topologyPortMapping.put("eerie", eeriePort);
-
-    masterServer = new MockServer("master", true);
-    GatewayTestConfig config = new GatewayTestConfig();
-    config.setGatewayPath("gateway");
-    config.setTopologyPortMapping(topologyPortMapping);
-
-    driver.setResourceBase(WebHdfsHaFuncTest.class);
-    driver.setupLdap(0);
-
-    driver.setupService("WEBHDFS", "http://vm.local:50070/webhdfs", "/eerie/webhdfs", USE_MOCK_SERVICES);
-
-    driver.setupGateway(config, "eerie", GatewayPortMappingFuncTest.createTopology("WEBHDFS", driver.getLdapUrl(), masterServer.getPort()), USE_GATEWAY);
-
-    LOG_EXIT();
+    init(null, topologyPortMapping);
   }
 
   @AfterClass

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayPortMappingFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayPortMappingFuncTest.java
@@ -16,12 +16,8 @@
  */
 package org.apache.knox.gateway;
 
-import com.mycila.xmltool.XMLDoc;
-import com.mycila.xmltool.XMLTag;
 import org.apache.knox.test.TestUtils;
 import org.apache.knox.test.category.ReleaseTest;
-import org.apache.knox.test.mock.MockServer;
-import org.apache.http.HttpStatus;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,72 +26,26 @@ import org.junit.experimental.categories.Category;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static io.restassured.RestAssured.given;
 import static org.apache.knox.test.TestUtils.LOG_ENTER;
 import static org.apache.knox.test.TestUtils.LOG_EXIT;
-import static org.hamcrest.CoreMatchers.is;
 
 /**
  * Test the Gateway Topology Port Mapping functionality
  *
  */
 @Category(ReleaseTest.class)
-public class GatewayPortMappingFuncTest {
-
-  // Specifies if the test requests should go through the gateway or directly to the services.
-  // This is frequently used to verify the behavior of the test both with and without the gateway.
-  private static final boolean USE_GATEWAY = true;
-
-  // Specifies if the test requests should be sent to mock services or the real services.
-  // This is frequently used to verify the behavior of the test both with and without mock services.
-  private static final boolean USE_MOCK_SERVICES = true;
-
-  private static GatewayTestDriver driver = new GatewayTestDriver();
-
-  private static MockServer masterServer;
-
-  private static int eeriePort;
+public class GatewayPortMappingFuncTest extends PortMappingHelper {
 
   public GatewayPortMappingFuncTest() {
     super();
   }
 
-  /**
-   * Creates a deployment of a gateway instance that all test methods will share.  This method also creates a
-   * registry of sorts for all of the services that will be used by the test methods.
-   * The createTopology method is used to create the topology file that would normally be read from disk.
-   * The driver.setupGateway invocation is where the creation of GATEWAY_HOME occurs.
-   * <p>
-   * This would normally be done once for this suite but the failure tests start affecting each other depending
-   * on the state the last 'active' url
-   *
-   * @throws Exception Thrown if any failure occurs.
-   */
   @BeforeClass
   public static void setup() throws Exception {
-    LOG_ENTER();
-
     eeriePort = getAvailablePort(1240, 49151);
-
     ConcurrentHashMap<String, Integer> topologyPortMapping = new ConcurrentHashMap<>();
     topologyPortMapping.put("eerie", eeriePort);
-
-    masterServer = new MockServer("master", true);
-    GatewayTestConfig config = new GatewayTestConfig();
-    config.setGatewayPath("gateway");
-    config.setTopologyPortMapping(topologyPortMapping);
-
-    // Enable default topology
-    config.setDefaultTopologyName("eerie");
-
-    driver.setResourceBase(WebHdfsHaFuncTest.class);
-    driver.setupLdap(0);
-
-    driver.setupService("WEBHDFS", "http://vm.local:50070/webhdfs", "/eerie/webhdfs", USE_MOCK_SERVICES);
-
-    driver.setupGateway(config, "eerie", createTopology("WEBHDFS", driver.getLdapUrl(), masterServer.getPort()), USE_GATEWAY);
-
-    LOG_EXIT();
+    init(null, topologyPortMapping);
   }
 
   @AfterClass
@@ -109,25 +59,12 @@ public class GatewayPortMappingFuncTest {
 
   /*
    * Test the standard case:
-   * http://localhost:{gatewayPort}/gateway/eerie/webhdfs/v1
+   * http://localhost:{topologyPort}/gateway/eerie/webhdfs/v1
    */
   @Test(timeout = TestUtils.MEDIUM_TIMEOUT )
   public void testBasicListOperation() throws IOException {
     LOG_ENTER();
-    test("http://localhost:" + driver.getGatewayPort() + "/gateway/eerie" + "/webhdfs" );
-    LOG_EXIT();
-  }
-
-  /*
-   * Test the Default Topology Feature, activated by property
-   * "default.app.topology.name"
-   *
-   * http://localhost:{eeriePort}/gateway/eerie/webhdfs/v1
-   */
-  @Test(timeout = TestUtils.MEDIUM_TIMEOUT )
-  public void testDefaultTopologyFeature() throws IOException {
-    LOG_ENTER();
-    test("http://localhost:" + driver.getGatewayPort() + "/webhdfs" );
+    test("http://localhost:" + eeriePort + "/gateway/eerie" + "/webhdfs" );
     LOG_EXIT();
   }
 
@@ -153,114 +90,6 @@ public class GatewayPortMappingFuncTest {
     LOG_ENTER();
     test("http://localhost:" + eeriePort + "/gateway/eerie" + "/webhdfs" );
     LOG_EXIT();
-  }
-
-  private void test (final String url) throws IOException {
-    String password = "hdfs-password";
-    String username = "hdfs";
-
-    masterServer.expect()
-        .method("GET")
-        .pathInfo("/webhdfs/v1/")
-        .queryParam("op", "LISTSTATUS")
-        .queryParam("user.name", username)
-        .respond()
-        .status(HttpStatus.SC_OK)
-        .content(driver.getResourceBytes("webhdfs-liststatus-success.json"))
-        .contentType("application/json");
-
-    given()
-        .auth().preemptive().basic(username, password)
-        .header("X-XSRF-Header", "jksdhfkhdsf")
-        .queryParam("op", "LISTSTATUS")
-        .then()
-        .log().ifError()
-        .statusCode(HttpStatus.SC_OK)
-        .body("FileStatuses.FileStatus[0].pathSuffix", is("app-logs"))
-        .when().get(url + "/v1/");
-    masterServer.isEmpty();
-  }
-
-  /**
-   * Creates a topology that is deployed to the gateway instance for the test suite.
-   * Note that this topology is shared by all of the test methods in this suite.
-   * @param role role name
-   * @param ldapURL ldap url
-   * @param gatewayPort port for the gateway
-   * @return A populated XML structure for a topology file.
-   */
-  public static XMLTag createTopology(final String role, final String ldapURL, final int gatewayPort ) {
-    return XMLDoc.newDocument(true)
-        .addRoot("topology")
-        .addTag("gateway")
-        .addTag("provider")
-        .addTag("role").addText("webappsec")
-        .addTag("name").addText("WebAppSec")
-        .addTag("enabled").addText("true")
-        .addTag("param")
-        .addTag("name").addText("csrf.enabled")
-        .addTag("value").addText("true").gotoParent().gotoParent()
-        .addTag("provider")
-        .addTag("role").addText("authentication")
-        .addTag("name").addText("ShiroProvider")
-        .addTag("enabled").addText("true")
-        .addTag("param")
-        .addTag("name").addText("main.ldapRealm")
-        .addTag("value").addText("org.apache.knox.gateway.shirorealm.KnoxLdapRealm").gotoParent()
-        .addTag("param")
-        .addTag("name").addText("main.ldapRealm.userDnTemplate")
-        .addTag("value").addText("uid={0},ou=people,dc=hadoop,dc=apache,dc=org").gotoParent()
-        .addTag("param")
-        .addTag("name").addText("main.ldapRealm.contextFactory.url")
-        .addTag("value").addText(ldapURL).gotoParent()
-        .addTag("param")
-        .addTag("name").addText("main.ldapRealm.contextFactory.authenticationMechanism")
-        .addTag("value").addText("simple").gotoParent()
-        .addTag("param")
-        .addTag("name").addText("urls./**")
-        .addTag("value").addText("authcBasic").gotoParent().gotoParent()
-        .addTag("provider")
-        .addTag("role").addText("identity-assertion")
-        .addTag("enabled").addText("true")
-        .addTag("name").addText("Default").gotoParent()
-        .addTag("provider")
-        .addTag("role").addText("authorization")
-        .addTag("enabled").addText("true")
-        .addTag("name").addText("AclsAuthz").gotoParent()
-        .addTag("param")
-        .addTag("name").addText("webhdfs-acl")
-        .addTag("value").addText("hdfs;*;*").gotoParent()
-        .addTag("provider")
-        .addTag("role").addText("ha")
-        .addTag("enabled").addText("true")
-        .addTag("name").addText("HaProvider")
-        .addTag("param")
-        .addTag("name").addText("WEBHDFS")
-        .addTag("value").addText("maxFailoverAttempts=3;failoverSleep=15;maxRetryAttempts=3;retrySleep=10;enabled=true").gotoParent()
-        .gotoRoot()
-        .addTag("service")
-        .addTag("role").addText(role)
-        .addTag("url").addText("http://localhost:" + gatewayPort + "/webhdfs")
-        .gotoRoot();
-  }
-
-  /**
-   * This utility method will return the next available port
-   * that can be used.
-   * @param min min port to check
-   * @param max max port to check
-   * @return Port that is available.
-   */
-  public static int getAvailablePort(final int min, final int max) {
-
-    for (int i = min; i <= max; i++) {
-
-      if (!GatewayServer.isPortInUse(i)) {
-        return i;
-      }
-    }
-    // too bad
-    return -1;
   }
 
 }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/PortMappingHelper.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/PortMappingHelper.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import com.mycila.xmltool.XMLDoc;
+import com.mycila.xmltool.XMLTag;
+import org.apache.http.HttpStatus;
+import org.apache.knox.test.mock.MockServer;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.knox.test.TestUtils.LOG_ENTER;
+import static org.apache.knox.test.TestUtils.LOG_EXIT;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * Helper class that contains common code used by port mapping tests
+ */
+public abstract class PortMappingHelper {
+  // Specifies if the test requests should go through the gateway or directly to the services.
+  // This is frequently used to verify the behavior of the test both with and without the gateway.
+  private static final boolean USE_GATEWAY = true;
+  // Specifies if the test requests should be sent to mock services or the real services.
+  // This is frequently used to verify the behavior of the test both with and without mock services.
+  private static final boolean USE_MOCK_SERVICES = true;
+  static GatewayTestDriver driver = new GatewayTestDriver();
+  static MockServer masterServer;
+  static int eeriePort;
+
+  public PortMappingHelper() {
+    super();
+  }
+
+  /**
+   * Creates a deployment of a gateway instance that all test methods will
+   * share.  This method also creates a registry of sorts for all of the
+   * services that will be used by the test methods. The createTopology method
+   * is used to create the topology file that would normally be read from disk.
+   * The driver.setupGateway invocation is where the creation of GATEWAY_HOME
+   * occurs.
+   * <p>
+   * This would normally be done once for this suite but the failure tests start
+   * affecting each other depending on the state the last 'active' url
+   *
+   * @throws Exception Thrown if any failure occurs.
+   */
+  public static void init(final String defaultTopologyName,
+      final ConcurrentHashMap<String, Integer> topologyPortMapping, final boolean isPortMappingEnabled)
+      throws Exception {
+    LOG_ENTER();
+
+    masterServer = new MockServer("master", true);
+    GatewayTestConfig config = new GatewayTestConfig();
+    config.setGatewayPath("gateway");
+
+    /* define default topology to be used */
+    if (defaultTopologyName != null) {
+      config.setDefaultTopologyName(defaultTopologyName);
+    }
+
+    if (topologyPortMapping != null) {
+      config.setTopologyPortMapping(topologyPortMapping);
+    }
+
+    config.setGatewayPortMappingEnabled(isPortMappingEnabled);
+
+    driver.setResourceBase(WebHdfsHaFuncTest.class);
+    driver.setupLdap(0);
+
+    driver.setupService("WEBHDFS", "http://vm.local:50070/webhdfs",
+        "/eerie/webhdfs", USE_MOCK_SERVICES);
+
+    driver.setupGateway(config, "eerie",
+        createTopology("WEBHDFS", driver.getLdapUrl(), masterServer.getPort()),
+        USE_GATEWAY);
+
+    LOG_EXIT();
+  }
+
+  public static void init(final String defaultTopologyName, final boolean isPortMappingEnabled)
+      throws Exception {
+    init(defaultTopologyName, null, isPortMappingEnabled);
+  }
+
+  public static void init(final String defaultTopologyName, final ConcurrentHashMap<String, Integer> topologyPortMapping)
+      throws Exception {
+    init(defaultTopologyName, topologyPortMapping, true);
+  }
+
+  /**
+   * Creates a topology that is deployed to the gateway instance for the test
+   * suite. Note that this topology is shared by all of the test methods in this
+   * suite.
+   *
+   * @param role        role name
+   * @param ldapURL     ldap url
+   * @param gatewayPort port for the gateway
+   * @return A populated XML structure for a topology file.
+   */
+  static XMLTag createTopology(final String role, final String ldapURL,
+      final int gatewayPort) {
+    return XMLDoc.newDocument(true).addRoot("topology").addTag("gateway")
+        .addTag("provider").addTag("role").addText("webappsec").addTag("name")
+        .addText("WebAppSec").addTag("enabled").addText("true").addTag("param")
+        .addTag("name").addText("csrf.enabled").addTag("value").addText("true")
+        .gotoParent().gotoParent().addTag("provider").addTag("role")
+        .addText("authentication").addTag("name").addText("ShiroProvider")
+        .addTag("enabled").addText("true").addTag("param").addTag("name")
+        .addText("main.ldapRealm").addTag("value")
+        .addText("org.apache.knox.gateway.shirorealm.KnoxLdapRealm")
+        .gotoParent().addTag("param").addTag("name")
+        .addText("main.ldapRealm.userDnTemplate").addTag("value")
+        .addText("uid={0},ou=people,dc=hadoop,dc=apache,dc=org").gotoParent()
+        .addTag("param").addTag("name")
+        .addText("main.ldapRealm.contextFactory.url").addTag("value")
+        .addText(ldapURL).gotoParent().addTag("param").addTag("name")
+        .addText("main.ldapRealm.contextFactory.authenticationMechanism")
+        .addTag("value").addText("simple").gotoParent().addTag("param")
+        .addTag("name").addText("urls./**").addTag("value")
+        .addText("authcBasic").gotoParent().gotoParent().addTag("provider")
+        .addTag("role").addText("identity-assertion").addTag("enabled")
+        .addText("true").addTag("name").addText("Default").gotoParent()
+        .addTag("provider").addTag("role").addText("authorization")
+        .addTag("enabled").addText("true").addTag("name").addText("AclsAuthz")
+        .gotoParent().addTag("param").addTag("name").addText("webhdfs-acl")
+        .addTag("value").addText("hdfs;*;*").gotoParent().addTag("provider")
+        .addTag("role").addText("ha").addTag("enabled").addText("true")
+        .addTag("name").addText("HaProvider").addTag("param").addTag("name")
+        .addText("WEBHDFS").addTag("value").addText(
+            "maxFailoverAttempts=3;failoverSleep=15;maxRetryAttempts=3;retrySleep=10;enabled=true")
+        .gotoParent().gotoRoot().addTag("service").addTag("role").addText(role)
+        .addTag("url").addText("http://localhost:" + gatewayPort + "/webhdfs")
+        .gotoRoot();
+  }
+
+  /**
+   * This utility method will return the next available port that can be used.
+   *
+   * @param min min port to check
+   * @param max max port to check
+   * @return Port that is available.
+   */
+  static int getAvailablePort(final int min, final int max) {
+
+    for (int i = min; i <= max; i++) {
+
+      if (!GatewayServer.isPortInUse(i)) {
+        return i;
+      }
+    }
+    // too bad
+    return -1;
+  }
+
+  void test(final String url) throws IOException {
+    String password = "hdfs-password";
+    String username = "hdfs";
+
+    masterServer.expect().method("GET").pathInfo("/webhdfs/v1/")
+        .queryParam("op", "LISTSTATUS").queryParam("user.name", username)
+        .respond().status(HttpStatus.SC_OK)
+        .content(driver.getResourceBytes("webhdfs-liststatus-success.json"))
+        .contentType("application/json");
+
+    given().auth().preemptive().basic(username, password)
+        .header("X-XSRF-Header", "jksdhfkhdsf").queryParam("op", "LISTSTATUS")
+        .then().log().ifError().statusCode(HttpStatus.SC_OK)
+        .body("FileStatuses.FileStatus[0].pathSuffix", is("app-logs")).when()
+        .get(url + "/v1/");
+    masterServer.isEmpty();
+  }
+}


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?
Currently with topology port mapping feature, port mapped topologies are exposed on gateway port as well (default 8443) this is undesirable in a lot of cases. This feature locks the topologies that are mapped to specific port to only those ports and they are not exposed on the default gateway port. 

## How was this patch tested?
There are new and old Unit tests added to test this feature. This patch was tested locally. Following cases were tested.

1. Make sure topology port mapping feature works as expected.
2. Make sure port mapped topologies are not exposed on gateway port.
3. Make sure default topology feature works as expected.
4. Make sure default topology can also be configured using port mapping configs.
