### PR TITLE
KNOX-1970 - CM discovery - Add Impala HS2 to auto discovery

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
@@ -19,6 +19,8 @@ package org.apache.knox.gateway.topology.discovery.cm.model;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.model.ApiConfig;
 import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.topology.discovery.cm.DiscoveryApiClient;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
@@ -76,6 +78,11 @@ public abstract class AbstractServiceModelGenerator implements ServiceModelGener
 
   protected ServiceModel createServiceModel(final String url) {
     return new ServiceModel(getModelType(), getService(), getServiceType(), getRoleType(), url);
+  }
+
+  @Override
+  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
+    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/atlas/AtlasAPIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/atlas/AtlasAPIServiceModelGenerator.java
@@ -19,7 +19,7 @@ package org.apache.knox.gateway.topology.discovery.cm.model.atlas;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 
 public class AtlasAPIServiceModelGenerator extends AtlasServiceModelGenerator {
-  private static final String SERVICE = "ATLAS-API";
+  public static final String SERVICE = "ATLAS-API";
 
   @Override
   public String getService() {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/atlas/AtlasServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/atlas/AtlasServiceModelGenerator.java
@@ -27,9 +27,9 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 import java.util.Locale;
 
 public class AtlasServiceModelGenerator extends AbstractServiceModelGenerator {
-  private static final String SERVICE = "ATLAS";
-  private static final String SERVICE_TYPE = "ATLAS";
-  private static final String ROLE_TYPE = "ATLAS_SERVER";
+  public static final String SERVICE = "ATLAS";
+  public static final String SERVICE_TYPE = "ATLAS";
+  public static final String ROLE_TYPE = "ATLAS_SERVER";
 
   @Override
   public String getService() {
@@ -49,11 +49,6 @@ public class AtlasServiceModelGenerator extends AbstractServiceModelGenerator {
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.UI;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hbase/WebHBaseServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hbase/WebHBaseServiceModelGenerator.java
@@ -27,9 +27,9 @@ import java.util.Locale;
 
 public class WebHBaseServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  private static final String SERVICE = "WEBHBASE";
-  private static final String SERVICE_TYPE = "HBASE";
-  private static final String ROLE_TYPE = "HBASERESTSERVER";
+  public static final String SERVICE      = "WEBHBASE";
+  public static final String SERVICE_TYPE = "HBASE";
+  public static final String ROLE_TYPE    = "HBASERESTSERVER";
 
   @Override
   public String getService() {
@@ -49,11 +49,6 @@ public class WebHBaseServiceModelGenerator extends AbstractServiceModelGenerator
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
@@ -27,9 +27,9 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 import java.util.Locale;
 
 public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator {
-  private static final String SERVICE      = "NAMENODE";
-  private static final String SERVICE_TYPE = "HDFS";
-  private static final String ROLE_TYPE    = "NAMENODE";
+  public static final String SERVICE      = "NAMENODE";
+  public static final String SERVICE_TYPE = "HDFS";
+  public static final String ROLE_TYPE    = "NAMENODE";
 
   @Override
   public String getServiceType() {
@@ -49,14 +49,6 @@ public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService       service,
-                         ApiServiceConfig serviceConfig,
-                         ApiRole          role,
-                         ApiConfigList    roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
@@ -18,7 +18,7 @@ package org.apache.knox.gateway.topology.discovery.cm.model.hive;
 
 public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
 
-  private static final String SERVICE_TYPE = "HIVE_ON_TEZ";
+  public static final String SERVICE_TYPE = "HIVE_ON_TEZ";
 
   @Override
   public String getServiceType() {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -28,9 +28,9 @@ import java.util.Locale;
 
 public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  private static final String SERVICE      = "HIVE";
-  private static final String SERVICE_TYPE = "HIVE";
-  private static final String ROLE_TYPE    = "HIVESERVER2";
+  public static final String SERVICE      = "HIVE";
+  public static final String SERVICE_TYPE = "HIVE";
+  public static final String ROLE_TYPE    = "HIVESERVER2";
 
   @Override
   public String getService() {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/WebHCatServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/WebHCatServiceModelGenerator.java
@@ -28,9 +28,9 @@ import java.util.Locale;
 
 public class WebHCatServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  public static final String SERVICE = "WEBHCAT";
-  private static final String SERVICE_TYPE = "HIVE";
-  private static final String ROLE_TYPE = "WEBHCAT";
+  public static final String SERVICE      = "WEBHCAT";
+  public static final String SERVICE_TYPE = "HIVE";
+  public static final String ROLE_TYPE    = "WEBHCAT";
 
   @Override
   public String getService() {
@@ -50,11 +50,6 @@ public class WebHCatServiceModelGenerator extends AbstractServiceModelGenerator 
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueLBServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueLBServiceModelGenerator.java
@@ -52,11 +52,6 @@ public class HueLBServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
-  }
-
-  @Override
   public ServiceModel generateService(ApiService       service,
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueServiceModelGenerator.java
@@ -52,11 +52,6 @@ public class HueServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
-  }
-
-  @Override
   public ServiceModel generateService(ApiService       service,
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGenerator.java
@@ -14,8 +14,9 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.knox.gateway.topology.discovery.cm.model.hbase;
+package org.apache.knox.gateway.topology.discovery.cm.model.impala;
 
+import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiService;
@@ -25,11 +26,11 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 
 import java.util.Locale;
 
-public class HBaseUIServiceModelGenerator extends AbstractServiceModelGenerator {
+public class ImpalaServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  public static final String SERVICE      = "HBASEUI";
-  public static final String SERVICE_TYPE = "HBASE";
-  public static final String ROLE_TYPE    = "MASTER";
+  public static final String SERVICE      = "IMPALA";
+  public static final String SERVICE_TYPE = "IMPALA";
+  public static final String ROLE_TYPE    = "IMPALAD";
 
   @Override
   public String getService() {
@@ -48,24 +49,18 @@ public class HBaseUIServiceModelGenerator extends AbstractServiceModelGenerator 
 
   @Override
   public ServiceModel.Type getModelType() {
-    return ServiceModel.Type.UI;
+    return ServiceModel.Type.API;
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
-    String scheme;
-    String port = getRoleConfigValue(roleConfig, "hbase_master_info_port"); // TODO: Is there an SSL port, or is this property re-used?
-    boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, "hbase_hadoop_ssl_enabled"));
-    if(sslEnabled) {
-      scheme = "https";
-    } else {
-      scheme = "http";
-    }
-    return createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s", scheme, hostname, port));
-  }
 
+    boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, "client_services_ssl_enabled"));
+    String scheme = sslEnabled ? "https" : "http";
+
+    // Role config properties
+    String port = getRoleConfigValue(roleConfig, "hs2_http_port");
+    return createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/", scheme, hostname, port));
+  }
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/livy/LivyServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/livy/LivyServiceModelGenerator.java
@@ -27,9 +27,9 @@ import java.util.Locale;
 
 public class LivyServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  private static final String SERVICE = "LIVYSERVER";
-  private static final String SERVICE_TYPE = "LIVY";
-  private static final String ROLE_TYPE = "LIVY_SERVER";
+  public static final String SERVICE      = "LIVYSERVER";
+  public static final String SERVICE_TYPE = "LIVY";
+  public static final String ROLE_TYPE    = "LIVY_SERVER";
 
   @Override
   public String getService() {
@@ -49,11 +49,6 @@ public class LivyServiceModelGenerator extends AbstractServiceModelGenerator {
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/oozie/OozieServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/oozie/OozieServiceModelGenerator.java
@@ -27,9 +27,9 @@ import java.util.Locale;
 
 public class OozieServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  private static final String SERVICE = "OOZIE";
-  private static final String SERVICE_TYPE = "OOZIE";
-  private static final String ROLE_TYPE = "OOZIE_SERVER";
+  public static final String SERVICE      = "OOZIE";
+  public static final String SERVICE_TYPE = "OOZIE";
+  public static final String ROLE_TYPE    = "OOZIE_SERVER";
 
   @Override
   public String getService() {
@@ -49,11 +49,6 @@ public class OozieServiceModelGenerator extends AbstractServiceModelGenerator {
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
@@ -27,9 +27,9 @@ import java.util.Locale;
 
 public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator {
 
-  private static final String SERVICE = "AVATICA";
-  private static final String SERVICE_TYPE = "PHOENIX";
-  private static final String ROLE_TYPE = "PHOENIX_QUERY_SERVER";
+  public static final String SERVICE      = "AVATICA";
+  public static final String SERVICE_TYPE = "PHOENIX";
+  public static final String ROLE_TYPE    = "PHOENIX_QUERY_SERVER";
 
   @Override
   public String getService() {
@@ -49,11 +49,6 @@ public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator 
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ranger/RangerServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ranger/RangerServiceModelGenerator.java
@@ -26,9 +26,9 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 import java.util.Locale;
 
 public class RangerServiceModelGenerator extends AbstractServiceModelGenerator {
-  private static final String SERVICE = "RANGER";
-  private static final String SERVICE_TYPE = "RANGER";
-  private static final String ROLE_TYPE = "RANGER_ADMIN";
+  public static final String SERVICE      = "RANGER";
+  public static final String SERVICE_TYPE = "RANGER";
+  public static final String ROLE_TYPE    = "RANGER_ADMIN";
 
   @Override
   public String getService() {
@@ -48,11 +48,6 @@ public class RangerServiceModelGenerator extends AbstractServiceModelGenerator {
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGenerator.java
@@ -26,9 +26,9 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 import java.util.Locale;
 
 public class SolrServiceModelGenerator extends AbstractServiceModelGenerator {
-  private static final String SERVICE = "SOLR";
-  private static final String SERVICE_TYPE = "SOLR";
-  private static final String ROLE_TYPE = "SOLR_SERVER";
+  public static final String SERVICE      = "SOLR";
+  public static final String SERVICE_TYPE = "SOLR";
+  public static final String ROLE_TYPE    = "SOLR_SERVER";
 
   @Override
   public String getService() {
@@ -48,11 +48,6 @@ public class SolrServiceModelGenerator extends AbstractServiceModelGenerator {
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.API;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/SparkHistoryUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/SparkHistoryUIServiceModelGenerator.java
@@ -26,9 +26,9 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 import java.util.Locale;
 
 public class SparkHistoryUIServiceModelGenerator extends AbstractServiceModelGenerator {
-  private static final String SERVICE = "SPARKHISTORYUI";
-  private static final String SERVICE_TYPE = "SPARK_ON_YARN";
-  private static final String ROLE_TYPE = "SPARK_YARN_HISTORY_SERVER";
+  public static final String SERVICE      = "SPARKHISTORYUI";
+  public static final String SERVICE_TYPE = "SPARK_ON_YARN";
+  public static final String ROLE_TYPE    = "SPARK_YARN_HISTORY_SERVER";
 
   @Override
   public String getService() {
@@ -48,11 +48,6 @@ public class SparkHistoryUIServiceModelGenerator extends AbstractServiceModelGen
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.UI;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobHistoryUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobHistoryUIServiceModelGenerator.java
@@ -53,11 +53,6 @@ public class JobHistoryUIServiceModelGenerator extends AbstractServiceModelGener
   }
 
   @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
-  }
-
-  @Override
   public ServiceModel generateService(ApiService       service,
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/ResourceManagerServiceModelGeneratorBase.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/ResourceManagerServiceModelGeneratorBase.java
@@ -16,10 +16,6 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.yarn;
 
-import com.cloudera.api.swagger.model.ApiConfigList;
-import com.cloudera.api.swagger.model.ApiRole;
-import com.cloudera.api.swagger.model.ApiService;
-import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGenerator;
 
 public abstract class ResourceManagerServiceModelGeneratorBase extends AbstractServiceModelGenerator {
@@ -35,11 +31,6 @@ public abstract class ResourceManagerServiceModelGeneratorBase extends AbstractS
   @Override
   public String getRoleType() {
     return ROLE_TYPE;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/zeppelin/ZeppelinServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/zeppelin/ZeppelinServiceModelGenerator.java
@@ -27,9 +27,9 @@ import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelG
 import java.util.Locale;
 
 public class ZeppelinServiceModelGenerator extends AbstractServiceModelGenerator {
-  private static final String SERVICE = "ZEPPELIN";
-  protected static final String SERVICE_TYPE = "ZEPPELIN";
-  protected static final String ROLE_TYPE = "ZEPPELIN_SERVER";
+  public static final String SERVICE      = "ZEPPELIN";
+  public static final String SERVICE_TYPE = "ZEPPELIN";
+  public static final String ROLE_TYPE    = "ZEPPELIN_SERVER";
 
   @Override
   public String getService() {
@@ -49,11 +49,6 @@ public class ZeppelinServiceModelGenerator extends AbstractServiceModelGenerator
   @Override
   public ServiceModel.Type getModelType() {
     return ServiceModel.Type.UI;
-  }
-
-  @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
+++ b/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
@@ -28,6 +28,8 @@ org.apache.knox.gateway.topology.discovery.cm.model.hive.HiveOnTezServiceModelGe
 org.apache.knox.gateway.topology.discovery.cm.model.hive.WebHCatServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hue.HueServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hue.HueLBServiceModelGenerator
+org.apache.knox.gateway.topology.discovery.cm.model.impala.ImpalaServiceModelGenerator
+org.apache.knox.gateway.topology.discovery.cm.model.impala.ImpalaUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.yarn.JobTrackerServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.livy.LivyServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.oozie.OozieServiceModelGenerator


### PR DESCRIPTION
Added support for Impala and Impala UI discovery from CM. Also moved the most commonly used implementation of ServiceModelGenerator#handles() to AbstractServiceModelGenerator.

## How was this patch tested?

Added discovery tests for Impala and Impala UI, executed all Knox tests, and manually tested Impala discovery against a CM cluster.