### PR TITLE
KNOX-1999 - Make WEBHDFS rule that rewrites hdfs:// local

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/rewrite.xml
@@ -17,7 +17,7 @@
 -->
 <rules>
 
-    <rule dir="OUT" name="WEBHDFS/webhdfs/outbound" pattern="hdfs://*:*/{path=**}?{**}">
+    <rule dir="OUT" scope="WEBHDFS" name="WEBHDFS/webhdfs/outbound" pattern="hdfs://*:*/{path=**}?{**}">
         <rewrite template="{$frontend[url]}/webhdfs/v1/{path=**}?{**}"/>
     </rule>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
All WEBHDFS rules are global for backwards compatibility, as a result the rule 'WEBHDFS/webhdfs/outbound' is rewriting links from AtlasUI.
There is no reason to rewrite hdfs:// to https://, at-least for other UIs so we need to limit the scope of this rule to local scope from global scope.

The fix is to make the scope of this rule local.

## How was this patch tested?
The patch was manually tested on a local hadoop cluster.
