### PR TITLE
KNOX-2144 - Alias API KnoxShell support should provide response types…

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/AbstractAliasRequest.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/AbstractAliasRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.shell.alias;
 
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -76,7 +77,7 @@ public abstract class AbstractAliasRequest extends AbstractRequest<AliasResponse
     return () -> {
       httpRequest = createRequest();
       try {
-        return new AliasResponse(execute(httpRequest));
+        return createResponse(execute(httpRequest));
       } catch (ErrorResponse e) {
         return new AliasResponse(e.getResponse());
       }
@@ -121,6 +122,10 @@ public abstract class AbstractAliasRequest extends AbstractRequest<AliasResponse
         break;
     }
     return request;
+  }
+
+  protected AliasResponse createResponse(HttpResponse response) {
+    return new AliasResponse(response);
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/AddAliasResponse.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/AddAliasResponse.java
@@ -17,31 +17,32 @@
 package org.apache.knox.gateway.shell.alias;
 
 import org.apache.http.HttpResponse;
-import org.apache.knox.gateway.shell.KnoxSession;
+import org.apache.http.HttpStatus;
+import java.util.Map;
 
-public class ListRequest extends AbstractAliasRequest {
+public class AddAliasResponse extends AliasResponse {
 
-  ListRequest(KnoxSession session) {
-    this(session, null);
-  }
+  private String alias;
 
-  ListRequest(final KnoxSession session, final String clusterName) {
-    this(session, clusterName, null);
-  }
+  AddAliasResponse(HttpResponse response) {
+    super(response);
 
-  ListRequest(final KnoxSession session, final String clusterName, final String doAsUser) {
-    super(session, clusterName, doAsUser);
-    requestURI = buildURI();
-  }
-
-  @Override
-  protected RequestType getRequestType() {
-    return RequestType.GET;
+    if (parsedResponse.containsKey("created")) {
+      Map<String, String> created = (Map<String, String>) parsedResponse.get("created");
+      if (created != null) {
+        cluster = created.get("topology");
+        alias = created.get("alias");
+      }
+    }
   }
 
   @Override
-  protected AliasResponse createResponse(HttpResponse response) {
-    return new ListAliasResponse(response);
+  protected boolean isExpectedResponseStatus() {
+    return (response().getStatusLine().getStatusCode() == HttpStatus.SC_CREATED);
+  }
+
+  public String getAlias() {
+    return alias;
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/AliasResponse.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/AliasResponse.java
@@ -16,13 +16,67 @@
  */
 package org.apache.knox.gateway.shell.alias;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.util.EntityUtils;
 import org.apache.knox.gateway.shell.BasicResponse;
+import org.apache.knox.gateway.shell.KnoxShellException;
+
+import java.util.Map;
 
 public class AliasResponse extends BasicResponse {
 
+  private static final String CONTENT_TYPE = "application/json";
+
+  private String responseContent;
+
+  protected Map<String, Object> parsedResponse;
+
+  protected String cluster;
+
+
   AliasResponse(HttpResponse response) {
     super(response);
+    parseResponseEntity();
+  }
+
+  private void parseResponseEntity() {
+    if (!isExpectedResponseStatus()) {
+      throw new KnoxShellException("Unexpected response: " + response().getStatusLine().getReasonPhrase());
+    }
+
+    HttpEntity entity = response().getEntity();
+    if (entity == null) {
+      throw new KnoxShellException("Missing expected response content");
+    }
+
+    String contentType = entity.getContentType().getValue();
+    if (!CONTENT_TYPE.equals(contentType)) {
+      throw new KnoxShellException("Unexpected response content type: " + contentType);
+    }
+
+    try {
+      responseContent = EntityUtils.toString(entity);
+      parsedResponse =
+          (new ObjectMapper()).readValue(responseContent, new TypeReference<Map<String, Object>>() {});
+    } catch (Exception e) {
+      throw new KnoxShellException("Unable to process response content", e);
+    }
+  }
+
+  protected boolean isExpectedResponseStatus() {
+    return (response().getStatusLine().getStatusCode() == HttpStatus.SC_OK);
+  }
+
+  public String getCluster() {
+    return cluster;
+  }
+
+  public String getResponseContent() {
+    return responseContent;
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/DeleteRequest.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/DeleteRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.shell.alias;
 
+import org.apache.http.HttpResponse;
 import org.apache.knox.gateway.shell.KnoxSession;
 
 import java.util.List;
@@ -54,4 +55,8 @@ public class DeleteRequest extends AbstractAliasRequest {
     return elements;
   }
 
+  @Override
+  protected AliasResponse createResponse(HttpResponse response) {
+    return new RemoveAliasResponse(response);
+  }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/ListAliasResponse.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/ListAliasResponse.java
@@ -17,31 +17,22 @@
 package org.apache.knox.gateway.shell.alias;
 
 import org.apache.http.HttpResponse;
-import org.apache.knox.gateway.shell.KnoxSession;
+import java.util.ArrayList;
+import java.util.List;
 
-public class ListRequest extends AbstractAliasRequest {
+public class ListAliasResponse extends AliasResponse {
 
-  ListRequest(KnoxSession session) {
-    this(session, null);
+  private List<String> aliases = new ArrayList<>();
+
+  ListAliasResponse(HttpResponse response) {
+    super(response);
+    cluster = (String) parsedResponse.get("topology");
+    List<String> values = (List<String>)parsedResponse.get("aliases");
+    aliases.addAll(values);
   }
 
-  ListRequest(final KnoxSession session, final String clusterName) {
-    this(session, clusterName, null);
-  }
-
-  ListRequest(final KnoxSession session, final String clusterName, final String doAsUser) {
-    super(session, clusterName, doAsUser);
-    requestURI = buildURI();
-  }
-
-  @Override
-  protected RequestType getRequestType() {
-    return RequestType.GET;
-  }
-
-  @Override
-  protected AliasResponse createResponse(HttpResponse response) {
-    return new ListAliasResponse(response);
+  public List<String> getAliases() {
+    return aliases;
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/PostRequest.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/PostRequest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.shell.alias;
 
+import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
@@ -73,6 +74,11 @@ public class PostRequest extends AbstractAliasRequest {
     formData.add(new BasicNameValuePair(FORM_PARAM_VALUE, pwd));
     ((HttpPost) request).setEntity(new UrlEncodedFormEntity(formData, StandardCharsets.UTF_8));
     return request;
+  }
+
+  @Override
+  protected AliasResponse createResponse(HttpResponse response) {
+    return new AddAliasResponse(response);
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/RemoveAliasResponse.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/alias/RemoveAliasResponse.java
@@ -17,31 +17,26 @@
 package org.apache.knox.gateway.shell.alias;
 
 import org.apache.http.HttpResponse;
-import org.apache.knox.gateway.shell.KnoxSession;
+import java.util.Map;
 
-public class ListRequest extends AbstractAliasRequest {
+public class RemoveAliasResponse extends AliasResponse {
 
-  ListRequest(KnoxSession session) {
-    this(session, null);
+  private String alias;
+
+  RemoveAliasResponse(HttpResponse response) {
+    super(response);
+
+    if (parsedResponse.containsKey("deleted")) {
+      Map<String, String> deleted = (Map<String, String>) parsedResponse.get("deleted");
+      if (deleted != null) {
+        cluster = deleted.get("topology");
+        alias = deleted.get("alias");
+      }
+    }
   }
 
-  ListRequest(final KnoxSession session, final String clusterName) {
-    this(session, clusterName, null);
-  }
-
-  ListRequest(final KnoxSession session, final String clusterName, final String doAsUser) {
-    super(session, clusterName, doAsUser);
-    requestURI = buildURI();
-  }
-
-  @Override
-  protected RequestType getRequestType() {
-    return RequestType.GET;
-  }
-
-  @Override
-  protected AliasResponse createResponse(HttpResponse response) {
-    return new ListAliasResponse(response);
+  public String getAlias() {
+    return alias;
   }
 
 }

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/AbstractResponseTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/AbstractResponseTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.alias;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.entity.StringEntity;
+import org.apache.knox.gateway.shell.KnoxShellException;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public abstract class AbstractResponseTest<T extends AliasResponse> {
+
+  @Test
+  public void testInvalidResponseStatus() {
+    // Anything other than the expected response status
+    HttpResponse httpResponse =
+        createTestResponse(createTestStatusLine(HttpStatus.SC_BAD_REQUEST, "Bad Request"), null);
+
+    try {
+      createResponse(httpResponse);
+    } catch (KnoxShellException e) {
+      // Expected
+      assertEquals("Unexpected response: " + httpResponse.getStatusLine().getReasonPhrase(), e.getMessage());
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testMissingResponseEntity() {
+    HttpResponse httpResponse = createTestResponse(createTestStatusLine(getExpectedResponseStatusCode()), null);
+
+    try {
+      createResponse(httpResponse);
+    } catch (KnoxShellException e) {
+      // Expected
+      assertEquals("Missing expected response content", e.getMessage());
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidResponseJSON() {
+    StringEntity entity = null;
+    try {
+      entity = new StringEntity("{ \"topology\": \"testInvalidJSONCluster\", \"aliases\" : [ ");
+      entity.setContentType("application/json");
+    } catch (UnsupportedEncodingException e) {
+      fail(e.getMessage());
+    }
+
+    HttpResponse httpResponse = createTestResponse(createTestStatusLine(getExpectedResponseStatusCode()), entity);
+
+    try {
+      createResponse(httpResponse);
+    } catch (KnoxShellException e) {
+      // Expected
+      assertEquals("Unable to process response content", e.getMessage());
+      assertTrue(e.getCause().getMessage().contains("Unexpected end-of-input"));
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidResponseContentType() {
+    StringEntity entity = null;
+    try {
+      entity = new StringEntity("{ \"topology\": \"testInvalidJSONCluster\", \"aliases\" : [ ");
+    } catch (UnsupportedEncodingException e) {
+      fail(e.getMessage());
+    }
+
+    HttpResponse httpResponse = createTestResponse(createTestStatusLine(getExpectedResponseStatusCode()), entity);
+
+    try {
+      createResponse(httpResponse);
+    } catch (KnoxShellException e) {
+      // Expected
+      assertTrue(e.getMessage().startsWith("Unexpected response content type: "));
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+
+  abstract StringEntity createTestEntity(String cluster, List<String> aliases) throws Exception;
+
+
+  abstract T createResponse(HttpResponse httpResponse);
+
+
+  int getExpectedResponseStatusCode() {
+    return HttpStatus.SC_OK;
+  }
+
+
+  HttpResponse createTestResponse(final StatusLine   statusLine,
+                                  final String       cluster,
+                                  final List<String> aliases) {
+    StringEntity entity = null;
+    try {
+      entity = createTestEntity(cluster, aliases);
+      entity.setContentType("application/json");
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+    return createTestResponse(statusLine, entity);
+  }
+
+
+  HttpResponse createTestResponse(final StatusLine statusLine, final StringEntity entity) {
+    HttpResponse httpResponse = EasyMock.createNiceMock(HttpResponse.class);
+    EasyMock.expect(httpResponse.getStatusLine()).andReturn(statusLine).anyTimes();
+    EasyMock.expect(httpResponse.getEntity()).andReturn(entity).anyTimes();
+    EasyMock.replay(httpResponse);
+    return httpResponse;
+  }
+
+
+  StatusLine createTestStatusLine(int statusCode) {
+    return createTestStatusLine(statusCode, null);
+  }
+
+
+  StatusLine createTestStatusLine(int statusCode, final String reasonPhrase) {
+    StatusLine statusLine = EasyMock.createNiceMock(StatusLine.class);
+    EasyMock.expect(statusLine.getStatusCode()).andReturn(statusCode).anyTimes();
+    EasyMock.expect(statusLine.getReasonPhrase()).andReturn(reasonPhrase).anyTimes();
+    EasyMock.replay(statusLine);
+    return statusLine;
+  }
+
+}

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/AddAliasResponseTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/AddAliasResponseTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.alias;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class AddAliasResponseTest extends AbstractResponseTest<AddAliasResponse> {
+
+  @Test
+  public void testAddAliasResponse() {
+    final String CLUSTER = "testValidCluster";
+    final String TEST_ALIAS = "alias1";
+
+    HttpResponse httpResponse = createTestResponse(createTestStatusLine(HttpStatus.SC_CREATED),
+                                                   CLUSTER,
+                                                   Collections.singletonList(TEST_ALIAS));
+
+    AddAliasResponse response = null;
+    try {
+      response = createResponse(httpResponse);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+    assertEquals(CLUSTER, response.getCluster());
+    assertEquals(TEST_ALIAS, response.getAlias());
+  }
+
+  @Override
+  int getExpectedResponseStatusCode() {
+    return HttpStatus.SC_CREATED;
+  }
+
+  @Override
+  AddAliasResponse createResponse(HttpResponse httpResponse) {
+    return new AddAliasResponse(httpResponse);
+  }
+
+  @Override
+  StringEntity createTestEntity(String cluster, List<String> aliases) throws Exception {
+    String content = "{ \"created\" : { \"topology\" : \"" + cluster + "\", \"alias\" : \"" + aliases.get(0) + "\" } }";
+    return new StringEntity(content);
+  }
+
+}

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/ListAliasResponseTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/ListAliasResponseTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.alias;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ListAliasResponseTest extends AbstractResponseTest<ListAliasResponse> {
+
+  @Test
+  public void testListAliasResponse() {
+    final String CLUSTER = "testValidCluster";
+    final List<String> TEST_ALIASES = Arrays.asList("alias1", "alias2", "alias3");
+
+    HttpResponse httpResponse = createTestResponse(createTestStatusLine(HttpStatus.SC_OK), CLUSTER, TEST_ALIASES);
+
+    ListAliasResponse response = null;
+    try {
+      response = createResponse(httpResponse);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+    assertEquals(CLUSTER, response.getCluster());
+    assertEquals(TEST_ALIASES, response.getAliases());
+  }
+
+  @Override
+  ListAliasResponse createResponse(HttpResponse httpResponse) {
+    return new ListAliasResponse(httpResponse);
+  }
+
+  @Override
+  StringEntity createTestEntity(final String cluster, final List<String> aliases) throws Exception {
+    StringBuilder sb = new StringBuilder(48);
+    sb.append("{ \"topology\": \"")
+      .append(cluster)
+      .append("\", \"aliases\" : [ ");
+
+    Iterator<String> iter = aliases.iterator();
+    while (iter.hasNext()) {
+      sb.append('\"')
+        .append(iter.next())
+        .append('\"');
+      if (iter.hasNext()) {
+        sb.append(", ");
+      }
+    }
+    sb.append(" ] }");
+
+    return new StringEntity(sb.toString());
+  }
+
+}

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/RemoveAliasResponseTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/alias/RemoveAliasResponseTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.shell.alias;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class RemoveAliasResponseTest extends AbstractResponseTest<RemoveAliasResponse> {
+
+  @Test
+  public void testRemoveAliasResponse() {
+    final String CLUSTER = "testValidCluster";
+    final String TEST_ALIAS = "alias1";
+
+    HttpResponse httpResponse = createTestResponse(createTestStatusLine(HttpStatus.SC_OK),
+                                                   CLUSTER,
+                                                   Collections.singletonList(TEST_ALIAS));
+
+    RemoveAliasResponse response = null;
+    try {
+      response = createResponse(httpResponse);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+    assertEquals(CLUSTER, response.getCluster());
+    assertEquals(TEST_ALIAS, response.getAlias());
+  }
+
+  @Override
+  RemoveAliasResponse createResponse(HttpResponse httpResponse) {
+    return new RemoveAliasResponse(httpResponse);
+  }
+
+  @Override
+  StringEntity createTestEntity(String cluster, List<String> aliases) throws Exception {
+    String content = "{ \"deleted\" : { \"topology\" : \"" + cluster + "\", \"alias\" : \"" + aliases.get(0) + "\" } }";
+    return new StringEntity(content);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve response handling of KnoxShell classes for interacting with the Alias Service API, such that every client thereof need not parse JSON.

## How was this patch tested?

Unit tests, and manual tests. Attached ExampleAliases.groovy to the JIRA issue.