### PR TITLE
KNOX-2017 - Making Cloudera repository available in Knox's parent POM so that Cloudera dependencies are available in every children project

### DIFF
--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -26,11 +26,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <properties>
-        <cloudera-manager.version>6.3.0</cloudera-manager.version>
-        <cloudera-manager-api-swagger.version>${cloudera-manager.version}</cloudera-manager-api-swagger.version>
-    </properties>
-
     <artifactId>gateway-discovery-cm</artifactId>
     <dependencies>
         <dependency>
@@ -40,36 +35,23 @@
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-i18n</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-util-configinjector</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.cloudera.api.swagger</groupId>
             <artifactId>cloudera-manager-api-swagger</artifactId>
-            <version>${cloudera-manager-api-swagger.version}</version>  <!-- or CM version 6.0 and above -->
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>Cloudera</id>
-            <name>Cloudera</name>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-        </repository>
-    </repositories>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,8 @@
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <cglib.version>3.2.12</cglib.version>
         <checkstyle.version>8.23</checkstyle.version>
+        <cloudera-manager.version>6.3.0</cloudera-manager.version>
+        <cloudera-manager-api-swagger.version>${cloudera-manager.version}</cloudera-manager-api-swagger.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-codec.version>1.13</commons-codec.version>
@@ -1972,6 +1974,11 @@
                 <artifactId>forbiddenapis</artifactId>
                 <version>${forbiddenapis.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.cloudera.api.swagger</groupId>
+                <artifactId>cloudera-manager-api-swagger</artifactId>
+                <version>${cloudera-manager-api-swagger.version}</version>  <!-- or CM version 6.0 and above -->
+            </dependency>
 
             <!-- ********** ********** ********** ********** ********** ********** -->
             <!-- ********** Test Dependencies                           ********** -->
@@ -2118,4 +2125,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>Cloudera</id>
+            <name>Cloudera</name>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixing build issue of MAven cannot find Cloudera dependencies in all Knox Maven projects (other than `gateway-discovery-cm`.

## How was this patch tested?

Running JUnit tests and checked manually if the packaged deliverable has the `cloudera-manager-api-swagger:jar`