### PR TITLE
KNOX-2072: Kudu web UI service definition

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/kuduui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/kuduui/1.0.0/rewrite.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<rules>
+  <!-- Match a URL with a base path ('/') and without any query parameters.
+
+       ?{foo} is a named match of a single query parameter: {foo} can be
+       used in the template as a substitution.
+  -->
+  <rule dir="IN" name="KUDUUI/kudu/inbound/base-path">
+    <match pattern="*://*:*/**/kuduui/?{scheme}?{host}?{port}"/>
+    <rewrite template="{scheme}://{host}:{port}/"/>
+  </rule>
+
+  <!-- Match a URL with a non-base path ('/foo') that might have query
+       parameters.
+
+       {**} is a positional match for any number of URL components.
+
+       ?{**} is the same, except it matches query parameters rather than path components.
+  -->
+  <rule dir="IN" name="KUDUUI/kudu/inbound/extra-path">
+    <match pattern="*://*:*/**/kuduui/{**}?{scheme}?{host}?{port}?{**}"/>
+    <rewrite template="{scheme}://{host}:{port}/{**}?{**}"/>
+  </rule>
+
+  <!-- Rewrite the Knox identifier in a base path URL with optional query
+       parameters.
+
+       {$inboundurl} is a special map that can be used to derive HTTP-specific
+       properties of the URL sent to Knox.
+
+       {gateway.url} is the portion of the URL that references the Knox gateway.
+  -->
+  <rule dir="OUT" name="KUDUUI/kudu/outbound/base-path" pattern="/KNOX-BASE/?{**}">
+    <rewrite template="{gateway.url}/kuduui/?scheme={$inboundurl[scheme]}?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
+  </rule>
+
+  <!-- Rewrite the Knox identifier in a non-base path URL with optional query
+       parameters.
+  -->
+  <rule dir="OUT" name="KUDUUI/kudu/outbound/extra-path" pattern="/KNOX-BASE/{**}?{**}">
+    <rewrite template="{gateway.url}/kuduui/{**}?scheme={$inboundurl[scheme]}?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
+  </rule>
+
+  <!-- Rewrite an external base path URL (i.e. to another Kudu server) with
+       optional query parameters.
+  -->
+  <rule dir="OUT" name="KUDUUI/kudu/outbound/external-base-path" pattern="{scheme}://{host}:{port}/?{**}">
+    <rewrite template="{gateway.url}/kuduui/?scheme={scheme}?host={host}?port={port}"/>
+  </rule>
+
+  <!-- Rewrite an external non-base path URL (i.e. to another Kudu server) with
+       optional query parameters.
+  -->
+  <rule dir="OUT" name="KUDUUI/kudu/outbound/external-extra-path" pattern="{scheme}://{host}:{port}/{**}?{**}">
+    <rewrite template="{gateway.url}/kuduui/{**}?scheme={scheme}?host={host}?port={port}?{**}"/>
+  </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/kuduui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/kuduui/1.0.0/service.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<service role="KUDUUI" name="kuduui" version="1.0.0">
+  <!-- We could also list the OUT rules that write response.body, but for some
+       reason Knox runs them automatically even if we don't list them.
+  -->
+  <routes>
+    <route path="/kuduui/">
+      <rewrite apply="KUDUUI/kudu/inbound/base-path" to="request.url"/>
+    </route>
+
+    <route path="/kuduui/**">
+      <rewrite apply="KUDUUI/kudu/inbound/extra-path" to="request.url"/>
+    </route>
+  </routes>
+</service>


### PR DESCRIPTION
This patch adds a new service definition for accessing Apache Kudu's web UI.

Like Apache Impala, every server has a web UI, so we use scheme/host/port
query parameters to disambiguate between servers. Unlike Impala, the Kudu
web UI will add /KNOX-BASE tokens to URLs in its web pages when it detects
it is being proxied by Knox; we use these tokens as the basis for pattern
matching in our rewrite rules.

I tried to avoid cargo culting from existing service definitions and I added
comments to explain syntax and other things that weren't obvious to me as a
non-Knox developer.

I tested this manually by deploying a small Kudu cluster on my machine along
with a Knox gateway and a really simple topology. I then browsed every page
in the web UI and verified its correct behavior.
