### PR TITLE
KNOX-2157 - Verifying the server's state in addition to PID check at gateway start and registering shutdown hook in order to stop the server gracefully.

### DIFF
--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -76,10 +76,37 @@ function main {
          setupEnv
          ;;
       start)
-         if [ "$2" = "--printEnv" ]; then
+         printEnv=0
+         while [[ $# -gt 0 ]]
+         do
+           key="$1"
+
+           case $key in
+             --printEnv)
+               printEnv=1
+               shift # past argument
+               ;;
+             --test-gateway-retry-attempts)
+               export APP_STATUS_TEST_RETRY_ATTEMPTS="$2"
+               shift # past argument
+               shift # past value
+               ;;
+             --test-gateway-retry-sleep)
+               export APP_STATUS_TEST_RETRY_SLEEP="$2"
+               shift # past argument
+               shift # past value
+               ;;
+             *)    # unknown option
+               shift # past argument
+               ;;
+           esac
+         done
+
+         if [ $printEnv -eq 1 ]; then
            printEnv
          fi
          checkEnv
+         export TEST_APP_STATUS=true
          appStart
          ;;
       stop)   

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -51,6 +51,9 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.INFO, text = "Stopped gateway." )
   void stoppedGateway();
 
+  @Message( level = MessageLevel.INFO, text = "Failed to stopped gateway." )
+  void failedToStopGateway(@StackTrace( level = MessageLevel.INFO ) Exception e);
+
   @Message( level = MessageLevel.INFO, text = "Loading configuration resource {0}" )
   void loadingConfigurationResource( String res );
 
@@ -679,4 +682,7 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.INFO, text = "Deleted service definition {0} / {1} / {2}")
   void deletedServiceDefinitionChange(String serviceName, String role, String version);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to save gateway status")
+  void failedToSaveGatewayStatus();
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServerLifecycleListener.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServerLifecycleListener.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+public class GatewayServerLifecycleListener implements LifeCycle.Listener {
+
+  private static final GatewayMessages log = MessagesFactory.get(GatewayMessages.class);
+
+  private static final ThreadLocal<DateFormat> DATE_FORMAT = ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault()));
+
+  private enum Status {
+    STARTING, STARTED, FAILURE, STOPPING, STOPPED
+  };
+
+  private final Path lifeCycleFilePath;
+
+  GatewayServerLifecycleListener(GatewayConfig gatewayConfig) throws IOException {
+    this.lifeCycleFilePath = Paths.get(gatewayConfig.getGatewayDataDir(), "gatewayServer.status");
+    Files.deleteIfExists(lifeCycleFilePath);
+    Files.createFile(lifeCycleFilePath);
+  }
+
+  @Override
+  public void lifeCycleStarting(LifeCycle event) {
+    saveStatus(Status.STARTING);
+  }
+
+  @Override
+  public void lifeCycleStarted(LifeCycle event) {
+    saveStatus(Status.STARTED);
+  }
+
+  @Override
+  public void lifeCycleFailure(LifeCycle event, Throwable cause) {
+    saveStatus(Status.FAILURE);
+  }
+
+  @Override
+  public void lifeCycleStopping(LifeCycle event) {
+    saveStatus(Status.STOPPING);
+  }
+
+  @Override
+  public void lifeCycleStopped(LifeCycle event) {
+    saveStatus(Status.STOPPED);
+  }
+
+  private void saveStatus(Status status) {
+    try {
+      // saving the current timestamp in the status file is very useful at debug time
+      final String message = DATE_FORMAT.get().format(new Date()) + System.getProperty("line.separator") + status.name() + System.getProperty("line.separator");
+      Files.write(lifeCycleFilePath, message.getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      log.failedToSaveGatewayStatus();
+    }
+  }
+}

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,6 +132,8 @@ public class SimpleDescriptorHandlerFuncTest {
     File testProvDir = new File(testConfDir, "shared-providers");
     File testTopoDir = new File(testConfDir, "topologies");
     File testDeployDir = new File(testConfDir, "deployments");
+    File testDataDir = new File(testRootDir, "data");
+    Files.createDirectories(Paths.get(testDataDir.getAbsolutePath()));
 
     // Write the externalized provider config to a temp file
     File providerConfig = new File(testProvDir, "ambari-cluster-policy.xml");
@@ -162,6 +166,7 @@ public class SimpleDescriptorHandlerFuncTest {
       // Try setting up enough of the GatewayServer to support the test...
       GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
       InetSocketAddress gatewayAddress = new InetSocketAddress(0);
+      EasyMock.expect(config.getGatewayDataDir()).andReturn(testDataDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayTopologyDir()).andReturn(testTopoDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayDeploymentDir()).andReturn(testDeployDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayAddress()).andReturn(gatewayAddress).anyTimes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apart from the already existing PID check, we are going to verify if the Jetty server is in `STARTED` state. We can achieve it by implementing Jetty's `LifeCylce.Listener` interface and write out the status (STARTING, STARTED, FAILURE, STOPPING, STOPPED) into `$DATA_DIR/gatewayServer.status` file. The startup script will return 0 when this file contains `STARTED`; 1 otherwise (the file is overwritten in every status change).

Additionally, two new command-line options are introduced to the `start` command:
* `--test-gateway-retry-attempts`: indicates the number of tries the startup script should execute before it fails. Defaults to 5.
* `--test-gateway-retry-sleep`: the amount of time that the test process will wait or sleep before a retry is issued. Defaults to 2s.

Additionally, in order to make the server stopped gracefully from `gateway.sh`, I registered a shutdown hook in `GatewayServer` which invokes the desired stop commands on services/monitor/Jetty and persists the appropriate states (`STOPPING` and `STOPPED`) in the new status file.

## How was this patch tested?

Executed a full build:
```
$ mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:24 min (Wall Clock)
[INFO] Finished at: 2020-01-02T18:50:47+01:00
[INFO] Final Memory: 410M/1798M
[INFO] ------------------------------------------------------------------------
```

Tested manually:
* confirmed that the new status file became created/removed when started/stopped the server. All the statuses were written out as expected. For instance
```
2020-01-07T10:55:10.684+0100
STARTING

2020-01-07T10:55:11.570+0100
STARTED

2020-01-07T10:55:46.599+0100
STOPPING

2020-01-07T10:55:46.620+0100
STOPPED
```
* tried the `start` command with different options (`--printEnv`, `--test-gateway-retry-attempts`, `--test-gateway-retry-sleep`)
* made sure (using debug messages in the shell scripts) that the status check took place (in my environment it needed 3 re-tries)