### PR TITLE
KNOX-1932 - CM discovery - WEBHCAT URLs not discovered

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/WebHCatServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/WebHCatServiceModelGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.model.hive;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
+import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGenerator;
+
+import java.util.Locale;
+
+public class WebHCatServiceModelGenerator extends AbstractServiceModelGenerator {
+
+  public static final String SERVICE = "WEBHCAT";
+  private static final String SERVICE_TYPE = "HIVE";
+  private static final String ROLE_TYPE = "WEBHCAT";
+
+  @Override
+  public String getService() {
+    return SERVICE;
+  }
+
+  @Override
+  public String getServiceType() {
+    return SERVICE_TYPE;
+  }
+
+  @Override
+  public String getRoleType() {
+    return ROLE_TYPE;
+  }
+
+  @Override
+  public ServiceModel.Type getModelType() {
+    return ServiceModel.Type.API;
+  }
+
+  @Override
+  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
+    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
+  }
+
+  @Override
+  public ServiceModel generateService(ApiService       service,
+                                      ApiServiceConfig serviceConfig,
+                                      ApiRole          role,
+                                      ApiConfigList    roleConfig) throws ApiException {
+    String hostname = role.getHostRef().getHostname();
+    String port = getRoleConfigValue(roleConfig, "hive_webhcat_address_port");
+    return createServiceModel(String.format(Locale.getDefault(), "http://%s:%s/templeton", hostname, port));
+  }
+}

--- a/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
+++ b/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
@@ -25,6 +25,7 @@ org.apache.knox.gateway.topology.discovery.cm.model.hdfs.HdfsUIServiceModelGener
 org.apache.knox.gateway.topology.discovery.cm.model.hdfs.WebHdfsServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hive.HiveServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hive.HiveOnTezServiceModelGenerator
+org.apache.knox.gateway.topology.discovery.cm.model.hive.WebHCatServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hue.HueServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hue.HueLBServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.yarn.JobTrackerServiceModelGenerator

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -324,6 +324,30 @@ public class ClouderaManagerServiceDiscoveryTest {
   }
 
   @Test
+  public void testWebHCatDiscovery() {
+    final String hostName = "webhcat-host";
+    final String port     = "22222";
+    final String expectedURL = "http://" + hostName + ":" + port + "/templeton";
+
+    // Configure the role
+    Map<String, String> roleProperties = new HashMap<>();
+    roleProperties.put("hive_webhcat_address_port", port);
+
+    ServiceDiscovery.Cluster cluster = doTestDiscovery(hostName,
+                                                       "HIVE-1",
+                                                       "HIVE",
+                                                       "HIVE-1-WEBHCAT-1",
+                                                       "WEBHCAT",
+                                                       Collections.emptyMap(),
+                                                       roleProperties);
+
+    List<String> urls = cluster.getServiceURLs("WEBHCAT");
+    assertNotNull(urls);
+    assertEquals(1, urls.size());
+    assertEquals(expectedURL, urls.get(0));
+  }
+
+  @Test
   public void testOozieDiscovery() {
     doTestOozieDiscovery("OOZIE", false);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added support for WEBHCAT service discovery from CM.

## How was this patch tested?
Ran existing CM discovery tests, added ClouderaManagerServiceDiscoveryTest#testWebHCatDiscovery(), and manually tested CM service discovery against a cluster.
