### PR TITLE
KNOX-1986 - Do not attempt to rewrite empty payload

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteRequest.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteRequest.java
@@ -235,7 +235,12 @@ public class UrlRewriteRequest extends GatewayRequestWrapper implements Resolver
   @Override
   public ServletInputStream getInputStream() throws IOException {
     ServletInputStream input = super.getInputStream();
-    if( getContentLength() != 0 ) {
+    /**
+     *  Make sure payload is not empty before adding
+     *  content-type specific filters. We cannot rely on request.getContentLength()
+     *  since previous filters update it to return -1
+     */
+    if( getContentLength() != 0 && input.available() != 0 ) {
       MimeType mimeType = getMimeType();
 
       /* In cases where content type is application/text and content-encoding is gzip */

--- a/gateway-test-utils/src/main/java/org/apache/knox/test/mock/MockServletInputStream.java
+++ b/gateway-test-utils/src/main/java/org/apache/knox/test/mock/MockServletInputStream.java
@@ -37,6 +37,11 @@ public class MockServletInputStream extends ServletInputStream {
   }
 
   @Override
+  public int available() throws IOException {
+    return stream.available();
+  }
+
+  @Override
   public boolean isFinished() {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Prevent Knox from rewriting empty payload, this is especially problematic for xml content types.

(Please fill in changes proposed in this fix)
See if there is payload data if not skip adding rewrite filters.
## How was this patch tested?
Manually tested. Unit test added as well.