### PR TITLE
KNOX-2155 - KnoxSSO should handle multiple cookies with the same name

### DIFF
--- a/gateway-adapter/src/main/java/org/apache/hadoop/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-adapter/src/main/java/org/apache/hadoop/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -39,18 +39,6 @@ public class SSOCookieFederationFilter
   }
 
   /**
-   * Encapsulate the acquisition of the JWT token from HTTP cookies within the
-   * request.
-   *
-   * @param req servlet request to get the JWT token from
-   * @return serialized JWT token
-   */
-  @Override
-  protected String getJWTFromCookie(HttpServletRequest req) {
-    return super.getJWTFromCookie(req);
-  }
-
-  /**
    * Create the URL to be used for authentication of the user in the absence of
    * a JWT token within the incoming request.
    *

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -50,9 +50,6 @@ public interface JWTMessages {
   @Message( level = MessageLevel.WARN, text = "Configuration for authentication provider URL is missing - will derive default URL." )
   void missingAuthenticationProviderUrlConfiguration();
 
-  @Message( level = MessageLevel.DEBUG, text = "{0} Cookie has been found and is being processed." )
-  void cookieHasBeenFound(String cookieName);
-
   @Message( level = MessageLevel.DEBUG, text = "Audience claim has been validated." )
   void jwtAudienceValidated();
 }

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
@@ -30,9 +30,6 @@ public interface KnoxSSOMessages {
   @Message( level = MessageLevel.DEBUG, text = "Adding the following JWT token as a cookie: {0}")
   void addingJWTCookie(String token);
 
-  @Message( level = MessageLevel.INFO, text = "Unable to find cookie with name: {0}")
-  void cookieNotFound(String name);
-
   @Message( level = MessageLevel.ERROR, text = "Unable to properly send needed HTTP status code: {0}, {1}")
   void unableToCloseOutputStream(String message, String string);
 

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/i18n/GatewayUtilCommonMessages.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/i18n/GatewayUtilCommonMessages.java
@@ -38,4 +38,10 @@ public interface GatewayUtilCommonMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Failed to serialize Object to Json string {0}: {1}" )
   void failedToSerializeObjectToJSON( Object obj, @StackTrace( level = MessageLevel.DEBUG ) Exception e );
+
+  @Message( level = MessageLevel.INFO, text = "Unable to find cookie with name: {0}")
+  void cookieNotFound(String name);
+
+  @Message( level = MessageLevel.DEBUG, text = "{0} Cookie has been found." )
+  void cookieHasBeenFound(String cookieName);
 }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/CookieUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/CookieUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.util;
+
+import org.apache.knox.gateway.i18n.GatewayUtilCommonMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CookieUtils {
+  private static final GatewayUtilCommonMessages LOGGER = MessagesFactory.get(GatewayUtilCommonMessages.class);
+
+  private CookieUtils() {
+  }
+
+  public static List<Cookie> getCookiesForName(HttpServletRequest request, String name) {
+    List<Cookie> cookiesByName = new ArrayList<>();
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for(Cookie cookie : cookies){
+        if(name.equals(cookie.getName())){
+          cookiesByName.add(cookie);
+        }
+      }
+    }
+    if (cookiesByName.isEmpty()) {
+      LOGGER.cookieNotFound(name);
+    }
+    return cookiesByName;
+  }
+}

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/CookieUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/CookieUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+public class CookieUtilsTest {
+  @Test
+  public void testNoCookies() {
+    HttpServletRequest httpServletRequest = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(httpServletRequest.getCookies()).andReturn(null);
+    EasyMock.replay(httpServletRequest);
+
+    Assert.assertTrue(CookieUtils.getCookiesForName(httpServletRequest, "any").isEmpty());
+  }
+
+  @Test
+  public void testNoCookiesByName() {
+    Cookie[] cookies = new Cookie[] {
+        new Cookie("one", "1"),
+        new Cookie("two", "2")
+    };
+
+    HttpServletRequest httpServletRequest = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(httpServletRequest.getCookies()).andReturn(cookies);
+    EasyMock.replay(httpServletRequest);
+
+    Assert.assertTrue(CookieUtils.getCookiesForName(httpServletRequest, "noMatch").isEmpty());
+  }
+
+  @Test
+  public void testCookiesByName() {
+    Cookie one = new Cookie("one", "1");
+    Cookie two = new Cookie("two", "2");
+    Cookie onea = new Cookie("one", "1a");
+    Cookie[] expectedCookies = new Cookie[] { one, two, onea };
+
+    HttpServletRequest httpServletRequest = EasyMock.createMock(HttpServletRequest.class);
+    EasyMock.expect(httpServletRequest.getCookies()).andReturn(expectedCookies);
+    EasyMock.replay(httpServletRequest);
+
+    List<Cookie> actualCookies = CookieUtils.getCookiesForName(httpServletRequest, "one");
+    Assert.assertEquals(2, actualCookies.size());
+    Assert.assertEquals(one, actualCookies.get(0));
+    Assert.assertEquals(onea, actualCookies.get(1));
+  }
+}


### PR DESCRIPTION
This commit moves getting cookies by name to a
new utility class. It forces callers to look
through multiple cookies returned and handle
that case.
