### PR TITLE
KNOX-2112 - Upgrade dom4j to 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
         <curator.version>4.2.0</curator.version>
         <dependency-check-maven.version>5.2.2</dependency-check-maven.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
+        <dom4j.version>2.1.1</dom4j.version>
         <easymock.version>4.0.2</easymock.version>
         <eclipselink.version>2.7.5</eclipselink.version>
         <ehcache.version>2.6.11</ehcache.version>
@@ -2067,6 +2068,10 @@
                         <groupId>org.springframework</groupId>
                         <artifactId>spring-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>dom4j</groupId>
+                        <artifactId>dom4j</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -2075,6 +2080,11 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-core</artifactId>
                 <version>${spring-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>${dom4j.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The dom4j Maven coordinates changed from 1.x to 2.x.
See https://github.com/dom4j/dom4j/issues/58 for details.
There are some CVEs associated with the older version so should upgrade.

## How was this patch tested?

`mvn -T.5C verify -Ppackage,release -Dshellcheck`