### PR TITLE
KNOX-1994 : Update Ranger API service definition to allow separate UR…

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/rewrite.xml
@@ -24,8 +24,14 @@
     <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/xusers/users/{path=**}?{**}">
         <rewrite template="{$serviceUrl[RANGER]}/service/xusers/users/{path=**}?{**}"/>
     </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/xusers/users">
+        <rewrite template="{$serviceUrl[RANGER]}/service/xusers/users"/>
+    </rule>
     <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/xusers/groups/{path=**}?{**}">
         <rewrite template="{$serviceUrl[RANGER]}/service/xusers/groups/{path=**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/plugins" pattern="*://*:*/**/ranger/service/xusers/groups">
+        <rewrite template="{$serviceUrl[RANGER]}/service/xusers/groups"/>
     </rule>
     <rule dir="IN" name="RANGER/ranger/inbound/healthcheck" pattern="*://*:*/**/ranger">
         <rewrite template="{$serviceUrl[RANGER]}"/>

--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
@@ -19,7 +19,11 @@
         <route path="/ranger/service/public/**"/>
         <route path="/ranger/service/plugins/**"/>
         <route path="/ranger/service/xusers/users/**"/>
+        <route path="/ranger/service/xusers/users/"/>
+        <route path="/ranger/service/xusers/users"/>
         <route path="/ranger/service/xusers/groups/**"/>
+        <route path="/ranger/service/xusers/groups/"/>
+        <route path="/ranger/service/xusers/groups"/>
         <route path="/ranger"/>
     </routes>
     <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch"/>


### PR DESCRIPTION
…L patterns

## What changes were proposed in this pull request?
Currently Ranger service and plugin endpoints are exposed via Knox. The endpoints should allow url query params too.
