### PR TITLE
KNOX-2186 - Advanced service discovery configuration handling

### DIFF
--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -44,4 +44,10 @@ public interface ClouderaManagerIntegrationMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Error while producing Knox descriptor: {0}")
   void failedToProduceKnoxDescriptor(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.WARN, text = "Service {0} is disabled. It will NOT be added in {1}")
+  void serviceDisabled(String serviceName, String descriptorName);
+
+  @Message(level = MessageLevel.INFO, text = "Updated advanced service discovery configuration.")
+  void updatedAdvanceServiceDiscoverytConfiguration();
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
@@ -148,6 +148,7 @@ public class ClouderaManagerDescriptorParser {
   /**
    * A service consists of the following parts:
    * <ul>
+   * <li><code>$SERVICE_NAME</code></li>
    * <li><code>$SERVICE_NAME:url=$URL</code></li>
    * <li><code>$SERVICE_NAME:version=$VERSION</code> (optional)</li>
    * <li><code>$SERVICE_NAME[:$PARAMETER_NAME=$PARAMETER_VALUE] (optional)</code></li>
@@ -169,21 +170,23 @@ public class ClouderaManagerDescriptorParser {
       descriptor.addService(service);
     }
 
-    // configuration value may contain ":" (for instance http://host:port) -> considering a configuration name/value pair everything after '$SERVICE_NAME:'
-    final String serviceConfiguration = configurationPair.substring(serviceName.length() + 1).trim();
-    final String[] serviceConfigurationParts = serviceConfiguration.split("=", 2);
-    final String serviceConfigurationName = serviceConfigurationParts[0].trim();
-    final String serviceConfigurationValue = serviceConfigurationParts[1].trim();
-    switch (serviceConfigurationName) {
-    case CONFIG_NAME_SERVICE_URL:
-      service.addUrl(serviceConfigurationValue);
-      break;
-    case CONFIG_NAME_SERVICE_VERSION:
-      service.setVersion(serviceConfigurationValue);
-      break;
-    default:
-      service.addParam(serviceConfigurationName, serviceConfigurationValue);
-      break;
+    if (serviceParts.length > 1) {
+      // configuration value may contain ":" (for instance http://host:port) -> considering a configuration name/value pair everything after '$SERVICE_NAME:'
+      final String serviceConfiguration = configurationPair.substring(serviceName.length() + 1).trim();
+      final String[] serviceConfigurationParts = serviceConfiguration.split("=", 2);
+      final String serviceConfigurationName = serviceConfigurationParts[0].trim();
+      final String serviceConfigurationValue = serviceConfigurationParts[1].trim();
+      switch (serviceConfigurationName) {
+      case CONFIG_NAME_SERVICE_URL:
+        service.addUrl(serviceConfigurationValue);
+        break;
+      case CONFIG_NAME_SERVICE_VERSION:
+        service.setVersion(serviceConfigurationValue);
+        break;
+      default:
+        service.addParam(serviceConfigurationName, serviceConfigurationValue);
+        break;
+      }
     }
   }
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
@@ -19,18 +19,21 @@ package org.apache.knox.gateway.cm.descriptor;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.knox.gateway.ClouderaManagerIntegrationMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.topology.discovery.advanced.AdvancedServiceDiscoveryConfig;
+import org.apache.knox.gateway.topology.discovery.advanced.AdvancedServiceDiscoveryConfigChangeListener;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorImpl;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorImpl.ApplicationImpl;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorImpl.ServiceImpl;
 
-public class ClouderaManagerDescriptorParser {
+public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscoveryConfigChangeListener {
   private static final ClouderaManagerIntegrationMessages log = MessagesFactory.get(ClouderaManagerIntegrationMessages.class);
   private static final String CONFIG_NAME_DISCOVERY_TYPE = "discoveryType";
   private static final String CONFIG_NAME_DISCOVERY_ADDRESS = "discoveryAddress";
@@ -42,6 +45,12 @@ public class ClouderaManagerDescriptorParser {
   private static final String CONFIG_NAME_SERVICE_URL = "url";
   private static final String CONFIG_NAME_SERVICE_VERSION = "version";
 
+  private AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig;
+
+  public ClouderaManagerDescriptorParser() {
+    advancedServiceDiscoveryConfig = new AdvancedServiceDiscoveryConfig();
+  }
+
   /**
    * Produces a set of {@link SimpleDescriptor}s from the specified file.
    *
@@ -49,7 +58,7 @@ public class ClouderaManagerDescriptorParser {
    *          The path to the configuration file which holds descriptor information in a pre-defined format.
    * @return A SimpleDescriptor based on the contents of the given file.
    */
-  public static Set<SimpleDescriptor> parse(String path) {
+  public Set<SimpleDescriptor> parse(String path) {
     try {
       log.parseClouderaManagerDescriptor(path);
       final Configuration xmlConfiguration = new Configuration(false);
@@ -64,7 +73,7 @@ public class ClouderaManagerDescriptorParser {
     }
   }
 
-  private static Set<SimpleDescriptor> parseXmlConfig(Configuration xmlConfiguration) {
+  private Set<SimpleDescriptor> parseXmlConfig(Configuration xmlConfiguration) {
     final Set<SimpleDescriptor> descriptors = new LinkedHashSet<>();
     xmlConfiguration.forEach(xmlDescriptor -> {
       SimpleDescriptor descriptor = parseXmlDescriptor(xmlDescriptor.getKey(), xmlDescriptor.getValue());
@@ -75,7 +84,7 @@ public class ClouderaManagerDescriptorParser {
     return descriptors;
   }
 
-  private static SimpleDescriptor parseXmlDescriptor(String name, String xmlValue) {
+  private SimpleDescriptor parseXmlDescriptor(String name, String xmlValue) {
     try {
       final SimpleDescriptorImpl descriptor = new SimpleDescriptorImpl();
       descriptor.setName(name);
@@ -111,11 +120,27 @@ public class ClouderaManagerDescriptorParser {
           break;
         }
       }
+      if (advancedServiceDiscoveryConfig.getExpectedTopologyNames().contains(name)) {
+        addEnabledServices(descriptor);
+      }
       return descriptor;
-    } catch(Exception e) {
+    } catch (Exception e) {
       log.failedToParseDescriptor(name, e.getMessage(), e);
       return null;
     }
+  }
+
+  /*
+   * Adds any enabled service which is not listed in the CM descriptor
+   */
+  private void addEnabledServices(SimpleDescriptorImpl descriptor) {
+    advancedServiceDiscoveryConfig.getEnabledServiceNames().forEach(enabledServiceName -> {
+      if(descriptor.getService(enabledServiceName) == null) {
+        ServiceImpl service = new ServiceImpl();
+        service.setName(enabledServiceName);
+        descriptor.addService(service);
+      }
+    });
   }
 
   /**
@@ -127,7 +152,7 @@ public class ClouderaManagerDescriptorParser {
    * <li>app:knoxauth:param1.name=param1.value</li>
    * </ul>
    */
-  private static void parseApplication(SimpleDescriptorImpl descriptor, String configurationPair) {
+  private void parseApplication(SimpleDescriptorImpl descriptor, String configurationPair) {
     final String[] applicationParts = configurationPair.split(":");
     final String applicationName = applicationParts[1].trim();
     ApplicationImpl application = (ApplicationImpl) descriptor.getApplication(applicationName);
@@ -160,34 +185,44 @@ public class ClouderaManagerDescriptorParser {
    * <li>HIVE:param1.name=param1.value</li>
    * </ul>
    */
-  private static void parseService(SimpleDescriptorImpl descriptor, String configurationPair) {
+  private void parseService(SimpleDescriptorImpl descriptor, String configurationPair) {
     final String[] serviceParts = configurationPair.split(":");
     final String serviceName = serviceParts[0].trim();
-    ServiceImpl service = (ServiceImpl) descriptor.getService(serviceName);
-    if (service == null) {
-      service = new ServiceImpl();
-      service.setName(serviceName);
-      descriptor.addService(service);
-    }
-
-    if (serviceParts.length > 1) {
-      // configuration value may contain ":" (for instance http://host:port) -> considering a configuration name/value pair everything after '$SERVICE_NAME:'
-      final String serviceConfiguration = configurationPair.substring(serviceName.length() + 1).trim();
-      final String[] serviceConfigurationParts = serviceConfiguration.split("=", 2);
-      final String serviceConfigurationName = serviceConfigurationParts[0].trim();
-      final String serviceConfigurationValue = serviceConfigurationParts[1].trim();
-      switch (serviceConfigurationName) {
-      case CONFIG_NAME_SERVICE_URL:
-        service.addUrl(serviceConfigurationValue);
-        break;
-      case CONFIG_NAME_SERVICE_VERSION:
-        service.setVersion(serviceConfigurationValue);
-        break;
-      default:
-        service.addParam(serviceConfigurationName, serviceConfigurationValue);
-        break;
+    if (advancedServiceDiscoveryConfig.isServiceEnabled(serviceName)) {
+      ServiceImpl service = (ServiceImpl) descriptor.getService(serviceName);
+      if (service == null) {
+        service = new ServiceImpl();
+        service.setName(serviceName);
+        descriptor.addService(service);
       }
+
+      if (serviceParts.length > 1) {
+        // configuration value may contain ":" (for instance http://host:port) -> considering a configuration name/value pair everything after '$SERVICE_NAME:'
+        final String serviceConfiguration = configurationPair.substring(serviceName.length() + 1).trim();
+        final String[] serviceConfigurationParts = serviceConfiguration.split("=", 2);
+        final String serviceConfigurationName = serviceConfigurationParts[0].trim();
+        final String serviceConfigurationValue = serviceConfigurationParts[1].trim();
+        switch (serviceConfigurationName) {
+        case CONFIG_NAME_SERVICE_URL:
+          service.addUrl(serviceConfigurationValue);
+          break;
+        case CONFIG_NAME_SERVICE_VERSION:
+          service.setVersion(serviceConfigurationValue);
+          break;
+        default:
+          service.addParam(serviceConfigurationName, serviceConfigurationValue);
+          break;
+        }
+      }
+    } else {
+      log.serviceDisabled(serviceName, descriptor.getName());
     }
+  }
+
+  @Override
+  public void onAdvancedServiceDiscoveryConfigurationChange(Properties newConfiguration) {
+    advancedServiceDiscoveryConfig = new AdvancedServiceDiscoveryConfig(newConfiguration);
+    log.updatedAdvanceServiceDiscoverytConfiguration();
   }
 
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.advanced;
+
+import org.apache.knox.gateway.i18n.messages.Message;
+import org.apache.knox.gateway.i18n.messages.MessageLevel;
+import org.apache.knox.gateway.i18n.messages.Messages;
+import org.apache.knox.gateway.i18n.messages.StackTrace;
+
+@Messages(logger = "org.apache.knox.gateway.topology.discovery.advanced")
+public interface AdvanceServiceDiscoveryConfigurationMessages {
+
+  @Message(level = MessageLevel.INFO, text = "Monitoring {0} for changes.")
+  void monitorStarted(String path);
+
+  @Message(level = MessageLevel.ERROR, text = "Error while monitoring CM advanced configuration: {1}")
+  void failedToMonitorClouderaManagerAdvancedConfiguration(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.INFO, text = "Notifying listeners due to advanced service discovery configuration changes...")
+  void notifyListeners();
+
+}

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.advanced;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Wrapper class providing useful methods on properties coming from
+ * <code>$KNOX_CONF_DIR/auto-discovery-advanced-configuration.properties</code>
+ */
+public class AdvancedServiceDiscoveryConfig {
+
+  public static final String PARAMETER_NAME_PREFIX_ENABLED_SERVICE = "gateway.auto.discovery.enabled.";
+  public static final String PARAMETER_NAME_EXPECTED_TOPOLOGIES = "gateway.auto.discovery.expected.topology.names";
+
+  private final Properties properties;
+
+  public AdvancedServiceDiscoveryConfig() {
+    this(null);
+  }
+
+  public AdvancedServiceDiscoveryConfig(Properties properties) {
+    this.properties = properties == null ? new Properties() : properties;
+  }
+
+  public boolean isServiceEnabled(String serviceName) {
+    return Boolean.valueOf(getPropertyIgnoreCase(PARAMETER_NAME_PREFIX_ENABLED_SERVICE + serviceName, "true"));
+  }
+
+  public Set<String> getEnabledServiceNames() {
+    return properties.entrySet().stream().filter(keyValuePair -> Boolean.valueOf((String) keyValuePair.getValue()))
+        .map(keyValuePair -> ((String) keyValuePair.getKey()).substring(PARAMETER_NAME_PREFIX_ENABLED_SERVICE.length()).toUpperCase(Locale.getDefault())).collect(toSet());
+  }
+
+  public Set<String> getExpectedTopologyNames() {
+    return Stream.of(properties.getProperty(PARAMETER_NAME_EXPECTED_TOPOLOGIES, "").split(",")).map(expectedToplogyName -> expectedToplogyName.trim()).collect(toSet());
+  }
+
+  private String getPropertyIgnoreCase(String propertyName, String defaultValue) {
+    final String property = properties.getProperty(propertyName);
+    if (property != null) {
+      return property;
+    } else {
+      for (Entry<Object, Object> entry : properties.entrySet()) {
+        if (propertyName.equalsIgnoreCase((String) entry.getKey())) {
+          return (String) entry.getValue();
+        }
+      }
+      return defaultValue;
+    }
+  }
+}

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigChangeListener.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigChangeListener.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.advanced;
+
+import java.util.Properties;
+
+/**
+ * The listener interface for receiving service discovery configuration events.
+ */
+public interface AdvancedServiceDiscoveryConfigChangeListener {
+
+  void onAdvancedServiceDiscoveryConfigurationChange(Properties newConfiguration);
+
+}

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigurationMonitor.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigurationMonitor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.advanced;
+
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+
+/**
+ * Monitoring <code>$KNOX_CONF_DIR/auto-discovery-advanced-configuration.properties</code> (if exists) and notifies any
+ * {@link AdvancedServiceDiscoveryConfigChangeListener} if the file is changed since the last time it was loaded
+ *
+ */
+public class AdvancedServiceDiscoveryConfigurationMonitor {
+
+  private static final String ADVANCED_CONFIGURATION_FILE_NAME = "auto-discovery-advanced-configuration.properties";
+  private static final AdvanceServiceDiscoveryConfigurationMessages LOG = MessagesFactory.get(AdvanceServiceDiscoveryConfigurationMessages.class);
+
+  private final List<AdvancedServiceDiscoveryConfigChangeListener> listeners;
+
+  private ScheduledExecutorService executorService;
+  private FileTime lastReloadTime;
+
+  public AdvancedServiceDiscoveryConfigurationMonitor(GatewayConfig gatewayConfig) {
+    final long monitoringInterval = gatewayConfig.getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval();
+    if (monitoringInterval > 0) {
+      this.executorService = newSingleThreadScheduledExecutor(new BasicThreadFactory.Builder().namingPattern("AdvancedServiceDiscoveryConfigurationMonitor-%d").build());
+      final Path resourcePath = Paths.get(gatewayConfig.getGatewayConfDir(), ADVANCED_CONFIGURATION_FILE_NAME);
+      executorService.scheduleAtFixedRate(() -> monitorAdvancedServiceConfiguration(resourcePath), 0, monitoringInterval, TimeUnit.MILLISECONDS);
+      LOG.monitorStarted(resourcePath.toString());
+    }
+
+    listeners = new ArrayList<>();
+  }
+
+  public void registerListener(AdvancedServiceDiscoveryConfigChangeListener listener) {
+    listeners.add(listener);
+  }
+
+  private void monitorAdvancedServiceConfiguration(Path resourcePath) {
+    try {
+      if (Files.exists(resourcePath) && Files.isReadable(resourcePath)) {
+        FileTime lastModifiedTime = Files.getLastModifiedTime(resourcePath);
+        if (lastReloadTime == null || lastReloadTime.compareTo(lastModifiedTime) < 0) {
+          lastReloadTime = lastModifiedTime;
+          try (InputStream advanceconfigurationFileInputStream = Files.newInputStream(resourcePath)) {
+            Properties properties = new Properties();
+            properties.load(advanceconfigurationFileInputStream);
+            notifyListeners(properties);
+          }
+        }
+      }
+    } catch (IOException e) {
+      LOG.failedToMonitorClouderaManagerAdvancedConfiguration(e.getMessage(), e);
+    }
+  }
+
+  private void notifyListeners(Properties properties) {
+    LOG.notifyListeners();
+    listeners.forEach(listener -> listener.onAdvancedServiceDiscoveryConfigurationChange(properties));
+  }
+
+}

--- a/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
+++ b/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
@@ -25,21 +25,31 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.knox.gateway.topology.discovery.advanced.AdvancedServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor.Application;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor.Service;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ClouderaManagerDescriptorParserTest {
 
+  private ClouderaManagerDescriptorParser cmDescriptorParser;
+
+  @Before
+  public void setUp() {
+    cmDescriptorParser = new ClouderaManagerDescriptorParser();
+  }
+
   @Test
-  public void testXmlParser() throws Exception {
+  public void testCMDescriptorParser() throws Exception {
     final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptor.xml").getPath();
-    final Set<SimpleDescriptor> descriptors = ClouderaManagerDescriptorParser.parse(testConfigPath);
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
     assertEquals(2, descriptors.size());
     final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
     validateTopology1(descriptorsIterator.next());
@@ -47,19 +57,53 @@ public class ClouderaManagerDescriptorParserTest {
   }
 
   @Test
-  public void testXmlParserWrongDescriptorContent() throws Exception {
+  public void testCMDescriptorParserWrongDescriptorContent() throws Exception {
     final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptorConfigurationWithWrongDescriptor.xml").getPath();
-    final Set<SimpleDescriptor> descriptors = ClouderaManagerDescriptorParser.parse(testConfigPath);
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
     assertEquals(1, descriptors.size());
     final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
     validateTopology1(descriptorsIterator.next());
   }
 
   @Test
-  public void testXmlParserWrongXMLContent() throws Exception {
+  public void testCMDescriptorParserWrongXMLContent() throws Exception {
     final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptorConfigurationWithNonHadoopStyleConfiguration.xml").getPath();
-    final Set<SimpleDescriptor> descriptors = ClouderaManagerDescriptorParser.parse(testConfigPath);
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
     assertTrue(descriptors.isEmpty());
+  }
+
+  @Test
+  public void testCMDescriptorParserWithNotEnabledServices() throws Exception {
+    final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptor.xml").getPath();
+    final Properties advancedConfiguration = new Properties();
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_PREFIX_ENABLED_SERVICE + "HIVE", "false");
+    cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfiguration);
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
+    assertEquals(2, descriptors.size());
+    final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
+    SimpleDescriptor descriptor = descriptorsIterator.next();
+    assertNotNull(descriptor);
+    // topology1 comes with HIVE which is disabled
+    assertTrue(descriptor.getServices().isEmpty());
+  }
+
+  @Test
+  public void testCMDescriptorParserWithEnabledNotListedServiceInTopology1() throws Exception {
+    final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptor.xml").getPath();
+    final Properties advancedConfiguration = new Properties();
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_PREFIX_ENABLED_SERVICE + "OOZIE", "true");
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_EXPECTED_TOPOLOGIES, "topology1, topology100");
+    cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfiguration);
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
+    final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
+    SimpleDescriptor descriptor = descriptorsIterator.next();
+    assertNotNull(descriptor);
+    // topology1 comes without OOZIE but it's enabled and topology1 is expected -> OOZIE should be added without any url/version/parameter
+    assertService(descriptor, "OOZIE", null, null, null);
+
+    descriptor = descriptorsIterator.next();
+    validateTopology2(descriptor);
+    assertNull(descriptor.getService("OOZIE"));
   }
 
   private void validateTopology1(SimpleDescriptor descriptor) {
@@ -90,7 +134,8 @@ public class ClouderaManagerDescriptorParserTest {
 
     final Map<String, String> expectedServiceParameters = Stream.of(new String[][] { { "httpclient.connectionTimeout", "5m" }, { "httpclient.socketTimeout", "100m" }, })
         .collect(Collectors.toMap(data -> data[0], data -> data[1]));
-    assertService(descriptor, "HDFS", null, Collections.singletonList("http://localhost:456"), expectedServiceParameters);
+    assertService(descriptor, "ATLAS-API", null, Collections.singletonList("http://localhost:456"), expectedServiceParameters);
+    assertService(descriptor, "NIFI", null, null, null);
   }
 
   private void assertApplication(SimpleDescriptor descriptor, String expectedApplicationName, Map<String, String> expectedParams) {

--- a/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
+++ b/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
@@ -114,6 +114,8 @@ public class ClouderaManagerDescriptorParserTest {
 
     if (expectedUrls != null) {
       assertTrue(service.getURLs().containsAll(expectedUrls));
+    } else {
+      assertNull(service.getURLs());
     }
 
     if (expectedParams != null) {

--- a/gateway-cm-integration/src/test/resources/testDescriptor.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptor.xml
@@ -39,9 +39,10 @@ limitations under the License.
         discoveryAddress=http://host:456;
         cluster=Cluster 2;
         providerConfigRef=topology2-provider;
-        HDFS:url=http://localhost:456;
-        HDFS:httpclient.connectionTimeout=5m;
-        HDFS:httpclient.socketTimeout=100m
+        ATLAS-API:url=http://localhost:456;
+        ATLAS-API:httpclient.connectionTimeout=5m;
+        ATLAS-API:httpclient.socketTimeout=100m;
+        NIFI
     </value>
   </property>
 </configuration>

--- a/gateway-cm-integration/src/test/resources/testDescriptorConfigurationWithWrongDescriptor.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptorConfigurationWithWrongDescriptor.xml
@@ -40,7 +40,7 @@ limitations under the License.
         cluster=Cluster 2;
         providerConfigRef=topology2-provider;
         HDFS:url=http://localhost:456;
-        HDFS <!-- can not be parsed -->
+        HDFS:noValueParam <!-- can not be parsed -->
     </value>
   </property>
 </configuration>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -28,6 +28,7 @@ import org.apache.knox.gateway.audit.api.Auditor;
 import org.apache.knox.gateway.audit.api.ResourceType;
 import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
 import org.apache.knox.gateway.cm.descriptor.ClouderaManagerDescriptorMonitor;
+import org.apache.knox.gateway.cm.descriptor.ClouderaManagerDescriptorParser;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.GatewayConfigurationException;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
@@ -48,6 +49,7 @@ import org.apache.knox.gateway.topology.Application;
 import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.topology.TopologyEvent;
 import org.apache.knox.gateway.topology.TopologyListener;
+import org.apache.knox.gateway.topology.discovery.advanced.AdvancedServiceDiscoveryConfigurationMonitor;
 import org.apache.knox.gateway.trace.AccessHandler;
 import org.apache.knox.gateway.trace.KnoxErrorHandler;
 import org.apache.knox.gateway.trace.TraceHandler;
@@ -622,8 +624,12 @@ public class GatewayServer {
         "org.eclipse.jetty.webapp.JettyWebXmlConfiguration",
         "org.eclipse.jetty.annotations.AnnotationConfiguration" );
 
-    final ClouderaManagerDescriptorMonitor cmDescriptorMonitor = new ClouderaManagerDescriptorMonitor(config);
+    final ClouderaManagerDescriptorParser cmDescriptorParser = new ClouderaManagerDescriptorParser();
+    final ClouderaManagerDescriptorMonitor cmDescriptorMonitor = new ClouderaManagerDescriptorMonitor(config, cmDescriptorParser);
     cmDescriptorMonitor.setupMonitor();
+    final AdvancedServiceDiscoveryConfigurationMonitor advancedServiceDiscoveryConfigurationMonitor = new AdvancedServiceDiscoveryConfigurationMonitor(config);
+    advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorParser);
+    advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorMonitor);
 
     // Load the current topologies.
     // Redeploy autodeploy topologies.

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -242,6 +242,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
   private static final long DEFAULT_CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = 30000L;
+  private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
+  private static final long DEFAULT_CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = 30000L;
 
   public GatewayConfigImpl() {
     init();
@@ -1101,5 +1103,10 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public long getClouderaManagerDescriptorsMonitoringInterval() {
     return getLong(CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL, DEFAULT_CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL);
+  }
+
+  @Override
+  public long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval() {
+    return getLong(CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL, DEFAULT_CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL);
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -647,4 +647,9 @@ public interface GatewayConfig {
    * @return the monitoring interval (in milliseconds) of Cloudera Manager descriptors
    */
   long getClouderaManagerDescriptorsMonitoringInterval();
+
+  /**
+   * @return the monitoring interval (in milliseconds) of Cloudera Manager advanced service discovery configuration
+   */
+  long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval();
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -769,4 +769,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public long getClouderaManagerDescriptorsMonitoringInterval() {
     return 0;
   }
+
+  @Override
+  public long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval() {
+    return 0;
+  }
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorImpl.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorImpl.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.topology.simple;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -120,6 +121,10 @@ public class SimpleDescriptorImpl implements SimpleDescriptor {
         services = new ArrayList<>();
       }
       services.add(service);
+    }
+
+    public void setServices(Collection<Service> services) {
+      this.services = new ArrayList<>(services);
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implemented CM specific advanced service discovery feature as described in [KNOX-2186](https://issues.apache.org/jira/browse/KNOX-2186).

## How was this patch tested?

Updated and ran JUnit tests:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:37 min (Wall Clock)
[INFO] Finished at: 2020-01-16T11:47:14+01:00
[INFO] Final Memory: 421M/2310M
[INFO] ------------------------------------------------------------------------
```

Additionally, I tested new features manually. I've used the following two files:
`/Users/smolnar/test/knoxGateway/conf/descriptors/testDescriptor.cm`
```
<configuration>
  <property>
    <name>topology1</name>
    <value>
        discoveryType=ClouderaManager;
        discoveryAddress=http://host:123;
        discoveryUser=user;
        discoveryPasswordAlias=alias;
        cluster=Cluster 1;
        providerConfigRef=topology1-provider;
        app:knoxauth:param1.name=param1.value;
        HIVE:url=http://localhost:456;
        HIVE:version=1.0;
        HIVE:httpclient.connectionTimeout=5m;
        HIVE:httpclient.socketTimeout=100m;
        MY_CUSTOM_SERVICE:url=https://custom_host:custom_port
    </value>
  </property>
  <property>
    <name>topology2</name>
    <value>
        providerConfigRef=topology2-provider;
        ATLAS_API:url=http://localhost:456;
        ATLAS_API:httpclient.connectionTimeout=15m;
        ATLAS_API:httpclient.socketTimeout=100m;
        RANGERUI:url=http://localhost:789;
        RANGER:url=http://localhost:rangerport
    </value>
  </property>
</configuration>

```

`/Users/smolnar/test/knoxGateway/conf/auto-discovery-advanced-configuration.properties`
```
gateway.auto.discovery.enforce.required.services=true
gateway.auto.discovery.enabled.ATLAS_API=true
gateway.auto.discovery.enabled.HIVE=false
gateway.auto.discovery.enabled.RANGERUI=true
gateway.auto.discovery.enabled.RANGER=false
```

During my test rounds, I modified the content of both files, combining them to cover all possible use-cases (e.g. enforcing required services, disabled enforcement, disabled/enabled services, used custom services, etc...). In all cases, I confirmed that CM specific monitors triggered the necessary actions and the expected descriptors were generated.