### PR TITLE
KNOX-1842 - Upgrade httpclient to 4.5.10

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -192,7 +192,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     }
   }
 
-  private static RequestConfig getRequestConfig( FilterConfig config ) {
+  static RequestConfig getRequestConfig( FilterConfig config ) {
     RequestConfig.Builder builder = RequestConfig.custom();
     int connectionTimeout = getConnectionTimeout( config );
     if ( connectionTimeout != -1 ) {
@@ -203,6 +203,15 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     if( socketTimeout != -1 ) {
       builder.setSocketTimeout( socketTimeout );
     }
+
+    // HttpClient 4.5.7 is broken for %2F handling with url normalization.
+    // However, HttpClient 4.5.8+ (HTTPCLIENT-1968) has reasonable url
+    // normalization that matches what Knox already does related to url handling.
+    //
+    // If this view changes later, need to change here as well as make sure
+    // rest-assured doesn't use the old HttpClient behavior.
+    builder.setNormalizeUri(true);
+
     return builder.build();
   }
 

--- a/gateway-test-utils/src/main/java/org/apache/knox/test/mock/MockRequestMatcher.java
+++ b/gateway-test-utils/src/main/java/org/apache/knox/test/mock/MockRequestMatcher.java
@@ -56,6 +56,7 @@ public class MockRequestMatcher {
   private MockResponseProvider response;
   private Set<String> methods;
   private String pathInfo;
+  private String requestURI;
   private String requestURL;
   Map<String,Matcher> headers;
   Set<Cookie> cookies;
@@ -92,6 +93,11 @@ public class MockRequestMatcher {
 
   public MockRequestMatcher pathInfo( String pathInfo ) {
     this.pathInfo = pathInfo;
+    return this;
+  }
+
+  public MockRequestMatcher requestURI( String requestURI ) {
+    this.requestURI = requestURI;
     return this;
   }
 
@@ -208,6 +214,12 @@ public class MockRequestMatcher {
               " does not have the expected pathInfo",
           request.getPathInfo(), is( pathInfo ) );
     }
+    if( requestURI != null ) {
+      assertThat(
+          "Request " + request.getMethod() + " " + request.getRequestURL() +
+              " does not have the expected requestURI",
+          request.getRequestURI(), is(requestURI) );
+    }
     if( requestURL != null ) {
       assertThat(
           "Request " + request.getMethod() + " " + request.getRequestURL() +
@@ -319,7 +331,7 @@ public class MockRequestMatcher {
 
   @Override
   public String toString() {
-    return "from=" + from + ", pathInfo=" + pathInfo;
+    return "from=" + from + ", pathInfo=" + pathInfo + ", requestURI=" + requestURI;
   }
 
   private static List<NameValuePair> parseQueryString( String queryString ) {

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <hadoop.version>3.2.1</hadoop.version>
         <hamcrest.version>2.2</hamcrest.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
-        <httpclient.version>4.5.6</httpclient.version>
+        <httpclient.version>4.5.10</httpclient.version>
         <httpcore.version>4.4.12</httpcore.version>
         <j2e-pac4j.version>4.1.0</j2e-pac4j.version>
         <jackson.version>2.10.0</jackson.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HttpClient 4.5.7 broke url normalization. Knox
didn't have any tests for this case and so we
had to revert after the fact. HttpClient 4.5.8
fixed a lot of the url normalization and some
libraries decided to turn url normalization off.

This commit does the following:
* Adds a test for %2F - KNOX-1005
    * This test passes under HttpClient 4.5.6 and 4.5.8+
    * It breaks as expected under HttpClient 4.5.7
* Adds an explicit config enabling url normalization
    * Ensures that we are in control of url normalization
    * Adds a test for this configuration as well
* Test with both HttpClient normalization enabled and disabled
    * `rest-assured` doesn't expose `RequestConfig` to disable
url normalization
    * Shows how to use HttpClient in `GatewayBasicFuncTest`

All the url safe characters like %2F are fixed by HTTPCLIENT-1968.

The case of `/abc///def` is normalized to `/abc/def` the same
way that Knox does internally with `getPathInfo` and Java URI.

## How was this patch tested?

* Tested against multiple versions of HttpClient (4.5.6, 4.5.7, and 4.5.10)
* `mvn -T.5C clean verify -Ppackage,release -Dshellcheck`