### PR TITLE
KNOX-1967 - Add a service definition for Impala Hiveserver2

### DIFF
--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -235,6 +235,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-service-impala</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-service-webhdfs</artifactId>
         </dependency>
         <dependency>

--- a/gateway-service-definitions/src/main/resources/services/impala/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/impala/1.0.0/rewrite.xml
@@ -1,0 +1,21 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="IMPALA/impala/inbound" pattern="*://*:*/**/impala">
+        <rewrite template="{$serviceUrl[IMPALA]}"/>
+    </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/impala/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/impala/1.0.0/service.xml
@@ -1,0 +1,22 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="IMPALA" name="impala" version="1.0.0">
+    <routes>
+        <route path="/impala"/>
+    </routes>
+    <dispatch classname="org.apache.knox.gateway.impala.ImpalaDispatch" ha-classname="org.apache.knox.gateway.impala.ImpalaHaDispatch"/>
+</service>

--- a/gateway-service-impala/pom.xml
+++ b/gateway-service-impala/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.knox</groupId>
+        <artifactId>gateway</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gateway-service-impala</artifactId>
+    <name>gateway-service-impala</name>
+    <description>The extension to the gateway for supporting Impala via JDBC+ODBC/Thrift/HTTP.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-provider-rewrite</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-provider-ha</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-configinjector</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/gateway-service-impala/src/main/java/org/apache/knox/gateway/impala/ImpalaDispatch.java
+++ b/gateway-service-impala/src/main/java/org/apache/knox/gateway/impala/ImpalaDispatch.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.impala;
+
+import org.apache.knox.gateway.config.Configure;
+import org.apache.knox.gateway.config.Default;
+import org.apache.knox.gateway.dispatch.DefaultDispatch;
+import org.apache.http.client.methods.HttpUriRequest;
+
+/**
+ * This specialized dispatch provides Impala specific features to the
+ * default HttpClientDispatch.
+ */
+public class ImpalaDispatch extends DefaultDispatch {
+  private boolean basicAuthPreemptive;
+
+  @Override
+  public void init() {
+    super.init();
+  }
+
+  @Override
+  protected void addCredentialsToRequest(HttpUriRequest request) {
+    if( isBasicAuthPreemptive() ) {
+      ImpalaDispatchUtils.addCredentialsToRequest(request);
+    }
+  }
+
+  @Configure
+  public void setBasicAuthPreemptive( @Default("false") boolean basicAuthPreemptive ) {
+    this.basicAuthPreemptive = basicAuthPreemptive;
+  }
+
+  public boolean isBasicAuthPreemptive() {
+    return basicAuthPreemptive;
+  }
+
+}
+

--- a/gateway-service-impala/src/main/java/org/apache/knox/gateway/impala/ImpalaDispatchUtils.java
+++ b/gateway-service-impala/src/main/java/org/apache/knox/gateway/impala/ImpalaDispatchUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.impala;
+
+import org.apache.http.auth.AuthenticationException;
+import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.auth.BasicScheme;
+
+public class ImpalaDispatchUtils {
+
+  private static final String PASSWORD_PLACEHOLDER = "*";
+
+  public static void addCredentialsToRequest(HttpUriRequest request) {
+    String principal = SubjectUtils.getCurrentEffectivePrincipalName();
+    if ( principal != null ) {
+      UsernamePasswordCredentials credentials =
+          new UsernamePasswordCredentials(principal, PASSWORD_PLACEHOLDER);
+      try {
+        request.addHeader(new BasicScheme().authenticate(credentials, request, null));
+      } catch (AuthenticationException e) {
+        // impossible
+      }
+    }
+  }
+}

--- a/gateway-service-impala/src/main/java/org/apache/knox/gateway/impala/ImpalaHaDispatch.java
+++ b/gateway-service-impala/src/main/java/org/apache/knox/gateway/impala/ImpalaHaDispatch.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.impala;
+
+import org.apache.knox.gateway.config.Configure;
+import org.apache.knox.gateway.config.Default;
+import org.apache.knox.gateway.ha.dispatch.DefaultHaDispatch;
+import org.apache.http.client.methods.HttpUriRequest;
+
+
+public class ImpalaHaDispatch extends DefaultHaDispatch {
+
+  private boolean basicAuthPreemptive;
+
+  public ImpalaHaDispatch() {
+    setServiceRole("IMPALA");
+  }
+
+  @Override
+  protected void addCredentialsToRequest(HttpUriRequest request) {
+    if ( isBasicAuthPreemptive() ) {
+      ImpalaDispatchUtils.addCredentialsToRequest(request);
+    }
+  }
+
+  @Configure
+  public void setBasicAuthPreemptive(@Default("false")boolean basicAuthPreemptive) {
+    this.basicAuthPreemptive = basicAuthPreemptive;
+  }
+
+  public boolean isBasicAuthPreemptive() {
+    return basicAuthPreemptive;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <module>gateway-service-as</module>
         <module>gateway-service-hbase</module>
         <module>gateway-service-hive</module>
+        <module>gateway-service-impala</module>
         <module>gateway-service-knoxsso</module>
         <module>gateway-service-knoxssout</module>
         <module>gateway-service-knoxtoken</module>
@@ -972,6 +973,11 @@
             <dependency>
                 <groupId>org.apache.knox</groupId>
                 <artifactId>gateway-service-hive</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.knox</groupId>
+                <artifactId>gateway-service-impala</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows for proxying connections to Impala's Hiveserver2 interface.
The service definition is based on Hive's Hiveserver2 definition.

Impala does not currently support HA.

## How was this patch tested?

Tested by setting up Impala and Knox in a real cluster and verifying that Impala can be connected to over Knox and queries can be run through jdbc and impala-shell