### PR TITLE
KNOX-2011 - Don't block SET-COOKIE response header for Ranger UI

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
@@ -34,10 +34,6 @@
     </routes>
     <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch" ha-classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch">
         <param>
-            <name>requestExcludeHeaders</name>
-            <value>Host,Authorization,Content-Length,Transfer-Encoding</value>
-        </param>
-        <param>
             <name>responseExcludeHeaders</name>
             <value>WWW-AUTHENTICATE</value>
         </param>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
@@ -32,5 +32,14 @@
             <rewrite apply="RANGERUI/rangerui/outbound/headers" to="response.headers"/>
         </route>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch" ha-classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch">
+        <param>
+            <name>requestExcludeHeaders</name>
+            <value>Host,Authorization,Content-Length,Transfer-Encoding</value>
+        </param>
+        <param>
+            <name>responseExcludeHeaders</name>
+            <value>WWW-AUTHENTICATE</value>
+        </param>
+    </dispatch>
 </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR updates the dispatch for RangerUI from DefaulrDispatch to ConfigurableDispatch. This is done to allow SET-COOKIE response header to pass through Knox.

## How was this patch tested?
This patch was tested on a local cluster.