### PR TITLE
KNOX-1788 - New XSS Provider is added to Web Application Security Provider List

### DIFF
--- a/gateway-admin-ui/admin-ui/app/provider-config-wizard/webappsec-wizard.ts
+++ b/gateway-admin-ui/admin-ui/app/provider-config-wizard/webappsec-wizard.ts
@@ -26,6 +26,7 @@ import {WebAppSecurityContributor} from './webappsec-contributor';
 import {STSProviderConfig} from './sts-provider-config';
 import {XFrameOptionsProviderConfig} from './xframeoptions-provider-config';
 import {XContentTypeOptionsProviderConfig} from './xcontent-type-options-provider-config';
+import {XSSProviderConfig} from './xss-provider-config';
 
 export class WebAppSecurityWizard extends CategoryWizard implements ProviderContributorWizard {
     // WebAppSec provider types
@@ -34,12 +35,14 @@ export class WebAppSecurityWizard extends CategoryWizard implements ProviderCont
     private static XFRAME = 'X-Frame-Options';
     private static XCONTENT_TYPE = 'X-Content-Type-Options';
     private static STS = 'Strict Transport Security';
+    private static XSS = 'X-XSS-Protection';
 
     private static webAppSecTypes: string[] = [WebAppSecurityWizard.CSRF,
         WebAppSecurityWizard.CORS,
         WebAppSecurityWizard.XFRAME,
         WebAppSecurityWizard.XCONTENT_TYPE,
-        WebAppSecurityWizard.STS
+        WebAppSecurityWizard.STS,
+        WebAppSecurityWizard.XSS
     ];
 
     private static typeConfigMap: Map<string, typeof WebAppSecurityContributor> =
@@ -48,7 +51,8 @@ export class WebAppSecurityWizard extends CategoryWizard implements ProviderCont
             [WebAppSecurityWizard.CORS, CORSProviderConfig],
             [WebAppSecurityWizard.XFRAME, XFrameOptionsProviderConfig],
             [WebAppSecurityWizard.XCONTENT_TYPE, XContentTypeOptionsProviderConfig],
-            [WebAppSecurityWizard.STS, STSProviderConfig]
+            [WebAppSecurityWizard.STS, STSProviderConfig],
+            [WebAppSecurityWizard.XSS, XSSProviderConfig]
         ] as [string, typeof WebAppSecurityContributor][]);
 
     private stepCount = 4;

--- a/gateway-admin-ui/admin-ui/app/provider-config-wizard/xss-provider-config.ts
+++ b/gateway-admin-ui/admin-ui/app/provider-config-wizard/xss-provider-config.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {WebAppSecurityContributor} from './webappsec-contributor';
+
+export class XSSProviderConfig extends WebAppSecurityContributor {
+    public static X_XSS_PROTECTION = 'X-XSS-Protection';
+
+    private static SUPPORTED_VALUES: string[] = ['0', '1', '1; mode=block'];
+
+    private static displayPropertyNames = [XSSProviderConfig.X_XSS_PROTECTION];
+
+    private static displayPropertyNameBindings: Map<string, string> = new Map(
+       [ [XSSProviderConfig.X_XSS_PROTECTION, 'xss.protection'] ] as [string, string][]
+    );
+
+    constructor() {
+        super();
+        // Set default values
+        this.setParam('xss.protection.enabled', 'true');
+        this.setParam(XSSProviderConfig.displayPropertyNameBindings.get(XSSProviderConfig.X_XSS_PROTECTION), '1; mode=block');
+    }
+
+    getDisplayPropertyNames(): string[] {
+        return XSSProviderConfig.displayPropertyNames;
+    }
+
+    getDisplayNamePropertyBinding(name: string): string {
+        return XSSProviderConfig.displayPropertyNameBindings.get(name);
+    }
+
+    isValidParamValue(paramName: string): boolean {
+        let isValid = false;
+        let value = this.getParam(this.getDisplayNamePropertyBinding(paramName));
+        if (value) {
+            switch (paramName) {
+                case XSSProviderConfig.X_XSS_PROTECTION:
+                    if (XSSProviderConfig.SUPPORTED_VALUES.includes(value)) {
+                        isValid = true;
+                    } else {
+                        // only supported in Chromium
+                        isValid = value.startsWith('1; report=');
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return isValid;
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `XSSProtectionFilter` has been added more than a year ago but there was no support to configure this filter on the `Admin UI`

## How was this patch tested?

Running JUnit tests and executed the following E2E test steps:
1. built and deployed Knox locally then logged into the `Admin UI`

2. added a new `Provider Configuration`: set the name to `smolnarTest` and selected `Web Application Security` from the provider category list and clicked the `Next` button

3. the new option - `X-XSS-Protection` - was displayed in the `Web Application Security Provider Type` list; I choose it and clicked the `Next button`
<img width="1606" alt="Screen Shot 2019-09-04 at 11 17 24 AM" src="https://user-images.githubusercontent.com/34065904/64248841-8b017400-cf12-11e9-8beb-114d8b5f9b16.png">

4. The only parameter for this provider was shown with the appropriate default value (`1;mode=block`)
<img width="1603" alt="Screen Shot 2019-09-04 at 11 18 21 AM" src="https://user-images.githubusercontent.com/34065904/64248939-c2702080-cf12-11e9-9dbe-80f475492aa4.png">

5. I tested different invalid inputs to see if validation works as expected
<img width="1588" alt="Screen Shot 2019-09-04 at 11 19 32 AM" src="https://user-images.githubusercontent.com/34065904/64248977-e29fdf80-cf12-11e9-92d7-ff30d9df1a2c.png">

6. Saved the newly created provider configuration
<img width="1658" alt="Screen Shot 2019-09-04 at 11 20 26 AM" src="https://user-images.githubusercontent.com/34065904/64249002-f51a1900-cf12-11e9-9f63-8db7ebd84f43.png">

7. Created a descriptor with the same name referencing the previously created provider; I only added `HDFSUI` service with a valid URL (used someone's existing cluster for testing purposes and configured the dispatch whitelist accordingly). Confirmed that the generated topology contained the proper configuration values.
<img width="1667" alt="Screen Shot 2019-09-04 at 11 51 45 AM" src="https://user-images.githubusercontent.com/34065904/64249172-5d68fa80-cf13-11e9-8f73-8ce64544c522.png">

8. Issued a `curl` command to see if the configured XSS header is added in the reponse while Knox dispatched my request

```
$ curl -i -k -u admin:admin-password -X GET 'https://localhost:8443/gateway/smolnarTest/hdfs?host=http://psinha-1.gce.cloudera.com:20101'
HTTP/1.1 200 OK
Date: Wed, 04 Sep 2019 09:47:46 GMT
X-XSS-Protection: 1; report=localhost:8443
Date: Wed, 04 Sep 2019 09:47:47 GMT
...
<meta http-equiv="REFRESH" content="0;url&equals;https://localhost:8443/gateway/smolnarTest/hdfs/dfshealth.html?host=http%3A%2F%2Fpsinha-1.gce.cloudera.com%3A20101"/>
<title>Hadoop Administration</title>
</head>
</html>
```

I repeated this step multiple times after I set the `X-XSS-Protection` to different valid values.