### PR TITLE
KNOX-2018 - KnoxShellTable Filtering needs greaterThan and lessThan, equals Methods

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
@@ -41,7 +41,7 @@ public class KnoxShellTableFilter {
     return this;
   }
 
-  //TODO: use Predicate to evaluate the Pattern.matches 
+  //TODO: use Predicate to evaluate the Pattern.matches
   // for regular expressions: startsWith, endsWith, contains,
   // doesn't contain, etc
   public KnoxShellTable regex(String regex) {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
@@ -91,15 +91,14 @@ public class KnoxShellTableFilter {
 
   @SuppressWarnings("unchecked")
   public KnoxShellTable greaterThanOrEqualTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
-    return filter(s -> s.compareTo(comparable) > 0 || s.compareTo(comparable) == 0);
+    return filter(s -> s.compareTo(comparable) > 0 || s.equals(comparable));
   }
 
   @SuppressWarnings("unchecked")
   public KnoxShellTable lessThanOrEqualTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
-    return filter(s -> s.compareTo(comparable) < 0 || s.compareTo(comparable) == 0);
+    return filter(s -> s.compareTo(comparable) < 0 || s.equals(comparable));
   }
 
-  @SuppressWarnings("unchecked")
   public KnoxShellTable equalTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
     return filter(s -> s.equals(comparable));
   }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
@@ -100,7 +100,7 @@ public class KnoxShellTableFilter {
   }
 
   @SuppressWarnings("unchecked")
-  public KnoxShellTable EqualTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
-    return filter(s -> s.compareTo(comparable) == 0);
+  public KnoxShellTable equalTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
+    return filter(s -> s.equals(comparable));
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
@@ -41,7 +41,9 @@ public class KnoxShellTableFilter {
     return this;
   }
 
-  //TODO: this method can be eliminated when the 'equalTo' method is implemented: regex(regex) = equalTo(anyString)
+  //TODO: use Predicate to evaluate the Pattern.matches 
+  // for regular expressions: startsWith, endsWith, contains,
+  // doesn't contain, etc
   public KnoxShellTable regex(String regex) {
     final Pattern pattern = Pattern.compile(regex);
     final KnoxShellTable filteredTable = new KnoxShellTable();
@@ -82,4 +84,23 @@ public class KnoxShellTableFilter {
     return filter(s -> s.compareTo(comparable) > 0);
   }
 
+  @SuppressWarnings("unchecked")
+  public KnoxShellTable lessThan(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
+    return filter(s -> s.compareTo(comparable) < 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  public KnoxShellTable greaterThanOrEqualTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
+    return filter(s -> s.compareTo(comparable) > 0 || s.compareTo(comparable) == 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  public KnoxShellTable lessThanOrEqualTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
+    return filter(s -> s.compareTo(comparable) < 0 || s.compareTo(comparable) == 0);
+  }
+
+  @SuppressWarnings("unchecked")
+  public KnoxShellTable EqualTo(Comparable<? extends Object> comparable) throws KnoxShellTableFilterException {
+    return filter(s -> s.compareTo(comparable) == 0);
+  }
 }

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilterTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilterTest.java
@@ -39,6 +39,7 @@ public class KnoxShellTableFilterTest {
     synchronized (TEST_DATE_FORMAT) { //sync is needed due to https://pmd.github.io/latest/pmd_rules_java_multithreading.html#unsynchronizedstaticformatter
       TABLE.row().value(10).value(20d).value("text30").value(TEST_DATE_FORMAT.parse("2010-01-01"));
       TABLE.row().value(30).value(40d).value("text50").value(TEST_DATE_FORMAT.parse("2012-01-01"));
+      TABLE.row().value(50).value(60d).value("text60").value(TEST_DATE_FORMAT.parse("2012-02-01"));
     }
   }
 
@@ -50,18 +51,86 @@ public class KnoxShellTableFilterTest {
 
   @Test
   public void testGreaterThanFilter() throws KnoxShellTableFilterException, ParseException {
-    assertEquals(TABLE.filter().name("Column Integer").greaterThan(5).getRows().size(), 2);
-    assertEquals(TABLE.filter().name("Column Integer").greaterThan(25).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Integer").greaterThan(5).getRows().size(), 3);
+    assertEquals(TABLE.filter().name("Column Integer").greaterThan(25).getRows().size(), 2);
 
-    assertEquals(TABLE.filter().name("Column Double").greaterThan(10d).getRows().size(), 2);
-    assertEquals(TABLE.filter().name("Column Double").greaterThan(30d).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Double").greaterThan(10d).getRows().size(), 3);
+    assertEquals(TABLE.filter().name("Column Double").greaterThan(30d).getRows().size(), 2);
 
-    assertEquals(TABLE.filter().name("Column String").greaterThan("text20").getRows().size(), 2);
-    assertEquals(TABLE.filter().name("Column String").greaterThan("text30").getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column String").greaterThan("text20").getRows().size(), 3);
+    assertEquals(TABLE.filter().name("Column String").greaterThan("text30").getRows().size(), 2);
 
     synchronized (TEST_DATE_FORMAT) {
-      assertEquals(TABLE.filter().name("Column Date").greaterThan(TEST_DATE_FORMAT.parse("2009-12-31")).getRows().size(), 2);
-      assertEquals(TABLE.filter().name("Column Date").greaterThan(TEST_DATE_FORMAT.parse("2011-01-01")).getRows().size(), 1);
+      assertEquals(TABLE.filter().name("Column Date").greaterThan(TEST_DATE_FORMAT.parse("2009-12-31")).getRows().size(), 3);
+      assertEquals(TABLE.filter().name("Column Date").greaterThan(TEST_DATE_FORMAT.parse("2011-01-01")).getRows().size(), 2);
+    }
+  }
+
+  @Test
+  public void testLessThanFilter() throws KnoxShellTableFilterException, ParseException {
+    assertEquals(TABLE.filter().name("Column Integer").lessThan(20).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Integer").lessThan(100).getRows().size(), 3);
+
+    assertEquals(TABLE.filter().name("Column Double").lessThan(30d).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Double").lessThan(100d).getRows().size(), 3);
+
+    assertEquals(TABLE.filter().name("Column String").lessThan("text40").getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column String").lessThan("text70").getRows().size(), 3);
+
+    synchronized (TEST_DATE_FORMAT) {
+      assertEquals(TABLE.filter().name("Column Date").lessThan(TEST_DATE_FORMAT.parse("2011-12-31")).getRows().size(), 1);
+      assertEquals(TABLE.filter().name("Column Date").lessThan(TEST_DATE_FORMAT.parse("2013-01-01")).getRows().size(), 3);
+    }
+  }
+
+  @Test
+  public void testGreaterThanOrEqualToThanFilter() throws KnoxShellTableFilterException, ParseException {
+    assertEquals(TABLE.filter().name("Column Integer").greaterThanOrEqualTo(30).getRows().size(), 2);
+    assertEquals(TABLE.filter().name("Column Integer").greaterThanOrEqualTo(50).getRows().size(), 1);
+
+    assertEquals(TABLE.filter().name("Column Double").greaterThanOrEqualTo(40d).getRows().size(), 2);
+    assertEquals(TABLE.filter().name("Column Double").greaterThanOrEqualTo(20d).getRows().size(), 3);
+
+    assertEquals(TABLE.filter().name("Column String").greaterThanOrEqualTo("text50").getRows().size(), 2);
+    assertEquals(TABLE.filter().name("Column String").greaterThanOrEqualTo("text30").getRows().size(), 3);
+
+    synchronized (TEST_DATE_FORMAT) {
+      assertEquals(TABLE.filter().name("Column Date").greaterThanOrEqualTo(TEST_DATE_FORMAT.parse("2009-12-31")).getRows().size(), 3);
+      assertEquals(TABLE.filter().name("Column Date").greaterThanOrEqualTo(TEST_DATE_FORMAT.parse("2012-01-01")).getRows().size(), 2);
+    }
+  }
+
+  @Test
+  public void testLessThanOrEqualToThanFilter() throws KnoxShellTableFilterException, ParseException {
+    assertEquals(TABLE.filter().name("Column Integer").lessThanOrEqualTo(30).getRows().size(), 2);
+    assertEquals(TABLE.filter().name("Column Integer").lessThanOrEqualTo(50).getRows().size(), 3);
+
+    assertEquals(TABLE.filter().name("Column Double").lessThanOrEqualTo(40d).getRows().size(), 2);
+    assertEquals(TABLE.filter().name("Column Double").lessThanOrEqualTo(20d).getRows().size(), 1);
+
+    assertEquals(TABLE.filter().name("Column String").lessThanOrEqualTo("text50").getRows().size(), 2);
+    assertEquals(TABLE.filter().name("Column String").lessThanOrEqualTo("text30").getRows().size(), 1);
+
+    synchronized (TEST_DATE_FORMAT) {
+      assertEquals(TABLE.filter().name("Column Date").lessThanOrEqualTo(TEST_DATE_FORMAT.parse("2012-02-01")).getRows().size(), 3);
+      assertEquals(TABLE.filter().name("Column Date").lessThanOrEqualTo(TEST_DATE_FORMAT.parse("2010-01-01")).getRows().size(), 1);
+    }
+  }
+
+  @Test
+  public void testEqualToFilter() throws KnoxShellTableFilterException, ParseException {
+    assertEquals(TABLE.filter().name("Column Integer").EqualTo(60).getRows().size(), 0);
+    assertEquals(TABLE.filter().name("Column Integer").EqualTo(50).getRows().size(), 1);
+
+    assertEquals(TABLE.filter().name("Column Double").EqualTo(40d).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Double").EqualTo(90d).getRows().size(), 0);
+
+    assertEquals(TABLE.filter().name("Column String").EqualTo("text90").getRows().size(), 0);
+    assertEquals(TABLE.filter().name("Column String").EqualTo("text30").getRows().size(), 1);
+
+    synchronized (TEST_DATE_FORMAT) {
+      assertEquals(TABLE.filter().name("Column Date").EqualTo(TEST_DATE_FORMAT.parse("2012-02-01")).getRows().size(), 1);
+      assertEquals(TABLE.filter().name("Column Date").EqualTo(TEST_DATE_FORMAT.parse("2016-01-01")).getRows().size(), 0);
     }
   }
 

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilterTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilterTest.java
@@ -119,18 +119,18 @@ public class KnoxShellTableFilterTest {
 
   @Test
   public void testEqualToFilter() throws KnoxShellTableFilterException, ParseException {
-    assertEquals(TABLE.filter().name("Column Integer").EqualTo(60).getRows().size(), 0);
-    assertEquals(TABLE.filter().name("Column Integer").EqualTo(50).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Integer").equalTo(60).getRows().size(), 0);
+    assertEquals(TABLE.filter().name("Column Integer").equalTo(50).getRows().size(), 1);
 
-    assertEquals(TABLE.filter().name("Column Double").EqualTo(40d).getRows().size(), 1);
-    assertEquals(TABLE.filter().name("Column Double").EqualTo(90d).getRows().size(), 0);
+    assertEquals(TABLE.filter().name("Column Double").equalTo(40d).getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column Double").equalTo(90d).getRows().size(), 0);
 
-    assertEquals(TABLE.filter().name("Column String").EqualTo("text90").getRows().size(), 0);
-    assertEquals(TABLE.filter().name("Column String").EqualTo("text30").getRows().size(), 1);
+    assertEquals(TABLE.filter().name("Column String").equalTo("text90").getRows().size(), 0);
+    assertEquals(TABLE.filter().name("Column String").equalTo("text30").getRows().size(), 1);
 
     synchronized (TEST_DATE_FORMAT) {
-      assertEquals(TABLE.filter().name("Column Date").EqualTo(TEST_DATE_FORMAT.parse("2012-02-01")).getRows().size(), 1);
-      assertEquals(TABLE.filter().name("Column Date").EqualTo(TEST_DATE_FORMAT.parse("2016-01-01")).getRows().size(), 0);
+      assertEquals(TABLE.filter().name("Column Date").equalTo(TEST_DATE_FORMAT.parse("2012-02-01")).getRows().size(), 1);
+      assertEquals(TABLE.filter().name("Column Date").equalTo(TEST_DATE_FORMAT.parse("2016-01-01")).getRows().size(), 0);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added lessThan, greaterThanOrEqualTo, lessThanOrEqualTo, and equalTo methods for KnoxShellTable. 

## How was this patch tested?

Unit and manual tests
