### PR TITLE
KNOX-2206 - Log exclusion of a discovered service due to configuration issues

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -37,6 +37,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.INFO, text = "Discovered service role: {0} ({1})")
   void discoveredServiceRole(String roleName, String roleType);
 
+  @Message(level = MessageLevel.WARN, text = "Service role {0} has configuration issues: {1}")
+  void serviceRoleHasConfigurationIssues(String roleName, String configurationIssuesText);
+
   @Message(level = MessageLevel.INFO, text = "Attempting to authenticate Knox using {0} ...")
   void attemptingKerberosLogin(String loginConfigPath);
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGenerator.java
@@ -43,14 +43,8 @@ public interface ServiceModelGenerator {
 
   void setApiClient(DiscoveryApiClient client);
 
-  boolean handles(ApiService       service,
-                  ApiServiceConfig serviceConfig,
-                  ApiRole          role,
-                  ApiConfigList    roleConfig);
+  ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig);
 
-  ServiceModel generateService(ApiService       service,
-                               ApiServiceConfig serviceConfig,
-                               ApiRole          role,
-                               ApiConfigList    roleConfig) throws ApiException;
+  ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException;
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorHandleResponse.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorHandleResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+public class ServiceModelGeneratorHandleResponse {
+  private final Collection<String> configurationIssues = new HashSet<>();
+  private boolean handled;
+
+  public ServiceModelGeneratorHandleResponse(boolean handled) {
+    this.handled = handled;
+  }
+
+  public boolean handled() {
+    return handled;
+  }
+
+  public void addConfigurationIssue(String configurationIssue) {
+    configurationIssues.add(configurationIssue);
+    handled = false;
+  }
+
+  public Collection<String> getConfigurationIssues() {
+    return Collections.unmodifiableCollection(configurationIssues);
+  }
+
+}

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
@@ -25,6 +25,7 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.topology.discovery.cm.DiscoveryApiClient;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGeneratorHandleResponse;
 
 import java.util.List;
 import java.util.regex.Matcher;
@@ -81,8 +82,8 @@ public abstract class AbstractServiceModelGenerator implements ServiceModelGener
   }
 
   @Override
-  public boolean handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-    return getServiceType().equals(service.getType()) && getRoleType().equals(role.getType());
+  public ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
+    return new ServiceModelGeneratorHandleResponse(getServiceType().equals(service.getType()) && getRoleType().equals(role.getType()));
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
@@ -29,7 +29,6 @@ import java.util.Map;
 public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
   private static final String SERVICE = "WEBHDFS";
   private static final String WEBHDFS_SUFFIX = "/webhdfs";
-  private static final String CONFIG_NAME_DFS_WEBHDFS_ENABLED = "dfs_webhdfs_enabled";
 
   static final String WEBHDFS_ENABLED = "dfs_webhdfs_enabled";
 
@@ -47,11 +46,11 @@ public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
   public ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
     final ServiceModelGeneratorHandleResponse response = super.handles(service, serviceConfig, role, roleConfig);
     if (response.handled()) {
-      final String webHdfsEnabled = getServiceConfigValue(serviceConfig, CONFIG_NAME_DFS_WEBHDFS_ENABLED);
+      final String webHdfsEnabled = getServiceConfigValue(serviceConfig, WEBHDFS_ENABLED);
       if (webHdfsEnabled == null) {
-        response.addConfigurationIssue("Missing configuration: " + CONFIG_NAME_DFS_WEBHDFS_ENABLED);
+        response.addConfigurationIssue("Missing configuration: " + WEBHDFS_ENABLED);
       } else if (!Boolean.parseBoolean(webHdfsEnabled)) {
-        response.addConfigurationIssue("Invalid configuration: " + CONFIG_NAME_DFS_WEBHDFS_ENABLED + ". Expected=true; Found=" + webHdfsEnabled);
+        response.addConfigurationIssue("Invalid configuration: " + WEBHDFS_ENABLED + ". Expected=true; Found=" + webHdfsEnabled);
       }
     }
     return response;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
@@ -22,12 +22,14 @@ import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGeneratorHandleResponse;
 
 import java.util.Map;
 
 public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
   private static final String SERVICE = "WEBHDFS";
   private static final String WEBHDFS_SUFFIX = "/webhdfs";
+  private static final String CONFIG_NAME_DFS_WEBHDFS_ENABLED = "dfs_webhdfs_enabled";
 
   static final String WEBHDFS_ENABLED = "dfs_webhdfs_enabled";
 
@@ -42,19 +44,21 @@ public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
   }
 
   @Override
-  public boolean handles(ApiService       service,
-                         ApiServiceConfig serviceConfig,
-                         ApiRole          role,
-                         ApiConfigList    roleConfig) {
-    return super.handles(service, serviceConfig, role, roleConfig) &&
-           Boolean.parseBoolean(getServiceConfigValue(serviceConfig, WEBHDFS_ENABLED));
+  public ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
+    final ServiceModelGeneratorHandleResponse response = super.handles(service, serviceConfig, role, roleConfig);
+    if (response.handled()) {
+      final String webHdfsEnabled = getServiceConfigValue(serviceConfig, CONFIG_NAME_DFS_WEBHDFS_ENABLED);
+      if (webHdfsEnabled == null) {
+        response.addConfigurationIssue("Missing configuration: " + CONFIG_NAME_DFS_WEBHDFS_ENABLED);
+      } else if (!Boolean.parseBoolean(webHdfsEnabled)) {
+        response.addConfigurationIssue("Invalid configuration: " + CONFIG_NAME_DFS_WEBHDFS_ENABLED + ". Expected=true; Found=" + webHdfsEnabled);
+      }
+    }
+    return response;
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException {
     ServiceModel parent = super.generateService(service, serviceConfig, role, roleConfig);
     String serviceUrl = parent.getServiceUrl() + WEBHDFS_SUFFIX;
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
@@ -28,7 +28,6 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
 
   public static final String SERVICE_TYPE = "HIVE_ON_TEZ";
-  private static final String CONFIG_NAME_HS2_TRANSPORT_MODE = "hive_server2_transport_mode";
 
   static final String HIVEONTEZ_TRANSPORT_MODE = TRANSPORT_MODE.replaceAll("\\.", "_");
   static final String HIVEONTEZ_HTTP_PORT      = HTTP_PORT.replaceAll("\\.", "_");
@@ -40,11 +39,11 @@ public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
 
   @Override
   protected void checkHiveServer2HTTPMode(ApiConfigList roleConfig, ServiceModelGeneratorHandleResponse response) {
-    final String hiveServer2TransportMode = getRoleConfigValue(roleConfig, CONFIG_NAME_HS2_TRANSPORT_MODE);
+    final String hiveServer2TransportMode = getRoleConfigValue(roleConfig, HIVEONTEZ_TRANSPORT_MODE);
     if (hiveServer2TransportMode == null) {
-      response.addConfigurationIssue("Missing configuration: " + CONFIG_NAME_HS2_TRANSPORT_MODE);
+      response.addConfigurationIssue("Missing configuration: " + HIVEONTEZ_TRANSPORT_MODE);
     } else if (!TRANSPORT_MODE_HTTP.equals(hiveServer2TransportMode)) {
-      response.addConfigurationIssue("Invalid configuration: " + CONFIG_NAME_HS2_TRANSPORT_MODE + ". Expected=" + TRANSPORT_MODE_HTTP + "; Found=" + hiveServer2TransportMode);
+      response.addConfigurationIssue("Invalid configuration: " + HIVEONTEZ_TRANSPORT_MODE + ". Expected=" + TRANSPORT_MODE_HTTP + "; Found=" + hiveServer2TransportMode);
     }
   }
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
@@ -16,16 +16,19 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.hive;
 
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGeneratorHandleResponse;
+
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
-import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 
 public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
 
   public static final String SERVICE_TYPE = "HIVE_ON_TEZ";
+  private static final String CONFIG_NAME_HS2_TRANSPORT_MODE = "hive_server2_transport_mode";
 
   static final String HIVEONTEZ_TRANSPORT_MODE = TRANSPORT_MODE.replaceAll("\\.", "_");
   static final String HIVEONTEZ_HTTP_PORT      = HTTP_PORT.replaceAll("\\.", "_");
@@ -36,8 +39,13 @@ public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
   }
 
   @Override
-  protected boolean checkHiveServer2HTTPMode(ApiConfigList roleConfig) {
-    return TRANSPORT_MODE_HTTP.equals(getRoleConfigValue(roleConfig, HIVEONTEZ_TRANSPORT_MODE));
+  protected void checkHiveServer2HTTPMode(ApiConfigList roleConfig, ServiceModelGeneratorHandleResponse response) {
+    final String hiveServer2TransportMode = getRoleConfigValue(roleConfig, CONFIG_NAME_HS2_TRANSPORT_MODE);
+    if (hiveServer2TransportMode == null) {
+      response.addConfigurationIssue("Missing configuration: " + CONFIG_NAME_HS2_TRANSPORT_MODE);
+    } else if (!TRANSPORT_MODE_HTTP.equals(hiveServer2TransportMode)) {
+      response.addConfigurationIssue("Invalid configuration: " + CONFIG_NAME_HS2_TRANSPORT_MODE + ". Expected=" + TRANSPORT_MODE_HTTP + "; Found=" + hiveServer2TransportMode);
+    }
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaUIServiceModelGenerator.java
@@ -32,7 +32,6 @@ public class ImpalaUIServiceModelGenerator extends AbstractServiceModelGenerator
   public static final String SERVICE      = "IMPALAUI";
   public static final String SERVICE_TYPE = "IMPALA";
   public static final String ROLE_TYPE    = "IMPALAD";
-  private static final String CONFIG_NAME_IMPLALAD_ENABLE_WEBSERVER = "impalad_enable_webserver";
 
   static final String ENABLE_WEBSERVER = "impalad_enable_webserver";
   static final String SSL_ENABLED      = "client_services_ssl_enabled";
@@ -62,11 +61,11 @@ public class ImpalaUIServiceModelGenerator extends AbstractServiceModelGenerator
   public ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
     final ServiceModelGeneratorHandleResponse response = super.handles(service, serviceConfig, role, roleConfig);
     if (response.handled()) {
-      final String impalaWebserverEnabled = getRoleConfigValue(roleConfig, CONFIG_NAME_IMPLALAD_ENABLE_WEBSERVER);
+      final String impalaWebserverEnabled = getRoleConfigValue(roleConfig, ENABLE_WEBSERVER);
       if (impalaWebserverEnabled == null) {
-        response.addConfigurationIssue("Missing configuration: " + CONFIG_NAME_IMPLALAD_ENABLE_WEBSERVER);
+        response.addConfigurationIssue("Missing configuration: " + ENABLE_WEBSERVER);
       } else if (!Boolean.parseBoolean(impalaWebserverEnabled)) {
-        response.addConfigurationIssue("Invalid configuration: " + CONFIG_NAME_IMPLALAD_ENABLE_WEBSERVER + ". Expected=true; Found=" + impalaWebserverEnabled);
+        response.addConfigurationIssue("Invalid configuration: " + ENABLE_WEBSERVER + ". Expected=true; Found=" + impalaWebserverEnabled);
       }
     }
     return response;

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractServiceModelGeneratorTest extends AbstractCMDiscov
     return generator.handles(createApiServiceMock(serviceType),
                              createApiServiceConfigMock(serviceConfig),
                              createApiRoleMock(roleType),
-                             createApiConfigListMock(roleProps));
+                             createApiConfigListMock(roleProps)).handled();
   }
 
 


### PR DESCRIPTION
# What changes were proposed in this pull request?

Adding a `WARN` level log in case there is a configuration issue with the discovered service role.

## How was this patch tested?

JUnit tests:
```
mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:14 min (Wall Clock)
[INFO] Finished at: 2020-01-30T09:38:40+01:00
[INFO] Final Memory: 421M/2282M
[INFO] ------------------------------------------------------------------------
```

Additionally, I executed the following manual test steps:

1. built, deployed and started Knox with may changes
2. produced a shared-provider and descriptor with proper CM discovery settings pointing to my test cluster
3. made sure that
`HIVE/HIVESERVER2` did not have a config called `hive.server2.transport.mode`
`impalad_enable_webserver` was set to `true` for `IMPALA/IMPALAD` (this is the expected config)
`dfs_webhdfs_enabled` was set to `true` for `HDFS/NAMENODE`  (this is the expected config)
`hive_server2_transport_mode` was set to `binary` for `HIVE_ON_TEZ/HIVESERVER2`
8. touched the descriptor file to trigger a topology re-generation

Relevant logs:
```
2020-01-30 09:15:36,180 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(180)) - Discovered service: HDFS-1 (HDFS)
2020-01-30 09:15:37,410 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-1-BALANCER-865a1c62c5bd7804fab20cae3eddca4f (BALANCER)
2020-01-30 09:15:37,716 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-1-DATANODE-d29bba6543c47ca01e7d90c1b76a60b3 (DATANODE)
2020-01-30 09:15:38,034 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-1-NAMENODE-865a1c62c5bd7804fab20cae3eddca4f (NAMENODE)
2020-01-30 09:15:38,522 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-NFSGATEWAY-1 (NFSGATEWAY)
2020-01-30 09:15:38,852 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-GATEWAY-1 (GATEWAY)
2020-01-30 09:15:39,150 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-1-SECONDARYNAMENODE-865a1c62c5bd7804fab20cae3eddca4f (SECONDARYNAMENODE)
2020-01-30 09:15:39,466 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HDFS-1-DATANODE-4f16be5c7d9e2ec9d96015b92d4115f4 (DATANODE)
...
2020-01-30 09:15:44,407 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(180)) - Discovered service: HIVE-1 (HIVE)
2020-01-30 09:15:45,397 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HIVE-1-GATEWAY-d29bba6543c47ca01e7d90c1b76a60b3 (GATEWAY)
2020-01-30 09:15:45,705 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HIVE-1-GATEWAY-865a1c62c5bd7804fab20cae3eddca4f (GATEWAY)
2020-01-30 09:15:46,012 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HIVE-1-HIVEMETASTORE-865a1c62c5bd7804fab20cae3eddca4f (HIVEMETASTORE)
2020-01-30 09:15:46,330 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HIVE-1-HIVESERVER2-d29bba6543c47ca01e7d90c1b76a60b3 (HIVESERVER2)
2020-01-30 09:15:46,865 WARN  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(199)) - Service role HIVE-1-HIVESERVER2-d29bba6543c47ca01e7d90c1b76a60b3 has configuration issues: Missing configuration: hive.server2.transport.mode
...
2020-01-30 09:15:58,150 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(180)) - Discovered service: IMPALA-1 (IMPALA)
2020-01-30 09:15:58,938 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: IMPALA-1-IMPALAD-4f16be5c7d9e2ec9d96015b92d4115f4 (IMPALAD)
2020-01-30 09:16:36,950 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: IMPALA-1-CATALOGSERVER-865a1c62c5bd7804fab20cae3eddca4f (CATALOGSERVER)
2020-01-30 09:16:46,045 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: IMPALA-1-STATESTORE-865a1c62c5bd7804fab20cae3eddca4f (STATESTORE)
2020-01-30 09:16:53,094 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: IMPALA-1-IMPALAD-d29bba6543c47ca01e7d90c1b76a60b3 (IMPALAD)
...
2020-01-30 09:17:18,173 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(180)) - Discovered service: HIVE_ON_TEZ-1 (HIVE_ON_TEZ)
2020-01-30 09:17:18,927 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(187)) - Discovered service role: HIVE_ON_TEZ-1-HIVESERVER2-865a1c62c5bd7804fab20cae3eddca4f (HIVESERVER2)
2020-01-30 09:17:19,890 WARN  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(199)) - Service role HIVE_ON_TEZ-1-HIVESERVER2-865a1c62c5bd7804fab20cae3eddca4f has configuration issues: Invalid configuration: hive_server2_transport_mode. Expected=http; Found=binary
```