### PR TITLE
KNOX-2129 - Improve deprecated javadoc

### DIFF
--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/audit/log4j/layout/AuditLayout.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/audit/log4j/layout/AuditLayout.java
@@ -18,22 +18,17 @@ package org.apache.hadoop.gateway.audit.log4j.layout;
 
 /**
  * An adapter class that delegate calls to {@link org.apache.knox.gateway.audit.log4j.layout.AuditLayout}
- * for backwards compatability with package structure.
+ * for backwards compatibility with package structure.
  *
- * This is class is deprecated and only used for backwards compatibility
- * please use
- * org.apache.knox.gateway.audit.log4j.layout.AuditLayout
  * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.audit.log4j.layout.AuditLayout}
  */
 @Deprecated
-public class AuditLayout
-    extends org.apache.knox.gateway.audit.log4j.layout.AuditLayout {
-
+public class AuditLayout extends org.apache.knox.gateway.audit.log4j.layout.AuditLayout {
   /**
    * Create an instance
    */
   public AuditLayout() {
     super();
   }
-
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/DefaultDispatch.java
@@ -24,22 +24,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Set;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.dispatch.DefaultDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.DefaultDispatch}
+ */
 @Deprecated
 public class DefaultDispatch extends org.apache.knox.gateway.dispatch.DefaultDispatch {
-  @Override
-  public void init() {
-    super.init();
-  }
-
-  @Override
-  public void destroy() {
-    super.destroy();
-  }
-
   @Override
   protected int getReplayBufferSize() {
     return super.getReplayBufferSize();
@@ -96,46 +90,5 @@ public class DefaultDispatch extends org.apache.knox.gateway.dispatch.DefaultDis
   protected HttpEntity createRequestEntity(HttpServletRequest request)
       throws IOException {
     return super.createRequestEntity(request);
-  }
-
-  @Override
-  public void doGet(URI url, HttpServletRequest request,
-      HttpServletResponse response) throws IOException, URISyntaxException {
-    super.doGet(url, request, response);
-  }
-
-  @Override
-  public void doOptions(URI url, HttpServletRequest request,
-      HttpServletResponse response) throws IOException, URISyntaxException {
-    super.doOptions(url, request, response);
-  }
-
-  @Override
-  public void doPut(URI url, HttpServletRequest request,
-      HttpServletResponse response) throws IOException, URISyntaxException {
-    super.doPut(url, request, response);
-  }
-
-  @Override
-  public void doPost(URI url, HttpServletRequest request,
-      HttpServletResponse response) throws IOException, URISyntaxException {
-    super.doPost(url, request, response);
-  }
-
-  @Override
-  public void doDelete(URI url, HttpServletRequest request,
-      HttpServletResponse response) throws IOException, URISyntaxException {
-    super.doDelete(url, request, response);
-  }
-
-  @Override
-  public void doHead(URI url, HttpServletRequest request,
-      HttpServletResponse response) throws IOException, URISyntaxException {
-    super.doHead(url, request, response);
-  }
-
-  @Override
-  public Set<String> getOutboundResponseExcludeHeaders() {
-    return super.getOutboundResponseExcludeHeaders();
   }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/NiFiDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/NiFiDispatch.java
@@ -23,6 +23,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.dispatch.NiFiDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.NiFiDispatch}
+ */
 @Deprecated
 public class NiFiDispatch extends org.apache.knox.gateway.dispatch.NiFiDispatch {
   @Override

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/NiFiHaDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/NiFiHaDispatch.java
@@ -23,6 +23,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.dispatch.NiFiHaDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.NiFiHaDispatch}
+ */
 @Deprecated
 public class NiFiHaDispatch extends org.apache.knox.gateway.dispatch.NiFiHaDispatch {
   public NiFiHaDispatch() {

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/PassAllHeadersDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/PassAllHeadersDispatch.java
@@ -16,22 +16,13 @@
  */
 package org.apache.hadoop.gateway.dispatch;
 
-import java.util.Set;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.dispatch.PassAllHeadersDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.PassAllHeadersDispatch}
+ */
 @Deprecated
-public class PassAllHeadersDispatch extends org.apache.knox.gateway.dispatch.PassAllHeadersDispatch{
-  @Override
-  public void init() {
-    super.init();
-  }
-
-  @Override
-  public Set<String> getOutboundResponseExcludeHeaders() {
-    return super.getOutboundResponseExcludeHeaders();
-  }
-
-  @Override
-  public Set<String> getOutboundRequestExcludeHeaders() {
-    return super.getOutboundRequestExcludeHeaders();
-  }
+public class PassAllHeadersDispatch extends org.apache.knox.gateway.dispatch.PassAllHeadersDispatch {
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/PassAllHeadersNoEncodingDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/dispatch/PassAllHeadersNoEncodingDispatch.java
@@ -16,13 +16,14 @@
  */
 package org.apache.hadoop.gateway.dispatch;
 
-import javax.servlet.http.HttpServletRequest;
-import java.net.URI;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.dispatch.PassAllHeadersNoEncodingDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.PassAllHeadersNoEncodingDispatch}
+ */
 @Deprecated
-public class PassAllHeadersNoEncodingDispatch extends org.apache.knox.gateway.dispatch.PassAllHeadersNoEncodingDispatch {
-  @Override
-  public URI getDispatchUrl(HttpServletRequest request) {
-    return super.getDispatchUrl(request);
-  }
+public class PassAllHeadersNoEncodingDispatch
+    extends org.apache.knox.gateway.dispatch.PassAllHeadersNoEncodingDispatch {
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -20,9 +20,15 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import java.util.Properties;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter}
+ */
 @Deprecated
 public class HadoopAuthFilter extends org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter {
-
   @Override
   protected Properties getConfiguration(String configPrefix,
       FilterConfig filterConfig) throws ServletException {

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hbase/HBaseDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hbase/HBaseDispatch.java
@@ -16,14 +16,13 @@
  */
 package org.apache.hadoop.gateway.hbase;
 
-import javax.servlet.http.HttpServletRequest;
-import java.net.URI;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.hbase.HBaseDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.hbase.HBaseDispatch}
+ */
 @Deprecated
-public class HBaseDispatch extends org.apache.knox.gateway.hbase.HBaseDispatch{
-
-  @Override
-  public URI getDispatchUrl(HttpServletRequest request) {
-    return super.getDispatchUrl(request);
-  }
+public class HBaseDispatch extends org.apache.knox.gateway.hbase.HBaseDispatch {
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hdfs/dispatch/HdfsHttpClientDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hdfs/dispatch/HdfsHttpClientDispatch.java
@@ -22,14 +22,19 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.hdfs.dispatch.HdfsHttpClientDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.hdfs.dispatch.HdfsHttpClientDispatch}
+ */
 @Deprecated
 public class HdfsHttpClientDispatch extends org.apache.knox.gateway.hdfs.dispatch.HdfsHttpClientDispatch {
-
   public HdfsHttpClientDispatch() throws ServletException {
     super();
   }
 
-  //@Override
   /**
    * This method ensures that the request InputStream is not acquired
    * prior to a dispatch to a component such as a namenode that doesn't
@@ -43,5 +48,4 @@ public class HdfsHttpClientDispatch extends org.apache.knox.gateway.hdfs.dispatc
       throws IOException {
     return super.createRequestEntity(request);
   }
-
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hdfs/dispatch/WebHdfsHaDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hdfs/dispatch/WebHdfsHaDispatch.java
@@ -18,33 +18,23 @@ package org.apache.hadoop.gateway.hdfs.dispatch;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.knox.gateway.ha.provider.HaProvider;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.hdfs.dispatch.WebHdfsHaDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.hdfs.dispatch.WebHdfsHaDispatch}
+ */
 @Deprecated
 public class WebHdfsHaDispatch extends org.apache.knox.gateway.hdfs.dispatch.WebHdfsHaDispatch {
-
   public WebHdfsHaDispatch() throws ServletException {
     super();
-  }
-
-  @Override
-  public void init() {
-    super.init();
-  }
-
-  @Override
-  public HaProvider getHaProvider() {
-    return super.getHaProvider();
-  }
-
-  @Override
-  public void setHaProvider(HaProvider haProvider) {
-    super.setHaProvider(haProvider);
   }
 
   @Override

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hive/HiveDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hive/HiveDispatch.java
@@ -18,25 +18,17 @@ package org.apache.hadoop.gateway.hive;
 
 import org.apache.http.client.methods.HttpUriRequest;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.hive.HiveDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.hive.HiveDispatch}
+ */
 @Deprecated
-public class HiveDispatch extends org.apache.knox.gateway.hive.HiveDispatch{
-  @Override
-  public void init() {
-    super.init();
-  }
-
+public class HiveDispatch extends org.apache.knox.gateway.hive.HiveDispatch {
   @Override
   protected void addCredentialsToRequest(HttpUriRequest request) {
     super.addCredentialsToRequest(request);
-  }
-
-  @Override
-  public void setBasicAuthPreemptive(boolean basicAuthPreemptive) {
-    super.setBasicAuthPreemptive(basicAuthPreemptive);
-  }
-
-  @Override
-  public boolean isBasicAuthPreemptive() {
-    return super.isBasicAuthPreemptive();
   }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hive/HiveHaDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/hive/HiveHaDispatch.java
@@ -18,8 +18,15 @@ package org.apache.hadoop.gateway.hive;
 
 import org.apache.http.client.methods.HttpUriRequest;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.hive.HiveHaDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.hive.HiveHaDispatch}
+ */
 @Deprecated
-public class HiveHaDispatch extends org.apache.knox.gateway.hive.HiveHaDispatch{
+public class HiveHaDispatch extends org.apache.knox.gateway.hive.HiveHaDispatch {
   public HiveHaDispatch() {
     super();
   }
@@ -27,15 +34,5 @@ public class HiveHaDispatch extends org.apache.knox.gateway.hive.HiveHaDispatch{
   @Override
   protected void addCredentialsToRequest(HttpUriRequest request) {
     super.addCredentialsToRequest(request);
-  }
-
-  @Override
-  public void setBasicAuthPreemptive(boolean basicAuthPreemptive) {
-    super.setBasicAuthPreemptive(basicAuthPreemptive);
-  }
-
-  @Override
-  public boolean isBasicAuthPreemptive() {
-    return super.isBasicAuthPreemptive();
   }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -16,34 +16,20 @@
  */
 package org.apache.hadoop.gateway.provider.federation.jwt.filter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * An adapter class that delegate calls to
+ * {@link org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter} for backwards
+ * compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter}
+ */
 @Deprecated
 public class JWTFederationFilter extends org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter {
-
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
-    super.init(filterConfig);
-  }
-
-  @Override
-  public void destroy() {
-    super.destroy();
-  }
-
-  @Override
-  public void doFilter(ServletRequest request, ServletResponse response,
-      FilterChain chain) throws IOException, ServletException {
-    super.doFilter(request, response, chain);
-  }
-
   @Override
   protected void handleValidationError(HttpServletRequest request,
       HttpServletResponse response, int status, String error)

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -16,34 +16,21 @@
  */
 package org.apache.hadoop.gateway.provider.federation.jwt.filter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/**
+ * An adapter class that delegate calls to
+ * {@link org.apache.knox.gateway.provider.federation.jwt.filter.SSOCookieFederationFilter} for backwards
+ * compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.provider.federation.jwt.filter.SSOCookieFederationFilter}
+ */
 @Deprecated
-public class SSOCookieFederationFilter extends org.apache.knox.gateway.provider.federation.jwt.filter.SSOCookieFederationFilter {
-
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
-    super.init(filterConfig);
-  }
-
-  @Override
-  public void destroy() {
-    super.destroy();
-  }
-
-  @Override
-  public void doFilter(ServletRequest request, ServletResponse response,
-      FilterChain chain) throws IOException, ServletException {
-    super.doFilter(request, response, chain);
-  }
-
+public class SSOCookieFederationFilter
+    extends org.apache.knox.gateway.provider.federation.jwt.filter.SSOCookieFederationFilter {
   @Override
   protected void handleValidationError(HttpServletRequest request,
       HttpServletResponse response, int status, String error)

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/rm/dispatch/RMHaDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/rm/dispatch/RMHaDispatch.java
@@ -16,22 +16,16 @@
  */
 package org.apache.hadoop.gateway.rm.dispatch;
 
-import org.apache.knox.gateway.ha.provider.HaProvider;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.rm.dispatch.RMHaDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.rm.dispatch.RMHaDispatch}
+ */
 @Deprecated
 public class RMHaDispatch extends org.apache.knox.gateway.rm.dispatch.RMHaDispatch {
-
   public RMHaDispatch() {
     super();
-  }
-
-  @Override
-  public void setHaProvider(HaProvider haProvider) {
-    super.setHaProvider(haProvider);
-  }
-
-  @Override
-  public void init() {
-    super.init();
   }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/rm/dispatch/RMUIHaDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/rm/dispatch/RMUIHaDispatch.java
@@ -16,23 +16,18 @@
  */
 package org.apache.hadoop.gateway.rm.dispatch;
 
-import org.apache.knox.gateway.ha.provider.HaProvider;
-
 import javax.servlet.ServletException;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.rm.dispatch.RMUIHaDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.rm.dispatch.RMUIHaDispatch}
+ */
 @Deprecated
 public class RMUIHaDispatch extends org.apache.knox.gateway.rm.dispatch.RMUIHaDispatch {
   public RMUIHaDispatch() throws ServletException {
     super();
-  }
-
-  @Override
-  public void setHaProvider(HaProvider haProvider) {
-    super.setHaProvider(haProvider);
-  }
-
-  @Override
-  public void init() {
-    super.init();
   }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/shirorealm/KnoxLdapContextFactory.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/shirorealm/KnoxLdapContextFactory.java
@@ -22,19 +22,13 @@ import java.util.Hashtable;
 
 /**
  * An adapter class that delegate calls to {@link org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory}
- * for backwards compatability with package structure.
+ * for backwards compatibility with package structure.
  *
- * This is class is deprecated and only used for backwards compatibility
- * please use
- * org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory
  * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory}
  */
 @Deprecated
 public class KnoxLdapContextFactory extends org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory {
-
-  /**
-   * Create an instance
-   */
   public KnoxLdapContextFactory() {
     super();
   }
@@ -44,5 +38,4 @@ public class KnoxLdapContextFactory extends org.apache.knox.gateway.shirorealm.K
       throws NamingException {
     return super.createLdapContext(env);
   }
-
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/shirorealm/KnoxLdapRealm.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/shirorealm/KnoxLdapRealm.java
@@ -28,20 +28,13 @@ import javax.naming.ldap.LdapContext;
 
 /**
  * An adapter class that delegate calls to {@link org.apache.knox.gateway.shirorealm.KnoxLdapRealm}
- * for backwards compatability with package structure.
+ * for backwards compatibility with package structure.
  *
- * This is class is deprecated and only used for backwards compatibility
- * please use
- * org.apache.knox.gateway.shirorealm.KnoxLdapRealm
  * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.shirorealm.KnoxLdapRealm}
  */
 @Deprecated
-public class KnoxLdapRealm
-    extends org.apache.knox.gateway.shirorealm.KnoxLdapRealm {
-
-  /**
-   * Create an instance
-   */
+public class KnoxLdapRealm extends org.apache.knox.gateway.shirorealm.KnoxLdapRealm {
   public KnoxLdapRealm() {
     super();
   }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/shirorealm/KnoxPamRealm.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/shirorealm/KnoxPamRealm.java
@@ -26,22 +26,14 @@ import org.apache.shiro.subject.PrincipalCollection;
  * An adapter class that delegate calls to {@link org.apache.knox.gateway.shirorealm.KnoxPamRealm}
  * for backwards compatibility with package structure.
  *
- * This is class is deprecated and only used for backwards compatibility
- * please use
- * org.apache.knox.gateway.shirorealm.KnoxPamRealm
- * @since 1.0.0
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.shirorealm.KnoxPamRealm}
  */
 @Deprecated
-public class KnoxPamRealm
-    extends org.apache.knox.gateway.shirorealm.KnoxPamRealm {
-
-  /**
-   * Create an instance
-   */
+public class KnoxPamRealm extends org.apache.knox.gateway.shirorealm.KnoxPamRealm {
   public KnoxPamRealm() {
     super();
   }
-
 
   @Override
   protected AuthenticationInfo doGetAuthenticationInfo(

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/storm/StormDispatch.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/storm/StormDispatch.java
@@ -16,12 +16,13 @@
  */
 package org.apache.hadoop.gateway.storm;
 
-import java.util.Set;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.storm.StormDispatch}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.storm.StormDispatch}
+ */
 @Deprecated
-public class StormDispatch extends org.apache.knox.gateway.storm.StormDispatch{
-  @Override
-  public Set<String> getOutboundResponseExcludeHeaders() {
-    return super.getOutboundResponseExcludeHeaders();
-  }
+public class StormDispatch extends org.apache.knox.gateway.storm.StormDispatch {
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/topology/Service.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/topology/Service.java
@@ -16,97 +16,13 @@
  */
 package org.apache.hadoop.gateway.topology;
 
-import org.apache.knox.gateway.topology.Param;
-import org.apache.knox.gateway.topology.Version;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.topology.Service}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.topology.Service}
+ */
 @Deprecated
 public class Service extends org.apache.knox.gateway.topology.Service {
-  @Override
-  public String getRole() {
-    return super.getRole();
-  }
-
-  @Override
-  public void setRole(String role) {
-    super.setRole(role);
-  }
-
-  @Override
-  public String getName() {
-    return super.getName();
-  }
-
-  @Override
-  public void setName(String name) {
-    super.setName(name);
-  }
-
-  @Override
-  public Version getVersion() {
-    return super.getVersion();
-  }
-
-  @Override
-  public void setVersion(Version version) {
-    super.setVersion(version);
-  }
-
-  @Override
-  public List<String> getUrls() {
-    return super.getUrls();
-  }
-
-  @Override
-  public void setUrls(List<String> urls) {
-    super.setUrls(urls);
-  }
-
-  @Override
-  public String getUrl() {
-    return super.getUrl();
-  }
-
-  @Override
-  public void addUrl(String url) {
-    super.addUrl(url);
-  }
-
-  @Override
-  public Map<String, String> getParams() {
-    return super.getParams();
-  }
-
-  @Override
-  public Collection<Param> getParamsList() {
-    return super.getParamsList();
-  }
-
-  @Override
-  public void setParamsList(Collection<Param> params) {
-    super.setParamsList(params);
-  }
-
-  @Override
-  public void setParams(Map<String, String> params) {
-    super.setParams(params);
-  }
-
-  @Override
-  public void addParam(Param param) {
-    super.addParam(param);
-  }
-
-  @Override
-  public boolean equals(Object object) {
-    return super.equals(object);
-  }
-
-  @Override
-  public int hashCode() {
-    return super.hashCode();
-  }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/topology/Topology.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/topology/Topology.java
@@ -16,113 +16,16 @@
  */
 package org.apache.hadoop.gateway.topology;
 
-import org.apache.knox.gateway.topology.Application;
-import org.apache.knox.gateway.topology.Provider;
-import org.apache.knox.gateway.topology.Service;
-import org.apache.knox.gateway.topology.Version;
-
-import java.net.URI;
-import java.util.Collection;
-
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.topology.Topology}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.topology.Topology}
+ */
 @Deprecated
 public class Topology extends org.apache.knox.gateway.topology.Topology {
-
   public Topology() {
     super();
-  }
-
-  @Override
-  public URI getUri() {
-    return super.getUri();
-  }
-
-  @Override
-  public void setUri(URI uri) {
-    super.setUri(uri);
-  }
-
-  @Override
-  public String getName() {
-    return super.getName();
-  }
-
-  @Override
-  public void setName(String name) {
-    super.setName(name);
-  }
-
-  @Override
-  public long getTimestamp() {
-    return super.getTimestamp();
-  }
-
-  @Override
-  public void setTimestamp(long timestamp) {
-    super.setTimestamp(timestamp);
-  }
-
-  @Override
-  public String getDefaultServicePath() {
-    return super.getDefaultServicePath();
-  }
-
-  @Override
-  public void setDefaultServicePath(String servicePath) {
-    super.setDefaultServicePath(servicePath);
-  }
-
-  @Override
-  public void setGenerated(boolean isGenerated) {
-    super.setGenerated(isGenerated);
-  }
-
-  @Override
-  public boolean isGenerated() {
-    return super.isGenerated();
-  }
-
-  @Override
-  public Collection<Service> getServices() {
-    return super.getServices();
-  }
-
-  @Override
-  public Service getService(String role, String name, Version version) {
-    return super.getService(role, name, version);
-  }
-
-  @Override
-  public void addService(Service service) {
-    super.addService(service);
-  }
-
-  @Override
-  public Collection<Application> getApplications() {
-    return super.getApplications();
-  }
-
-  @Override
-  public Application getApplication(String url) {
-    return super.getApplication(url);
-  }
-
-  @Override
-  public void addApplication(Application application) {
-    super.addApplication(application);
-  }
-
-  @Override
-  public Collection<Provider> getProviders() {
-    return super.getProviders();
-  }
-
-  @Override
-  public Provider getProvider(String role, String name) {
-    return super.getProvider(role, name);
-  }
-
-  @Override
-  public void addProvider(Provider provider) {
-    super.addProvider(provider);
   }
 }

--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/util/RegExUtils.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/util/RegExUtils.java
@@ -16,7 +16,13 @@
  */
 package org.apache.hadoop.gateway.util;
 
+/**
+ * An adapter class that delegate calls to {@link org.apache.knox.gateway.util.RegExUtils}
+ * for backwards compatibility with package structure.
+ *
+ * @since 0.14.0
+ * @deprecated Use {@link org.apache.knox.gateway.util.RegExUtils}
+ */
 @Deprecated
 public class RegExUtils extends org.apache.knox.gateway.util.RegExUtils {
-
 }

--- a/gateway-service-hbase/src/main/java/org/apache/knox/gateway/hbase/HBaseDispatch.java
+++ b/gateway-service-hbase/src/main/java/org/apache/knox/gateway/hbase/HBaseDispatch.java
@@ -27,11 +27,11 @@ import org.apache.knox.gateway.dispatch.DefaultDispatch;
 
 /**
  * This used to be a specialized dispatch providing HBase specific features to the
- * default dispatch. Now it is just a marker class for backwards compatibility
+ * default dispatch. Now it is just a marker class for backwards compatibility.
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.DefaultDispatch}
  */
 @Deprecated
 public class HBaseDispatch extends DefaultDispatch {
-
   // KNOX-709: HBase can't handle URL encoded paths.
   @Override
   public URI getDispatchUrl(HttpServletRequest request) {
@@ -48,6 +48,5 @@ public class HBaseDispatch extends DefaultDispatch {
     }
     return URI.create( str.toString() );
   }
-
 }
 

--- a/gateway-service-hbase/src/main/java/org/apache/knox/gateway/hbase/HBaseHttpClientDispatch.java
+++ b/gateway-service-hbase/src/main/java/org/apache/knox/gateway/hbase/HBaseHttpClientDispatch.java
@@ -22,13 +22,13 @@ import org.apache.knox.gateway.dispatch.GatewayDispatchFilter;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 
-/***
+/**
  * KNOX-526. Need to keep this class around for backward compatibility of deployed
  * topologies. This is required for releases older than Apache Knox 0.6.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.GatewayDispatchFilter}
  */
 @Deprecated
 public class HBaseHttpClientDispatch extends GatewayDispatchFilter {
-
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
     setDispatch(new HBaseDispatch());

--- a/gateway-service-hive/src/main/java/org/apache/knox/gateway/hive/HiveHttpClientDispatch.java
+++ b/gateway-service-hive/src/main/java/org/apache/knox/gateway/hive/HiveHttpClientDispatch.java
@@ -22,13 +22,13 @@ import org.apache.knox.gateway.dispatch.GatewayDispatchFilter;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 
-/***
+/**
  * KNOX-526. Need to keep this class around for backward compatibility of deployed
  * topologies. This is required for releases older than Apache Knox 0.6.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.GatewayDispatchFilter}
  */
 @Deprecated
 public class HiveHttpClientDispatch extends GatewayDispatchFilter {
-
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
     setDispatch(new HiveDispatch());

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsDispatch.java
@@ -22,13 +22,13 @@ import org.apache.knox.gateway.dispatch.GatewayDispatchFilter;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 
-/***
+/**
  * KNOX-526. Need to keep this class around for backward compatibility of deployed
  * topologies. This is required for releases older than Apache Knox 0.6.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.GatewayDispatchFilter}
  */
 @Deprecated
 public class HdfsDispatch extends GatewayDispatchFilter {
-
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
     setDispatch(new HdfsHttpClientDispatch());

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsHttpClientDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsHttpClientDispatch.java
@@ -30,7 +30,6 @@ public class HdfsHttpClientDispatch extends DefaultDispatch {
     super();
   }
 
-  //@Override
   /**
    * This method ensures that the request InputStream is not acquired
    * prior to a dispatch to a component such as a namenode that doesn't

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/WebHdfsHaHttpClientDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/WebHdfsHaHttpClientDispatch.java
@@ -22,14 +22,13 @@ import org.apache.knox.gateway.dispatch.GatewayDispatchFilter;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 
-
-/***
+/**
  * KNOX-526. Need to keep this class around for backward compatibility of deployed
  * topologies. This is required for releases older than Apache Knox 0.6.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.GatewayDispatchFilter}
  */
 @Deprecated
 public class WebHdfsHaHttpClientDispatch extends GatewayDispatchFilter {
-
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
     setDispatch(new WebHdfsHaDispatch());

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Hadoop.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Hadoop.java
@@ -22,9 +22,11 @@ import java.security.GeneralSecurityException;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
+/**
+ * @deprecated Use {@link org.apache.knox.gateway.shell.KnoxSession}
+ */
 @Deprecated
 public class Hadoop extends KnoxSession {
-
   public Hadoop(ClientContext clientContext) throws KnoxShellException, URISyntaxException {
     this.executor = Executors.newCachedThreadPool();
     this.base = clientContext.url();

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -33,6 +33,7 @@ public interface GatewayConfig {
    *
    * @deprecated use {@link GatewayConfig#KNOX_GATEWAY_CONF_DIR_VAR} instead
    */
+  @Deprecated
   String GATEWAY_CONF_HOME_VAR = "GATEWAY_CONF_HOME";
 
   String KNOX_GATEWAY_CONF_DIR_VAR = "KNOX_GATEWAY_CONF_DIR";
@@ -42,6 +43,7 @@ public interface GatewayConfig {
    *
    * @deprecated use {@link GatewayConfig#KNOX_GATEWAY_DATA_DIR} instead
    */
+  @Deprecated
   String GATEWAY_DATA_HOME_VAR = "GATEWAY_DATA_HOME";
 
   String KNOX_GATEWAY_DATA_DIR = "KNOX_GATEWAY_DATA_DIR";

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/HttpClientDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/HttpClientDispatch.java
@@ -20,13 +20,13 @@ package org.apache.knox.gateway.dispatch;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 
-/***
+/**
  * KNOX-526. Need to keep this class around for backward compatibility of deployed
  * topologies. This is required for releases older than Apache Knox 0.6.0
+ * @deprecated Use {@link org.apache.knox.gateway.dispatch.GatewayDispatchFilter}
  */
 @Deprecated
 public class HttpClientDispatch extends GatewayDispatchFilter {
-
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
     setDispatch(new DefaultDispatch());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix javadoc for deprecated classes and remove public overrides.

## How was this patch tested?

* `mvn -T.75C verify -U -Ppackage,release -Dshellcheck`
* `mvn -Dmaven.javadoc.failOnError=true -Dmaven.javadoc.failOnWarnings=true -DskipTests=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dmdep.skip=true -Djacoco.skip=true javadoc:javadoc javadoc:test-javadoc`
