### PR TITLE
KNOX-2151 - HIVE_ON_TEZ HS2 Discovery doesn't work

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
@@ -16,6 +16,8 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.hive;
 
+import com.cloudera.api.swagger.model.ApiConfigList;
+
 public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
 
   public static final String SERVICE_TYPE = "HIVE_ON_TEZ";
@@ -23,6 +25,11 @@ public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
   @Override
   public String getServiceType() {
     return SERVICE_TYPE;
+  }
+
+  @Override
+  protected boolean checkHiveServer2HTTPMode(ApiConfigList roleConfig) {
+    return TRANSPORT_MODE_HTTP.equals(getRoleConfigValue(roleConfig, "hive_server2_transport_mode"));
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -32,6 +32,10 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
   public static final String SERVICE_TYPE = "HIVE";
   public static final String ROLE_TYPE    = "HIVESERVER2";
 
+  protected static final String TRANSPORT_MODE_HTTP = "http";
+
+
+
   @Override
   public String getService() {
     return SERVICE;
@@ -54,7 +58,9 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
 
   @Override
   public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType()) && checkHiveServer2HTTPMode(roleConfig);
+    return getServiceType().equals(service.getType()) &&
+           getRoleType().equals(role.getType()) &&
+           checkHiveServer2HTTPMode(roleConfig);
   }
 
   @Override
@@ -71,13 +77,13 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
     return createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/%s", scheme, hostname, port, httpPath));
   }
 
-  private boolean checkHiveServer2HTTPMode(ApiConfigList roleConfig) {
+  protected boolean checkHiveServer2HTTPMode(ApiConfigList roleConfig) {
+    boolean isHttp = false;
     String hiveServer2SafetyValve = getRoleConfigValue(roleConfig, "hive_hs2_config_safety_valve");
     if(hiveServer2SafetyValve != null) {
-      String transportMode = getSafetyValveValue(hiveServer2SafetyValve, "hive.server2.transport.mode");
-      return "http".equals(transportMode);
+      isHttp = TRANSPORT_MODE_HTTP.equals(getSafetyValveValue(hiveServer2SafetyValve, "hive.server2.transport.mode"));
     }
-    return false;
+    return isHttp;
   }
 
 }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -770,12 +770,12 @@ public class ClouderaManagerServiceDiscoveryTest {
                                                                    final String  thriftPath,
                                                                    final boolean enableSSL) {
     final String hs2SafetyValveValue =
-        "<property><name>hive.server2.transport.mode</name><value>http</value></property>\n" +
         "<property><name>hive.server2.thrift.http.port</name><value>" + thriftPort + "</value></property>\n" +
         "<property><name>hive.server2.thrift.http.path</name><value>" + thriftPath + "</value></property>";
 
     // Configure the role
     Map<String, String> roleProperties = new HashMap<>();
+    roleProperties.put("hive_server2_transport_mode", "http");
     roleProperties.put("hive_hs2_config_safety_valve", hs2SafetyValveValue);
     roleProperties.put("hive.server2.use.SSL", String.valueOf(enableSSL));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the HIVE_ON_TEZ HS2 discovery from ClouderaManager-managed clusters. Changed to check the role configuration, rather than the hive-site safety valve for the transport mode.

## How was this patch tested?

Updated ClouderaManagerServiceDiscoveryTest#doTestHiveOnTezServiceDiscovery, manually tested against a cluster, and executed all the Knox tests.
