### PR TITLE
KNOX-2121 - Zookeeper - Reduce amount of resources required to run tests

### DIFF
--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/AtlasZookeeperURLManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/AtlasZookeeperURLManagerTest.java
@@ -47,7 +47,7 @@ public class AtlasZookeeperURLManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        cluster = new TestingCluster(3);
+        cluster = new TestingCluster(1);
         cluster.start();
 
         try(CuratorFramework zooKeeperClient =

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HBaseZookeeperURLManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HBaseZookeeperURLManagerTest.java
@@ -49,7 +49,7 @@ public class HBaseZookeeperURLManagerTest {
 
   @Before
   public void setUp() throws Exception {
-    cluster = new TestingCluster(3);
+    cluster = new TestingCluster(1);
     cluster.start();
   }
 

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HS2ZookeeperURLManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HS2ZookeeperURLManagerTest.java
@@ -43,7 +43,7 @@ public class HS2ZookeeperURLManagerTest {
 
   @Before
   public void setUp() throws Exception {
-    cluster = new TestingCluster(3);
+    cluster = new TestingCluster(1);
     cluster.start();
 
     try(CuratorFramework zooKeeperClient =

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/KafkaZookeeperURLManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/KafkaZookeeperURLManagerTest.java
@@ -44,7 +44,7 @@ public class KafkaZookeeperURLManagerTest {
 
   @Before
   public void setUp() throws Exception {
-    cluster = new TestingCluster(3);
+    cluster = new TestingCluster(1);
     cluster.start();
 
     try (CuratorFramework zooKeeperClient = CuratorFrameworkFactory.builder()

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/SOLRZookeeperURLManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/SOLRZookeeperURLManagerTest.java
@@ -48,7 +48,7 @@ public class SOLRZookeeperURLManagerTest {
 
   @Before
   public void setUp() throws Exception {
-    cluster = new TestingCluster(3);
+    cluster = new TestingCluster(1);
     cluster.start();
 
     try(CuratorFramework zooKeeperClient =

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasMonitorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasMonitorTest.java
@@ -78,7 +78,7 @@ public class ZookeeperRemoteAliasMonitorTest {
 
     // Define the test cluster
     List<InstanceSpec> instanceSpecs = new ArrayList<>();
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 1; i++) {
       InstanceSpec is = new InstanceSpec(null, -1, -1, -1, false, (i + 1), -1,
           -1, customInstanceSpecProps);
       instanceSpecs.add(is);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/ZookeeperRemoteAliasServiceTest.java
@@ -88,7 +88,7 @@ public class ZookeeperRemoteAliasServiceTest {
 
     // Define the test cluster
     List<InstanceSpec> instanceSpecs = new ArrayList<>();
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 1; i++) {
       InstanceSpec is = new InstanceSpec(null, -1, -1, -1, false, (i + 1), -1,
           -1, customInstanceSpecProps);
       instanceSpecs.add(is);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/monitor/ZooKeeperConfigurationMonitorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/monitor/ZooKeeperConfigurationMonitorTest.java
@@ -93,7 +93,7 @@ public class ZooKeeperConfigurationMonitorTest {
 
         // Define the test cluster
         List<InstanceSpec> instanceSpecs = new ArrayList<>();
-        for (int i = 0 ; i < 3 ; i++) {
+        for (int i = 0 ; i < 1 ; i++) {
             InstanceSpec is = new InstanceSpec(null, -1, -1, -1, false, (i+1), -1, -1, customInstanceSpecProps);
             instanceSpecs.add(is);
         }

--- a/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryClientServiceTest.java
+++ b/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryClientServiceTest.java
@@ -233,7 +233,7 @@ public class RemoteConfigurationRegistryClientServiceTest {
 
         // Define the test cluster
         List<InstanceSpec> instanceSpecs = new ArrayList<>();
-        for (int i = 0 ; i < 3 ; i++) {
+        for (int i = 0 ; i < 1 ; i++) {
             InstanceSpec is = new InstanceSpec(null, -1, -1, -1, false, (i+1), -1, -1, customInstanceSpecProps);
             instanceSpecs.add(is);
         }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorTest.java
@@ -163,7 +163,7 @@ public class RemoteConfigurationMonitorTest {
 
         // Define the test cluster
         List<InstanceSpec> instanceSpecs = new ArrayList<>();
-        for (int i = 0 ; i < 3 ; i++) {
+        for (int i = 0 ; i < 1 ; i++) {
             InstanceSpec is = new InstanceSpec(null, -1, -1, -1, false, (i+1), -1, -1, customInstanceSpecProps);
             instanceSpecs.add(is);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Our Zookeeper tests don't require 3 instances
for them to run. We can instead use 1 instance
and run the tests with fewer resources.

The timeout for cluster starting up is determined
by hostname lookup speed and can't easily be changed.

https://github.com/apache/curator/blob/master/curator-test/src/main/java/org/apache/curator/test/TestingZooKeeperMain.java#L74

## How was this patch tested?

`mvn -T.75C verify -U -Ppackage,release -Dshellcheck`
