### PR TITLE
KNOX-2208 - AclsAuthorizationFilter should log access at DEBUG level

### DIFF
--- a/gateway-provider-security-authz-acls/src/main/java/org/apache/knox/gateway/filter/AclsAuthorizationMessages.java
+++ b/gateway-provider-security-authz-acls/src/main/java/org/apache/knox/gateway/filter/AclsAuthorizationMessages.java
@@ -39,7 +39,7 @@ public interface AclsAuthorizationMessages {
   @Message( level = MessageLevel.DEBUG, text = "No ACLs found for: {0}" )
   void noAclsFoundForResource(String resourceRole);
 
-  @Message( level = MessageLevel.INFO, text = "Access Granted: {0}" )
+  @Message( level = MessageLevel.DEBUG, text = "Access Granted: {0}" )
   void accessGranted(boolean accessGranted);
 
   @Message( level = MessageLevel.DEBUG, text = "PrimaryPrincipal: {0}" )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move AclsAuthorizationFilter log access at DEBUG level

## How was this patch tested?

* `mvn -T.75C verify -Ppackage,release -Dshellcheck`
* Checked that log is at DEBUG instead of INFO when running Knox
