### PR TITLE
KNOX-2099 - Using the default port of the protocol when no port is declared in the URL when building truststore.

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSh.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSh.java
@@ -31,7 +31,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
-import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -67,9 +67,9 @@ public class KnoxSh {
       "   [" + KnoxList.USAGE + "]\n";
 
   /** allows stdout to be captured if necessary */
-  public PrintStream out = System.out;
+  PrintStream out = System.out;
   /** allows stderr to be captured if necessary */
-  public PrintStream err = System.err;
+  PrintStream err = System.err;
 
   private Command command;
   private String gateway;
@@ -172,7 +172,7 @@ public class KnoxSh {
     public abstract String getUsage();
   }
 
-  private class KnoxBuildTrustStore extends Command {
+  class KnoxBuildTrustStore extends Command {
 
     private static final String USAGE = "buildTrustStore --gateway server-url";
     private static final String DESC = "Downloads the gateway server's public certificate and builds a trust store.";
@@ -204,9 +204,10 @@ public class KnoxSh {
       final SSLContext sslContext = SSLContext.getInstance("TLS");
       sslContext.init(null, new TrustManager[] { trustManagerWithCertificateChain }, null);
 
-      final URI uri = URI.create(gateway);
-      out.println("Opening connection to " + uri.getHost() + ":" + uri.getPort() + "...");
-      try (Socket socket = sslContext.getSocketFactory().createSocket(uri.getHost(), uri.getPort())) {
+      final URL url = new URL(gateway);
+      final int port = url.getPort() == -1 ? url.getDefaultPort() : url.getPort();
+      out.println("Opening connection to " + url.getHost() + ":" + port + "...");
+      try (Socket socket = sslContext.getSocketFactory().createSocket(url.getHost(), port)) {
         socket.setSoTimeout(10000);
         out.println("Starting SSL handshake...");
         ((SSLSocket) socket).startHandshake();

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/KnoxShTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/KnoxShTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class KnoxShTest {
+
+  private static final String BUILD_TRUSTSTORE = "buildTrustStore";
+  private static final String GATEWAY_SWITCH = "--gateway";
+
+  @Test
+  public void shouldBuildTrustStoreWithDefaultPortIfGatewayUrlHasNoPort() throws Exception {
+    testBuildTruststore("https://localhost", 443);
+  }
+
+  @Test
+  public void shouldBuildTrustStoreWithGatewayUrlPort() throws Exception {
+    testBuildTruststore("https://localhost:8443", 8443);
+  }
+
+  private void testBuildTruststore(String gatewayUrl, int expectedPort) throws Exception {
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream(); PrintStream ps = new PrintStream(baos, true, "UTF-8")) {
+      final KnoxSh knoxSh = new KnoxSh();
+      knoxSh.out = ps;
+      knoxSh.run(new String[] { BUILD_TRUSTSTORE, GATEWAY_SWITCH, gatewayUrl });
+      assertTrue(new String(baos.toByteArray(), StandardCharsets.UTF_8).contains("Opening connection to localhost:" + expectedPort));
+    }
+
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using the default port of the protocol when no port is declared in the URL when building truststore

## How was this patch tested?

Added new unit test cases as well as tested manually:
```
mvn clean -Dshellcheck=true -T1C verify -Prelease,package -am -pl gateway-shell-release
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] build-tools ........................................ SUCCESS [  1.747 s]
[INFO] gateway ............................................ SUCCESS [ 23.531 s]
[INFO] gateway-test-utils ................................. SUCCESS [ 12.192 s]
[INFO] gateway-i18n ....................................... SUCCESS [ 10.662 s]
[INFO] gateway-util-common ................................ SUCCESS [ 15.405 s]
[INFO] gateway-util-launcher .............................. SUCCESS [ 10.571 s]
[INFO] gateway-shell ...................................... SUCCESS [ 17.488 s]
[INFO] gateway-shell-launcher ............................. SUCCESS [  0.721 s]
[INFO] hadoop-examples .................................... SUCCESS [ 10.850 s]
[INFO] gateway-shell-samples .............................. SUCCESS [  2.021 s]
[INFO] gateway-shell-release .............................. SUCCESS [ 10.800 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:33 min (Wall Clock)
[INFO] Finished at: 2019-11-11T16:10:11+01:00
[INFO] Final Memory: 130M/1475M
[INFO] ------------------------------------------------------------------------
```
```
$ bin/knoxshell.sh buildTrustStore https://localhost
Opening connection to localhost:443...
org.apache.knox.gateway.shell.KnoxShellException: Error while building trust store
	at org.apache.knox.gateway.shell.KnoxSh$KnoxBuildTrustStore.execute(KnoxSh.java:194)
	at org.apache.knox.gateway.shell.KnoxSh.run(KnoxSh.java:85)
	at org.apache.knox.gateway.shell.KnoxSh.main(KnoxSh.java:393)
	at org.apache.knox.gateway.shell.Shell.main(Shell.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
	at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
	at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
	at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
	at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
```