### PR TITLE
KNOX-1742 - Simple SQL Client in KnoxShell for access to JDBC sources

### DIFF
--- a/build-tools/src/main/resources/build-tools/pmd/pmd-ruleset.xml
+++ b/build-tools/src/main/resources/build-tools/pmd/pmd-ruleset.xml
@@ -88,7 +88,6 @@ limitations under the License.
     <rule ref="category/java/multithreading.xml">
         <exclude name="AvoidSynchronizedAtMethodLevel" />
         <exclude name="UseConcurrentHashMap" />
-        <exclude name="DoNotUseThreads" />
     </rule>
     <rule ref="category/java/performance.xml">
         <exclude name="AvoidInstantiatingObjectsInLoops" />

--- a/build-tools/src/main/resources/build-tools/pmd/pmd-ruleset.xml
+++ b/build-tools/src/main/resources/build-tools/pmd/pmd-ruleset.xml
@@ -88,6 +88,7 @@ limitations under the License.
     <rule ref="category/java/multithreading.xml">
         <exclude name="AvoidSynchronizedAtMethodLevel" />
         <exclude name="UseConcurrentHashMap" />
+        <exclude name="DoNotUseThreads" />
     </rule>
     <rule ref="category/java/performance.xml">
         <exclude name="AvoidInstantiatingObjectsInLoops" />

--- a/build-tools/src/main/resources/build-tools/spotbugs-filter.xml
+++ b/build-tools/src/main/resources/build-tools/spotbugs-filter.xml
@@ -65,6 +65,11 @@ limitations under the License.
     <Class name="org.apache.knox.gateway.shell.commands.DataSourceCommand" />
     <Bug pattern="SQL_INJECTION_JDBC" />
   </Match>
+
+  <Match>
+    <Class name="org.apache.knox.gateway.shell.jdbc.KnoxLine" />
+    <Bug pattern="SQL_INJECTION_JDBC" />
+  </Match>
   
   <Match>
     <Class name="~org.apache.hadoop.gateway..*" />

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
@@ -78,7 +78,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -595,8 +594,7 @@ public class KnoxSession implements Closeable {
     String home = System.getProperty("user.home");
     try {
       write(new File(
-          home + File.separator + ".knoxshell" + File.separator + fileName),
-          s, StandardCharsets.UTF_8);
+          home + File.separator + ".knoxshell" + File.separator + fileName), s);
     } catch (IOException e) {
       e.printStackTrace();
     }
@@ -614,14 +612,13 @@ public class KnoxSession implements Closeable {
     try {
       write(new File(
           home + File.separator +
-          ".knoxshell" + File.separator + fileName),
-          s, StandardCharsets.UTF_8);
+          ".knoxshell" + File.separator + fileName), s);
     } catch (IOException e) {
       e.printStackTrace();
     }
   }
 
-  private static void write(File file, String s, Charset utf8) throws IOException {
+  private static void write(File file, String s) throws IOException {
     synchronized(KnoxSession.class) {
       // Ensure the parent directory exists...
       // This will attempt to create all missing directories.  No failures will occur if the directories already exist.
@@ -629,7 +626,7 @@ public class KnoxSession implements Closeable {
       try (FileChannel channel = FileChannel.open(file.toPath(), StandardOpenOption.WRITE,
           StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
         channel.tryLock();
-        FileUtils.write(file, s, utf8);
+        FileUtils.write(file, s, StandardCharsets.UTF_8);
       } catch (OverlappingFileLockException e) {
         System.out.println("Unable to acquire write lock for: " + file.getAbsolutePath());
       }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
@@ -603,6 +603,25 @@ public class KnoxSession implements Closeable {
     }
   }
 
+  /**
+   * Persist provided Map to a file within the {user.home}/.knoxshell directory
+   * @param <T>
+   * @param fileName of persisted file
+   * @param map to persist
+   */
+  public static <T> void persistDataSourcesToKnoxShell(String fileName, Map<String, T> map) {
+    String s = JsonUtils.renderAsJsonString(map);
+    String home = System.getProperty("user.home");
+    try {
+      write(new File(
+          home + File.separator +
+          ".knoxshell" + File.separator + fileName),
+          s, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
   private static void write(File file, String s, Charset utf8) throws IOException {
     synchronized(KnoxSession.class) {
       // Ensure the parent directory exists...
@@ -623,8 +642,8 @@ public class KnoxSession implements Closeable {
     persistToKnoxShell(KNOXSQLHISTORIES_JSON, sqlHistories);
   }
 
-  public static void persistDataSources(Map<String, List<KnoxDataSource>> datasources) {
-    persistToKnoxShell(KNOXDATASOURCES_JSON, datasources);
+  public static void persistDataSources(Map<String, KnoxDataSource> datasources) {
+    persistDataSourcesToKnoxShell(KNOXDATASOURCES_JSON, datasources);
   }
 
   /**

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSh.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSh.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.shell;
 
+import org.apache.knox.gateway.shell.jdbc.KnoxLine;
 import org.apache.knox.gateway.shell.knox.token.Get;
 import org.apache.knox.gateway.shell.knox.token.Token;
 import org.apache.knox.gateway.shell.util.ClientTrustStoreHelper;
@@ -41,6 +42,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashSet;
@@ -122,6 +124,8 @@ public class KnoxSh {
         command = new KnoxInit();
       } else if ( args[i].equals("list") ) {
         command = new KnoxList();
+      } else if ( args[i].equals("knoxline") ) {
+        command = new KnoxLineCommand();
       } else if (args[i].equals("--gateway")) {
         if( i+1 >= args.length || args[i+1].startsWith( "-" ) ) {
           printKnoxShellUsage();
@@ -389,6 +393,23 @@ public class KnoxSh {
         stringBuilder.append(ls);
       }
       return stringBuilder.toString();
+    }
+  }
+
+  private class KnoxLineCommand extends Command {
+
+    public static final String USAGE = "knoxline";
+    public static final String DESC = "Simple SQL Client.";
+
+    @Override
+    public void execute() throws Exception {
+      KnoxLine line = new KnoxLine();
+      line.execute(new ArrayList<String>().toArray(new String[0]));
+    }
+
+    @Override
+    public String getUsage() {
+      return USAGE + ":\n\n" + DESC;
     }
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Shell {
 
-  private static final List<String> NON_INTERACTIVE_COMMANDS = Arrays.asList("buildTrustStore", "init", "list", "destroy");
+  private static final List<String> NON_INTERACTIVE_COMMANDS = Arrays.asList("buildTrustStore", "init", "list", "destroy", "knoxline");
 
   private static final String[] IMPORTS = new String[] {
       KnoxSession.class.getName(),

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractSQLCommandSupport.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractSQLCommandSupport.java
@@ -79,8 +79,8 @@ public abstract class AbstractSQLCommandSupport extends AbstractKnoxShellCommand
   }
 
   protected void persistDataSources() {
-    Map<String, List<KnoxDataSource>> datasources =
-        (Map<String, List<KnoxDataSource>>) getVariables().get(KNOXDATASOURCES);
+    Map<String, KnoxDataSource> datasources =
+        (Map<String, KnoxDataSource>) getVariables().get(KNOXDATASOURCES);
     KnoxSession.persistDataSources(datasources);
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/DataSourceCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/DataSourceCommand.java
@@ -54,12 +54,19 @@ public class DataSourceCommand extends AbstractSQLCommandSupport {
       }
       // if the removed datasource is currently selected, unselect it
       dataSources.remove(args.get(1));
-      if (((String)getVariables().get(KNOXDATASOURCE)).equals(args.get(1))) {
-        System.out.println("unselecting datasource.");
-        getVariables().put(KNOXDATASOURCE, "");
-        getVariables().put(KNOXDATASOURCES, dataSources);
-        persistDataSources();
+      if (getVariables().get(KNOXDATASOURCE) != null) {
+        if (args.get(1) != null) {
+          if (((String)getVariables().get(KNOXDATASOURCE)).equals(args.get(1))) {
+            System.out.println("unselecting datasource.");
+            getVariables().put(KNOXDATASOURCE, "");
+          }
+        }
+        else {
+          System.out.println("Missing datasource name to remove.");
+        }
       }
+      getVariables().put(KNOXDATASOURCES, dataSources);
+      persistDataSources();
     }
     else if (args.get(0).equalsIgnoreCase("list")) {
       // valid command no additional work needed though

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/KnoxLine.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/KnoxLine.java
@@ -37,6 +37,7 @@ public class KnoxLine {
   KnoxDataSource datasource;
   Connection conn;
 
+  @SuppressWarnings("PMD.DoNotUseThreads") // we need to define a Thread to be able to register a shutdown hook
   public void execute(String[] args)
       throws ClassNotFoundException, SQLException, CredentialCollectionException {
 
@@ -86,12 +87,7 @@ public class KnoxLine {
               }
             }
             catch(SQLException e) {
-              //e.printStackTrace()
               System.out.println("SQL Exception encountered... " + e.getMessage());
-  //            if (e.getMessage().contains("org.apache.thrift.transport.TTransportException")) {
-  //              System.out.println("reconnecting... ");
-  //              connection = DriverManager.getConnection( connectionString, user, pass );
-  //            }
             }
           }
           else {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/KnoxLine.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/KnoxLine.java
@@ -117,11 +117,19 @@ public class KnoxLine {
       selectDataSource(args[2]);
     }
     else if (args[1].equals("add")) {
-      if (args.length == 5) {
+      if (args.length == 6) {
         addDataSource(args[2], args[3], args[4], args[5]);
       }
       else {
         System.out.println("Invalid number of arguments for :ds add. Useage: :ds add {ds-name} {connectStr} {driver} {authnType: none|basic}");
+      }
+    }
+    else if (args[1].contentEquals("remove")) {
+      if (args.length == 3) {
+        removeDataSource(args[2]);
+      }
+      else {
+        System.out.println("Invalid number of arguments for :ds remove. Useage: :ds remove {ds-name}");
       }
     }
   }
@@ -146,7 +154,14 @@ public class KnoxLine {
     Map<String, KnoxDataSource> datasources = getDataSources();
     KnoxDataSource ds = new KnoxDataSource(name, connectStr, driver, authnType);
     datasources.put(name, ds);
+    KnoxSession.persistDataSources(datasources);
     return ds;
+  }
+
+  private void removeDataSource(String name) {
+    Map<String, KnoxDataSource> datasources = getDataSources();
+    datasources.remove(name);
+    KnoxSession.persistDataSources(datasources);
   }
 
   private void selectDataSource(String name) throws CredentialCollectionException {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/KnoxLine.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/KnoxLine.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell.jdbc;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.knox.gateway.shell.CredentialCollectionException;
+import org.apache.knox.gateway.shell.Credentials;
+import org.apache.knox.gateway.shell.KnoxDataSource;
+import org.apache.knox.gateway.shell.KnoxSession;
+import org.apache.knox.gateway.shell.table.KnoxShellTable;
+
+public class KnoxLine {
+  String user;
+  String pass;
+  KnoxDataSource datasource;
+  Connection conn;
+
+  public void execute(String[] args)
+      throws ClassNotFoundException, SQLException, CredentialCollectionException {
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        System.out.println("Closing any open connections ...");
+        closeConnection();
+      }
+    });
+    executeShell();
+  }
+
+  private void executeShell() {
+    String sql;
+
+    System.out.println(" _                    _ _            ");
+    System.out.println("| | ___ __   _____  _| (_)_ __   ___ ");
+    System.out.println("| |/ / '_ \\ / _ \\ \\/ / | | '_ \\ / _ \\");
+    System.out.println("|   <| | | | (_) >  <| | | | | |  __/");
+    System.out.println("|_|\\_\\_| |_|\\___/_/\\_\\_|_|_| |_|\\\\__|");
+    System.out.println("powered by Apache Knox");
+    System.out.println("");
+    System.out.println("");
+
+    while(true) {
+      sql = System.console().readLine("knoxline> ");
+      if (sql != null && !sql.isEmpty()) {
+        if (sql.startsWith(":ds") || sql.startsWith(":datasource")) {
+          try {
+            processDataSourceCommand(sql);
+          } catch (CredentialCollectionException | SQLException e) {
+            e.printStackTrace();
+          }
+        }
+        else {
+          // Configure JDBC connection
+          if (datasource != null) {
+            System.out.println(sql);
+            try (Statement statement = conn.createStatement()) {
+              if (statement.execute(sql)) {
+                try (ResultSet resultSet = statement.getResultSet()) {
+                  KnoxShellTable table = KnoxShellTable.builder().jdbc().resultSet(resultSet);
+                  System.out.println(table.toString());
+                  System.out.println("\nRows: " + table.getRows().size() + "\n");
+                }
+              }
+            }
+            catch(SQLException e) {
+              //e.printStackTrace()
+              System.out.println("SQL Exception encountered... " + e.getMessage());
+  //            if (e.getMessage().contains("org.apache.thrift.transport.TTransportException")) {
+  //              System.out.println("reconnecting... ");
+  //              connection = DriverManager.getConnection( connectionString, user, pass );
+  //            }
+            }
+          }
+          else {
+            System.out.println("No datasource selected. Use :ds select {datasource-name}");
+          }
+        }
+      }
+    }
+  }
+
+  private void establishConnection() throws SQLException {
+    if (conn == null || conn.isClosed()) {
+      conn = JDBCUtils.createConnection(datasource.getConnectStr(), user, pass);
+    }
+  }
+
+  void processDataSourceCommand(String sql) throws CredentialCollectionException, SQLException {
+    String[] args = sql.split(" ");
+    if (args.length == 1 || args[1].equals("list")) {
+      listDataSources();
+    }
+    else if (args[1].equals("select")) {
+      selectDataSource(args[2]);
+    }
+    else if (args[1].equals("add")) {
+      if (args.length == 5) {
+        addDataSource(args[2], args[3], args[4], args[5]);
+      }
+      else {
+        System.out.println("Invalid number of arguments for :ds add. Useage: :ds add {ds-name} {connectStr} {driver} {authnType: none|basic}");
+      }
+    }
+  }
+
+  private void listDataSources() {
+    Map<String, KnoxDataSource> sources = getDataSources();
+    sources.forEach((name, ds)->System.out.println("Name : " + name + " : " + ds.getConnectStr()));
+  }
+
+  private Map<String, KnoxDataSource> getDataSources() {
+    Map<String, KnoxDataSource> datasources = new HashMap<>();
+    try {
+      datasources = KnoxSession.loadDataSources();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    return datasources;
+  }
+
+  private KnoxDataSource addDataSource(String name, String connectStr, String driver, String authnType) {
+    Map<String, KnoxDataSource> datasources = getDataSources();
+    KnoxDataSource ds = new KnoxDataSource(name, connectStr, driver, authnType);
+    datasources.put(name, ds);
+    return ds;
+  }
+
+  private void selectDataSource(String name) throws CredentialCollectionException {
+    Map<String, KnoxDataSource> sources = getDataSources();
+    datasource = sources.get(name);
+
+    if (datasource == null) {
+      System.out.println("Invalid datasource name provided. See output from: :ds list");
+      return;
+    }
+
+    user = null;
+    pass = null;
+    if (datasource.getAuthnType().contentEquals("basic")) {
+      collectCredentials();
+    }
+
+    closeConnection();
+
+    try {
+      establishConnection();
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void closeConnection() {
+    try {
+      if (conn != null && !conn.isClosed()) {
+        conn.close();
+      }
+    } catch (SQLException e) {
+      //nop
+    }
+    finally {
+      conn = null;
+    }
+  }
+
+  private void collectCredentials() throws CredentialCollectionException {
+    Credentials credentials = new Credentials();
+    credentials.add("ClearInput", "Enter username: ", "user")
+      .add("HiddenInput", "Enter pas" + "sword: ", "pass")
+      .collect();
+
+    user = credentials.get("user").string();
+    pass = credentials.get("pass").string();
+  }
+}


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?
Adding a simple SQL client/shell to KnoxShell for accessing JDBC data sources such as HiveServer2 and others. Rather than providing connection details on the command line for the data source, this shell leverages the DataSource persistence introduced in KNOX-2128.

Enter the SQL client, list datasources, select datasources and execute SQL query:

lmccay@strange:~/Projects/releases/knoxshell-1.4.0-SNAPSHOT$ bin/knoxshell.sh knoxline
 _                    _ _            
| | ___ __   _____  _| (_)_ __   ___ 
| |/ / '_ \ / _ \ \/ / | | '_ \ / _ \
|   <| | | | (_) >  <| | | | | |  __/
|_|\_\_| |_|\___/_/\_\_|_|_| |_|\\__|
powered by Apache Knox


knoxline> :ds
Name : secgov : jdbc:hive2://sme-secgov-de-01.sme-secg.a465-9q4k.cloudera.site:8443/;ssl=true;transportMode=http;httpPath=sme-secgov-de-01/cdp-proxy-api/hive
Name : anatva : jdbc:hive2://de-anatva-master0.sandbox.a465-9q4k.cloudera.site/;ssl=true;transportMode=http;httpPath=de-anatva/cdp-proxy-api/hive
Name : derby1 : jdbc:derby:codejava/webdb1
knoxline> :ds select derby1
knoxline> select * from book
select * from book
BOOK
+------------+--------------------+
|  BOOK_ID   |       TITLE        |
+------------+--------------------+
|     1      |   Effective Java   |
|     2      |     Core Java      |
|     3      |  Core Apache Knox  |
+------------+--------------------+


Rows: 3

knoxline> ^CClosing any open connections ...

## How was this patch tested?
Manual testing of this feature and unit testing run to ensure no regressions.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
