### PR TITLE
KNOX-2188 - Handling discovery details via advanced configuration

### DIFF
--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.knox.gateway.ClouderaManagerIntegrationMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
@@ -121,12 +122,27 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
         }
       }
       if (advancedServiceDiscoveryConfig.getExpectedTopologyNames().contains(name)) {
+        setDiscoveryDetails(descriptor);
         addEnabledServices(descriptor);
       }
       return descriptor;
     } catch (Exception e) {
       log.failedToParseDescriptor(name, e.getMessage(), e);
       return null;
+    }
+  }
+
+  private void setDiscoveryDetails(SimpleDescriptorImpl descriptor) {
+    if (StringUtils.isBlank(descriptor.getDiscoveryAddress())) {
+      descriptor.setDiscoveryAddress(advancedServiceDiscoveryConfig.getDiscoveryAddress());
+    }
+
+    if (StringUtils.isBlank(descriptor.getCluster())) {
+      descriptor.setCluster(advancedServiceDiscoveryConfig.getDiscoveryCluster());
+    }
+
+    if (StringUtils.isBlank(descriptor.getDiscoveryType())) {
+      descriptor.setDiscoveryType("ClouderaManager");
     }
   }
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
@@ -32,6 +32,8 @@ public class AdvancedServiceDiscoveryConfig {
 
   public static final String PARAMETER_NAME_PREFIX_ENABLED_SERVICE = "gateway.auto.discovery.enabled.";
   public static final String PARAMETER_NAME_EXPECTED_TOPOLOGIES = "gateway.auto.discovery.expected.topology.names";
+  public static final String PARAMETER_NAME_DISCOVERY_ADDRESS = "gateway.auto.discovery.address";
+  public static final String PARAMETER_NAME_DISCOVERY_CLUSTER  = "gateway.auto.discovery.cluster";
 
   private final Properties properties;
 
@@ -53,7 +55,15 @@ public class AdvancedServiceDiscoveryConfig {
   }
 
   public Set<String> getExpectedTopologyNames() {
-    return Stream.of(properties.getProperty(PARAMETER_NAME_EXPECTED_TOPOLOGIES, "").split(",")).map(expectedToplogyName -> expectedToplogyName.trim()).collect(toSet());
+    return Stream.of(getPropertyIgnoreCase(PARAMETER_NAME_EXPECTED_TOPOLOGIES, "").split(",")).map(expectedToplogyName -> expectedToplogyName.trim()).collect(toSet());
+  }
+
+  public String getDiscoveryAddress() {
+    return getPropertyIgnoreCase(PARAMETER_NAME_DISCOVERY_ADDRESS, "");
+  }
+
+  public String getDiscoveryCluster() {
+    return getPropertyIgnoreCase(PARAMETER_NAME_DISCOVERY_CLUSTER, "");
   }
 
   private String getPropertyIgnoreCase(String propertyName, String defaultValue) {

--- a/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
+++ b/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
@@ -106,6 +106,24 @@ public class ClouderaManagerDescriptorParserTest {
     assertNull(descriptor.getService("OOZIE"));
   }
 
+  @Test
+  public void testSettingDiscoveryDetails() throws Exception {
+    final String address = "http://myCmHost:7180";
+    final String cluster = "My Test Cluster";
+    final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptorWithoutDiscoveryDetails.xml").getPath();
+    final Properties advancedConfiguration = new Properties();
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_EXPECTED_TOPOLOGIES, "topology1");
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_DISCOVERY_ADDRESS, address);
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_DISCOVERY_CLUSTER, cluster);
+    cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfiguration);
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
+    final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
+    SimpleDescriptor descriptor = descriptorsIterator.next();
+    assertEquals(address, descriptor.getDiscoveryAddress());
+    assertEquals(cluster, descriptor.getCluster());
+    assertEquals("ClouderaManager", descriptor.getDiscoveryType());
+  }
+
   private void validateTopology1(SimpleDescriptor descriptor) {
     assertEquals("topology1", descriptor.getName());
     assertEquals("ClouderaManager", descriptor.getDiscoveryType());

--- a/gateway-cm-integration/src/test/resources/testDescriptorWithoutDiscoveryDetails.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptorWithoutDiscoveryDetails.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>topology1</name>
+    <value>
+        providerConfigRef=topology1-provider;
+        app:knoxauth:param1.name=param1.value;
+        app:admin-ui;
+        HIVE:url=http://localhost:123;
+    </value>
+  </property>
+</configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Setting the following discovery details in a Knox descriptor, if they are not customized in the CM descriptors file:

- discovery address
- discovery cluster
- discovery type

## How was this patch tested?

Updated and executed JUnit tests:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:59 min (Wall Clock)
[INFO] Finished at: 2020-01-20T10:28:22+01:00
[INFO] Final Memory: 424M/1987M
[INFO] ------------------------------------------------------------------------
```