### PR TITLE
KNOX-2057 - Using unique table IDs through different test cases even if they are in different test classes (JVM is shared in during parallel execution)

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -29,8 +29,8 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
 
   private boolean withHeaders;
 
-  CSVKnoxShellTableBuilder(long id) {
-    super(id);
+  CSVKnoxShellTableBuilder(KnoxShellTable table) {
+    super(table);
   }
 
   public CSVKnoxShellTableBuilder withHeaders() {
@@ -40,35 +40,32 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
 
   public KnoxShellTable url(String url) throws IOException {
     int rowIndex = 0;
-    KnoxShellTable table = null;
     URL urlToCsv = new URL(url);
     URLConnection connection = urlToCsv.openConnection();
     try (Reader urlConnectionStreamReader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(urlConnectionStreamReader);) {
-      table = new KnoxShellTable();
       if (title != null) {
-        table.title(title);
+        this.table.title(title);
       }
-      table.id(id);
       String row = null;
       while ((row = csvReader.readLine()) != null) {
         boolean addingHeaders = (withHeaders && rowIndex == 0);
         if (!addingHeaders) {
-          table.row();
+          this.table.row();
         }
         String[] data = row.split(",");
 
         for (String value : data) {
           if (addingHeaders) {
-            table.header(value);
+            this.table.header(value);
           } else {
-            table.value(value);
+            this.table.value(value);
           }
         }
         rowIndex++;
       }
     }
-    return table;
+    return this.table;
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/JSONKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/JSONKnoxShellTableBuilder.java
@@ -30,8 +30,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class JSONKnoxShellTableBuilder extends KnoxShellTableBuilder {
 
-  JSONKnoxShellTableBuilder(long id) {
-    super(id);
+  JSONKnoxShellTableBuilder(KnoxShellTable table) {
+    super(table);
   }
 
   public KnoxShellTable fromJson(String json) throws IOException {
@@ -42,16 +42,15 @@ public class JSONKnoxShellTableBuilder extends KnoxShellTableBuilder {
   private KnoxShellTable toKnoxShellTable(String json) throws IOException {
     final ObjectMapper mapper = new ObjectMapper(new JsonFactory());
     final SimpleModule module = new SimpleModule();
-    module.addDeserializer(KnoxShellTable.class, new KnoxShellTableRowDeserializer());
+    module.addDeserializer(KnoxShellTable.class, new KnoxShellTableRowDeserializer(table));
     mapper.registerModule(module);
 
-    final KnoxShellTable table = mapper.readValue(json, new TypeReference<KnoxShellTable>() {
+    final KnoxShellTable tableFromJson = mapper.readValue(json, new TypeReference<KnoxShellTable>() {
     });
     if (title != null) {
-      table.title(title);
+      tableFromJson.title(title);
     }
-    table.id(id);
-    return table;
+    return tableFromJson;
   }
 
   public KnoxShellTable path(String path) throws IOException {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/JoinKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/JoinKnoxShellTableBuilder.java
@@ -26,8 +26,8 @@ public class JoinKnoxShellTableBuilder extends KnoxShellTableBuilder {
   private KnoxShellTable left;
   private KnoxShellTable right;
 
-  JoinKnoxShellTableBuilder(long id) {
-    super(id);
+  JoinKnoxShellTableBuilder(KnoxShellTable table) {
+    super(table);
   }
 
   @Override
@@ -53,22 +53,20 @@ public class JoinKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable on(int leftIndex, int rightIndex) {
-    final KnoxShellTable joinedTable = new KnoxShellTable();
     if (title != null) {
-      joinedTable.title(title);
+      this.table.title(title);
     }
-    joinedTable.id(id);
 
-    joinedTable.headers.addAll(new ArrayList<String>(left.headers));
+    this.table.headers.addAll(new ArrayList<String>(left.headers));
     for (List<Comparable<? extends Object>> row : left.rows) {
-      joinedTable.rows.add(new ArrayList<Comparable<? extends Object>>(row));
+      this.table.rows.add(new ArrayList<Comparable<? extends Object>>(row));
     }
     List<Comparable<? extends Object>> row;
     Comparable<? extends Object> leftKey;
     int matchedIndex;
 
-    joinedTable.headers.addAll(new ArrayList<String>(right.headers));
-    for (Iterator<List<Comparable<? extends Object>>> it = joinedTable.rows.iterator(); it.hasNext();) {
+    this.table.headers.addAll(new ArrayList<String>(right.headers));
+    for (Iterator<List<Comparable<? extends Object>>> it = this.table.rows.iterator(); it.hasNext();) {
       row = (List<Comparable<? extends Object>>) it.next();
       leftKey = row.get(leftIndex);
       if (leftKey != null) {
@@ -80,7 +78,7 @@ public class JoinKnoxShellTableBuilder extends KnoxShellTableBuilder {
         }
       }
     }
-    return joinedTable;
+    return this.table;
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -42,13 +42,12 @@ public class KnoxShellTable {
   String title;
   long id;
 
-  public KnoxShellTable title(String title) {
-    this.title = title;
-    return this;
+  KnoxShellTable() {
+    this.id = getUniqueTableId();
   }
 
-  public KnoxShellTable id(long id) {
-    this.id = id;
+  public KnoxShellTable title(String title) {
+    this.title = title;
     return this;
   }
 
@@ -113,7 +112,7 @@ public class KnoxShellTable {
   }
 
   public static KnoxShellTableBuilder builder() {
-    return new KnoxShellTableBuilder(getUniqueTableId());
+    return new KnoxShellTableBuilder();
   }
 
   static long getUniqueTableId() {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableBuilder.java
@@ -19,10 +19,14 @@ package org.apache.knox.gateway.shell.table;
 
 public class KnoxShellTableBuilder {
   protected String title;
-  protected final long id;
+  protected KnoxShellTable table;
 
-  KnoxShellTableBuilder(long id) {
-    this.id = id;
+  KnoxShellTableBuilder() {
+    this.table = new KnoxShellTable();
+  }
+
+  protected KnoxShellTableBuilder(KnoxShellTable table) {
+    this.table = table;
   }
 
   public KnoxShellTableBuilder title(String title) {
@@ -31,18 +35,18 @@ public class KnoxShellTableBuilder {
   }
 
   public CSVKnoxShellTableBuilder csv() {
-    return new CSVKnoxShellTableBuilder(id);
+    return new CSVKnoxShellTableBuilder(table);
   }
 
   public JSONKnoxShellTableBuilder json() {
-    return new JSONKnoxShellTableBuilder(id);
+    return new JSONKnoxShellTableBuilder(table);
   }
 
   public JoinKnoxShellTableBuilder join() {
-    return new JoinKnoxShellTableBuilder(id);
+    return new JoinKnoxShellTableBuilder(table);
   }
 
   public JDBCKnoxShellTableBuilder jdbc() {
-    return new JDBCKnoxShellTableBuilder(id);
+    return new JDBCKnoxShellTableBuilder(table);
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFilter.java
@@ -23,16 +23,15 @@ import java.util.regex.Pattern;
 
 public class KnoxShellTableFilter {
 
-  final long id;
+  final KnoxShellTable filteredTable = new KnoxShellTable();
   final KnoxShellTable tableToFilter;
   private int index;
 
   KnoxShellTableFilter(KnoxShellTable table) {
-    this.id = KnoxShellTable.getUniqueTableId();
     this.tableToFilter = table;
     //inheriting the original table's call history
     final List<KnoxShellTableCall> callHistory = KnoxShellTableCallHistory.getInstance().getCallHistory(tableToFilter.id);
-    KnoxShellTableCallHistory.getInstance().saveCalls(id, callHistory);
+    KnoxShellTableCallHistory.getInstance().saveCalls(filteredTable.id, callHistory);
   }
 
   public KnoxShellTableFilter name(String name) throws KnoxShellTableFilterException {
@@ -58,7 +57,7 @@ public class KnoxShellTableFilter {
   // doesn't contain, etc
   public KnoxShellTable regex(Comparable<String> regex) {
     final Pattern pattern = Pattern.compile((String) regex);
-    final KnoxShellTable filteredTable = prepareFilteredTable();
+    prepareFilteredTable();
     for (List<Comparable<?>> row : tableToFilter.rows) {
       if (pattern.matcher(row.get(index).toString()).matches()) {
         filteredTable.row();
@@ -70,18 +69,15 @@ public class KnoxShellTableFilter {
     return filteredTable;
   }
 
-  private KnoxShellTable prepareFilteredTable() {
-    final KnoxShellTable filteredTable = new KnoxShellTable();
-    filteredTable.id(id);
+  private void prepareFilteredTable() {
     filteredTable.headers.addAll(tableToFilter.headers);
     filteredTable.title(tableToFilter.title);
-    return filteredTable;
   }
 
   @SuppressWarnings("rawtypes")
   private KnoxShellTable filter(Predicate<Comparable> p) throws KnoxShellTableFilterException {
     try {
-      final KnoxShellTable filteredTable = prepareFilteredTable();
+      prepareFilteredTable();
       for (List<Comparable<? extends Object>> row : tableToFilter.rows) {
         if (p.test(row.get(index))) {
           filteredTable.row(); // Adds a new empty row to filtered table

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableHistoryAspect.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableHistoryAspect.java
@@ -59,19 +59,19 @@ public class KnoxShellTableHistoryAspect {
       filter = (KnoxShellTableFilter) joinPoint.proceed();
       return filter;
     } finally {
-      saveKnoxShellTableCall(joinPoint, filter.id);
+      saveKnoxShellTableCall(joinPoint, filter.filteredTable.id);
     }
   }
 
   @After("org.apache.knox.gateway.shell.table.KnoxShellTableHistoryAspect.knoxShellTableBuilderPointcut()")
   public void afterBuilding(JoinPoint joinPoint) throws Throwable {
-    final long builderId = ((KnoxShellTableBuilder) joinPoint.getTarget()).id;
+    final long builderId = ((KnoxShellTableBuilder) joinPoint.getTarget()).table.id;
     saveKnoxShellTableCall(joinPoint, builderId);
   }
 
   @After("org.apache.knox.gateway.shell.table.KnoxShellTableHistoryAspect.knoxShellTableFilterPointcut()")
   public void afterFiltering(JoinPoint joinPoint) throws Throwable {
-    final long builderId = ((KnoxShellTableFilter) joinPoint.getTarget()).id;
+    final long builderId = ((KnoxShellTableFilter) joinPoint.getTarget()).filteredTable.id;
     saveKnoxShellTableCall(joinPoint, builderId);
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableRowDeserializer.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableRowDeserializer.java
@@ -46,12 +46,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @SuppressWarnings("serial")
 public class KnoxShellTableRowDeserializer extends StdDeserializer<KnoxShellTable> {
 
-  KnoxShellTableRowDeserializer() {
-    this(KnoxShellTable.class);
+  private final KnoxShellTable table;
+
+  KnoxShellTableRowDeserializer(KnoxShellTable table) {
+    this(KnoxShellTable.class, table);
   }
 
-  protected KnoxShellTableRowDeserializer(Class<?> vc) {
+  protected KnoxShellTableRowDeserializer(Class<?> vc, KnoxShellTable table) {
     super(vc);
+    this.table = table;
   }
 
   @Override
@@ -68,8 +71,10 @@ public class KnoxShellTableRowDeserializer extends StdDeserializer<KnoxShellTabl
     final List<KnoxShellTableCall> calls = parseCallHistoryListJSONNode(jsonContent.get("callHistoryList"));
     long tempId = KnoxShellTable.getUniqueTableId();
     KnoxShellTableCallHistory.getInstance().saveCalls(tempId, calls);
-    final KnoxShellTable table = KnoxShellTableCallHistory.getInstance().replay(tempId, calls.size());
+    final KnoxShellTable tableFromJson = KnoxShellTableCallHistory.getInstance().replay(tempId, calls.size());
+    table.rows = tableFromJson.rows;
     KnoxShellTableCallHistory.getInstance().removeCallsById(tempId);
+    KnoxShellTableCallHistory.getInstance().removeCallsById(tableFromJson.id);
     return table;
   }
 
@@ -134,7 +139,6 @@ public class KnoxShellTableRowDeserializer extends StdDeserializer<KnoxShellTabl
   }
 
   private KnoxShellTable parseJsonWithData(final TreeNode jsonContent) {
-    final KnoxShellTable table = new KnoxShellTable();
     if (jsonContent.get("title").size() != 0) {
       table.title(trimJSONQuotes(jsonContent.get("title").toString()));
     }

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableCallHistoryTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableCallHistoryTest.java
@@ -51,13 +51,13 @@ public class KnoxShellTableCallHistoryTest {
 
   @Test
   public void shouldReturnEmptyListInCaseThereWasNoCall() throws Exception {
-    long id = 0;
+    final long id = KnoxShellTable.getUniqueTableId();
     assertTrue(KnoxShellTableCallHistory.getInstance().getCallHistory(id).isEmpty());
   }
 
   @Test
   public void shouldReturnCallHistoryInProperOrder() throws Exception {
-    final long id = 1;
+    final long id = KnoxShellTable.getUniqueTableId();
     recordCallHistory(id, 2);
     final List<KnoxShellTableCall> callHistory = KnoxShellTableCallHistory.getInstance().getCallHistory(id);
     assertFalse(callHistory.isEmpty());
@@ -67,7 +67,7 @@ public class KnoxShellTableCallHistoryTest {
 
   @Test
   public void shouldThrowIllegalArgumentExceptionIfReplayingToInappropriateStep() {
-    final long id = 2;
+    final long id = KnoxShellTable.getUniqueTableId();
     recordCallHistory(id, 3);
 
     // step 2 - second call - does not produce KnoxShellTable (builderMethod=false)
@@ -78,7 +78,7 @@ public class KnoxShellTableCallHistoryTest {
 
   @Test
   public void shouldProduceKnoxShellTableIfReplayingToValidStep() {
-    final long id = 3;
+    final long id = KnoxShellTable.getUniqueTableId();
     recordCallHistory(id, 3);
 
     final KnoxShellTable table = KnoxShellTableCallHistory.getInstance().replay(id, 3);
@@ -90,7 +90,7 @@ public class KnoxShellTableCallHistoryTest {
 
   @Test
   public void shouldNotRollBackIfNoBuilderMethodRecorded() throws Exception {
-    final long id = 4;
+    final long id = KnoxShellTable.getUniqueTableId();
     recordCallHistory(id, 1);
 
     expectedException.expect(IllegalArgumentException.class);
@@ -100,7 +100,7 @@ public class KnoxShellTableCallHistoryTest {
 
   @Test
   public void shouldNotRollBackIfOnlyOneBuilderMethodRecorded() throws Exception {
-    final long id = 5;
+    final long id = KnoxShellTable.getUniqueTableId();
     recordCallHistory(id, 3);
 
     expectedException.expect(IllegalArgumentException.class);
@@ -110,7 +110,7 @@ public class KnoxShellTableCallHistoryTest {
 
   @Test
   public void shouldRollbackToValidPreviousStep() throws Exception {
-    long id = 6;
+    final long id = KnoxShellTable.getUniqueTableId();
     recordCallHistory(id, 6);
     // filtered table where ZIPs are greater than "5" (in CSV everything is String)
     final KnoxShellTable table = KnoxShellTableCallHistory.getInstance().replay(id, 6);

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -362,11 +362,9 @@ public class KnoxShellTableTest {
   @Test
   public void shouldReturnDifferentCallHistoryForDifferentTables() throws Exception {
     final KnoxShellTable table1 = new KnoxShellTable();
-    table1.id(1);
-    KnoxShellTableCallHistory.getInstance().saveCall(1, new KnoxShellTableCall("class1", "method1", true, Collections.singletonMap("param1", String.class)));
+    KnoxShellTableCallHistory.getInstance().saveCall(table1.getId(), new KnoxShellTableCall("class1", "method1", true, Collections.singletonMap("param1", String.class)));
     final KnoxShellTable table2 = new KnoxShellTable();
-    table1.id(2);
-    KnoxShellTableCallHistory.getInstance().saveCall(2, new KnoxShellTableCall("class2", "method2", false, Collections.singletonMap("param2", String.class)));
+    KnoxShellTableCallHistory.getInstance().saveCall(table2.getId(), new KnoxShellTableCall("class2", "method2", false, Collections.singletonMap("param2", String.class)));
     assertNotEquals(table1.getCallHistoryList(), table2.getCallHistoryList());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Maven `surefire-plugin` reuse JVM forks by default which might end-up overwriting the KnoxShellTable call history with undesired value(s) during parallel execution. To avoid this we need to make sure to use unique table IDs in our tests.

## How was this patch tested?

Ran JUnit tests locally (note: I did it previously many times but I couldn't reproduce this issue).

Executed the same tests as described in #162 .