### PR TITLE
KNOX-2123 - Setting requestURI using the given servletRequest in case the service is unavailable and logging it with the appropriate action outcome

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -32,6 +32,7 @@ import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
 import org.apache.knox.gateway.topology.Topology;
+import org.apache.knox.gateway.util.ServletRequestUtils;
 import org.apache.knox.gateway.util.urltemplate.Matcher;
 import org.apache.knox.gateway.util.urltemplate.Parser;
 import org.apache.knox.gateway.util.urltemplate.Template;
@@ -101,11 +102,9 @@ public class GatewayFilter implements Filter {
     HttpServletResponse httpResponse = (HttpServletResponse)servletResponse;
 
     //TODO: The resulting pathInfo + query needs to be added to the servlet context somehow so that filters don't need to rebuild it.  This is done in HttpClientDispatch right now for example.
-    String servlet = httpRequest.getServletPath();
     String path = httpRequest.getPathInfo();
-    String query = httpRequest.getQueryString();
-    String requestPath = ( servlet == null ? "" : servlet ) + ( path == null ? "" : path );
-    String requestPathWithQuery = requestPath + ( query == null ? "" : "?" + query );
+    String requestPath = ServletRequestUtils.getRequestPath(httpRequest);
+    String requestPathWithQuery = ServletRequestUtils.getRequestPathWithQuery(httpRequest);
 
     Template pathWithQueryTemplate;
     try {
@@ -113,7 +112,7 @@ public class GatewayFilter implements Filter {
     } catch( URISyntaxException e ) {
       throw new ServletException( e );
     }
-    String contextWithPathAndQuery = httpRequest.getContextPath() + requestPathWithQuery;
+    String contextWithPathAndQuery = ServletRequestUtils.getContextPathWithQuery(httpRequest);
     LOG.receivedRequest( httpRequest.getMethod(), requestPath );
 
     servletRequest.setAttribute(

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/ServletRequestUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/ServletRequestUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Provides useful methods to fetch different parts from {@link ServletRequest} and {@link HttpServletRequest} interfaces.
+ */
+public class ServletRequestUtils {
+
+  public static String getRequestPath(ServletRequest servletRequest) {
+    return getRequestPath((HttpServletRequest) servletRequest);
+  }
+
+  public static String getRequestPath(HttpServletRequest httpServletRequest) {
+    return emptyOrValue(httpServletRequest.getServletPath()) + emptyOrValue(httpServletRequest.getPathInfo());
+  }
+
+  public static String getRequestPathWithQuery(ServletRequest servletRequest) {
+    return getRequestPathWithQuery((HttpServletRequest) servletRequest);
+  }
+
+  public static String getRequestPathWithQuery(HttpServletRequest httpServletRequest) {
+    return getRequestPath(httpServletRequest) + emptyOrValue(httpServletRequest.getQueryString(), "?");
+  }
+
+  public static String getContextPathWithQuery(ServletRequest servletRequest) {
+    return getContextPathWithQuery((HttpServletRequest) servletRequest);
+  }
+
+  public static String getContextPathWithQuery(HttpServletRequest httpServletRequest) {
+    return httpServletRequest.getContextPath() + getRequestPathWithQuery(httpServletRequest);
+  }
+
+  private static String emptyOrValue(String toTest) {
+    return emptyOrValue(toTest, null);
+  }
+
+  private static String emptyOrValue(String toTest, String prefix) {
+    if (toTest == null) {
+      return "";
+    } else {
+      return prefix == null ? toTest : prefix + toTest;
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the service was unavailable at the time of the service was being served then there was no `SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME` attribute set in the given `servletRequest`. This led to a NPE when logging into audit log. Another mistake was that we did not consider the action-outcome in this case and we tried to log everything as `SUCCESS`. I changed this too.

## How was this patch tested?

Running JUnit tests:
```
mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:31 min (Wall Clock)
[INFO] Finished at: 2019-12-16T15:58:38+01:00
[INFO] Final Memory: 412M/1951M
[INFO] ------------------------------------------------------------------------
```