### PR TITLE
KNOX-1987: knox failed to start because knoxcli failed with "java.lan…g.NoSuchFieldError: DEFAULT_XML_TYPE_ATTRIBUTE"

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -142,6 +142,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jaxws-ri.version>2.3.1</jaxws-ri.version>
+        <jaxws-ri.version>2.3.2</jaxws-ri.version>
         <jericho-html.version>3.4</jericho-html.version>
         <jersey.version>2.6</jersey.version>
         <jetty.version>9.4.19.v20190610</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <jaxb.version>2.3.0</jaxb.version>
         <jaxws-ri.version>2.3.2</jaxws-ri.version>
+        <jakarta.xml.bind.version>2.3.2</jakarta.xml.bind.version>
         <jericho-html.version>3.4</jericho-html.version>
         <jersey.version>2.6</jersey.version>
         <jetty.version>9.4.19.v20190610</jetty.version>
@@ -1208,6 +1209,12 @@
                 <artifactId>jaxws-ri</artifactId>
                 <version>${jaxws-ri.version}</version>
                 <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade jaxws-ri version to 2.3.2 so that it uses the same version (2.7.4) of eclipse persistence classes.

Otherwise, there are these files in knox/dep folder, and depends on loading sequence of classloader, you might encouter the NoSuchFieldError:
eclipselink-2.7.4.jar
org.eclipse.persistence.core-2.7.2.jar
org.eclipse.persistence.moxy-2.7.2.jar
org.eclipse.persistence.asm-2.7.2.jar
org.eclipse.persistence.sdo-2.7.2.jar

## How was this patch tested?
Manual tests
