### PR TITLE
KNOX-2015 - Allow end-users to exclude only certain directives of the SET-COOKIE HTTP header

### DIFF
--- a/gateway-service-storm/src/main/java/org/apache/knox/gateway/storm/StormDispatch.java
+++ b/gateway-service-storm/src/main/java/org/apache/knox/gateway/storm/StormDispatch.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.storm;
 
 import org.apache.knox.gateway.dispatch.DefaultDispatch;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -29,7 +30,7 @@ public class StormDispatch extends DefaultDispatch {
 
   @Override
   public Set<String> getOutboundResponseExcludeHeaders() {
-    return null;
+    return Collections.emptySet();
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of now, end-users can either exclude the SET-COOKIE header entirely (as well as any other request/response header) or include it in the outbound response by invoking `ConfigurableDispatch.setResponseExcludeHeaders` with the appropriate `Set`. What this change brought to the table is that certain SET-COOKIE headers are excluded but some of them are not. 

For instance:
- let say the following header is set in the inbound response: `Set-Cookie: Domain=<domain-value>; Secure; HttpOnly`
- as of now, one can configure Knox to exclude all of these (in fact the default setting is to exclude the SET-COOKIE header)
- however, one may want to configure Knox to exclude only the `Domain=<domain-value>` name/value pair going forward -> the outbound response header will still contain `Set-Cookie: Secure; HttpOnly`

## How was this patch tested?

Added JUnit tests and executed them (running integration tests too where some of the test cases - e.g. `org.apache.knox.gateway.GatewayBasicFuncTest.testXForwardHeadersPopulate()` - check response headers too)

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 17:46 min (Wall Clock)
[INFO] Finished at: 2019-09-23T22:32:34+02:00
[INFO] Final Memory: 383M/2024M
[INFO] ------------------------------------------------------------------------
```