### PR TITLE
KNOX-1971 - Upgrade Hashicorp Vault test to vault:1.2.1

### DIFF
--- a/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
+++ b/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
@@ -57,7 +57,7 @@ public class TestHashicorpVaultAliasService {
   private static final Logger LOG = LoggerFactory.getLogger(TestHashicorpVaultAliasService.class);
 
   private static final Random RANDOM = new Random();
-  private static final String vaultVersion = "1.0.3";
+  private static final String vaultVersion = "1.2.1";
   private static final String vaultImage = "vault:" + vaultVersion;
   private static final Integer vaultPort = 8200;
   private static final String vaultToken = "myroot";


### PR DESCRIPTION
## What changes were proposed in this pull request?

`vaultVersion` in `TestHashicorpVaultAliasService` has been upgraded to 1.2.1.

## How was this patch tested?

Ran Junit tests