### PR TITLE
KNOX-1718 - Hide org.apache.directory.api.ldap.model.entry.Value errors

### DIFF
--- a/gateway-test/src/test/resources/log4j.properties
+++ b/gateway-test/src/test/resources/log4j.properties
@@ -40,3 +40,5 @@ log4j.appender.collectappender = org.apache.knox.test.log.CollectAppender
 #log4j.logger.org.apache.http.wire=DEBUG
 #log4j.logger.org.apache.http.client=DEBUG
 
+# Hide verbose logging - see KNOX-1718 for more details
+log4j.logger.org.apache.directory.api.ldap.model.entry.Value=OFF


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable logging `org.apache.directory.api.ldap.model.entry.Value` ERRORs when running `gateway-test` tests. There might be other places this applies but this is a majority of the integration tests.

## How was this patch tested?

`mvn -T.5C clean verify -Ppackage,release -Dshellcheck`