### PR TITLE
KNOX-2130 - Handle InterruptedException better

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariConfigurationMonitor.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariConfigurationMonitor.java
@@ -475,7 +475,6 @@ class AmbariConfigurationMonitor implements ClusterConfigurationMonitor {
             this.interval = interval;
         }
 
-
         void stop() {
             isActive = false;
         }
@@ -521,7 +520,7 @@ class AmbariConfigurationMonitor implements ClusterConfigurationMonitor {
                 try {
                     Thread.sleep(interval * 1000L);
                 } catch (InterruptedException e) {
-                    // Ignore
+                    Thread.currentThread().interrupt();
                 }
             }
         }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -116,6 +116,7 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
           Thread.sleep(failoverSleep);
         } catch ( InterruptedException e ) {
           LOG.failoverSleepFailed(getServiceRole(), e);
+          Thread.currentThread().interrupt();
         }
       }
       executeRequest(outboundRequest, inboundRequest, outboundResponse);

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatch.java
@@ -114,6 +114,7 @@ public class DefaultHaDispatch extends DefaultDispatch {
           Thread.sleep(failoverSleep);
         } catch ( InterruptedException e ) {
           LOG.failoverSleepFailed(getServiceRole(), e);
+          Thread.currentThread().interrupt();
         }
       }
       executeRequest(outboundRequest, inboundRequest, outboundResponse);
@@ -126,5 +127,4 @@ public class DefaultHaDispatch extends DefaultDispatch {
       }
     }
   }
-
 }

--- a/gateway-service-rm/src/main/java/org/apache/knox/gateway/rm/dispatch/RMHaBaseDispatcher.java
+++ b/gateway-service-rm/src/main/java/org/apache/knox/gateway/rm/dispatch/RMHaBaseDispatcher.java
@@ -135,6 +135,7 @@ class  RMHaBaseDispatcher extends DefaultDispatch {
                 Thread.sleep(failoverSleep);
              } catch (InterruptedException e) {
                 LOG.failoverSleepFailed(this.resourceRole, e);
+                Thread.currentThread().interrupt();
              }
           }
           executeRequest(outboundRequest, inboundRequest, outboundResponse);

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/AbstractHdfsHaDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/AbstractHdfsHaDispatch.java
@@ -128,6 +128,7 @@ public abstract class AbstractHdfsHaDispatch extends HdfsHttpClientDispatch {
                Thread.sleep(failoverSleep);
             } catch (InterruptedException e) {
                LOG.failoverSleepFailed(getResourceRole(), e);
+               Thread.currentThread().interrupt();
             }
          }
          LOG.failingOverRequest(outboundRequest.getURI().toString());
@@ -141,5 +142,4 @@ public abstract class AbstractHdfsHaDispatch extends HdfsHttpClientDispatch {
          }
       }
    }
-
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
@@ -83,6 +83,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -94,7 +95,6 @@ import java.util.concurrent.TimeoutException;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 
 public class KnoxSession implements Closeable {
-
   private static final String DEFAULT_JAAS_FILE = "/jaas.conf";
   public static final String JGSS_LOGIN_MOUDLE = "com.sun.security.jgss.initiate";
   public static final String END_CERTIFICATE = "-----END CERTIFICATE-----\n";
@@ -559,17 +559,15 @@ public class KnoxSession implements Closeable {
     try {
       shutdown();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new KnoxShellException("Can not shutdown underlying resources", e);
     }
   }
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder("KnoxSession{base='");
-    sb.append(base).append("\'}");
-    return sb.toString();
+    return String.format(Locale.ROOT, "KnoxSession{base='%s'}", base);
   }
-
 
   private static final class JAASClientConfig extends Configuration {
 
@@ -603,7 +601,6 @@ public class KnoxSession implements Closeable {
 
   @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
   private static class ConfigurationFactory {
-
     private static final Class implClazz;
     static {
       // Oracle and OpenJDK use the Sun implementation
@@ -639,5 +636,4 @@ public class KnoxSession implements Closeable {
       return config;
     }
   }
-
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/KnoxSpnegoAuthScheme.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/KnoxSpnegoAuthScheme.java
@@ -21,7 +21,6 @@ import org.apache.http.impl.auth.SPNegoScheme;
 import org.ietf.jgss.GSSException;
 
 public class KnoxSpnegoAuthScheme extends SPNegoScheme {
-
   private static long nano = Long.MIN_VALUE;
 
   public KnoxSpnegoAuthScheme( boolean stripPort ) {
@@ -43,7 +42,7 @@ public class KnoxSpnegoAuthScheme extends SPNegoScheme {
         try {
           Thread.sleep( 0 );
         } catch( InterruptedException e ) {
-          // Ignore it.
+          Thread.currentThread().interrupt();
         }
       }
       nano = now;

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/impl/CMFMasterService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/impl/CMFMasterService.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class CMFMasterService {
-  private static GatewaySpiMessages LOG = MessagesFactory.get( GatewaySpiMessages.class );
+  private static final GatewaySpiMessages LOG = MessagesFactory.get( GatewaySpiMessages.class );
 
   private static final String MASTER_PASSPHRASE = "masterpassphrase";
   private static final String MASTER_PERSISTENCE_TAG = "#1.0# " + TimeStamp.getCurrentTime().toDateString();
@@ -132,8 +132,8 @@ public class CMFMasterService {
   }
 
   protected void persistMaster(char[] master, File masterFile) {
-    EncryptionResult atom = encryptMaster(master);
     try {
+      EncryptionResult atom = encryptMaster(master);
       ArrayList<String> lines = new ArrayList<>();
       lines.add(MASTER_PERSISTENCE_TAG);
 
@@ -151,13 +151,13 @@ public class CMFMasterService {
     }
   }
 
-  private EncryptionResult encryptMaster(char[] master) {
+  private EncryptionResult encryptMaster(char[] master) throws IOException {
     try {
       return encryptor.encrypt(new String(master));
     } catch (Exception e) {
       LOG.failedToEncryptMasterSecret(e);
+      throw new IOException(e);
     }
-    return null;
   }
 
   protected void initializeFromMaster(File masterFile) throws Exception {

--- a/gateway-test-utils/src/main/java/org/apache/knox/test/TestUtils.java
+++ b/gateway-test-utils/src/main/java/org/apache/knox/test/TestUtils.java
@@ -60,8 +60,7 @@ public class TestUtils {
   }
 
   public static String getResourceName( Class clazz, String name ) {
-    name = clazz.getName().replaceAll( "\\.", "/" ) + "/" + name;
-    return name;
+    return clazz.getName().replaceAll( "\\.", "/" ) + "/" + name;
   }
 
   public static URL getResourceUrl( Class clazz, String name ) throws FileNotFoundException {
@@ -216,7 +215,7 @@ public class TestUtils {
       try {
         Thread.sleep( wait );
       } catch( InterruptedException e ) {
-        // Ignore.
+        Thread.currentThread().interrupt();
       }
     }
   }
@@ -231,6 +230,4 @@ public class TestUtils {
     LOG.debug( "execute: reponse=" + response );
     return response;
   }
-
-
 }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/audit/log4j/appender/JdbmStoreAndForwardAppender.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/audit/log4j/appender/JdbmStoreAndForwardAppender.java
@@ -82,8 +82,11 @@ public class JdbmStoreAndForwardAppender extends AppenderSkeleton {
       queue.stop();
       forwarder.join();
       queue.close();
-    } catch( InterruptedException | IOException e ) {
-      throw new RuntimeException( e );
+    } catch(InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch(IOException e) {
+      throw new RuntimeException(e);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we catch interrupted exception in a bunch of places. We should at minimum let the calling method know that we have been interrupted. See the Jira for a description and rationale.

## How was this patch tested?

`mvn -T.75C verify -U -Ppackage,release -Dshellcheck`
