### PR TITLE
KNOX-2190 - Processing advanced service discovery configuration on topology level

### DIFF
--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -33,6 +33,9 @@ public interface ClouderaManagerIntegrationMessages {
   @Message(level = MessageLevel.INFO, text = "Found Knox descriptors {0} in {1}")
   void parsedClouderaManagerDescriptor(String descriptorList, String path);
 
+  @Message(level = MessageLevel.INFO, text = "Ignoring {0} Knox descriptor update because it did not change.")
+  void descriptorDidNotChange(String descriptorName);
+
   @Message(level = MessageLevel.ERROR, text = "Parsing Knox descriptor {0} failed: {1}")
   void failedToParseDescriptor(String name, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -27,8 +27,8 @@ public interface ClouderaManagerIntegrationMessages {
   @Message(level = MessageLevel.INFO, text = "Monitoring Cloudera Manager descriptors in {0} ...")
   void monitoringClouderaManagerDescriptor(String path);
 
-  @Message(level = MessageLevel.INFO, text = "Parsing Cloudera Manager descriptor {0}")
-  void parseClouderaManagerDescriptor(String path);
+  @Message(level = MessageLevel.INFO, text = "Parsing Cloudera Manager descriptor {0}. Looking up {1}...")
+  void parseClouderaManagerDescriptor(String path, String topologyName);
 
   @Message(level = MessageLevel.INFO, text = "Found Knox descriptors {0} in {1}")
   void parsedClouderaManagerDescriptor(String descriptorList, String path);

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -48,6 +48,6 @@ public interface ClouderaManagerIntegrationMessages {
   @Message(level = MessageLevel.WARN, text = "Service {0} is disabled. It will NOT be added in {1}")
   void serviceDisabled(String serviceName, String descriptorName);
 
-  @Message(level = MessageLevel.INFO, text = "Updated advanced service discovery configuration.")
-  void updatedAdvanceServiceDiscoverytConfiguration();
+  @Message(level = MessageLevel.INFO, text = "Updated advanced service discovery configuration for {0}.")
+  void updatedAdvanceServiceDiscoverytConfiguration(String topologyName);
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
@@ -76,7 +76,7 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
    */
   public Set<SimpleDescriptor> parse(String path, String topologyName) {
     try {
-      log.parseClouderaManagerDescriptor(path);
+      log.parseClouderaManagerDescriptor(path, topologyName == null ? "all topologies" : topologyName);
       final Configuration xmlConfiguration = new Configuration(false);
       xmlConfiguration.addResource(Paths.get(path).toUri().toURL());
       xmlConfiguration.reloadConfiguration();
@@ -139,9 +139,11 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
           break;
         }
       }
-      if (advancedServiceDiscoveryConfigMap.containsKey(name)) {
-        setDiscoveryDetails(descriptor, advancedServiceDiscoveryConfigMap.get(name));
-        addEnabledServices(descriptor, advancedServiceDiscoveryConfigMap.get(name));
+
+      final AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig = advancedServiceDiscoveryConfigMap.get(name);
+      if (advancedServiceDiscoveryConfig != null) {
+        setDiscoveryDetails(descriptor, advancedServiceDiscoveryConfig);
+        addEnabledServices(descriptor, advancedServiceDiscoveryConfig);
       }
       return descriptor;
     } catch (Exception e) {
@@ -169,7 +171,7 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
    */
   private void addEnabledServices(SimpleDescriptorImpl descriptor, AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig) {
     advancedServiceDiscoveryConfig.getEnabledServiceNames().forEach(enabledServiceName -> {
-      if(descriptor.getService(enabledServiceName) == null) {
+      if (descriptor.getService(enabledServiceName) == null) {
         ServiceImpl service = new ServiceImpl();
         service.setName(enabledServiceName);
         descriptor.addService(service);

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
@@ -19,8 +19,10 @@ package org.apache.knox.gateway.cm.descriptor;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -46,10 +48,21 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
   private static final String CONFIG_NAME_SERVICE_URL = "url";
   private static final String CONFIG_NAME_SERVICE_VERSION = "version";
 
-  private AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig;
+  private Map<String, AdvancedServiceDiscoveryConfig> advancedServiceDiscoveryConfigMap;
 
   public ClouderaManagerDescriptorParser() {
-    advancedServiceDiscoveryConfig = new AdvancedServiceDiscoveryConfig();
+    advancedServiceDiscoveryConfigMap = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Produces a set of {@link SimpleDescriptor}s from the specified file. Parses ALL descriptors listed in the given file.
+   *
+   * @param path
+   *          The path to the configuration file which holds descriptor information in a pre-defined format.
+   * @return A SimpleDescriptor based on the contents of the given file.
+   */
+  public Set<SimpleDescriptor> parse(String path) {
+    return parse(path, null);
   }
 
   /**
@@ -57,15 +70,17 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
    *
    * @param path
    *          The path to the configuration file which holds descriptor information in a pre-defined format.
+   * @param topologyName
+   *          if set, the parser should only parse a descriptor with the same name
    * @return A SimpleDescriptor based on the contents of the given file.
    */
-  public Set<SimpleDescriptor> parse(String path) {
+  public Set<SimpleDescriptor> parse(String path, String topologyName) {
     try {
       log.parseClouderaManagerDescriptor(path);
       final Configuration xmlConfiguration = new Configuration(false);
       xmlConfiguration.addResource(Paths.get(path).toUri().toURL());
       xmlConfiguration.reloadConfiguration();
-      final Set<SimpleDescriptor> descriptors = parseXmlConfig(xmlConfiguration);
+      final Set<SimpleDescriptor> descriptors = parseXmlConfig(xmlConfiguration, topologyName);
       log.parsedClouderaManagerDescriptor(String.join(", ", descriptors.stream().map(descriptor -> descriptor.getName()).collect(Collectors.toSet())), path);
       return descriptors;
     } catch (Exception e) {
@@ -74,12 +89,15 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
     }
   }
 
-  private Set<SimpleDescriptor> parseXmlConfig(Configuration xmlConfiguration) {
+  private Set<SimpleDescriptor> parseXmlConfig(Configuration xmlConfiguration, String topologyName) {
     final Set<SimpleDescriptor> descriptors = new LinkedHashSet<>();
     xmlConfiguration.forEach(xmlDescriptor -> {
-      SimpleDescriptor descriptor = parseXmlDescriptor(xmlDescriptor.getKey(), xmlDescriptor.getValue());
-      if (descriptor != null) {
-        descriptors.add(descriptor);
+      String descriptorName = xmlDescriptor.getKey();
+      if (topologyName == null || descriptorName.equals(topologyName)) {
+        SimpleDescriptor descriptor = parseXmlDescriptor(descriptorName, xmlDescriptor.getValue());
+        if (descriptor != null) {
+          descriptors.add(descriptor);
+        }
       }
     });
     return descriptors;
@@ -121,9 +139,9 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
           break;
         }
       }
-      if (advancedServiceDiscoveryConfig.getExpectedTopologyNames().contains(name)) {
-        setDiscoveryDetails(descriptor);
-        addEnabledServices(descriptor);
+      if (advancedServiceDiscoveryConfigMap.containsKey(name)) {
+        setDiscoveryDetails(descriptor, advancedServiceDiscoveryConfigMap.get(name));
+        addEnabledServices(descriptor, advancedServiceDiscoveryConfigMap.get(name));
       }
       return descriptor;
     } catch (Exception e) {
@@ -132,7 +150,7 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
     }
   }
 
-  private void setDiscoveryDetails(SimpleDescriptorImpl descriptor) {
+  private void setDiscoveryDetails(SimpleDescriptorImpl descriptor, AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig) {
     if (StringUtils.isBlank(descriptor.getDiscoveryAddress())) {
       descriptor.setDiscoveryAddress(advancedServiceDiscoveryConfig.getDiscoveryAddress());
     }
@@ -149,7 +167,7 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
   /*
    * Adds any enabled service which is not listed in the CM descriptor
    */
-  private void addEnabledServices(SimpleDescriptorImpl descriptor) {
+  private void addEnabledServices(SimpleDescriptorImpl descriptor, AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig) {
     advancedServiceDiscoveryConfig.getEnabledServiceNames().forEach(enabledServiceName -> {
       if(descriptor.getService(enabledServiceName) == null) {
         ServiceImpl service = new ServiceImpl();
@@ -204,7 +222,7 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
   private void parseService(SimpleDescriptorImpl descriptor, String configurationPair) {
     final String[] serviceParts = configurationPair.split(":");
     final String serviceName = serviceParts[0].trim();
-    if (advancedServiceDiscoveryConfig.isServiceEnabled(serviceName)) {
+    if (isServiceEnabled(descriptor.getName(), serviceName)) {
       ServiceImpl service = (ServiceImpl) descriptor.getService(serviceName);
       if (service == null) {
         service = new ServiceImpl();
@@ -235,10 +253,19 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
     }
   }
 
+  private boolean isServiceEnabled(String descriptorName, String serviceName) {
+    return advancedServiceDiscoveryConfigMap.containsKey(descriptorName) ? advancedServiceDiscoveryConfigMap.get(descriptorName).isServiceEnabled(serviceName) : true;
+  }
+
   @Override
   public void onAdvancedServiceDiscoveryConfigurationChange(Properties newConfiguration) {
-    advancedServiceDiscoveryConfig = new AdvancedServiceDiscoveryConfig(newConfiguration);
-    log.updatedAdvanceServiceDiscoverytConfiguration();
+    final AdvancedServiceDiscoveryConfig advancedServiceDiscoveryConfig = new AdvancedServiceDiscoveryConfig(newConfiguration);
+    final String topologyName = advancedServiceDiscoveryConfig.getTopologyName();
+    if (StringUtils.isBlank(topologyName)) {
+      throw new IllegalArgumentException("Invalid advanced service discovery configuration: topology name is missing!");
+    }
+    advancedServiceDiscoveryConfigMap.put(topologyName, advancedServiceDiscoveryConfig);
+    log.updatedAdvanceServiceDiscoverytConfiguration(topologyName);
   }
 
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
@@ -30,7 +30,7 @@ public interface AdvanceServiceDiscoveryConfigurationMessages {
   @Message(level = MessageLevel.ERROR, text = "Error while monitoring CM advanced configuration: {1}")
   void failedToMonitorClouderaManagerAdvancedConfiguration(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
-  @Message(level = MessageLevel.INFO, text = "Notifying listeners due to advanced service discovery configuration changes...")
-  void notifyListeners();
+  @Message(level = MessageLevel.INFO, text = "Notifying listeners due to advanced service discovery configuration changes in {0}...")
+  void notifyListeners(String path);
 
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
@@ -24,8 +24,8 @@ import org.apache.knox.gateway.i18n.messages.StackTrace;
 @Messages(logger = "org.apache.knox.gateway.topology.discovery.advanced")
 public interface AdvanceServiceDiscoveryConfigurationMessages {
 
-  @Message(level = MessageLevel.INFO, text = "Monitoring {0} for changes.")
-  void monitorStarted(String path);
+  @Message(level = MessageLevel.INFO, text = "Monitoring {0}/{1}* for advanced service discovery configuration changes.")
+  void monitorStarted(String directory, String prefix);
 
   @Message(level = MessageLevel.ERROR, text = "Error while monitoring CM advanced configuration: {1}")
   void failedToMonitorClouderaManagerAdvancedConfiguration(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
@@ -52,7 +52,7 @@ public class AdvancedServiceDiscoveryConfig {
 
   public Set<String> getEnabledServiceNames() {
     return properties.entrySet().stream().filter(keyValuePair -> Boolean.valueOf((String) keyValuePair.getValue()))
-        .map(keyValuePair -> ((String) keyValuePair.getKey()).substring(((String) keyValuePair.getKey()).lastIndexOf(".") + 1).toUpperCase(Locale.getDefault())).collect(toSet());
+        .map(keyValuePair -> ((String) keyValuePair.getKey()).substring(((String) keyValuePair.getKey()).lastIndexOf('.') + 1).toUpperCase(Locale.getDefault())).collect(toSet());
   }
 
   public String getTopologyName() {

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
@@ -80,4 +80,9 @@ public class AdvancedServiceDiscoveryConfig {
       return defaultValue;
     }
   }
+
+  @Override
+  public String toString() {
+    return this.properties.toString();
+  }
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfig.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.Locale;
 import java.util.Map.Entry;
-import java.util.stream.Stream;
 import java.util.Properties;
 import java.util.Set;
 
@@ -30,10 +29,11 @@ import java.util.Set;
  */
 public class AdvancedServiceDiscoveryConfig {
 
-  public static final String PARAMETER_NAME_PREFIX_ENABLED_SERVICE = "gateway.auto.discovery.enabled.";
-  public static final String PARAMETER_NAME_EXPECTED_TOPOLOGIES = "gateway.auto.discovery.expected.topology.names";
+  public static final String PARAMETER_NAME_PREFIX_ENABLED_SERVICE = "gateway.auto.discovery.";
+  public static final String PARAMETER_NAME_POSTFIX_ENABLED_SERVICE = ".enabled.";
+  public static final String PARAMETER_NAME_TOPOLOGY_NAME = "gateway.auto.discovery.topology.name";
   public static final String PARAMETER_NAME_DISCOVERY_ADDRESS = "gateway.auto.discovery.address";
-  public static final String PARAMETER_NAME_DISCOVERY_CLUSTER  = "gateway.auto.discovery.cluster";
+  public static final String PARAMETER_NAME_DISCOVERY_CLUSTER = "gateway.auto.discovery.cluster";
 
   private final Properties properties;
 
@@ -46,16 +46,17 @@ public class AdvancedServiceDiscoveryConfig {
   }
 
   public boolean isServiceEnabled(String serviceName) {
-    return Boolean.valueOf(getPropertyIgnoreCase(PARAMETER_NAME_PREFIX_ENABLED_SERVICE + serviceName, "true"));
+    final String propertyName = PARAMETER_NAME_PREFIX_ENABLED_SERVICE + getTopologyName() + PARAMETER_NAME_POSTFIX_ENABLED_SERVICE + serviceName;
+    return Boolean.valueOf(getPropertyIgnoreCase(propertyName, "true"));
   }
 
   public Set<String> getEnabledServiceNames() {
     return properties.entrySet().stream().filter(keyValuePair -> Boolean.valueOf((String) keyValuePair.getValue()))
-        .map(keyValuePair -> ((String) keyValuePair.getKey()).substring(PARAMETER_NAME_PREFIX_ENABLED_SERVICE.length()).toUpperCase(Locale.getDefault())).collect(toSet());
+        .map(keyValuePair -> ((String) keyValuePair.getKey()).substring(((String) keyValuePair.getKey()).lastIndexOf(".") + 1).toUpperCase(Locale.getDefault())).collect(toSet());
   }
 
-  public Set<String> getExpectedTopologyNames() {
-    return Stream.of(getPropertyIgnoreCase(PARAMETER_NAME_EXPECTED_TOPOLOGIES, "").split(",")).map(expectedToplogyName -> expectedToplogyName.trim()).collect(toSet());
+  public String getTopologyName() {
+    return getPropertyIgnoreCase(PARAMETER_NAME_TOPOLOGY_NAME, "");
   }
 
   public String getDiscoveryAddress() {

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigurationMonitor.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigurationMonitor.java
@@ -87,7 +87,7 @@ public class AdvancedServiceDiscoveryConfigurationMonitor {
           try (InputStream advanceconfigurationFileInputStream = Files.newInputStream(resourcePath)) {
             Properties properties = new Properties();
             properties.load(advanceconfigurationFileInputStream);
-            notifyListeners(properties);
+            notifyListeners(resourcePath.toString(), properties);
           }
         }
       }
@@ -96,8 +96,8 @@ public class AdvancedServiceDiscoveryConfigurationMonitor {
     }
   }
 
-  private void notifyListeners(Properties properties) {
-    LOG.notifyListeners();
+  private void notifyListeners(String path, Properties properties) {
+    LOG.notifyListeners(path);
     listeners.forEach(listener -> listener.onAdvancedServiceDiscoveryConfigurationChange(properties));
   }
 

--- a/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
+++ b/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
@@ -53,7 +53,15 @@ public class ClouderaManagerDescriptorParserTest {
     assertEquals(2, descriptors.size());
     final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
     validateTopology1(descriptorsIterator.next());
-    validateTopology2(descriptorsIterator.next());
+    validateTopology2(descriptorsIterator.next(), true);
+  }
+
+  @Test
+  public void testCMDescriptorParserOnlyTopology2() throws Exception {
+    final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptor.xml").getPath();
+    final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath, "topology2");
+    assertEquals(1, descriptors.size());
+    validateTopology2(descriptors.iterator().next(), true);
   }
 
   @Test
@@ -75,35 +83,52 @@ public class ClouderaManagerDescriptorParserTest {
   @Test
   public void testCMDescriptorParserWithNotEnabledServices() throws Exception {
     final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptor.xml").getPath();
-    final Properties advancedConfiguration = new Properties();
-    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_PREFIX_ENABLED_SERVICE + "HIVE", "false");
-    cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfiguration);
+
+    final Properties advancedConfigurationTopology1 = new Properties();
+    advancedConfigurationTopology1.put(buildEnabledParameter("topology1", "HIVE"), "false");
+    advancedConfigurationTopology1.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_TOPOLOGY_NAME, "topology1");
+    cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfigurationTopology1);
+
+    final Properties advancedConfigurationTopology2 = new Properties();
+    advancedConfigurationTopology2.put(buildEnabledParameter("topology2", "NIFI"), "false");
+    advancedConfigurationTopology2.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_TOPOLOGY_NAME, "topology2");
+    cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfigurationTopology2);
+
     final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
     assertEquals(2, descriptors.size());
     final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
-    SimpleDescriptor descriptor = descriptorsIterator.next();
-    assertNotNull(descriptor);
+    SimpleDescriptor topology1 = descriptorsIterator.next();
+    assertNotNull(topology1);
     // topology1 comes with HIVE which is disabled
-    assertTrue(descriptor.getServices().isEmpty());
+    assertTrue(topology1.getServices().isEmpty());
+
+    SimpleDescriptor topology2 = descriptorsIterator.next();
+    assertNotNull(topology2);
+    // topology1 comes with ATLAS and NIFI but the latter one is disabled
+    validateTopology2(topology2, false);
   }
 
   @Test
   public void testCMDescriptorParserWithEnabledNotListedServiceInTopology1() throws Exception {
     final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptor.xml").getPath();
     final Properties advancedConfiguration = new Properties();
-    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_PREFIX_ENABLED_SERVICE + "OOZIE", "true");
-    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_EXPECTED_TOPOLOGIES, "topology1, topology100");
+    advancedConfiguration.put(buildEnabledParameter("topology1", "oozie"), "true"); //it should not matter if service name is lowercase advanced configuration
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_TOPOLOGY_NAME, "topology1");
     cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfiguration);
     final Set<SimpleDescriptor> descriptors = cmDescriptorParser.parse(testConfigPath);
     final Iterator<SimpleDescriptor> descriptorsIterator = descriptors.iterator();
     SimpleDescriptor descriptor = descriptorsIterator.next();
     assertNotNull(descriptor);
-    // topology1 comes without OOZIE but it's enabled and topology1 is expected -> OOZIE should be added without any url/version/parameter
+    // topology1 comes without OOZIE but it's enabled in topology1 -> OOZIE should be added without any url/version/parameter
     assertService(descriptor, "OOZIE", null, null, null);
 
     descriptor = descriptorsIterator.next();
-    validateTopology2(descriptor);
+    validateTopology2(descriptor, true);
     assertNull(descriptor.getService("OOZIE"));
+  }
+
+  private String buildEnabledParameter(String topologyName, String serviceName) {
+    return AdvancedServiceDiscoveryConfig.PARAMETER_NAME_PREFIX_ENABLED_SERVICE + topologyName + AdvancedServiceDiscoveryConfig.PARAMETER_NAME_POSTFIX_ENABLED_SERVICE + serviceName;
   }
 
   @Test
@@ -112,7 +137,7 @@ public class ClouderaManagerDescriptorParserTest {
     final String cluster = "My Test Cluster";
     final String testConfigPath = this.getClass().getClassLoader().getResource("testDescriptorWithoutDiscoveryDetails.xml").getPath();
     final Properties advancedConfiguration = new Properties();
-    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_EXPECTED_TOPOLOGIES, "topology1");
+    advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_TOPOLOGY_NAME, "topology1");
     advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_DISCOVERY_ADDRESS, address);
     advancedConfiguration.put(AdvancedServiceDiscoveryConfig.PARAMETER_NAME_DISCOVERY_CLUSTER, cluster);
     cmDescriptorParser.onAdvancedServiceDiscoveryConfigurationChange(advancedConfiguration);
@@ -142,7 +167,7 @@ public class ClouderaManagerDescriptorParserTest {
     assertService(descriptor, "HIVE", "1.0", Collections.singletonList("http://localhost:456"), expectedServiceParameters);
   }
 
-  private void validateTopology2(SimpleDescriptor descriptor) {
+  private void validateTopology2(SimpleDescriptor descriptor, boolean nifiExpected) {
     assertEquals("topology2", descriptor.getName());
     assertEquals("Ambari", descriptor.getDiscoveryType());
     assertEquals("http://host:456", descriptor.getDiscoveryAddress());
@@ -153,7 +178,11 @@ public class ClouderaManagerDescriptorParserTest {
     final Map<String, String> expectedServiceParameters = Stream.of(new String[][] { { "httpclient.connectionTimeout", "5m" }, { "httpclient.socketTimeout", "100m" }, })
         .collect(Collectors.toMap(data -> data[0], data -> data[1]));
     assertService(descriptor, "ATLAS-API", null, Collections.singletonList("http://localhost:456"), expectedServiceParameters);
-    assertService(descriptor, "NIFI", null, null, null);
+    if (nifiExpected) {
+      assertService(descriptor, "NIFI", null, null, null);
+    } else {
+      assertNull(descriptor.getService("NIFI"));
+    }
   }
 
   private void assertApplication(SimpleDescriptor descriptor, String expectedApplicationName, Map<String, String> expectedParams) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -626,10 +626,11 @@ public class GatewayServer {
 
     final ClouderaManagerDescriptorParser cmDescriptorParser = new ClouderaManagerDescriptorParser();
     final ClouderaManagerDescriptorMonitor cmDescriptorMonitor = new ClouderaManagerDescriptorMonitor(config, cmDescriptorParser);
-    cmDescriptorMonitor.setupMonitor();
     final AdvancedServiceDiscoveryConfigurationMonitor advancedServiceDiscoveryConfigurationMonitor = new AdvancedServiceDiscoveryConfigurationMonitor(config);
     advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorParser);
     advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorMonitor);
+    advancedServiceDiscoveryConfigurationMonitor.init();
+    cmDescriptorMonitor.setupMonitor();
 
     // Load the current topologies.
     // Redeploy autodeploy topologies.

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -166,6 +166,7 @@ public class SimpleDescriptorHandlerFuncTest {
       // Try setting up enough of the GatewayServer to support the test...
       GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
       InetSocketAddress gatewayAddress = new InetSocketAddress(0);
+      EasyMock.expect(config.getGatewayConfDir()).andReturn(testConfDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayDataDir()).andReturn(testDataDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayTopologyDir()).andReturn(testTopoDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayDeploymentDir()).andReturn(testDeployDir.getAbsolutePath()).anyTimes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of applying advance service discovery configuration listed in `KNOX_CONF_DIR/conf/auto-discovery-advanced-configuration.properties`. From now on, the advance service configuration monitor checks any files in `KNOX_CONF_DIR` with `auto-discovery-advanced-configuration` prefix. This file contains the advanced configuration of one topology which is declared within the configuration. If such a file is updated the affected topology will be redeployed.

## How was this patch tested?

JUnit:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:24 min (Wall Clock)
[INFO] Finished at: 2020-01-22T11:48:12+01:00
[INFO] Final Memory: 421M/2351M
[INFO] ------------------------------------------------------------------------
```

Additionally, I executed manual tests using the following teat resources:
```
$ cat ~/test/knoxGateway/conf/descriptors/knox-descriptors.cm
<configuration>
  <property>
    <name>topology1</name>
    <value>
        providerConfigRef=topology1-provider;
        app:knoxauth:param1.name=param1.value;
        HIVE:url=http://localhost:456;
        HIVE:version=1.0;
        HIVE:httpclient.connectionTimeout=5m;
        HIVE:httpclient.socketTimeout=100m;
        MY_CUSTOM_SERVICE:url=https://custom_host:custom_port
    </value>
  </property>
  <property>
    <name>topology2</name>
    <value>
        providerConfigRef=topology2-provider;
        ATLAS_API:url=http://localhost:456;
        ATLAS_API:httpclient.connectionTimeout=15m;
        ATLAS_API:httpclient.socketTimeout=100m;
        RANGERUI:url=http://localhost:789;
        RANGER:url=http://localhost:rangerport
    </value>
  </property>
</configuration>
```
```
$ cat ~/test/knoxGateway/conf/auto-discovery-advanced-configuration-topology1.properties
gateway.auto.discovery.address=http://myCmHost:7180
gateway.auto.discovery.cluster=Cluster 1
gateway.auto.discovery.topology.name=topology1
gateway.auto.discovery.topology1.enabled.HIVE=false
gateway.auto.discovery.topology1.enabled.RANGERUI=false
gateway.auto.discovery.topology1.enabled.RANGER=true
```
```
$ cat ~/test/knoxGateway/conf/auto-discovery-advanced-configuration-topology2.properties
gateway.auto.discovery.address=http://myCmHost:7180
gateway.auto.discovery.cluster=Cluster 1
gateway.auto.discovery.topology.name=topology2
gateway.auto.discovery.topology2.enabled.ATLAS_API=true
gateway.auto.discovery.topology2.enabled.HIVE=false
gateway.auto.discovery.topology2.enabled.RANGERUI=false
gateway.auto.discovery.topology2.enabled.RANGER=false
```

I switched the boolean flags of different services, as well as added/removed custom/known services in the Knox descriptor file. I confirmed that Knox always picked up the newest config and redeployed the relevant topology.