### PR TITLE
KNOX-1995 - If a rule doesn't match, shouldn't error. Need to handle null case

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/i18n/UrlRewriteMessages.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/i18n/UrlRewriteMessages.java
@@ -73,7 +73,7 @@ public interface UrlRewriteMessages {
   @Message( level = MessageLevel.DEBUG, text = "Rewrote URL: {0}, direction: {1} via explicit rule: {2} to URL: {3}" )
   void rewroteUrlViaExplicitRule( Template inputUri, UrlRewriter.Direction direction, String ruleName, Template outputUri );
 
-  @Message( level = MessageLevel.ERROR, text = "Failed to rewrite URL: {0}, direction: {1} via rule: {2}, status: {3}" )
+  @Message( level = MessageLevel.TRACE, text = "Failed to rewrite URL: {0}, direction: {1} via rule: {2}, status: {3}" )
   void failedToRewriteUrl( Template inputUri, UrlRewriter.Direction direction, String ruleName, UrlRewriteStepStatus stepStatus );
 
   @Message( level = MessageLevel.ERROR, text = "Failed to rewrite URL: {0}, direction: {1}, rule: {2}" )

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonUrlRewriteFilterReader.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonUrlRewriteFilterReader.java
@@ -30,7 +30,6 @@ import java.io.Reader;
 import java.net.URISyntaxException;
 
 public class JsonUrlRewriteFilterReader extends JsonFilterReader {
-
   private static final UrlRewriteMessages LOG = MessagesFactory.get( UrlRewriteMessages.class );
 
   private Resolver resolver;
@@ -62,7 +61,10 @@ public class JsonUrlRewriteFilterReader extends JsonFilterReader {
       try {
         Template input = Parser.parseLiteral( value );
         Template output = rewriter.rewrite( resolver, input, direction, rule );
-        value = output.getPattern();
+        // We should only use output if it is valid. If a rule doesn't match output could be null.
+        if(output != null) {
+          value = output.getPattern();
+        }
       } catch( URISyntaxException e ) {
         LOG.failedToParseValueForUrlRewrite( value );
       }
@@ -72,5 +74,4 @@ public class JsonUrlRewriteFilterReader extends JsonFilterReader {
       return value;
     }
   }
-
 }

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.filter.rewrite.api;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -389,6 +390,25 @@ public class UrlRewriteProcessorTest {
     assertEquals("true", reWrittenParams.get("indent"));
   }
 
+  @Test
+  public void testNoMatchOutput() throws IOException, URISyntaxException {
+    UrlRewriteEnvironment environment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
+    HttpServletRequest request = EasyMock.createNiceMock( HttpServletRequest.class );
+    HttpServletResponse response = EasyMock.createNiceMock( HttpServletResponse.class );
+    EasyMock.replay( environment, request, response );
+
+    UrlRewriteProcessor processor = new UrlRewriteProcessor();
+    UrlRewriteRulesDescriptor config = UrlRewriteRulesDescriptorFactory.load(
+        "xml", getTestResourceReader( "rewrite-no-match.xml" ) );
+    processor.initialize( environment, config );
+
+    Template inputUrl = Parser.parseLiteral( "HTTP" );
+    Template outputUrl = processor.rewrite( null, inputUrl, UrlRewriter.Direction.IN, "YARNUIV2/yarnuiv2/outbound/timeline" );
+
+    assertThat( "Expect rewrite to not change the value",
+        outputUrl, nullValue() );
+    processor.destroy();
+  }
 
   /**
    * Turn a string containing URL parameters, e.g.

--- a/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite-no-match.xml
+++ b/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite-no-match.xml
@@ -1,0 +1,22 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="YARNUIV2/yarnuiv2/outbound/timeline">
+        <match pattern="{host}:{port}"/>
+        <rewrite template="{$frontend[url]}/yarnuiv2/timeline?{host}?{port}"/>
+    </rule>
+</rules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If an explicit rule doesn't match, log at `DEBUG`. Need to handle null output in case of `JsonUrlRewriteFilterReader`.

## How was this patch tested?

* `mvn -T.5C clean verify -Ppackage,release -Dshellcheck`
* Manual checking of YARNUIV2 that exposed this error in the log in the first place