### PR TITLE
KNOX-2060 - Extend KnoxShellTable statistics methods to work with columns of Strings

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -42,7 +42,8 @@ public class KnoxShellTable {
         FLOAT,
         BYTE,
         SHORT,
-        LONG
+        LONG,
+        STRING
     }
 
   private static final String LINE_SEPARATOR = System.getProperty("line.separator");
@@ -97,29 +98,37 @@ public class KnoxShellTable {
   }
 
   private Conversions getConversion(Comparable<? extends Object> colIndex) {
-      Conversions type = null;
-      if (colIndex instanceof Double) {
-        type = Conversions.DOUBLE;
-      }
-      else if (colIndex instanceof Integer) {
-        type = Conversions.INTEGER;
-      }
-      else if (colIndex instanceof Float) {
-        type = Conversions.FLOAT;
-      }
-      else if (colIndex instanceof Byte) {
-        type = Conversions.BYTE;
-      }
-      else if (colIndex instanceof Short) {
-        type = Conversions.SHORT;
-      }
-      else if (colIndex instanceof Long) {
-        type = Conversions.LONG;
+    Conversions type = null;
+    if (colIndex instanceof Double) {
+      type = Conversions.DOUBLE;
+    }
+    else if (colIndex instanceof Integer) {
+      type = Conversions.INTEGER;
+    }
+    else if (colIndex instanceof Float) {
+      type = Conversions.FLOAT;
+    }
+    else if (colIndex instanceof Byte) {
+      type = Conversions.BYTE;
+    }
+    else if (colIndex instanceof Short) {
+      type = Conversions.SHORT;
+    }
+    else if (colIndex instanceof Long) {
+      type = Conversions.LONG;
+    }
+    else if (colIndex instanceof String) {
+      if (((String) colIndex).matches("-?\\d+(\\.\\d+)?")) {
+          type = Conversions.STRING;
       }
       else {
-          throw new IllegalArgumentException();
+        throw new IllegalArgumentException("String contains non-numeric characters");
       }
-      return type;
+    }
+    else {
+        throw new IllegalArgumentException("Unsupported data type");
+    }
+    return type;
   }
 
   private double[] toDoubleArray(String colName) throws IllegalArgumentException {
@@ -148,6 +157,9 @@ public class KnoxShellTable {
           break;
         case LONG:
           colArray[i] = (double) ((Long) col.get(i)).longValue();
+          break;
+        case STRING:
+          colArray[i] = (double) (Double.parseDouble((String) col.get(i)));
           break;
       }
     }

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -385,9 +385,9 @@ public class KnoxShellTableTest {
       Long long20 = (long) 200000000;
       Long long30 = (long) 300000000;
 
-      String string10 = "-10";
-      String string20 = "-20";
-      String string30 = "-30.00";
+      String string10 = "1023.98000000000";
+      String string20 = "2089743.6";
+      String string30 = "-3";
 
       KnoxShellTable TABLE = new KnoxShellTable();
       TABLE.header("Column Integer").header("Column Double").header("Column Float").header("Column Byte").header("Column Short").header("Column Long").header("Column String");
@@ -404,7 +404,7 @@ public class KnoxShellTableTest {
       assertEquals(20, TABLE.mean("Column Byte"), 0.1);
       assertEquals(20, TABLE.mean("Column Short"), 0.1);
       assertEquals(2.0E8, TABLE.mean("Column Long"), 0.1);
-      assertEquals(-20, TABLE.mean("Column String"), 0.1);
+      assertEquals(696921.52666666, TABLE.mean("Column String"), 0.1);
   }
 
   @Test

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -385,11 +385,15 @@ public class KnoxShellTableTest {
       Long long20 = (long) 200000000;
       Long long30 = (long) 300000000;
 
+      String string10 = "-10";
+      String string20 = "-20";
+      String string30 = "-30.00";
+
       KnoxShellTable TABLE = new KnoxShellTable();
-      TABLE.header("Column Integer").header("Column Double").header("Column Float").header("Column Byte").header("Column Short").header("Column Long");
-      TABLE.row().value(10).value(20d).value(20.9999).value(byte10).value(short10).value(long10);
-      TABLE.row().value(30).value(40d).value(40.9999).value(byte20).value(short20).value(long20);
-      TABLE.row().value(27).value(60d).value(60.9999).value(byte30).value(short30).value(long30);
+      TABLE.header("Column Integer").header("Column Double").header("Column Float").header("Column Byte").header("Column Short").header("Column Long").header("Column String");
+      TABLE.row().value(10).value(20d).value(20.9999).value(byte10).value(short10).value(long10).value(string10);
+      TABLE.row().value(30).value(40d).value(40.9999).value(byte20).value(short20).value(long20).value(string20);
+      TABLE.row().value(27).value(60d).value(60.9999).value(byte30).value(short30).value(long30).value(string30);
 
       assertEquals(22.3, TABLE.mean("Column Integer"), 0.1);
       assertEquals(40, TABLE.mean("Column Double"), 0.1);
@@ -400,6 +404,7 @@ public class KnoxShellTableTest {
       assertEquals(20, TABLE.mean("Column Byte"), 0.1);
       assertEquals(20, TABLE.mean("Column Short"), 0.1);
       assertEquals(2.0E8, TABLE.mean("Column Long"), 0.1);
+      assertEquals(-20, TABLE.mean("Column String"), 0.1);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added ability to convert columns of type String to double[] for operations with StatUtils (mean, median, mode, etc). 

## How was this patch tested?

Manual and unit tests.
