### PR TITLE
KNOX-1934 - Setting the default value of knoxsso.cookie.secure.only based on ssl.enabled flag in gateway-site.xml

### DIFF
--- a/gateway-release/home/conf/topologies/knoxsso.xml
+++ b/gateway-release/home/conf/topologies/knoxsso.xml
@@ -103,10 +103,12 @@
 
     <service>
         <role>KNOXSSO</role>
+        <!--
         <param>
             <name>knoxsso.cookie.secure.only</name>
             <value>true</value>
         </param>
+         -->
         <param>
             <name>knoxsso.token.ttl</name>
             <value>-1</value>

--- a/gateway-service-knoxsso/pom.xml
+++ b/gateway-service-knoxsso/pom.xml
@@ -72,7 +72,10 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -44,7 +44,9 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.WebApplicationException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.audit.log4j.audit.Log4jAuditor;
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
@@ -133,8 +135,13 @@ public class WebSSOResource {
       cookieName = DEFAULT_SSO_COOKIE_NAME;
     }
 
-    String secure = context.getInitParameter(SSO_COOKIE_SECURE_ONLY_INIT_PARAM);
-    secureOnly = Boolean.parseBoolean(secure);
+    final String secure = context.getInitParameter(SSO_COOKIE_SECURE_ONLY_INIT_PARAM);
+    if (StringUtils.isBlank(secure)) {
+      final GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+      secureOnly = config.isSSLEnabled();
+    } else {
+      secureOnly = Boolean.parseBoolean(secure);
+    }
     if (!secureOnly) {
       log.cookieSecureOnly(secureOnly);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case the `knoxsso.cookie.secure.only` is not set we use the value of `ssl.enabled` flag (defaults to true). Using this approach and not setting `knoxsso.cookie.secure.only` in our OOTB `knoxsso.xml` makes it easier to access the admin UI without the need to edit the `knoxsso` topology in case SSL is disabled.

## How was this patch tested?

Adding new JUnit tests:
```
$ mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 17:33 min (Wall Clock)
[INFO] Finished at: 2019-08-25T17:21:54+02:00
[INFO] Final Memory: 384M/2246M
[INFO] ------------------------------------------------------------------------
```
Also tested the deliverable by changing the values in `gateway-site.xml` and `knoxsso.xml` as follows:
```
ssl.enabled=false
knoxsso.cookie.secure.only is not set
----
ssl.enabled=true
knoxsso.cookie.secure.only is not set
----
ssl.enabled=false
knoxsso.cookie.secure.only=false
----
ssl.enabled=false
knoxsso.cookie.secure.only=true
```
It's been working as expected.