### PR TITLE
KNOX-2160 - Monitoring and processing refreshable service parameters

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -685,4 +685,16 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Failed to save gateway status")
   void failedToSaveGatewayStatus();
+
+  @Message(level = MessageLevel.INFO, text = "Monitoring service parameter changes in {0}")
+  void monitoringServiceParameterChanges(String folder);
+
+  @Message(level = MessageLevel.INFO, text = "Refreshing service parameters...")
+  void refreshingServiceParameters();
+
+  @Message(level = MessageLevel.INFO, text = "Refreshed service parameters {0}")
+  void refreshedServiceParameters(String updatedDescriptors);
+
+  @Message(level = MessageLevel.WARN, text = "Unable to refresh service parameters")
+  void unableToRefreshServiceParameters(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -233,6 +233,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   static final String REMOTE_ALIAS_SERVICE_CONFIG_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.config.prefix";
   static final String REMOTE_ALIAS_SERVICE_CONFIG_PREFIX_DEFAULT = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.config.";
 
+  public static final String REFRESHABLE_SERVIVCE_PARAMETERS_FILENAME = "refreshable-service-parameters.xml";
+  private static final String REFRESHABLE_SERVICE_PARAMETERS_FOLDER = GATEWAY_CONFIG_FILE_PREFIX + ".refreshable.service.parameters.folder";
+  private static final String REFRESHABLE_SERVICE_PARAMETERS_FOLDER_MONITORING_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX
+          + ".refreshable.service.parameters.folder.monitor.interval";
+  private static final int REFRESHABLE_SERVICE_PARAMETERS_FOLDER_MONITORING_INTERVAL_DEFAULT = 60000;
+
   private static final List<String> DEFAULT_GLOBAL_RULES_SERVICES = Arrays.asList(
       "NAMENODE", "JOBTRACKER", "WEBHDFS", "WEBHCAT",
       "OOZIE", "WEBHBASE", "HIVE", "RESOURCEMANAGER");
@@ -1093,5 +1099,15 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     }
 
     return set;
+  }
+
+  @Override
+  public String getRefreshableServiceParametersFolder() {
+  return get(REFRESHABLE_SERVICE_PARAMETERS_FOLDER);
+  }
+
+  @Override
+  public int getServiceParametersFolderRefreshInterval() {
+    return getInt(REFRESHABLE_SERVICE_PARAMETERS_FOLDER_MONITORING_INTERVAL, REFRESHABLE_SERVICE_PARAMETERS_FOLDER_MONITORING_INTERVAL_DEFAULT);
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/descriptor/RefreshableServiceParametersConfiguration.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/descriptor/RefreshableServiceParametersConfiguration.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.descriptor;
+
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.knox.gateway.config.GatewayConfig;
+
+/**
+ * Parses <code>refreshable-service-parameters.xml</code> within the pre-configured
+ * {@link GatewayConfig#getRefreshableServiceParametersFolder} (if any) and provides useful methods to get topologies and service parameters
+ */
+public class RefreshableServiceParametersConfiguration {
+  private static final String CONFIGURATION_NAME = "refreshable.service.parameters";
+  private final Set<TopologyServiceParameters> topologyServiceParameters = new HashSet<>();
+
+  public RefreshableServiceParametersConfiguration(Path resourcePath) throws MalformedURLException {
+    final Configuration configuration = new Configuration();
+    configuration.addResource(resourcePath.toUri().toURL());
+    configuration.reloadConfiguration();
+    parseConfig(configuration);
+  }
+
+  // the configuration value equals to BLOCK_1;BLOCK_2;...BLOCK_N,
+  // where BLOCK_* is built up as $TOPOLOGY.$SERVICE.$PARMAPETER_NAME=$PARAMETER_VALUE
+  // For instance: test-topology.HDFS.test.pramameter=test.value
+  private void parseConfig(final Configuration configuration) {
+    final String parametersText = configuration.get(CONFIGURATION_NAME);
+    if (parametersText != null && !parametersText.isEmpty()) {
+      for (String topologyServiceParameterConfig : parametersText.split(";")) {
+        String[] parameterPairParts = topologyServiceParameterConfig.trim().split("=", 2);
+        String[] topologyAndServiceAndParameterNames = parameterPairParts[0].trim().split("\\.");
+        String topology = topologyAndServiceAndParameterNames[0].trim();
+        if (getServiceParameters(topology) == null) {
+          topologyServiceParameters.add(new TopologyServiceParameters(topology));
+        }
+
+        String serviceName = topologyAndServiceAndParameterNames[1].trim();
+        String parameterName = parameterPairParts[0].substring(topology.length() + serviceName.length() + 2).trim();
+        String parameterValue = parameterPairParts[1].trim();
+        getServiceParameters(topology).addServiceParameter(serviceName, parameterName, parameterValue);
+      }
+    }
+  }
+
+  public Set<String> getTopologies() {
+    return topologyServiceParameters.stream().map(topologyServiceParameter -> topologyServiceParameter.getTopology()).collect(Collectors.toSet());
+  }
+
+  public TopologyServiceParameters getServiceParameters(String topologyName) {
+    return topologyServiceParameters.stream().filter(topologyServiceParameters -> topologyServiceParameters.getTopology().equals(topologyName)).findFirst().orElse(null);
+  }
+
+  public class TopologyServiceParameters {
+    private String topology;
+    private Map<String, Map<String, String>> serviceParameters;
+
+    TopologyServiceParameters(String topology) {
+      this.topology = topology;
+      this.serviceParameters = new TreeMap<>();
+    }
+
+    public String getTopology() {
+      return topology;
+    }
+
+    void addServiceParameter(String serviceName, String parameterName, String parameterValue) {
+      serviceParameters.computeIfAbsent(serviceName, k -> new TreeMap<>()).put(parameterName, parameterValue);
+    }
+
+    public Map<String, Map<String, String>> getServiceParameters() {
+      return serviceParameters;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+      return HashCodeBuilder.reflectionHashCode(this);
+    }
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -872,8 +872,9 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
           final RefreshableServiceParametersConfiguration.TopologyServiceParameters serviceParameters = serviceParametersConfig.getServiceParameters(topology);
           final SimpleDescriptor descriptor = SimpleDescriptorFactory.parse(descriptorPath);
           for (SimpleDescriptor.Service service : descriptor.getServices()) {
-            if (serviceParameters.getServiceParameters().containsKey(service.getName())) {
-              service.addParams(serviceParameters.getServiceParameters().get(service.getName()));
+            Map<String, String> serviceParams = serviceParameters.getServiceParameters(service.getName(), service.getVersion());
+            if (!serviceParams.isEmpty()) {
+              service.addParams(serviceParams);
               updatedDescriptors.add(descriptor.getName());
               redeploy = true;
             }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptor.java
@@ -31,7 +31,7 @@ public interface SimpleDescriptor {
 
     String getDiscoveryPasswordAlias();
 
-    String getClusterName();
+    String getCluster();
 
     String getProviderConfig();
 
@@ -46,6 +46,8 @@ public interface SimpleDescriptor {
         String getVersion();
 
         Map<String, String> getParams();
+
+        void addParams(Map<String, String> paramsToAdd);
 
         List<String> getURLs();
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorFactory.java
@@ -16,15 +16,28 @@
  */
 package org.apache.knox.gateway.topology.simple;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.commons.io.FilenameUtils;
-
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FilenameUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 
 public class SimpleDescriptorFactory {
+
+    /**
+     * @param path
+     *          The path to the file
+     * @return A SimpleDescriptor based on the contents of the file referenced by the given path.
+     * @throws IOException
+     *           in case of any parsing error
+     */
+    public static SimpleDescriptor parse(Path path) throws IOException {
+      return parse(path.toString());
+    }
 
     /**
      * Create a SimpleDescriptor from the specified file.

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -220,7 +220,7 @@ public class SimpleDescriptorHandler {
             discoveryInstances.put(discoveryType, sd);
         }
 
-        return sd.discover(config, sdc, desc.getClusterName());
+        return sd.discover(config, sdc, desc.getCluster());
     }
 
 
@@ -574,7 +574,7 @@ public class SimpleDescriptorHandler {
             // Write the generated content to a file
             String topologyFilename = desc.getName();
             if (topologyFilename == null) {
-                topologyFilename = desc.getClusterName();
+                topologyFilename = desc.getCluster();
             }
             topologyDescriptor = new File(destDirectory, topologyFilename + ".xml");
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorImpl.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.topology.simple;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,7 +82,7 @@ class SimpleDescriptorImpl implements SimpleDescriptor {
     }
 
     @Override
-    public String getClusterName() {
+    public String getCluster() {
         return cluster;
     }
 
@@ -134,6 +135,14 @@ class SimpleDescriptorImpl implements SimpleDescriptor {
         @Override
         public Map<String, String> getParams() {
             return params;
+        }
+
+        @Override
+        public void addParams(Map<String, String> paramsToAdd) {
+          if (params == null) {
+            params = new HashMap<>();
+          }
+          params.putAll(paramsToAdd);
         }
 
         @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/descriptor/RefreshableServiceParametersConfigurationTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/descriptor/RefreshableServiceParametersConfigurationTest.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.descriptor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Paths;
@@ -38,19 +39,22 @@ public class RefreshableServiceParametersConfigurationTest {
 
     TopologyServiceParameters topologyServiceParameters = serviceParametersConfiguration.getServiceParameters("topology1");
     assertEquals(1, topologyServiceParameters.getServiceParameters().size());
-    assertServiceParameters(topologyServiceParameters, "NIFI-REGISTRY", "useTwoWaySsl", "true");
+    assertServiceParameters(topologyServiceParameters, "NIFI-REGISTRY", "1.0", "useTwoWaySsl", "true");
 
     topologyServiceParameters = serviceParametersConfiguration.getServiceParameters("topology2");
-    assertEquals(2, topologyServiceParameters.getServiceParameters().size());
-    assertServiceParameters(topologyServiceParameters, "HIVE", "httpclient.connectionTimeout", "5m");
-    assertServiceParameters(topologyServiceParameters, "HIVE", "httpclient.socketTimeout", "200m");
-    assertServiceParameters(topologyServiceParameters, "HUE", "httpclient.connectionTimeout", "5m");
+    assertEquals(3, topologyServiceParameters.getServiceParameters().size());
+    assertServiceParameters(topologyServiceParameters, "HIVE", "1.0", "httpclient.connectionTimeout", "5m");
+    assertServiceParameters(topologyServiceParameters, "HIVE", "1.0", "httpclient.socketTimeout", "100m");
+    assertServiceParameters(topologyServiceParameters, "HIVE", "2.0", "httpclient.socketTimeout", "200m");
+    assertServiceParameters(topologyServiceParameters, "HUE", "2.0", "httpclient.connectionTimeout", "5m");
+    assertServiceParameters(topologyServiceParameters, "HUE", null, "httpclient.connectionTimeout", "5m");
+    assertServiceParameters(topologyServiceParameters, "HUE", "", "httpclient.connectionTimeout", "5m");
   }
 
-  private void assertServiceParameters(TopologyServiceParameters topologyServiceParameters, String expectedServiceName, String expectedParameterName,
+  private void assertServiceParameters(TopologyServiceParameters topologyServiceParameters, String expectedServiceName, String expectedVersion, String expectedParameterName,
       String expectedParameterValue) {
-    assertTrue(topologyServiceParameters.getServiceParameters().containsKey(expectedServiceName));
-    assertTrue(topologyServiceParameters.getServiceParameters().get(expectedServiceName).containsKey(expectedParameterName));
-    assertTrue(topologyServiceParameters.getServiceParameters().get(expectedServiceName).get(expectedParameterName).equals(expectedParameterValue));
+    assertFalse(topologyServiceParameters.getServiceParameters(expectedServiceName, expectedVersion).isEmpty());
+    assertTrue(topologyServiceParameters.getServiceParameters(expectedServiceName, expectedVersion).containsKey(expectedParameterName));
+    assertTrue(topologyServiceParameters.getServiceParameters(expectedServiceName, expectedVersion).get(expectedParameterName).equals(expectedParameterValue));
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/descriptor/RefreshableServiceParametersConfigurationTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/descriptor/RefreshableServiceParametersConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.descriptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Paths;
+
+import org.apache.knox.gateway.descriptor.RefreshableServiceParametersConfiguration.TopologyServiceParameters;
+import org.junit.Test;
+
+public class RefreshableServiceParametersConfigurationTest {
+
+  @Test
+  public void testRefreshableServiceParametersConfiguration() throws Exception {
+    final String testConfigPath = this.getClass().getClassLoader().getResource("refreshableServiceParams/refreshable-service-parameters.xml").getPath();
+    final RefreshableServiceParametersConfiguration serviceParametersConfiguration = new RefreshableServiceParametersConfiguration(Paths.get(testConfigPath));
+
+    assertEquals(2, serviceParametersConfiguration.getTopologies().size());
+    assertTrue(serviceParametersConfiguration.getTopologies().contains("topology1"));
+    assertTrue(serviceParametersConfiguration.getTopologies().contains("topology2"));
+
+    TopologyServiceParameters topologyServiceParameters = serviceParametersConfiguration.getServiceParameters("topology1");
+    assertEquals(1, topologyServiceParameters.getServiceParameters().size());
+    assertServiceParameters(topologyServiceParameters, "NIFI-REGISTRY", "useTwoWaySsl", "true");
+
+    topologyServiceParameters = serviceParametersConfiguration.getServiceParameters("topology2");
+    assertEquals(2, topologyServiceParameters.getServiceParameters().size());
+    assertServiceParameters(topologyServiceParameters, "HIVE", "httpclient.connectionTimeout", "5m");
+    assertServiceParameters(topologyServiceParameters, "HIVE", "httpclient.socketTimeout", "200m");
+    assertServiceParameters(topologyServiceParameters, "HUE", "httpclient.connectionTimeout", "5m");
+  }
+
+  private void assertServiceParameters(TopologyServiceParameters topologyServiceParameters, String expectedServiceName, String expectedParameterName,
+      String expectedParameterValue) {
+    assertTrue(topologyServiceParameters.getServiceParameters().containsKey(expectedServiceName));
+    assertTrue(topologyServiceParameters.getServiceParameters().get(expectedServiceName).containsKey(expectedParameterName));
+    assertTrue(topologyServiceParameters.getServiceParameters().get(expectedServiceName).get(expectedParameterName).equals(expectedParameterValue));
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -217,7 +217,7 @@ public class DefaultTopologyServiceTest {
       EasyMock.expect(aliasService.getPasswordFromAliasForGateway(anyObject(String.class))).andReturn(null).anyTimes();
       EasyMock.replay(aliasService);
       DefaultTopologyService.DescriptorsMonitor dm =
-              new DefaultTopologyService.DescriptorsMonitor(config, topologyDir, aliasService);
+              new DefaultTopologyService.DescriptorsMonitor(config, topologyDir, aliasService, provider);
 
       // Listener to simulate the topologies directory monitor, to notice when a topology has been deleted
       provider.addTopologyChangeListener(new TestTopologyDeleteListener(provider));

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorFactoryTest.java
@@ -755,7 +755,7 @@ public class SimpleDescriptorFactoryTest {
         assertEquals(discoveryType, sd.getDiscoveryType());
         assertEquals(discoveryAddress, sd.getDiscoveryAddress());
         assertEquals(providerConfig, sd.getProviderConfig());
-        assertEquals(clusterName, sd.getClusterName());
+        assertEquals(clusterName, sd.getCluster());
 
         List<SimpleDescriptor.Service> actualServices = sd.getServices();
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
@@ -199,7 +199,7 @@ public class SimpleDescriptorHandlerTest {
             EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn(type).anyTimes();
             EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
             EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
-            EasyMock.expect(testDescriptor.getClusterName()).andReturn(clusterName).anyTimes();
+            EasyMock.expect(testDescriptor.getCluster()).andReturn(clusterName).anyTimes();
             List<SimpleDescriptor.Service> serviceMocks = new ArrayList<>();
             for (String serviceName : serviceURLs.keySet()) {
                 SimpleDescriptor.Service svc = EasyMock.createNiceMock(SimpleDescriptor.Service.class);
@@ -377,7 +377,7 @@ public class SimpleDescriptorHandlerTest {
             EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn(type).anyTimes();
             EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
             EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
-            EasyMock.expect(testDescriptor.getClusterName()).andReturn(CLUSTER_NAME).anyTimes();
+            EasyMock.expect(testDescriptor.getCluster()).andReturn(CLUSTER_NAME).anyTimes();
             List<SimpleDescriptor.Service> serviceMocks = new ArrayList<>();
             for (String serviceName : serviceURLs.keySet()) {
                 SimpleDescriptor.Service svc = EasyMock.createNiceMock(SimpleDescriptor.Service.class);
@@ -580,7 +580,7 @@ public class SimpleDescriptorHandlerTest {
             EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn(type).anyTimes();
             EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
             EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
-            EasyMock.expect(testDescriptor.getClusterName()).andReturn(clusterName).anyTimes();
+            EasyMock.expect(testDescriptor.getCluster()).andReturn(clusterName).anyTimes();
             List<SimpleDescriptor.Service> serviceMocks = new ArrayList<>();
             for (String serviceName : serviceURLs.keySet()) {
                 SimpleDescriptor.Service svc = EasyMock.createNiceMock(SimpleDescriptor.Service.class);
@@ -781,7 +781,7 @@ public class SimpleDescriptorHandlerTest {
         EasyMock.expect(testDescriptor.getDiscoveryAddress()).andReturn(discoveryConfig.getAbsolutePath()).anyTimes();
         EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn("PROPERTIES_FILE").anyTimes();
         EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
-        EasyMock.expect(testDescriptor.getClusterName()).andReturn(clusterName).anyTimes();
+        EasyMock.expect(testDescriptor.getCluster()).andReturn(clusterName).anyTimes();
 
         final SimpleDescriptor.Service knoxService = EasyMock.createNiceMock(SimpleDescriptor.Service.class);
         EasyMock.expect(knoxService.getName()).andReturn("KNOX").anyTimes();

--- a/gateway-server/src/test/resources/refreshableServiceParams/refreshable-service-parameters.xml
+++ b/gateway-server/src/test/resources/refreshableServiceParams/refreshable-service-parameters.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>refreshable.service.parameters</name>
+    <value>topology1.NIFI-REGISTRY.useTwoWaySsl=true;
+        topology2.HIVE.httpclient.connectionTimeout=5m;
+        topology2.HIVE.httpclient.socketTimeout=200m;
+        topology2.HUE.httpclient.connectionTimeout=5m</value>
+  </property>
+</configuration>

--- a/gateway-server/src/test/resources/refreshableServiceParams/refreshable-service-parameters.xml
+++ b/gateway-server/src/test/resources/refreshableServiceParams/refreshable-service-parameters.xml
@@ -19,9 +19,10 @@ limitations under the License.
 <configuration>
   <property>
     <name>refreshable.service.parameters</name>
-    <value>topology1.NIFI-REGISTRY.useTwoWaySsl=true;
-        topology2.HIVE.httpclient.connectionTimeout=5m;
-        topology2.HIVE.httpclient.socketTimeout=200m;
-        topology2.HUE.httpclient.connectionTimeout=5m</value>
+    <value>topology1:NIFI-REGISTRY:1.0:useTwoWaySsl=true;
+        topology2:HIVE:1.0:httpclient.connectionTimeout=5m;
+        topology2:HIVE:1.0:httpclient.socketTimeout=100m;
+        topology2:HIVE:2.0:httpclient.socketTimeout=200m;
+        topology2:HUE:2.0:httpclient.connectionTimeout=5m</value>
   </property>
 </configuration>

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -642,4 +642,14 @@ public interface GatewayConfig {
    * @return a set of service principal names that indicate which services to ignore doAs request
    */
   Set<String> getServicesToIgnoreDoAs();
+
+  /**
+   * @return the name of the folder where refreshable service parameters should be monitored; <code>null</code> if monitoring is disabled
+   */
+  String getRefreshableServiceParametersFolder();
+
+  /**
+   * @return the service parameter folder refresh interval in ms.
+   */
+  int getServiceParametersFolderRefreshInterval();
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -764,4 +764,14 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public Set<String> getServicesToIgnoreDoAs() {
     return null;
   }
+
+  @Override
+  public String getRefreshableServiceParametersFolder() {
+    return null;
+  }
+
+  @Override
+  public int getServiceParametersFolderRefreshInterval() {
+    return 0;
+  }
 }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -150,7 +150,7 @@ public class SimpleDescriptorHandlerFuncTest {
       EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn(discoveryType).anyTimes();
       EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
       EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
-      EasyMock.expect(testDescriptor.getClusterName()).andReturn(clusterName).anyTimes();
+      EasyMock.expect(testDescriptor.getCluster()).andReturn(clusterName).anyTimes();
       List<SimpleDescriptor.Service> serviceMocks = new ArrayList<>();
       for (String serviceName : serviceURLs.keySet()) {
         SimpleDescriptor.Service svc = EasyMock.createNiceMock(SimpleDescriptor.Service.class);

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -43,7 +43,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.knox.gateway.i18n.GatewayUtilCommonMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -48,10 +49,18 @@ public class JsonUtils {
   }
 
   public static String renderAsJsonString(Object obj) {
-    return renderAsJsonString(obj, null, null);
+    return renderAsJsonString(obj, false);
+  }
+
+  public static String renderAsJsonString(Object obj, boolean ignoreNullValues) {
+    return renderAsJsonString(obj, null, null, ignoreNullValues);
   }
 
   public static String renderAsJsonString(Object obj, FilterProvider filterProvider, DateFormat dateFormat) {
+    return renderAsJsonString(obj, filterProvider, dateFormat, false);
+  }
+
+  public static String renderAsJsonString(Object obj, FilterProvider filterProvider, DateFormat dateFormat, boolean ignoreNullValues) {
     String json = null;
     ObjectMapper mapper = new ObjectMapper();
     if (filterProvider != null) {
@@ -60,6 +69,10 @@ public class JsonUtils {
 
     if (dateFormat != null) {
       mapper.setDateFormat(dateFormat);
+    }
+
+    if (ignoreNullValues) {
+      mapper.setSerializationInclusion(Include.NON_NULL);
     }
 
     try {

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
@@ -45,6 +46,9 @@ public class JsonUtilsTest {
     assertThat( result, containsString( expiresIn ) );
     assertThat( result, containsString( tokenType ) );
     assertThat( result, containsString( accessToken ) );
+
+    map.put("KeyWithNullValue", null);
+    assertThat(JsonUtils.renderAsJsonString(map, true), not(containsString("KeyWithNullValue")));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Monitoring a pre-defined folder for service parameter changes and, if there was a change in the `refreshable-service-parameters.xml`, processing the new service parameters. 

## How was this patch tested?

Added and updated JUnit tests then executed them:
```
$ mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:37 min
[INFO] Finished at: 2020-01-08T12:16:47+01:00
[INFO] Final Memory: 156M/1615M
[INFO] ------------------------------------------------------------------------
```

Additionally, the following E2E testing took place locally:
- deployed Knox with my changes
- set
    -`gateway.refreshable.service.parameters.folder=/Users/smolnar/test/conf_dir`
    -`gateway.refreshable.service.parameters.folder.monitor.interval=10000`
   in `gateway-site.xml`
- produced `/Users/smolnar/test/conf_dir/refreshable-service-parameters.xml` (used the same sample I added as a new JUnit test resource)
- started Knox (confirmed - using remote debugging - that the monitoring thread got created)
- created `cdp-proxy-api` provider/descriptor pair (with HIVE, RANGER and NIFI services; gave the dummy URLs)
- edited the content of `/Users/smolnar/test/conf_dir/refreshable-service-parameters.xml`
- confirmed that `cdp-proxy-api` got re-deployed: saw the proper log messages and checked the re-deployed topology content in the Admin UI
- changed the service parameters in the Admin UI too

Relevant `gateway.log` messages:
```
2020-01-08 12:32:59,484 INFO  knox.gateway (DefaultTopologyService.java:refreshServiceParameters(855)) - Refreshing service parameters...
2020-01-08 12:32:59,494 INFO  knox.gateway (DefaultTopologyService.java:refreshServiceParameters(857)) - Refreshed service parameters in cdp-proxy-api
...

2020-01-08 12:33:03,733 INFO  knox.gateway (DefaultTopologyService.java:onFileChange(946)) - Generated topology cdp-proxy-api.xml because the associated descriptor cdp-proxy-api.json changed.
2020-01-08 12:33:06,179 INFO  knox.gateway (GatewayServer.java:handleCreateDeployment(998)) - Deploying topology cdp-proxy-api to /Users/smolnar/test/knoxGateway/data/deployments/cdp-proxy-api.topo.16f84eded98
2020-01-08 12:33:06,179 INFO  knox.gateway (GatewayServer.java:internalDeactivateTopology(917)) - Deactivating topology cdp-proxy-api
2020-01-08 12:33:06,238 INFO  knox.gateway (DefaultGatewayServices.java:initializeContribution(164)) - Credential store found for the cluster: cdp-proxy-api - no need to create one.
2020-01-08 12:33:06,607 INFO  knox.gateway (GatewayServer.java:internalActivateTopology(883)) - Activating topology cdp-proxy-api
2020-01-08 12:33:06,607 INFO  knox.gateway (GatewayServer.java:internalActivateArchive(893)) - Activating topology cdp-proxy-api archive %2F
2020-01-08 12:33:06,666 INFO  knox.gateway (GatewayServer.java:cleanupTopologyDeployments(356)) - Deleting backup deployed topology /Users/smolnar/test/knoxGateway/data/deployments/cdp-proxy-api.topo.16f84d7c1d0
```