### PR TITLE
KNOX-2114 - Upgrade cas-client-core and cas-client-support-saml to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
         <aspectj.version>1.9.4</aspectj.version>
         <bcprov-jdk15on.version>1.64</bcprov-jdk15on.version>
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
+        <cas.version>3.5.1</cas.version>
         <cglib.version>3.3.0</cglib.version>
         <checkstyle.version>8.24</checkstyle.version>
         <cloudera-manager.version>6.3.0</cloudera-manager.version>
@@ -2006,6 +2007,18 @@
                 <artifactId>pac4j-cas</artifactId>
                 <version>${pac4j.version}</version>
             </dependency>
+            <!-- Upgrade pac4j-saml dependencies to avoid known CVEs -->
+            <dependency>
+                <groupId>org.jasig.cas.client</groupId>
+                <artifactId>cas-client-core</artifactId>
+                <version>${cas.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jasig.cas.client</groupId>
+                <artifactId>cas-client-support-saml</artifactId>
+                <version>${cas.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.pac4j</groupId>
                 <artifactId>pac4j-config</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

pac4j-cas pulls in cas-client-core 3.5.0 which has a CVE.
This upgrades to 3.5.1 to fix that. pacj4j 3.9/4.x has
already upgraded, but is not released yet.

## How was this patch tested?

`mvn -T.5C verify -Ppackage,release -Dshellcheck`
