### PR TITLE
KNOX-2025 - KnoxShellTable - Join Builder on Method should accept Col Names

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/JoinKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/JoinKnoxShellTableBuilder.java
@@ -52,6 +52,12 @@ public class JoinKnoxShellTableBuilder extends KnoxShellTableBuilder {
     return on(leftIndex, rightIndex);
   }
 
+  public KnoxShellTable on(String columnName, String columnName2) {
+      final int leftIndex = left.headers.indexOf(columnName);
+      final int rightIndex = right.headers.indexOf(columnName2);
+      return on(leftIndex, rightIndex);
+    }
+
   public KnoxShellTable on(int leftIndex, int rightIndex) {
     if (title != null) {
       this.table.title(title);

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -278,14 +278,20 @@ public class KnoxShellTableTest {
     assertEquals(joined.cell(0, 0).value, "123");
     String json = joined.toJSON();
 
+    KnoxShellTable joined2 = KnoxShellTable.builder().join().title("Joined Table").left(table).right(table2).on("Column A", "Column D");
+
+    assertEquals(joined2.getRows().size(), 1);
+    assertEquals(joined2.getTitle(), "Joined Table");
+    assertEquals(joined2.cell(0, 0).value, "123");
+
     KnoxShellTable zombie = KnoxShellTable.builder().json().fromJson(json);
     zombie.title("Zombie Table");
 
     assertEquals(zombie.getRows().size(), 1);
     assertEquals(zombie.getTitle(), "Zombie Table");
     assertEquals(zombie.cell(0, 0).value, "123");
-    KnoxShellTable joined2 = KnoxShellTable.builder().join().title("Joined Table 2").left(table).right(table2).on(1, 3);
-    assertEquals(1, joined2.getRows().size());
+    KnoxShellTable joined3 = KnoxShellTable.builder().join().title("Joined Table 3").left(table).right(table2).on(1, 3);
+    assertEquals(1, joined3.getRows().size());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Overloaded method to join on columns of the same data with different names (ex. ID vs Student_ID)

## How was this patch tested?

Manual and unit tests.
