### PR TITLE
KNOX-2056 - Adding Service Definitions management into Admin UI

### DIFF
--- a/gateway-admin-ui/admin-ui/app/app.component.ts
+++ b/gateway-admin-ui/admin-ui/app/app.component.ts
@@ -16,6 +16,7 @@
  */
 import {Component} from '@angular/core';
 import {TopologyService} from './topology.service';
+import {ServiceDefinitionService} from './service-definition/servicedefinition.service';
 import {ResourceTypesService} from './resourcetypes/resourcetypes.service';
 
 @Component({
@@ -35,11 +36,12 @@ import {ResourceTypesService} from './resourcetypes/resourcetypes.service';
             </div>
         </div>
     `,
-    providers: [TopologyService, ResourceTypesService]
+    providers: [TopologyService, ServiceDefinitionService, ResourceTypesService]
 })
 
 export class AppComponent {
     constructor(private topologyService: TopologyService,
+                private serviceDefinitionService: ServiceDefinitionService,
                 private resourcetypesService: ResourceTypesService) {
     }
 }

--- a/gateway-admin-ui/admin-ui/app/app.module.ts
+++ b/gateway-admin-ui/admin-ui/app/app.module.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import {NgModule} from '@angular/core';
+import {DataTableModule} from 'angular2-datatable';
 import {BrowserModule} from '@angular/platform-browser';
 import {HttpClientModule, HttpClientXsrfModule} from '@angular/common/http';
 import {FormsModule} from '@angular/forms';
@@ -23,6 +24,8 @@ import {APP_BASE_HREF} from '@angular/common';
 
 import {AppComponent} from './app.component';
 import {TopologyService} from './topology.service';
+import {ServiceDefinitionService} from './service-definition/servicedefinition.service';
+import {ServiceDefinitionDetailComponent} from './service-definition/servicedefinition-detail.component';
 import {GatewayVersionService} from './gateway-version.service';
 import {GatewayVersionComponent} from './gateway-version.component';
 import {TopologyComponent} from './topology.component';
@@ -51,11 +54,13 @@ import {ProviderConfigWizardComponent} from './provider-config-wizard/provider-c
         FormsModule,
         CustomFormsModule,
         BsModalModule,
-        AceEditorModule
+        AceEditorModule,
+        DataTableModule
     ],
     declarations: [AppComponent,
         TopologyComponent,
         TopologyDetailComponent,
+        ServiceDefinitionDetailComponent,
         GatewayVersionComponent,
         XmlPipe,
         JsonPrettyPipe,
@@ -70,6 +75,7 @@ import {ProviderConfigWizardComponent} from './provider-config-wizard/provider-c
         ProviderConfigWizardComponent
     ],
     providers: [TopologyService,
+        ServiceDefinitionService,
         GatewayVersionService,
         ResourceComponent,
         ResourceTypesService,

--- a/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.html
+++ b/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="resourceType && resourceType !== 'Topologies'" class="panel panel-default">
+<div *ngIf="resourceType && resourceType !== 'Topologies' && resourceType !== 'Service Definitions'" class="panel panel-default">
     <div class="panel-heading">
         <h4 class="panel-title">
             {{ getTitleSubject() }} Detail <span *ngIf="hasSelectedResource()"
@@ -550,4 +550,9 @@
 <!-- Topology Details -->
 <div *ngIf="resourceType === 'Topologies'">
     <app-topology-detail></app-topology-detail>
+</div>
+
+<!-- Service Definition Details -->
+<div *ngIf="resourceType === 'Service Definitions'">
+    <app-servicedefinition-detail></app-servicedefinition-detail>
 </div>

--- a/gateway-admin-ui/admin-ui/app/resource/resource.component.html
+++ b/gateway-admin-ui/admin-ui/app/resource/resource.component.html
@@ -1,6 +1,6 @@
 <div>
     <div class="table-responsive" style="width:100%; overflow: auto; overflow-y: scroll">
-        <table class="table table-hover">
+        <table class="table table-hover" [mfData]="resources" #mf="mfDataTable" [mfRowsOnPage]="10">
             <thead>
             <tr>
                 <th>
@@ -23,7 +23,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr *ngFor="let resource of resources"
+            <tr *ngFor="let resource of mf.data"
                 [class.selected]="resource === selectedResource"
                 [class.active]="isSelectedResource(resource)"
                 (click)="onSelect(resource)"
@@ -32,6 +32,13 @@
                 <td *ngIf="resourceType === 'Topologies'">{{resource.timestamp | date:'medium'}}</td>
             </tr>
             </tbody>
+		    <tfoot>
+		    <tr>
+		        <td colspan="4">
+		            <mfBootstrapPaginator [rowsOnPageSet]="[5,10,15]"></mfBootstrapPaginator>
+		        </td>
+		    </tr>
+		    </tfoot>
         </table>
     </div>
     <div>

--- a/gateway-admin-ui/admin-ui/app/resourcetypes/resourcetypes.service.ts
+++ b/gateway-admin-ui/admin-ui/app/resourcetypes/resourcetypes.service.ts
@@ -20,7 +20,7 @@ import {Subject} from 'rxjs/Subject';
 @Injectable()
 export class ResourceTypesService {
 
-    resourceTypes = ['Provider Configurations', 'Descriptors', 'Topologies'];
+    resourceTypes = ['Provider Configurations', 'Descriptors', 'Topologies', 'Service Definitions'];
     selectedResourceTypeSource = new Subject<string>();
     public selectedResourceType$ = this.selectedResourceTypeSource.asObservable();
 

--- a/gateway-admin-ui/admin-ui/app/service-definition/rewrite.rule.ts
+++ b/gateway-admin-ui/admin-ui/app/service-definition/rewrite.rule.ts
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-export class Resource {
-    timestamp: number;
+export class RewriteRule {
+    dir: string;
     name: string;
-    uri: string;
-    href: string;
-    content: string;
-    service: string;
+    pattern: string;
 }

--- a/gateway-admin-ui/admin-ui/app/service-definition/rewrite.rules.ts
+++ b/gateway-admin-ui/admin-ui/app/service-definition/rewrite.rules.ts
@@ -14,12 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {RewriteRule} from './rewrite.rule';
 
-export class Resource {
-    timestamp: number;
-    name: string;
-    uri: string;
-    href: string;
-    content: string;
-    service: string;
+export class RewriteRules {
+    rules: RewriteRule[];
 }

--- a/gateway-admin-ui/admin-ui/app/service-definition/service.ts
+++ b/gateway-admin-ui/admin-ui/app/service-definition/service.ts
@@ -15,11 +15,8 @@
  * limitations under the License.
  */
 
-export class Resource {
-    timestamp: number;
+export class Service {
     name: string;
-    uri: string;
-    href: string;
-    content: string;
-    service: string;
+    role: string;
+    version: string;
 }

--- a/gateway-admin-ui/admin-ui/app/service-definition/servicedefinition-detail.component.ts
+++ b/gateway-admin-ui/admin-ui/app/service-definition/servicedefinition-detail.component.ts
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {BsModalComponent} from 'ng2-bs3-modal/ng2-bs3-modal';
+import {ServiceDefinition} from './servicedefinition';
+import {ServiceDefinitionService} from './servicedefinition.service';
+import {ResourceTypesService} from '../resourcetypes/resourcetypes.service';
+
+import 'brace/theme/monokai';
+import 'brace/mode/xml';
+
+@Component({
+    selector: 'app-servicedefinition-detail',
+    template: `
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h4 class="panel-title">{{title}} <span class="pull-right">{{titleSuffix}}</span></h4>
+            </div>
+            <div *ngIf="serviceDefinitionContent" class="panel-body">
+                <ace-editor
+                        [(text)]="serviceDefinitionContent"
+                        [mode]="'xml'"
+                        [options]="options"
+                        [theme]="theme"
+                        style="min-height: 430px; width:100%; overflow: auto;"
+                        (textChanged)="onChange($event)">
+                </ace-editor>
+		        <div class="panel-footer">
+		            <button id="deleteServiceDefinition" (click)="deleteServiceDefConfirmModal.open('sm')"
+		                    class="btn btn-default btn-sm" type="submit">
+		                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
+		            </button>
+		            <button id="updateServiceDefinition" (click)="updateServiceDefConfirmModal.open('sm')"
+		                class="btn btn-default btn-sm pull-right" type="submit">
+		                <span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span>
+		            </button>
+		        </div>
+            </div>
+        </div>
+        <bs-modal (onClose)="updateServiceDefinition()" #updateServiceDefConfirmModal>
+            <bs-modal-header [showDismiss]="true">
+                <h4 class="modal-title">Updating Service Definition {{titleSuffix}}</h4>
+            </bs-modal-header>
+            <bs-modal-body>
+                Are you sure you want to update this service definition?
+            </bs-modal-body>
+            <bs-modal-footer>
+                <button type="button" class="btn btn-default btn-sm" data-dismiss="updateServiceDefConfirmModal"
+                        (click)="updateServiceDefConfirmModal.dismiss()">Cancel
+                </button>
+                <button type="button" class="btn btn-primary btn-sm" (click)="updateServiceDefConfirmModal.close()">Ok</button>
+            </bs-modal-footer>
+        </bs-modal>
+        <bs-modal (onClose)="deleteServiceDefinition()" #deleteServiceDefConfirmModal>
+            <bs-modal-header [showDismiss]="true">
+                <h4 class="modal-title">Deleting Service Definition {{titleSuffix}}</h4>
+            </bs-modal-header>
+            <bs-modal-body>
+                Are you sure you want to delete this service definition?
+            </bs-modal-body>
+            <bs-modal-footer>
+                <button type="button" class="btn btn-default btn-sm" data-dismiss="deleteServiceDefConfirmModal"
+                        (click)="deleteServiceDefConfirmModal.dismiss()">Cancel
+                </button>
+                <button type="button" class="btn btn-primary btn-sm" (click)="deleteServiceDefConfirmModal.close()">Ok</button>
+            </bs-modal-footer>
+        </bs-modal>
+    `
+})
+
+export class ServiceDefinitionDetailComponent implements OnInit {
+    serviceDefinition: ServiceDefinition;
+    title = 'Service Definition Detail';
+    titleSuffix: string;
+    serviceDefinitionContent: string;
+    changedServiceDefinitionContent: string;
+    theme: String = 'monokai';
+    options: any = {useWorker: false, printMargin: false};
+
+    @ViewChild('editor') editor;
+
+    @ViewChild('deleteServiceDefConfirmModal')
+    deleteServiceDefConfirmModal: BsModalComponent;
+
+    constructor(private serviceDefinitionService: ServiceDefinitionService, private resourceTypesService: ResourceTypesService) {
+    }
+
+    ngOnInit(): void {
+        this.serviceDefinitionService.selectedServiceDefinition$.subscribe(value => this.populateContent(value));
+    }
+
+    setTitleSuffix(value: string) {
+        this.titleSuffix = value;
+    }
+
+    onChange(code: any) {
+        this.changedServiceDefinitionContent = code;
+    }
+
+    populateContent(serviceDefinition: ServiceDefinition) {
+        if (serviceDefinition) {
+            this.serviceDefinition = serviceDefinition;
+            this.setTitleSuffix(serviceDefinition.role + ' (' + serviceDefinition.version + ')');
+            this.serviceDefinitionService.getServiceDefinitionXml(serviceDefinition)
+                .then(content => this.serviceDefinitionContent = content);
+        }
+    }
+
+    updateServiceDefinition() {
+        this.serviceDefinitionService.updateServiceDefinition(this.changedServiceDefinitionContent ? this.changedServiceDefinitionContent
+                                                                : this.serviceDefinitionContent)
+            .then(() => {
+                // This refreshes the list of service definitions
+                this.resourceTypesService.selectResourceType('Service Definitions');
+            });
+    }
+
+    deleteServiceDefinition() {
+        this.serviceDefinitionService.deleteServiceDefinition(this.serviceDefinition)
+            .then(() => {
+                // This refreshes the list of service definitions
+                this.resourceTypesService.selectResourceType('Service Definitions');
+                // This refreshes the service definition content panel to the first one in the list
+                this.serviceDefinitionService.getServiceDefinitions()
+                    .then(serviceDefinitions => {
+                        this.serviceDefinitionService.selectedServiceDefinition(serviceDefinitions[0]);
+                    });
+            });
+    }
+}

--- a/gateway-admin-ui/admin-ui/app/service-definition/servicedefinition.service.ts
+++ b/gateway-admin-ui/admin-ui/app/service-definition/servicedefinition.service.ts
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import {RestURLBuilder} from 'rest-url-builder';
+
+import 'rxjs/add/operator/toPromise';
+import {Subject} from 'rxjs/Subject';
+
+import {ServiceDefinition} from './servicedefinition';
+
+ @Injectable()
+export class ServiceDefinitionService {
+    apiUrl = window.location.pathname.replace(new RegExp('admin-ui/.*'), 'api/v1/');
+    serviceDefinitionsBaseUrl = this.apiUrl + 'servicedefinitions';
+    serviceDefinitionUrlTemplate = this.serviceDefinitionsBaseUrl + '/:service/:role/:version';
+    selectedServiceDefinitionSource = new Subject<ServiceDefinition>();
+    selectedServiceDefinition$ = this.selectedServiceDefinitionSource.asObservable();
+    urlBuilder = new RestURLBuilder();
+
+    constructor(private http: HttpClient) {
+    }
+
+    getServiceDefinitions(): Promise<ServiceDefinition[]> {
+        let headers = new HttpHeaders();
+        headers = this.addXmlHeaders(headers);
+        return this.http.get(this.serviceDefinitionsBaseUrl, { headers: headers})
+            .toPromise()
+            .then(response => response['serviceDefinitions'].serviceDefinition as ServiceDefinition[])
+            .catch((err: HttpErrorResponse) => {
+                console.debug('ServiceDefinitionService --> getServiceDefinitions() --> ' + this.serviceDefinitionsBaseUrl
+                              + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    getServiceDefinitionXml(serviceDefinition: ServiceDefinition) {
+        let headers = new HttpHeaders();
+        headers = this.addXmlHeaders(headers);
+        let urlBuilder = this.urlBuilder.buildRestURL(this.serviceDefinitionUrlTemplate);
+        urlBuilder.setNamedParameter('service', serviceDefinition.service);
+        urlBuilder.setNamedParameter('role', serviceDefinition.role);
+        urlBuilder.setNamedParameter('version', serviceDefinition.version);
+        return this.http.get(urlBuilder.get(), {headers: headers, responseType: 'text'})
+            .toPromise()
+            .then(response => response)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('ServiceDefinitionService --> getServiceDefinitionXml() --> ' + urlBuilder.get()
+                              + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    updateServiceDefinition(xml: string): Promise<string> {
+        let xheaders = new HttpHeaders();
+        xheaders = this.addXmlHeaders(xheaders);
+        let serviceDefintionXml = xml.replace('<serviceDefinitions>', '').replace('</serviceDefinitions>', '');
+        return this.http.put(this.serviceDefinitionsBaseUrl, serviceDefintionXml, {headers: xheaders, responseType: 'text'})
+            .toPromise()
+            .then(response => response)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('ServiceDefinitionService --> updateServiceDefinition() --> ' + this.serviceDefinitionsBaseUrl
+                              + '\n  error: ' + err.status + ' ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    deleteServiceDefinition(serviceDefinition: ServiceDefinition): Promise<string> {
+        let xheaders = new HttpHeaders();
+        xheaders = this.addXmlHeaders(xheaders);
+        let urlBuilder = this.urlBuilder.buildRestURL(this.serviceDefinitionUrlTemplate);
+        urlBuilder.setNamedParameter('service', serviceDefinition.service);
+        urlBuilder.setNamedParameter('role', serviceDefinition.role);
+        urlBuilder.setNamedParameter('version', serviceDefinition.version);
+        return this.http.delete(urlBuilder.get(), {headers: xheaders, responseType: 'text'})
+            .toPromise()
+            .then(response => response)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('ServiceDefinitionService --> deleteServiceDefinition() --> ' + urlBuilder.get()
+                              + '\n  error: ' + err.status + ' ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    selectedServiceDefinition(value: ServiceDefinition) {
+        this.selectedServiceDefinitionSource.next(value);
+    }
+
+    addJsonHeaders(headers: HttpHeaders): HttpHeaders {
+        return this.addCsrfHeaders(headers.append('Accept', 'application/json')
+            .append('Content-Type', 'application/json'));
+    }
+
+    addXmlHeaders(headers: HttpHeaders): HttpHeaders {
+        return this.addCsrfHeaders(headers.append('Accept', 'application/xml')
+            .append('Content-Type', 'application/xml'));
+    }
+
+    addCsrfHeaders(headers: HttpHeaders): HttpHeaders {
+        return this.addXHRHeaders(headers.append('X-XSRF-Header', 'admin-ui'));
+    }
+
+    addXHRHeaders(headers: HttpHeaders): HttpHeaders {
+        return headers.append('X-Requested-With', 'XMLHttpRequest');
+    }
+
+    private handleError(error: any): Promise<any> {
+        console.error('An error occurred', error); // for demo purposes only
+        return Promise.reject(error.message || error);
+    }
+
+}

--- a/gateway-admin-ui/admin-ui/app/service-definition/servicedefinition.ts
+++ b/gateway-admin-ui/admin-ui/app/service-definition/servicedefinition.ts
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {RewriteRules} from './rewrite.rules';
+import {Service} from './service';
 
-export class Resource {
-    timestamp: number;
+export class ServiceDefinition {
     name: string;
-    uri: string;
-    href: string;
-    content: string;
     service: string;
+    role: string;
+    version: string;
 }

--- a/gateway-admin-ui/package-lock.json
+++ b/gateway-admin-ui/package-lock.json
@@ -379,6 +379,14 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "angular2-datatable": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/angular2-datatable/-/angular2-datatable-0.6.0.tgz",
+      "integrity": "sha1-ygCPdAh/DLh9pXCe0vLR0GF3JjI=",
+      "requires": {
+        "lodash": "^4.0.0"
+      }
+    },
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
@@ -4683,8 +4691,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -6966,6 +6973,11 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "rest-url-builder": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/rest-url-builder/-/rest-url-builder-1.0.6.tgz",
+      "integrity": "sha1-TmYdivTydMX/Li/EnfKjcS65NiI="
     },
     "ret": {
       "version": "0.1.15",

--- a/gateway-admin-ui/package.json
+++ b/gateway-admin-ui/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
+    "angular2-datatable": "^0.6.0",
     "bootstrap": "^3.4.1",
     "core-js": "^2.6.4",
     "jquery": ">=3.0.0",
@@ -26,6 +27,7 @@
     "ng2-bs3-modal": "^0.13.0",
     "ng2-validation": "^4.2.0",
     "popper.js": "^1.14.7",
+    "rest-url-builder": "^1.0.6",
     "rxjs": "^5.5.2",
     "ts-helpers": "^1.1.1",
     "zone.js": "^0.8.29"

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -670,4 +670,13 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.INFO, text = "Redeploying topology {0} due to service definition change {1} / {2} / {3}")
   void redeployingTopologyOnServiceDefinitionChange(String topologyName, String serviceName, String role, String version);
+
+  @Message(level = MessageLevel.INFO, text = "Saved service definition {0} / {1} / {2}")
+  void savedServiceDefinitionChange(String serviceName, String role, String version);
+
+  @Message(level = MessageLevel.INFO, text = "Updated service definition {0} / {1} / {2}")
+  void updatedServiceDefinitionChange(String serviceName, String role, String version);
+
+  @Message(level = MessageLevel.INFO, text = "Deleted service definition {0} / {1} / {2}")
+  void deletedServiceDefinitionChange(String serviceName, String role, String version);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/registry/impl/DefaultServiceDefinitionRegistry.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/registry/impl/DefaultServiceDefinitionRegistry.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -148,7 +149,7 @@ public class DefaultServiceDefinitionRegistry implements ServiceDefinitionRegist
   public Set<ServiceDefinitionPair> getServiceDefinitions() {
     readLock.lock();
     try {
-      return serviceDefinitions;
+      return Collections.unmodifiableSet(serviceDefinitions);
     } finally {
       readLock.unlock();
     }
@@ -157,11 +158,13 @@ public class DefaultServiceDefinitionRegistry implements ServiceDefinitionRegist
   @Override
   public void saveServiceDefinition(ServiceDefinitionPair serviceDefinition) throws ServiceDefinitionRegistryException {
     saveOrUpdateServiceDefinition(serviceDefinition, false);
+    LOG.savedServiceDefinitionChange(serviceDefinition.getService().getName(), serviceDefinition.getService().getRole(), serviceDefinition.getService().getVersion());
   }
 
   @Override
   public void saveOrUpdateServiceDefinition(ServiceDefinitionPair serviceDefinition) throws ServiceDefinitionRegistryException {
     saveOrUpdateServiceDefinition(serviceDefinition, true);
+    LOG.updatedServiceDefinitionChange(serviceDefinition.getService().getName(), serviceDefinition.getService().getRole(), serviceDefinition.getService().getVersion());
   }
 
   public void saveOrUpdateServiceDefinition(ServiceDefinitionPair serviceDefinition, boolean allowUpdate) throws ServiceDefinitionRegistryException {
@@ -228,6 +231,7 @@ public class DefaultServiceDefinitionRegistry implements ServiceDefinitionRegist
         writeLock.unlock();
       }
       notifyListeners(name, role, version);
+      LOG.deletedServiceDefinitionChange(name, role, version);
     } else {
       throw new ServiceDefinitionRegistryException("There is no service definition with the given attributes: " + name + "," + role + "," + version);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following features are implemented with this PR:
- listing existing service definitions in admin UI (using pagination since Knox comes with 65 service definitions OOTB)
- end-users can remove a service definition
- end-users can update a service definition

## How was this patch tested?

Tested locally:

Listing:
<img width="963" alt="Screen Shot 2019-10-25 at 3 44 17 PM" src="https://user-images.githubusercontent.com/34065904/67576309-9e74d280-f73e-11e9-9ae3-951880c2909c.png">
<img width="1667" alt="Screen Shot 2019-10-25 at 3 45 43 PM" src="https://user-images.githubusercontent.com/34065904/67576311-9e74d280-f73e-11e9-872f-1f9b71437459.png">

Updating:
<img width="1672" alt="Screen Shot 2019-10-25 at 3 46 13 PM" src="https://user-images.githubusercontent.com/34065904/67576365-b8161a00-f73e-11e9-9e44-0f1f6b8f0481.png">

Deleting:
<img width="1664" alt="Screen Shot 2019-10-25 at 3 46 00 PM" src="https://user-images.githubusercontent.com/34065904/67576382-bf3d2800-f73e-11e9-95b7-6036f1948b7d.png">
