### PR TITLE
KNOX-1990 - Testing non-existing/non-parsable JAAS configuration in sequential order even if parallel test execution is enabled

### DIFF
--- a/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
+++ b/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
@@ -185,7 +185,13 @@ public class RemoteConfigurationRegistryJAASConfigTest {
     }
 
     @Test
-    public void shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeRead() throws Exception {
+    public void shouldRaiseAnErrorWithMeaningfulErrorMessageInCaseOfJAASConfigError() throws Exception {
+      shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeRead();
+      shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeParsed();
+      shouldRaiseAnErrorWithMeaningfulErrorMessageIfReferencedKeytabFileDoesNotExists();
+    }
+
+    private void shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeRead() throws Exception {
       final List<RemoteConfigurationRegistryConfig> registryConfigs = new ArrayList<>();
       System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, "nonExistingFilePath");
 
@@ -200,8 +206,7 @@ public class RemoteConfigurationRegistryJAASConfigTest {
       }
     }
 
-    @Test
-    public void shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeParsed() throws Exception {
+    private void shouldRaiseAnErrorWithMeaningfulErrorMessageIfAuthLoginConfigCannotBeParsed() throws Exception {
       final List<RemoteConfigurationRegistryConfig> registryConfigs = new ArrayList<>();
       final String jaasConfigFilePath = writeInvalidJaasConf(false, "jaasConfWithInvalidKeytab", createTempKeytabFile("invalidKeytab"));
       System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, jaasConfigFilePath);
@@ -217,8 +222,7 @@ public class RemoteConfigurationRegistryJAASConfigTest {
       }
     }
 
-    @Test
-    public void shouldRaiseAnErrorWithMeaningfulErrorMessageIfReferencedKeytabFileDoesNotExists() throws Exception {
+    private void shouldRaiseAnErrorWithMeaningfulErrorMessageIfReferencedKeytabFileDoesNotExists() throws Exception {
       final String jaasConfigFilePath = writeInvalidJaasConf(true, "jaasConfWithMissingKeytab", "nonExistingKeytabFile");
       System.setProperty(GatewayConfig.KRB5_LOGIN_CONFIG, jaasConfigFilePath);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RemoteConfigurationRegistryJAASConfigTest.shouldRaiseAnErrorWithMeaningfulErrorMessageXXX` fails while Travis CI is building the project upon submitting a new PR (or patch) in Github, intermittently.
 
This was happening due to the parallel JUnit test execution (I could never reproduce this issue while running that test class sequentially from my IDE) because those test cases manipulated the System properties by setting valid/non-existing/non-parsable JAAS configuration. To fix this issue I made sure these test cases are running sequentially.

## How was this patch tested?

Executed `mvn clean -Dshellcheck=true -T1C verify -Prelease,package -pl gateway-service-remoteconfig` 10 times with the following outcome:

1. before my changes: failed 4 times out of 10
2. after my changes: succeeded every time
