### PR TITLE
KNOX-2136 - Caching credentials in DefaultKeystoreService when an alias is being added or loaded from keystore and using a different cache implementation

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -371,6 +371,10 @@
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-util-configinjector</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <!-- ********** ********** ********** ********** ********** ********** -->
         <!-- ********** Test Dependencies                           ********** -->

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
         <asm.version>7.2</asm.version>
         <aspectj.version>1.9.4</aspectj.version>
         <bcprov-jdk15on.version>1.64</bcprov-jdk15on.version>
+        <ben-manes.caffeine.version>2.8.0</ben-manes.caffeine.version>
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <cglib.version>3.3.0</cglib.version>
         <checkstyle.version>8.26</checkstyle.version>
@@ -2202,6 +2203,21 @@
                 <groupId>com.cloudera.api.swagger</groupId>
                 <artifactId>cloudera-manager-api-swagger</artifactId>
                 <version>${cloudera-manager-api-swagger.version}</version>  <!-- or CM version 6.0 and above -->
+            </dependency>
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${ben-manes.caffeine.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- ********** ********** ********** ********** ********** ********** -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following changes we made in `DefaultKeystoreService`:

- make sure we cache a credential of a given alias right after we saved it in the keystore (until my change it was cached after the first time the credential was fetched from the keystore)
- changing cache implementation from a simple `ConcurrentHashMap` to [Caffeine Cache](https://github.com/ben-manes/caffeine/wiki). This change allows us to configure appropriate eviction policy (as of now, policy attributes are hard-coded)

## How was this patch tested?

Added a new JUnit test and executed a full build:
```
$ mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:41 min (Wall Clock)
[INFO] Finished at: 2019-12-12T12:51:54+01:00
[INFO] Final Memory: 414M/2402M
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing, I've executed a performance test to check how much do we gain when adding/fetching 200/500 credentials (repeated 5 times) after my changes were in place:

| Num of credentials | Before Change (ms) | After Change (ms) |
|--|--|--|
| 200 | 44686<br>51197<br>50423<br>50734<br>50207 | 23011<br>28117<br>27075<br>26996<br>27070 |
|500| 139908<br>188967<br>184465<br>175496<br>182561 | 77049<br>105465<br>105407<br>105488<br>105559 |
