### PR TITLE
KNOX-2071 - Configurable maximum token lifetime for TokenStateService

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
@@ -123,6 +123,27 @@ public class DefaultTokenStateServiceTest {
   }
 
 
+  @Test
+  public void testRenewalBeyondMaxLifetime() {
+    long issueTime = System.currentTimeMillis();
+    long expiration = issueTime + 5000;
+    final JWTToken token = createMockToken(expiration);
+    final TokenStateService tss = createTokenStateService();
+
+    // Add the token with a short maximum lifetime
+    tss.addToken(token.getPayload(), issueTime, expiration, 5000L);
+
+    try {
+      // Attempt to renew the token for the default interval, which should exceed the specified short maximum lifetime
+      // for this token.
+      tss.renewToken(token);
+      fail("Token renewal should have been disallowed because the maximum lifetime will have been exceeded.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("The renewal limit for the token has been exceeded", e.getMessage());
+    }
+  }
+
+
   protected static JWTToken createMockToken(final long expiration) {
     return createMockToken("ABCD1234", expiration);
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -28,13 +28,22 @@ public interface TokenStateService extends Service {
   String CONFIG_SERVER_MANAGED = "knox.token.exp.server-managed";
 
   /**
+   * @return The default duration (in milliseconds) for which a token's life will be extended when it is renewed.
+   */
+  long getDefaultRenewInterval();
+
+  /**
+   * @return The default maximum lifetime duration (in milliseconds) of a token.
+   */
+  long getDefaultMaxLifetimeDuration();
+
+  /**
    * Add state for the specified token.
    *
    * @param token     The token.
    * @param issueTime The time the token was issued.
    */
   void addToken(JWTToken token, long issueTime);
-
   /**
    * Add state for the specified token.
    *
@@ -43,6 +52,16 @@ public interface TokenStateService extends Service {
    * @param expiration The token expiration time.
    */
   void addToken(String token, long issueTime, long expiration);
+
+  /**
+   * Add state for the specified token.
+   *
+   * @param token               The token.
+   * @param issueTime           The time the token was issued.
+   * @param expiration          The token expiration time.
+   * @param maxLifetimeDuration The maximum allowed lifetime for the token.
+   */
+  void addToken(String token, long issueTime, long expiration, long maxLifetimeDuration);
 
   /**
    *
@@ -91,7 +110,7 @@ public interface TokenStateService extends Service {
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(JWTToken token, Long renewInterval);
+  long renewToken(JWTToken token, long renewInterval);
 
   /**
    * Extend the lifetime of the specified token by the default amount of time.
@@ -110,7 +129,7 @@ public interface TokenStateService extends Service {
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(String token, Long renewInterval);
+  long renewToken(String token, long renewInterval);
 
   /**
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the ability to specify the maximum token lifetime (i.e., token renewal limit) via topology service params.

## How was this patch tested?

Ran automated unit/integration tests and manual tests.
Manual tests included configuration a short maximum token lifetime, attempting to renew a token (via curl), and verifying the error response.
