### PR TITLE
KNOX-2101 - knoxshell doesn't handle invalid TLS well

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSh.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSh.java
@@ -290,7 +290,15 @@ public class KnoxSh {
           Files.setPosixFilePermissions(Paths.get(System.getProperty("user.home") + "/.knoxtokencache"), perms);
         }
       } catch(KnoxShellException he) {
-        System.out.println("Failure to acquire token. Please verify your credentials and Knox URL and try again.");
+          String message = "Failure to acquire token. Please verify your credentials, Knox URL, and TLS truststore configuration.";
+          Throwable t = he.getCause();
+          if (t != null) {
+              String rc = t.getMessage();
+              if (rc != null) {
+                  message += " Cause: " + rc;
+              }
+          }
+        System.out.println(message);
       }
       if ( session != null ) {
         session.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified exception message to include the specific reason for failure with "Cause:" as seen in the following examples

Untrusted certificate:
![untrusted-cert](https://user-images.githubusercontent.com/46705753/71796844-c4a9cf00-3019-11ea-9528-df6155eac27a.png)

Hostname verification failure:
![hostname-verification-failure](https://user-images.githubusercontent.com/46705753/71796861-d5f2db80-3019-11ea-8ee4-e5f4fce35797.png)

Invalid login credentials:
![invalid-login](https://user-images.githubusercontent.com/46705753/71796870-e4d98e00-3019-11ea-915d-516b7900136a.png)


## How was this patch tested?

Manual tests
