### PR TITLE
KNOX-2013 - CM discovery - Add Phoenix to auto discovery

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.model.phoenix;
+
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
+import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGenerator;
+
+import java.util.Locale;
+
+public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator {
+
+  private static final String SERVICE = "AVATICA";
+  private static final String SERVICE_TYPE = "PHOENIX";
+  private static final String ROLE_TYPE = "PHOENIX_QUERY_SERVER";
+
+  @Override
+  public String getService() {
+    return SERVICE;
+  }
+
+  @Override
+  public String getServiceType() {
+    return SERVICE_TYPE;
+  }
+
+  @Override
+  public String getRoleType() {
+    return ROLE_TYPE;
+  }
+
+  @Override
+  public ServiceModel.Type getModelType() {
+    return ServiceModel.Type.API;
+  }
+
+  @Override
+  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
+    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
+  }
+
+  @Override
+  public ServiceModel generateService(ApiService       service,
+                                      ApiServiceConfig serviceConfig,
+                                      ApiRole          role,
+                                      ApiConfigList    roleConfig) {
+    String hostname = role.getHostRef().getHostname();
+    // Phoenix Query Server does not support https
+    String scheme = "http";
+    String port = getRoleConfigValue(roleConfig, "phoenix_query_server_port");
+    return createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s", scheme, hostname, port));
+  }
+
+}

--- a/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
+++ b/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
@@ -31,6 +31,7 @@ org.apache.knox.gateway.topology.discovery.cm.model.yarn.JobTrackerServiceModelG
 org.apache.knox.gateway.topology.discovery.cm.model.livy.LivyServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.oozie.OozieServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.oozie.OozieUIServiceModelGenerator
+org.apache.knox.gateway.topology.discovery.cm.model.phoenix.PhoenixServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.ranger.RangerServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.ranger.RangerUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.solr.SolrServiceModelGenerator

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -311,6 +311,17 @@ public class ClouderaManagerServiceDiscoveryTest {
     assertEquals("https://" + hostName + ":" + port, livyURLs.get(0));
   }
 
+  @Test
+  public void testPhoenixDiscovery() {
+    final String hostName    = "phoenix-host";
+    final String port        = "8765";
+    ServiceDiscovery.Cluster cluster = doTestPhoenixDiscovery(hostName, port, false);
+    assertNotNull(cluster);
+    List<String> phoenixURLs = cluster.getServiceURLs("AVATICA");
+    assertNotNull(phoenixURLs);
+    assertEquals(1, phoenixURLs.size());
+    assertEquals("http://" + hostName + ":" + port, phoenixURLs.get(0));
+  }
 
   @Test
   public void testOozieDiscovery() {
@@ -755,6 +766,19 @@ public class ClouderaManagerServiceDiscoveryTest {
                            "LIVY_SERVER",
                            Collections.emptyMap(),
                            roleProperties);
+  }
+
+
+  private ServiceDiscovery.Cluster doTestPhoenixDiscovery(final String hostName,
+                                                          final String port,
+                                                          final boolean isSSL) {
+      // Configure the role
+      Map<String, String> roleProperties = new HashMap<>();
+      roleProperties.put("phoenix_query_server_port", port);
+      roleProperties.put("ssl_enabled", String.valueOf(isSSL));
+
+      return doTestDiscovery(hostName, "PHOENIX-1", "PHOENIX", "PHOENIX-PHOENIX_QUERY_SERVER-1", "PHOENIX_QUERY_SERVER", Collections.emptyMap(),
+              roleProperties);
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a new module to CM discovery to automatically create AVATICA service that can be used to access the Phoenix Query Servers running in the cluster

## How was this patch tested?

I have brought up a test cluster, added "AVATICA" to the list autoconfigured services, started autodiscovery, and checked that the default.xml topology file gets correctly generated.

I have also connected to the Phoenix Query Server via Knox.