### PR TITLE
KNOX-2202 - Knox should use UTF-8 as default encoding instead of ISO-8859-1

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteStreamFilterFactory.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteStreamFilterFactory.java
@@ -49,7 +49,7 @@ public abstract class UrlRewriteStreamFilterFactory {
       UrlRewriteFilterContentDescriptor config )
           throws IOException {
     UrlRewriteStreamFilter filter = create(type, name);
-    String charset = MimeTypes.getCharset( type, StandardCharsets.ISO_8859_1.name() );
+    String charset = MimeTypes.getCharset( type, StandardCharsets.UTF_8.name() );
     final InputStream filteredStream;
     if( filter != null ) {
       filteredStream = filter.filter( stream, charset, rewriter, resolver, direction, config );

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteRequest.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteRequest.java
@@ -267,7 +267,7 @@ public class UrlRewriteRequest extends GatewayRequestWrapper implements Resolver
       final InputStream stream;
       UrlRewriteStreamFilter filter = UrlRewriteStreamFilterFactory.create(mimeType, null);
       if(filter != null) {
-        String charset = MimeTypes.getCharset( mimeType, StandardCharsets.ISO_8859_1.name() );
+        String charset = MimeTypes.getCharset( mimeType, StandardCharsets.UTF_8.name() );
         stream = filter.filter(input, charset, rewriter, this, UrlRewriter.Direction.IN, filterContentConfig );
       } else {
         stream = input;

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponse.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponse.java
@@ -180,7 +180,7 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
       } else {
         unFilteredStream = inBuffer;
       }
-      String charset = MimeTypes.getCharset( mimeType, StandardCharsets.ISO_8859_1.name() );
+      String charset = MimeTypes.getCharset( mimeType, StandardCharsets.UTF_8.name() );
       inStream = filter.filter( unFilteredStream, charset, rewriter, this, UrlRewriter.Direction.OUT, filterContentConfig );
       outStream = (isGzip) ? new GZIPOutputStream(output, STREAM_BUFFER_SIZE) : output;
     } else {

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteRequestTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteRequestTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.filter.rewrite.impl;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.knox.gateway.dispatch.InputStreamEntity;
@@ -53,8 +54,7 @@ import static org.junit.Assert.assertEquals;
 
 public class UrlRewriteRequestTest {
   @Test
-  public void testResolve() throws Exception {
-
+  public void testResolve() {
     UrlRewriteProcessor rewriter = EasyMock.createNiceMock( UrlRewriteProcessor.class );
 
     ServletContext context = EasyMock.createNiceMock( ServletContext.class );
@@ -104,7 +104,6 @@ public class UrlRewriteRequestTest {
 
   @Test
   public void testEmptyPayload() throws Exception {
-
     /* copy results */
     final ByteArrayOutputStream results = new ByteArrayOutputStream();
     final ByteArrayInputStream bai = new ByteArrayInputStream(
@@ -113,12 +112,12 @@ public class UrlRewriteRequestTest {
     final ServletInputStream payload = new ServletInputStream() {
 
       @Override
-      public int read() throws IOException {
+      public int read() {
         return bai.read();
       }
 
       @Override
-      public int available() throws IOException {
+      public int available() {
         return bai.available();
       }
 
@@ -134,12 +133,10 @@ public class UrlRewriteRequestTest {
 
       @Override
       public void setReadListener(ReadListener readListener) {
-
       }
     };
 
-    UrlRewriteProcessor rewriter = EasyMock
-        .createNiceMock(UrlRewriteProcessor.class);
+    UrlRewriteProcessor rewriter = EasyMock.createNiceMock(UrlRewriteProcessor.class);
 
     ServletContext context = EasyMock.createNiceMock(ServletContext.class);
     EasyMock.expect(context.getServletContextName())
@@ -155,26 +152,20 @@ public class UrlRewriteRequestTest {
         .andReturn("test-filter-init-param-value").anyTimes();
     EasyMock.expect(config.getServletContext()).andReturn(context).anyTimes();
 
-    HttpServletRequest request = EasyMock
-        .createNiceMock(HttpServletRequest.class);
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
     EasyMock.expect(request.getScheme()).andReturn("https").anyTimes();
-    EasyMock.expect(request.getServerName()).andReturn("targethost.com")
-        .anyTimes();
+    EasyMock.expect(request.getServerName()).andReturn("targethost.com").anyTimes();
     EasyMock.expect(request.getServerPort()).andReturn(80).anyTimes();
     EasyMock.expect(request.getRequestURI()).andReturn("/").anyTimes();
     EasyMock.expect(request.getQueryString()).andReturn(null).anyTimes();
-    EasyMock.expect(request.getHeader("Host")).andReturn("sourcehost.com")
-        .anyTimes();
+    EasyMock.expect(request.getHeader("Host")).andReturn("sourcehost.com").anyTimes();
 
     EasyMock.expect(request.getMethod()).andReturn("POST").anyTimes();
-    EasyMock.expect(request.getContentType())
-        .andReturn("application/xml").anyTimes();
+    EasyMock.expect(request.getContentType()).andReturn("application/xml").anyTimes();
     EasyMock.expect(request.getInputStream()).andReturn(payload).anyTimes();
     EasyMock.expect(request.getContentLength()).andReturn(-1).anyTimes();
 
-    HttpServletResponse response = EasyMock
-        .createNiceMock(HttpServletResponse.class);
-    //    EasyMock.replay( rewriter, context, config, request, response );
+    HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     EasyMock.replay(rewriter, context, config, request, response);
 
     // instantiate UrlRewriteRequest so that we can use it as a Template factory for targetUrl
@@ -199,7 +190,6 @@ public class UrlRewriteRequestTest {
     final InputStream input = Files.newInputStream(
         Paths.get(ClassLoader.getSystemResource("KNOX-1412.xml.gz").toURI()));
     final ServletInputStream payload = new ServletInputStream() {
-
       @Override
       public int read() throws IOException {
         return input.read();
@@ -221,10 +211,8 @@ public class UrlRewriteRequestTest {
       }
     };
 
-    GatewayServices gatewayServices = EasyMock
-        .createNiceMock(GatewayServices.class);
-    UrlRewriteEnvironment environment = EasyMock
-        .createNiceMock(UrlRewriteEnvironment.class);
+    GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
+    UrlRewriteEnvironment environment = EasyMock.createNiceMock(UrlRewriteEnvironment.class);
     EasyMock.expect(
         environment.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE))
         .andReturn(gatewayServices).anyTimes();
@@ -236,8 +224,7 @@ public class UrlRewriteRequestTest {
 
     EasyMock.replay(gatewayServices, environment);
 
-    UrlRewriteRulesDescriptor descriptor = UrlRewriteRulesDescriptorFactory
-        .create();
+    UrlRewriteRulesDescriptor descriptor = UrlRewriteRulesDescriptorFactory.create();
     UrlRewriteRuleDescriptor rule = descriptor.addRule("test-location");
     rule.pattern("{*}://{*}:{*}/{**}/?{**}");
     UrlRewriteActionRewriteDescriptorExt rewrite = rule.addStep("rewrite");
@@ -246,8 +233,7 @@ public class UrlRewriteRequestTest {
     rewriter.initialize(environment, descriptor);
 
     ServletContext context = EasyMock.createNiceMock(ServletContext.class);
-    EasyMock.expect(context.getServletContextName())
-        .andReturn("test-cluster-name").anyTimes();
+    EasyMock.expect(context.getServletContextName()).andReturn("test-cluster-name").anyTimes();
     EasyMock.expect(context.getInitParameter("test-init-param-name"))
         .andReturn("test-init-param-value").anyTimes();
     EasyMock.expect(context.getAttribute(
@@ -263,58 +249,42 @@ public class UrlRewriteRequestTest {
     HttpServletRequest request1 = EasyMock
         .createNiceMock(HttpServletRequest.class);
     EasyMock.expect(request1.getScheme()).andReturn("https").anyTimes();
-    EasyMock.expect(request1.getServerName()).andReturn("targethost.com")
-        .anyTimes();
+    EasyMock.expect(request1.getServerName()).andReturn("targethost.com").anyTimes();
     EasyMock.expect(request1.getServerPort()).andReturn(80).anyTimes();
     EasyMock.expect(request1.getRequestURI()).andReturn("/").anyTimes();
     EasyMock.expect(request1.getQueryString()).andReturn(null).anyTimes();
     EasyMock.expect(request1.getInputStream()).andReturn(payload).anyTimes();
-    EasyMock.expect(request1.getContentLength()).andReturn(input.available())
-        .anyTimes();
+    EasyMock.expect(request1.getContentLength()).andReturn(input.available()).anyTimes();
     EasyMock.expect(request1.getContentType()).andReturn("text/xml").anyTimes();
-    EasyMock.expect(request1.getHeader("Content-Encoding")).andReturn("gzip")
-        .anyTimes();
-    EasyMock.expect(request1.getHeader("Host")).andReturn("sourcehost.com")
-        .anyTimes();
+    EasyMock.expect(request1.getHeader("Content-Encoding")).andReturn("gzip").anyTimes();
+    EasyMock.expect(request1.getHeader("Host")).andReturn("sourcehost.com").anyTimes();
 
     /* Request wih Content-Type:application/gzip and Content-Encoding:gzip */
-    HttpServletRequest request2 = EasyMock
-        .createNiceMock(HttpServletRequest.class);
+    HttpServletRequest request2 = EasyMock.createNiceMock(HttpServletRequest.class);
     EasyMock.expect(request2.getScheme()).andReturn("https").anyTimes();
-    EasyMock.expect(request2.getServerName()).andReturn("targethost.com")
-        .anyTimes();
+    EasyMock.expect(request2.getServerName()).andReturn("targethost.com").anyTimes();
     EasyMock.expect(request2.getServerPort()).andReturn(80).anyTimes();
     EasyMock.expect(request2.getRequestURI()).andReturn("/").anyTimes();
     EasyMock.expect(request2.getQueryString()).andReturn(null).anyTimes();
     EasyMock.expect(request2.getInputStream()).andReturn(payload).anyTimes();
-    EasyMock.expect(request2.getContentLength()).andReturn(input.available())
-        .anyTimes();
-    EasyMock.expect(request2.getContentType()).andReturn("application/gzip")
-        .anyTimes();
-    EasyMock.expect(request2.getHeader("Content-Encoding")).andReturn("gzip")
-        .anyTimes();
-    EasyMock.expect(request2.getHeader("Host")).andReturn("sourcehost.com")
-        .anyTimes();
+    EasyMock.expect(request2.getContentLength()).andReturn(input.available()).anyTimes();
+    EasyMock.expect(request2.getContentType()).andReturn("application/gzip").anyTimes();
+    EasyMock.expect(request2.getHeader("Content-Encoding")).andReturn("gzip").anyTimes();
+    EasyMock.expect(request2.getHeader("Host")).andReturn("sourcehost.com").anyTimes();
 
     /* Request wih Content-Type:application/gzip no content encoding */
-    HttpServletRequest request3 = EasyMock
-        .createNiceMock(HttpServletRequest.class);
+    HttpServletRequest request3 = EasyMock.createNiceMock(HttpServletRequest.class);
     EasyMock.expect(request3.getScheme()).andReturn("https").anyTimes();
-    EasyMock.expect(request3.getServerName()).andReturn("targethost.com")
-        .anyTimes();
+    EasyMock.expect(request3.getServerName()).andReturn("targethost.com").anyTimes();
     EasyMock.expect(request3.getServerPort()).andReturn(80).anyTimes();
     EasyMock.expect(request3.getRequestURI()).andReturn("/").anyTimes();
     EasyMock.expect(request3.getQueryString()).andReturn(null).anyTimes();
     EasyMock.expect(request3.getInputStream()).andReturn(payload).anyTimes();
-    EasyMock.expect(request3.getContentLength()).andReturn(input.available())
-        .anyTimes();
-    EasyMock.expect(request3.getContentType()).andReturn("application/gzip")
-        .anyTimes();
-    EasyMock.expect(request3.getHeader("Host")).andReturn("sourcehost.com")
-        .anyTimes();
+    EasyMock.expect(request3.getContentLength()).andReturn(input.available()).anyTimes();
+    EasyMock.expect(request3.getContentType()).andReturn("application/gzip").anyTimes();
+    EasyMock.expect(request3.getHeader("Host")).andReturn("sourcehost.com").anyTimes();
 
-    HttpServletResponse response = EasyMock
-        .createNiceMock(HttpServletResponse.class);
+    HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
 
     EasyMock.replay(context, config, response, request1, request2, request3);
 
@@ -343,7 +313,75 @@ public class UrlRewriteRequestTest {
     entity = new InputStreamEntity(inputStream, request1.getContentLength(),
         ContentType.parse("application/gzip"));
     entity.writeTo(results);
-
   }
 
+  @Test
+  public void testUnicodePayload() throws Exception {
+    String data = "<?xml version=\"1.0\" standalone=\"no\"?><data>abc-大数据</data>";
+
+    final ByteArrayInputStream bai = new ByteArrayInputStream(
+        data.getBytes(StandardCharsets.UTF_8));
+
+    final ServletInputStream payload = new ServletInputStream() {
+      @Override
+      public int read() {
+        return bai.read();
+      }
+
+      @Override
+      public int available() {
+        return bai.available();
+      }
+
+      @Override
+      public boolean isFinished() {
+        return false;
+      }
+
+      @Override
+      public boolean isReady() {
+        return false;
+      }
+
+      @Override
+      public void setReadListener(ReadListener readListener) {
+      }
+    };
+
+    UrlRewriteProcessor rewriter = EasyMock.createNiceMock(UrlRewriteProcessor.class);
+
+    ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getServletContextName())
+        .andReturn("test-cluster-name").anyTimes();
+    EasyMock.expect(context.getInitParameter("test-init-param-name"))
+        .andReturn("test-init-param-value").anyTimes();
+    EasyMock.expect(context.getAttribute(
+        UrlRewriteServletContextListener.PROCESSOR_ATTRIBUTE_NAME))
+        .andReturn(rewriter).anyTimes();
+
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameter("test-filter-init-param-name"))
+        .andReturn("test-filter-init-param-value").anyTimes();
+    EasyMock.expect(config.getServletContext()).andReturn(context).anyTimes();
+
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getScheme()).andReturn("https").anyTimes();
+    EasyMock.expect(request.getServerName()).andReturn("targethost.com").anyTimes();
+    EasyMock.expect(request.getServerPort()).andReturn(80).anyTimes();
+    EasyMock.expect(request.getRequestURI()).andReturn("/").anyTimes();
+    EasyMock.expect(request.getQueryString()).andReturn(null).anyTimes();
+    EasyMock.expect(request.getHeader("Host")).andReturn("sourcehost.com").anyTimes();
+
+    EasyMock.expect(request.getMethod()).andReturn("POST").anyTimes();
+    EasyMock.expect(request.getContentType()).andReturn("application/xml").anyTimes();
+    EasyMock.expect(request.getInputStream()).andReturn(payload).anyTimes();
+    EasyMock.expect(request.getContentLength()).andReturn(-1).anyTimes();
+
+    HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+    EasyMock.replay(rewriter, context, config, request, response);
+
+    UrlRewriteRequest rewriteRequest = new UrlRewriteRequest(config, request);
+
+    assertEquals(data, IOUtils.toString(rewriteRequest.getInputStream(), StandardCharsets.UTF_8));
+  }
 }

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponseTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponseTest.java
@@ -24,17 +24,16 @@ import org.apache.knox.gateway.filter.rewrite.api.UrlRewriteServletFilter;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
-import javax.activation.MimeTypeParseException;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -116,7 +115,31 @@ public class UrlRewriteResponseTest {
   }
 
   @Test
-  public void testStreamResponse() throws IOException, MimeTypeParseException {
+  public void testStreamXmlUnicodeResponse() throws IOException {
+    UrlRewriteProcessor rewriter = EasyMock.createNiceMock(UrlRewriteProcessor.class);
+    EasyMock.expect(rewriter.getConfig()).andReturn(null).anyTimes();
+
+    ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getAttribute(UrlRewriteServletContextListener.PROCESSOR_ATTRIBUTE_NAME)).andReturn(rewriter).anyTimes();
+
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameter(UrlRewriteServletFilter.RESPONSE_BODY_FILTER_PARAM)).andReturn("test-filter").anyTimes();
+    EasyMock.expect(config.getServletContext()).andReturn(context).anyTimes();
+
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getContentType()).andReturn("application/xml");
+    HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+    EasyMock.expect(response.getContentType()).andReturn("application/xml");
+
+    EasyMock.replay(rewriter, context, config, request, response);
+
+    UrlRewriteResponse rewriteResponse = new UrlRewriteResponse(config, request, response);
+    String content = "<?xml version=\"1.0\" standalone=\"no\"?><data>abc-大数据</data>";
+    testStreamResponse(content, rewriteResponse, false);
+  }
+
+  @Test
+  public void testStreamResponse() throws IOException {
     UrlRewriteProcessor rewriter = EasyMock.createNiceMock( UrlRewriteProcessor.class );
     EasyMock.expect( rewriter.getConfig() ).andReturn( null ).anyTimes();
 
@@ -135,32 +158,31 @@ public class UrlRewriteResponseTest {
     UrlRewriteResponse rewriteResponse = new UrlRewriteResponse( config, request, response );
 
     String content = "content to test gzip streaming";
-    testStreamResponseGzip ( content, rewriteResponse, false );
-    testStreamResponseGzip ( content, rewriteResponse, true );
+    testStreamResponse(content, rewriteResponse, false);
+    testStreamResponse(content, rewriteResponse, true);
   }
 
-  private void testStreamResponseGzip( String content, UrlRewriteResponse rewriteResponse , boolean isGzip ) throws IOException {
-    File targetDir = new File( System.getProperty( "user.dir" ), "target" );
-    File inputFile = new File( targetDir, "input.test" );
-    File outputFile = new File( targetDir, "output.test" );
-    try (OutputStream outputStream = Files.newOutputStream(inputFile.toPath())) {
-      try(OutputStream outStream = isGzip ? new GZIPOutputStream( outputStream ) : outputStream) {
+  private void testStreamResponse(String content, UrlRewriteResponse rewriteResponse, boolean isGzip) throws IOException {
+    Path inputFile = Files.createTempFile("input", "test");
+    Path outputFile = Files.createTempFile("output", "test");
+    try {
+      try(OutputStream outputStream = Files.newOutputStream(inputFile);
+          OutputStream outStream = isGzip ? new GZIPOutputStream( outputStream ) : outputStream) {
         outStream.write(content.getBytes(StandardCharsets.UTF_8));
       }
 
-      try(InputStream input = Files.newInputStream(inputFile.toPath());
-          OutputStream output = Files.newOutputStream(outputFile.toPath())){
-
+      try(InputStream input = Files.newInputStream(inputFile);
+          OutputStream output = Files.newOutputStream(outputFile)) {
         rewriteResponse.streamResponse(input, output);
       }
 
-      try(InputStream inputStream = Files.newInputStream(outputFile.toPath());
+      try(InputStream inputStream = Files.newInputStream(outputFile);
           InputStream inStream = isGzip ? new GZIPInputStream(inputStream) : inputStream) {
         assertThat(String.valueOf(IOUtils.toCharArray(inStream, StandardCharsets.UTF_8)), is(content));
       }
     } finally {
-      inputFile.delete();
-      outputFile.delete();
+      Files.delete(inputFile);
+      Files.delete(outputFile);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Using UTF-8 for default content encoding instead of ISO-8859-1. 

## How was this patch tested?

* Added unit tests showing failure before change
* Checked that failing unit tests pass after change
* Manually verified that changes fix Oozie UTF-8 XML issue
* `mvn -T.75C verify -Ppackage,release -Dshellcheck`
