### PR TITLE
KNOX-2105 - KnoxShell support for token renewal and revocation

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ErrorResponse.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ErrorResponse.java
@@ -19,7 +19,7 @@ package org.apache.knox.gateway.shell;
 
 import org.apache.http.HttpResponse;
 
-class ErrorResponse extends RuntimeException {
+public class ErrorResponse extends RuntimeException {
 
   HttpResponse response;
 
@@ -28,7 +28,7 @@ class ErrorResponse extends RuntimeException {
     this.response = response;
   }
 
-  public HttpResponse getReponse() {
+  public HttpResponse getResponse() {
     return response;
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/AbstractTokenLifecycleRequest.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/AbstractTokenLifecycleRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.knox.token;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.StringEntity;
+import org.apache.knox.gateway.shell.AbstractRequest;
+import org.apache.knox.gateway.shell.ErrorResponse;
+import org.apache.knox.gateway.shell.KnoxSession;
+import org.apache.knox.gateway.shell.KnoxShellException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.Callable;
+
+public abstract class AbstractTokenLifecycleRequest extends AbstractRequest<TokenLifecycleResponse> {
+
+  AbstractTokenLifecycleRequest(final KnoxSession session, final String token) {
+    this(session, token, null);
+  }
+
+  AbstractTokenLifecycleRequest(final KnoxSession session, final String token, final String doAsUser) {
+    super(session, doAsUser);
+    this.token = token;
+    try {
+      URIBuilder uri = uri(Token.SERVICE_PATH, "/", getOperation());
+      requestURI = uri.build();
+    } catch (URISyntaxException e) {
+      throw new KnoxShellException(e);
+    }
+  }
+
+  protected abstract String getOperation();
+
+  private URI requestURI;
+
+  private HttpPost httpPostRequest;
+
+  private String token;
+
+  public URI getRequestURI() {
+    return requestURI;
+  }
+
+  public HttpPost getRequest() {
+    return httpPostRequest;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  @Override
+  protected Callable<TokenLifecycleResponse> callable() {
+    return () -> {
+      httpPostRequest = new HttpPost(requestURI);
+      httpPostRequest.setEntity(new StringEntity(token));
+      try {
+        return new TokenLifecycleResponse(execute(httpPostRequest));
+      } catch (ErrorResponse e) {
+        return new TokenLifecycleResponse(e.getResponse());
+      }
+    };
+  }
+}
+
+

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Renew.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Renew.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.knox.token;
+
+import org.apache.knox.gateway.shell.KnoxSession;
+
+public class Renew {
+
+  public static class Request extends AbstractTokenLifecycleRequest {
+
+    public static final String OPERATION = "renew";
+
+    Request(final KnoxSession session, final String token) {
+      super(session, token);
+    }
+
+    Request(final KnoxSession session, final String token, final String doAsUser) {
+      super(session, token, doAsUser);
+    }
+
+    @Override
+    protected String getOperation() {
+      return OPERATION;
+    }
+  }
+
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Revoke.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Revoke.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.knox.token;
+
+import org.apache.knox.gateway.shell.KnoxSession;
+
+public class Revoke {
+
+  public static class Request extends AbstractTokenLifecycleRequest {
+
+    public static final String OPERATION = "revoke";
+
+    Request(final KnoxSession session, final String token) {
+      super(session, token);
+    }
+
+    Request(final KnoxSession session, final String token, final String doAsUser) {
+      super(session, token, doAsUser);
+    }
+
+    @Override
+    protected String getOperation() {
+      return OPERATION;
+    }
+  }
+
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Token.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Token.java
@@ -23,11 +23,28 @@ public class Token {
 
   static String SERVICE_PATH = "/knoxtoken/api/v1/token";
 
-  public static Get.Request get(KnoxSession session) {
+  public static Get.Request get(final KnoxSession session) {
     return new Get.Request(session);
   }
 
-  public static Get.Request get(KnoxSession session, String doAsUser) {
+  public static Get.Request get(final KnoxSession session, final String doAsUser) {
     return new Get.Request(session, doAsUser);
   }
+
+  public static Renew.Request renew(final KnoxSession session, final String token) {
+    return new Renew.Request(session, token);
+  }
+
+  public static Renew.Request renew(final KnoxSession session, final String token, final String doAsUser) {
+    return new Renew.Request(session, token, doAsUser);
+  }
+
+  public static Revoke.Request revoke(final KnoxSession session, final String token) {
+    return new Revoke.Request(session, token);
+  }
+
+  public static Revoke.Request revoke(final KnoxSession session, final String token, final String doAsUser) {
+    return new Revoke.Request(session, token, doAsUser);
+  }
+
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/TokenLifecycleResponse.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/TokenLifecycleResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.knox.token;
+
+import org.apache.http.HttpResponse;
+import org.apache.knox.gateway.shell.BasicResponse;
+
+public class TokenLifecycleResponse extends BasicResponse {
+
+  TokenLifecycleResponse(HttpResponse response) {
+    super(response);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds KnoxShell support for Knox token renewal and revocation.

## How was this patch tested?

Automated unit/integration tests, manual tests. Manual testing included the groovy script attached to the JIRA issue, invoked with different user credentials (some in the configured whitelist, others not).