### PR TITLE
KNOX-718 - KnoxSSO login page doesn't display any feedback on error

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
@@ -70,13 +70,14 @@ var login = function() {
                     redirectUrl = "redirecting.html?originalUrl=" + originalUrl;
                   }
                   redirect(redirectUrl);
-                }
-                else {
+                } else {
+                  $('#errorBox').show();
+                  $('#signInLoading').hide();
+                  $('#signIn').removeAttr('disabled');
                   if (request.status==401) {
-                    $('#errorBox').show();
-                    $('#signInLoading').hide();
-                    $('#signIn').removeAttr('disabled');
                     $('#errorBox .errorMsg').text("The username or password you entered is incorrect.");
+                  } else {
+                    $('#errorBox .errorMsg').text("Response from " + request.responseURL + " - " + request.status + ": " + request.statusText);
                   }
                 }
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provide feedback on the KnoxSSO login page when an error occurs dispatching to the backend.

## How was this patch tested?

* `mvn -T.5C verify -Ppackage,release -Dshellcheck`
* Checked with KnoxSSO login against WebHDFS that if no WebHDFS 500 error and message is shown to end user.