### PR TITLE
[WIP] KNOX-2095 - Adding in DefaultDispatch code and tests to handle 504 errors

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -147,6 +147,9 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
     } catch( SocketTimeoutException e ) {
         //Set a 504 instead of throwing an IO exception in the event of a socket timeout,
         //as an IO exception forces a 500 to be displayed.
+        int timeoutStatus = HttpStatus.SC_GATEWAY_TIMEOUT;
+        auditor.audit( Action.DISPATCH, outboundRequest.getURI().toString(), ResourceType.URI, ActionOutcome.FAILURE, RES.responseStatus(timeoutStatus));
+        LOG.dispatchServiceConnectionException( outboundRequest.getURI(), e );
         inboundResponse = generateInboundResponseOverride(HttpStatus.SC_GATEWAY_TIMEOUT);
     } catch( Exception e ) {
       // We do not want to expose back end host. port end points to clients, see JIRA KNOX-58


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Knox masks all connection errors as 500 errors, when they may be more accurately described using other error codes, especially 504. A change has been made to display a 504 error in the event of a socket timeout..

## How was this patch tested?

Ran ant verify under Knox 1.2.0. The patch was generated against the Knox 1.2.0 branch, and subsequently applied to Knox 1.4.0. Currently ant verify is failing, but these are most likely transient errors as the same errors appear in master. Still running tests.
