### PR TITLE
KNOX-1654 - Ability to exclude services to apply global rewrite rules

### DIFF
--- a/gateway-provider-rewrite-common/src/main/java/org/apache/knox/gateway/filter/rewrite/i18n/UrlRewriteMessages.java
+++ b/gateway-provider-rewrite-common/src/main/java/org/apache/knox/gateway/filter/rewrite/i18n/UrlRewriteMessages.java
@@ -87,4 +87,7 @@ public interface UrlRewriteMessages {
 
   @Message( level = MessageLevel.INFO, text = "No rewrite rule was found, skipping rewriting JSON request body" )
   void skippingRewritingJsonRequestBody();
+
+  @Message(level = MessageLevel.DEBUG, text = "Excluding GLOBAL rule {0} for role {1}")
+  void excludeGlobalRewriteRule(String globalRuleName, String role);
 }

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessor.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.filter.rewrite.api;
 
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.filter.rewrite.ext.ScopedMatcher;
 import org.apache.knox.gateway.filter.rewrite.i18n.UrlRewriteMessages;
 import org.apache.knox.gateway.filter.rewrite.impl.UrlRewriteContextImpl;
@@ -31,6 +32,7 @@ import org.apache.knox.gateway.util.urltemplate.Matcher;
 import org.apache.knox.gateway.util.urltemplate.Resolver;
 import org.apache.knox.gateway.util.urltemplate.Template;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -43,8 +45,8 @@ public class UrlRewriteProcessor implements UrlRewriter {
   UrlRewriteEnvironment environment;
   UrlRewriteRulesDescriptor descriptor;
   Map<String,UrlRewriteRuleProcessorHolder> rules = new HashMap<>();
-  ScopedMatcher inbound = new ScopedMatcher();
-  ScopedMatcher outbound = new ScopedMatcher();
+  ScopedMatcher inbound;
+  ScopedMatcher outbound;
   Map<String,UrlRewriteFunctionProcessor> functions = new HashMap<>();
 
   public UrlRewriteProcessor() {
@@ -54,6 +56,10 @@ public class UrlRewriteProcessor implements UrlRewriter {
   public void initialize( UrlRewriteEnvironment environment, UrlRewriteRulesDescriptor descriptor ) {
     this.environment = environment;
     this.descriptor = descriptor;
+    GatewayConfig gatewayConfig = environment.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    List<String> globalRulesExcludedServices = gatewayConfig == null ? Collections.emptyList() : gatewayConfig.getGlobalRulesExcludedServices();
+    this.inbound = new ScopedMatcher(globalRulesExcludedServices);
+    this.outbound = new ScopedMatcher(globalRulesExcludedServices);
     initializeFunctions( descriptor );
     initializeRules( descriptor );
   }

--- a/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite-global-rules.xml
+++ b/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite-global-rules.xml
@@ -1,0 +1,29 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<rules>
+
+    <rule name="test-rule-1/test-rule-1/outbound" dir="OUT" pattern="ShouldNotMatchAnything">
+        <match pattern="ShouldNotMatchAnything" />
+        <rewrite template="output-mock-scheme-1://output-mock-host-1:{port}/{path=**}" />
+    </rule>
+
+    <rule name="test-rule-2/test-rule-2/outbound" dir="OUT" pattern="*://*:*/**?**">
+        <match pattern="*://{host}:{port}/{path=**}?{**}" />
+        <rewrite template="output-mock-scheme-2://output-mock-host-2:{port}/{path=**}" />
+    </rule>
+
+</rules>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -104,6 +104,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String DATA_DIR = GATEWAY_CONFIG_FILE_PREFIX + ".data.dir";
   public static final String STACKS_SERVICES_DIR = GATEWAY_CONFIG_FILE_PREFIX + ".services.dir";
   public static final String GLOBAL_RULES_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".global.rules.services";
+  public static final String GLOBAL_RULES_EXCLUDED_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".global.rules.excluded.services";
   public static final String APPLICATIONS_DIR = GATEWAY_CONFIG_FILE_PREFIX + ".applications.dir";
   public static final String HADOOP_CONF_DIR = GATEWAY_CONFIG_FILE_PREFIX + ".hadoop.conf.dir";
   public static final String FRONTEND_URL = GATEWAY_CONFIG_FILE_PREFIX + ".frontend.url";
@@ -511,32 +512,30 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public List<String> getExcludedSSLProtocols() {
-    List<String> protocols = null;
-    String value = get(SSL_EXCLUDE_PROTOCOLS);
-    if (!"none".equals(value)) {
-      protocols = Arrays.asList(value.split("\\s*,\\s*"));
+    return getPropertyValueAsList(SSL_EXCLUDE_PROTOCOLS);
+  }
+
+  private List<String> getPropertyValueAsList(String propertyName) {
+    return getPropertyValueAsList(propertyName, null);
+  }
+
+  private List<String> getPropertyValueAsList(String propertyName, List<String> defaultValue) {
+    final String propertyValue = get(propertyName);
+    if (propertyValue != null && !propertyValue.isEmpty() && !"none".equalsIgnoreCase(propertyValue.trim())) {
+      return Arrays.asList(propertyValue.trim().split("\\s*,\\s*"));
+    } else {
+      return defaultValue == null ? Collections.emptyList() : defaultValue;
     }
-    return protocols;
   }
 
   @Override
   public List<String> getIncludedSSLCiphers() {
-    List<String> list = null;
-    String value = get(SSL_INCLUDE_CIPHERS);
-    if (value != null && !value.isEmpty() && !"none".equalsIgnoreCase(value.trim())) {
-      list = Arrays.asList(value.trim().split("\\s*,\\s*"));
-    }
-    return list;
+    return getPropertyValueAsList(SSL_INCLUDE_CIPHERS);
   }
 
   @Override
   public List<String> getExcludedSSLCiphers() {
-    List<String> list = null;
-    String value = get(SSL_EXCLUDE_CIPHERS);
-    if (value != null && !value.isEmpty() && !"none".equalsIgnoreCase(value.trim())) {
-      list = Arrays.asList(value.trim().split("\\s*,\\s*"));
-    }
-    return list;
+    return getPropertyValueAsList(SSL_EXCLUDE_CIPHERS);
   }
 
   @Override
@@ -774,11 +773,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public List<String> getGlobalRulesServices() {
-    String value = get( GLOBAL_RULES_SERVICES );
-    if ( value != null && !value.isEmpty() && !"none".equalsIgnoreCase(value.trim()) ) {
-      return Arrays.asList( value.trim().split("\\s*,\\s*") );
-    }
-    return DEFAULT_GLOBAL_RULES_SERVICES;
+    return getPropertyValueAsList(GLOBAL_RULES_SERVICES, DEFAULT_GLOBAL_RULES_SERVICES);
+  }
+
+  @Override
+  public List<String> getGlobalRulesExcludedServices() {
+    return getPropertyValueAsList(GLOBAL_RULES_EXCLUDED_SERVICES);
   }
 
   @Override
@@ -1075,12 +1075,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public List<String> getXForwardContextAppendServices() {
-    String value = get( X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES );
-    if ( value != null && !value.isEmpty() && !"none".equalsIgnoreCase(value.trim()) ) {
-      return Arrays.asList( value.trim().split("\\s*,\\s*") );
-    } else {
-      return new ArrayList<>();
-    }
+    return getPropertyValueAsList(X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES);
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
@@ -17,21 +17,21 @@
  */
 package org.apache.knox.gateway;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.test.TestUtils;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.io.File;
-import java.net.URL;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class GatewayGlobalConfigTest {
 
@@ -48,7 +48,7 @@ public class GatewayGlobalConfigTest {
     GatewayConfig config = new GatewayConfigImpl();
     assertThat( config.getGatewayPort(), is( 7777 ) );
     assertThat( config.isClientAuthNeeded(), is( false ) );
-    assertNull("ssl.exclude.protocols should be null.", config.getExcludedSSLProtocols());
+    assertThat("ssl.exclude.protocols should be empty.", config.getExcludedSSLProtocols(), is(empty()));
     //assertThat( config.getShiroConfigFile(), is( "full-shiro.ini") );
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -116,13 +116,13 @@ public class GatewayConfigImplTest {
     List<String> list;
 
     list = config.getIncludedSSLCiphers();
-    assertThat( list, is(nullValue()) );
+    assertThat( list, is(empty()));
 
     config.set( "ssl.include.ciphers", "none" );
-    assertThat( config.getIncludedSSLCiphers(), is(nullValue()) );
+    assertThat( config.getIncludedSSLCiphers(), is(empty()) );
 
     config.set( "ssl.include.ciphers", "" );
-    assertThat( config.getIncludedSSLCiphers(), is(nullValue()) );
+    assertThat( config.getIncludedSSLCiphers(), is(empty()) );
 
     config.set( "ssl.include.ciphers", "ONE" );
     assertThat( config.getIncludedSSLCiphers(), is(hasItems("ONE")) );
@@ -140,13 +140,13 @@ public class GatewayConfigImplTest {
     assertThat( config.getIncludedSSLCiphers(), is(hasItems("ONE","TWO","THREE")) );
 
     list = config.getExcludedSSLCiphers();
-    assertThat( list, is(nullValue()) );
+    assertThat( list, is(empty()) );
 
     config.set( "ssl.exclude.ciphers", "none" );
-    assertThat( config.getExcludedSSLCiphers(), is(nullValue()) );
+    assertThat( config.getExcludedSSLCiphers(), is(empty()) );
 
     config.set( "ssl.exclude.ciphers", "" );
-    assertThat( config.getExcludedSSLCiphers(), is(nullValue()) );
+    assertThat( config.getExcludedSSLCiphers(), is(empty()) );
 
     config.set( "ssl.exclude.ciphers", "ONE" );
     assertThat( config.getExcludedSSLCiphers(), is(hasItems("ONE")) );
@@ -189,6 +189,21 @@ public class GatewayConfigImplTest {
 
     config.set( GatewayConfigImpl.GLOBAL_RULES_SERVICES, " ONE , TWO , THREE " );
     assertThat( config.getGlobalRulesServices(), is(hasItems("ONE","TWO","THREE")) );
+  }
+
+  @Test
+  public void testGlobalRulesExcludedServices() {
+    final GatewayConfigImpl gatewayConfig = new GatewayConfigImpl();
+    assertTrue(gatewayConfig.getGlobalRulesExcludedServices().isEmpty());
+
+    gatewayConfig.set(GatewayConfigImpl.GLOBAL_RULES_EXCLUDED_SERVICES, "");
+    assertTrue(gatewayConfig.getGlobalRulesExcludedServices().isEmpty());
+
+    gatewayConfig.set(GatewayConfigImpl.GLOBAL_RULES_EXCLUDED_SERVICES, "none");
+    assertTrue(gatewayConfig.getGlobalRulesExcludedServices().isEmpty());
+
+    gatewayConfig.set(GatewayConfigImpl.GLOBAL_RULES_EXCLUDED_SERVICES, " S1, S2,    S3 ,  S4 ");
+    assertThat(gatewayConfig.getGlobalRulesExcludedServices(), is(hasItems("S1", "S2", "S3", "S4")));
   }
 
   @Test( timeout = TestUtils.SHORT_TIMEOUT )

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -323,6 +323,11 @@ public interface GatewayConfig {
   List<String> getGlobalRulesServices();
 
   /**
+   * @return The list of services which the global rules have no any affect on
+   */
+  List<String> getGlobalRulesExcludedServices();
+
+  /**
    * Returns true if websocket feature enabled else false.
    * Default is false.
    * @since 0.10

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -506,6 +506,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public List<String> getGlobalRulesExcludedServices() {
+    return Collections.emptyList();
+  }
+
+  @Override
   public boolean isWebsocketEnabled() {
     return DEFAULT_WEBSOCKET_FEATURE_ENABLED;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need to allow end-users to declare certain service(s) which are not affected by global rules even if they would match by them.

## How was this patch tested?

Added new uni tests; updated existing ones and ran them:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:23 min (Wall Clock)
[INFO] Finished at: 2019-11-15T16:19:43+01:00
[INFO] Final Memory: 408M/1814M
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing the following E2E test steps were executed:
1. started a local web server with `netcat` with the following content:
```
<!doctype html>
<html>
<body>
<h1>A webpage served by netcat</h1>
<a href="http://localhost:1234/testLink">test link</a>
</body>
</html>
```
2. Added two new service definitions:
SERVICE 1 without any outboud rule:
<img width="938" alt="Screen Shot 2019-11-15 at 4 36 19 PM" src="https://user-images.githubusercontent.com/34065904/68955435-4cb3eb00-07c6-11ea-840c-7ca23d4bd450.png">
SERVICE2 with an outbound rule which matches the above link in the test HTML:
<img width="947" alt="Screen Shot 2019-11-15 at 4 36 30 PM" src="https://user-images.githubusercontent.com/34065904/68955449-53426280-07c6-11ea-860a-938eac4e3584.png">
3. Added these services in `sandbox` topology
<img width="945" alt="Screen Shot 2019-11-15 at 4 39 37 PM" src="https://user-images.githubusercontent.com/34065904/68955533-8edd2c80-07c6-11ea-8eb4-44273de1069a.png">

4. Made SERVICE2 global in `gateway-site.xml` and re-started the gateway:
```
    <property>
        <name>gateway.global.rules.services</name>
        <value>SERVICE2</value>
    </property>
```
5. Tested both services using `curl`:
```
$ curl -ku guest:guest-password 'https://localhost:8443/gateway/sandbox/service2/test'
<!doctype html>
<html>
<body>
<h1>A webpage served by netcat</h1>
<a href="/gateway/sandbox/SERVICE2/">test link</a>
</body>
</html>
```
```
$ curl -ku guest:guest-password 'https://localhost:8443/gateway/sandbox/service1/test'
<!doctype html>
<html>
<body>
<h1>A webpage served by netcat</h1>
<a href="/gateway/sandbox/SERVICE2/">test link</a>
</body>
</html>
```
As expected, the global rule `SERVICE2/service2/outbound/links` defined in `SERVICE2` has been applied here too.

6. Marked `SERVICE1`  as a service to exclude global rules in `gateway-site.xml` and re-started the gateway:
```
    <property>
        <name>gateway.global.rules.excluded.services</name>
        <value>SERVICE1</value>
    </property>
```

7. Re-tested the services:
```
$ curl -ku guest:guest-password 'https://localhost:8443/gateway/sandbox/service2/test:
<!doctype html>
<html>
<body>
<h1>A webpage served by netcat</h1>
<a href="/gateway/sandbox/SERVICE2/">test link</a>
</body>
</html>
```
```
$ curl -ku guest:guest-password 'https://localhost:8443/gateway/sandbox/service1/test'
<!doctype html>
<html>
<body>
<h1>A webpage served by netcat</h1>
<a href="http://localhost:1234/testLink">test link</a>
</body>
</html>
```