### PR TITLE
KNOX-2152 - Disable Ambari cluster configuration monitoring by default

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -953,7 +953,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public boolean isClusterMonitorEnabled(String type) {
-    return getBoolean(CLUSTER_CONFIG_MONITOR_PREFIX + type.toLowerCase(Locale.ROOT) + CLUSTER_CONFIG_MONITOR_ENABLED_SUFFIX, true);
+    return getBoolean(CLUSTER_CONFIG_MONITOR_PREFIX + type.toLowerCase(Locale.ROOT) + CLUSTER_CONFIG_MONITOR_ENABLED_SUFFIX, false);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disabling Ambari cluster monitoring by default.

## How was this patch tested?

Ran Knox build/tests, manual validation