### PR TITLE
KNOX-2104 - Removing redundant resource cleanup so that data table can keep track of its activePage/rowsOnTable attributes

### DIFF
--- a/gateway-admin-ui/admin-ui/app/resource/resource.component.ts
+++ b/gateway-admin-ui/admin-ui/app/resource/resource.component.ts
@@ -51,7 +51,6 @@ export class ResourceComponent implements OnInit {
 
         this.resourceType = resType;
         this.resourceService.selectedResourceType(this.resourceType);
-        this.resources = []; // Clear the table before loading the new resources
         this.resourceService.getResources(resType)
             .then(resources => {
                 this.resources = resources;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Staying on the same page after updating/removing a Knox resource (note: currently only `Service Definitions` is displayed with pagination since the number of other resources is less than 10).

(another note: having this one line change is a result of several hours of coding and analyzing `DataTable` and trying to understand why did `activePage` always got reset even if I told the exact number. That one line caused the headache :) )

## How was this patch tested?

See [this video](https://streamable.com/so8wi) about my manual testing.