### PR TITLE
KNOX-2100 - Make sure knoxshell initializes logging by using the 'launcher' framework like other products (gateway, cli, ldap) do

### DIFF
--- a/gateway-shell-release/home/bin/knoxshell.sh
+++ b/gateway-shell-release/home/bin/knoxshell.sh
@@ -64,40 +64,25 @@ function buildAppJavaOpts {
     if [ -n "$APP_DBG_OPTS" ]; then
       addAppJavaOpts "${APP_DBG_OPTS}"
     fi
-
-    if [ -n "$APP_JAVA_LIB_PATH" ]; then
-      addAppJavaOpts "${APP_JAVA_LIB_PATH}"
-    fi
-
-    # echo "APP_JAVA_OPTS =" "${APP_JAVA_OPTS[@]}"
 }
 
 function main {
-   checkJava
-
-   #printf "Starting $APP_LABEL \n"
-   #printf "$@"
    case "$1" in
       init|buildTrustStore)
         if [ "$#" -ne 2 ]; then
             echo "Illegal number of parameters."
-            printHelp
-        else
-          $JAVA -cp "$APP_JAR" org.apache.knox.gateway.shell.KnoxSh "$1" --gateway "$2" || exit 1
+            printHelp && exit 1
         fi
-         ;;
-      list|destroy)
-        "$JAVA" -cp "$APP_JAR" org.apache.knox.gateway.shell.KnoxSh "$1" || exit 1
-         ;;
+        ;;
       help)
-         printHelp
-         ;;
-      *)
-         buildAppJavaOpts
-         $JAVA "${APP_JAVA_OPTS[@]}" -javaagent:"$APP_BIN_DIR"/../lib/aspectjweaver.jar -jar "$APP_JAR" "$@" || exit 1
+         printHelp && exit 0
          ;;
    esac
-   
+
+   checkJava
+   buildAppJavaOpts
+   $JAVA "${APP_JAVA_OPTS[@]}" -javaagent:"$APP_BIN_DIR"/../lib/aspectjweaver.jar -jar "$APP_JAR" "$@" || exit 1
+
    return 0
 }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
@@ -31,10 +31,13 @@ import org.codehaus.groovy.tools.shell.Groovysh;
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.AnsiConsole;
 
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class Shell {
+
+  private static final List<String> NON_INTERACTIVE_COMMANDS = Arrays.asList("buildTrustStore", "init", "list", "destroy");
 
   private static final String[] IMPORTS = new String[] {
       KnoxSession.class.getName(),
@@ -54,10 +57,20 @@ public class Shell {
     System.setProperty( "groovysh.prompt", "knox" );
   }
 
-  public static void main( String... args ) throws IOException {
+  public static void main( String... args ) throws Exception {
     PropertyConfigurator.configure( System.getProperty( "log4j.configuration" ) );
     if( args.length > 0 ) {
-      GroovyMain.main( args );
+      if (NON_INTERACTIVE_COMMANDS.contains(args[0])) {
+          final String[] arguments = new String[args.length == 1 ? 1:3];
+          arguments[0] = args[0];
+          if (args.length > 1) {
+            arguments[1] = "--gateway";
+            arguments[2] = args[1];
+          }
+          KnoxSh.main(arguments);
+      } else {
+          GroovyMain.main( args );
+      }
     } else {
       Groovysh shell = new Groovysh();
       for( String name : IMPORTS ) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Eliminated 1 of the 2 entry points in the `knoxshell.sh`. Only invoking `org.apache.knox.gateway.shell.Shell` results in the `launcher` framework doing its job (setting launcher.name, log4j configuration, etc..). The removed bash logic has been moved to the Java class.

## How was this patch tested?

Manually tested:
```
$ bin/knoxshell.sh destroy

$ bin/knoxshell.sh list
Knox token cache does not exist. Please login with init.

$ bin/knoxshell.sh init https://localhost:8443/gateway/sandbox
Enter username: admin
Enter password: 
knoxinit successful!
Token Type: Bearer
Expires On: 11/09/2019 02:26:20

Target URL: https://localhost:8443/gateway/tokenbased

$ ls -al logs/
total 0
drwxr-xr-x   3 smolnar  staff  102 Nov  8 15:49 .
drwxr-xr-x  10 smolnar  staff  340 Nov  8 15:49 ..
-rw-r--r--   1 smolnar  staff    0 Nov  8 15:49 knoxshell.log

$ bin/knoxshell.sh
2019-11-08 16:26:52.639 java[77845:5642100] unable to obtain configuration from file://localhost/Library/Preferences/com.apple.ViewBridge.plist due to Error Domain=NSCocoaErrorDomain Code=260 "The file “com.apple.ViewBridge.plist” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Library/Preferences/com.apple.ViewBridge.plist, NSUnderlyingError=0x7fbe1f60aa30 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
===> org.apache.knox.gateway.shell.KnoxSession
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs, org.apache.knox.gateway.shell.job.Job
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs, org.apache.knox.gateway.shell.job.Job, org.apache.knox.gateway.shell.workflow.Workflow
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs, org.apache.knox.gateway.shell.job.Job, org.apache.knox.gateway.shell.workflow.Workflow, org.apache.knox.gateway.shell.yarn.Yarn
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs, org.apache.knox.gateway.shell.job.Job, org.apache.knox.gateway.shell.workflow.Workflow, org.apache.knox.gateway.shell.yarn.Yarn, java.util.concurrent.TimeUnit
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs, org.apache.knox.gateway.shell.job.Job, org.apache.knox.gateway.shell.workflow.Workflow, org.apache.knox.gateway.shell.yarn.Yarn, java.util.concurrent.TimeUnit, org.apache.knox.gateway.shell.manager.Manager
===> org.apache.knox.gateway.shell.KnoxSession, org.apache.knox.gateway.shell.hbase.HBase, org.apache.knox.gateway.shell.hdfs.Hdfs, org.apache.knox.gateway.shell.job.Job, org.apache.knox.gateway.shell.workflow.Workflow, org.apache.knox.gateway.shell.yarn.Yarn, java.util.concurrent.TimeUnit, org.apache.knox.gateway.shell.manager.Manager, org.apache.knox.gateway.shell.table.KnoxShellTable
Groovy Shell (2.5.8, JVM: 1.8.0_212)
Type ':help' or ':h' for help.
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
knox:000> 
knox:000>
```
