### PR TITLE
KNOX-1992: Add a service definition for Impala's debug web pages

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/impalaui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/impalaui/1.0.0/rewrite.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<rules>
+  <rule dir="IN" name="IMPALAUI/impala/inbound/extrapath">
+    <match pattern="*://*:*/**/impalaui/{**}?{scheme}?{host}?{port}?{**}"/>
+    <rewrite template="{scheme}://{host}:{port}/{**}?{**}"/>
+  </rule>
+
+  <rule dir="IN" name="IMPALAUI/impala/inbound/basepath">
+    <match pattern="*://*:*/**/impalaui/?{scheme}?{host}?{port}?{**}"/>
+    <rewrite template="{scheme}://{host}:{port}/?{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="IMPALAUI/cssi-and-js" pattern="{scheme}://{host}:{port}/www/{path=**}">
+    <rewrite template="{$frontend[url]}/impalaui/www/{path}?scheme={scheme}?host={host}?port={port}"/>
+  </rule>
+
+  <rule dir="OUT" name="IMPALAUI/impala/outbound/extrapath" pattern="{scheme}://{host}:{port}/{path=**}?{**}">
+    <rewrite template="{$frontend[path]}/impalaui/{path}?scheme={scheme}?host={host}?port={port}?{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="IMPALAUI/impala/outbound/basepath" pattern="{scheme}://{host}:{port}/?{**}">
+    <rewrite template="{$frontend[path]}/impalaui/?scheme={scheme}?host={host}?port={port}?{**}"/>
+  </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/impalaui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/impalaui/1.0.0/service.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<service role="IMPALAUI" name="impalaui" version="1.0.0">
+  <routes>
+    <route path="/impalaui/">
+      <rewrite apply="IMPALAUI/impala/inbound/basepath" to="request.url"/>
+    </route>
+    <route path="/impalaui/**">
+      <rewrite apply="IMPALAUI/impala/inbound/extrapath" to="request.url"/>
+    </route>
+  </routes>
+</service>


### PR DESCRIPTION
Allows for proxying connections to Impala's debug web pages.

Testing:
- Deployed in a cluster and verified that it works as expected.