### PR TITLE
KNOX-1988 - In Spark History Server UI, make links for Executor logs point to YARN UI v2

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
@@ -92,10 +92,10 @@
 
   <!-- re-write rules for yarn container logs -->
   <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}">
-    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{scheme}?{host}?{port}"/>
+    <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{scheme}?{host}?{port}"/>
   </rule>
 
   <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
-    <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
+    <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
   </rule>
 </rules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

KNOX-1744 fixed the links but made them point to the old YARN UI.
Change the links to point to YARN UI v2.

## How was this patch tested?

Tested manually. Applied the change to a cluster and verified the links in the Knox-proxied Spark History Server.
