### PR TITLE
KNOX-2207 - TokenStateService revocation should remove persisted token state

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -105,14 +105,8 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService {
   @Override
   public void revokeToken(final String token) {
     /* no reason to keep revoked tokens around */
-    removeRevokedExpiredToken(token);
+    removeToken(token);
     log.revokedToken(getTokenDisplayText(token));
-  }
-
-  @Override
-  protected boolean isRevoked(final String token) {
-    /* since we no longer maintain revoked tokens, revoked tokens are unknown tokens */
-    return isUnknown(token);
   }
 
   @Override
@@ -127,11 +121,8 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService {
   }
 
   @Override
-  protected void removeRevokedExpiredToken(final String token) {
-    if (isUnknown(token)) {
-      log.unknownToken(getTokenDisplayText(token));
-      throw new IllegalArgumentException("Unknown or revoked token.");
-    }
+  protected void removeToken(final String token) {
+    validateToken(token);
 
     try {
       aliasService.removeAliasForCluster(AliasService.NO_CLUSTER_NAME, token);
@@ -146,7 +137,7 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService {
   protected void updateExpiration(final String token, long expiration) {
     if (isUnknown(token)) {
       log.unknownToken(getTokenDisplayText(token));
-      throw new IllegalArgumentException("Unknown or revoked token.");
+      throw new IllegalArgumentException("Unknown token.");
     }
 
     try {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -167,15 +167,16 @@ public class DefaultTokenStateService implements TokenStateService {
 
   @Override
   public boolean isExpired(final String token) {
-    boolean isUnknownToken;
-
-    isUnknownToken = isUnknown(token); // Check if the token exist
-    if (!isUnknownToken) {
-      // If it not unknown, check its expiration
-      isUnknownToken = (getTokenExpiration(token) <= System.currentTimeMillis());
+    try {
+      validateToken(token);
+    } catch (final IllegalArgumentException e) {
+      if (e.toString().contains("Token data cannot be null.") || e.toString().contains("Unknown token")) {
+        return true;
+      } else {
+        throw e;
+      }
     }
-
-    return isUnknownToken;
+    return (getTokenExpiration(token) <= System.currentTimeMillis());
   }
 
   protected void setMaxLifetime(final String token, long issueTime, long maxLifetimeDuration) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -167,16 +167,13 @@ public class DefaultTokenStateService implements TokenStateService {
 
   @Override
   public boolean isExpired(final String token) {
-    try {
-      validateToken(token);
-    } catch (final IllegalArgumentException e) {
-      if (e.toString().contains("Token data cannot be null.") || e.toString().contains("Unknown token")) {
-        return true;
-      } else {
-        throw e;
-      }
+    boolean isExpired;
+    isExpired = isUnknown(token); // Check if the token exist
+    if (!isExpired) {
+      // If it not unknown, check its expiration
+      isExpired = (getTokenExpiration(token) <= System.currentTimeMillis());
     }
-    return (getTokenExpiration(token) <= System.currentTimeMillis());
+    return isExpired;
   }
 
   protected void setMaxLifetime(final String token, long issueTime, long maxLifetimeDuration) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -33,7 +33,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.DEBUG, text = "Revoked token {0}")
   void revokedToken(String tokenDisplayText);
 
-  @Message(level = MessageLevel.DEBUG, text = "Unknown token {0}")
+  @Message(level = MessageLevel.DEBUG, text = "Unknown or revoked token {0}")
   void unknownToken(String tokenDisplayText);
 
   @Message(level = MessageLevel.ERROR, text = "The renewal limit for the token ({0}) has been exceeded.")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -33,7 +33,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.DEBUG, text = "Revoked token {0}")
   void revokedToken(String tokenDisplayText);
 
-  @Message(level = MessageLevel.DEBUG, text = "Unknown or revoked token {0}")
+  @Message(level = MessageLevel.DEBUG, text = "Unknown token {0}")
   void unknownToken(String tokenDisplayText);
 
   @Message(level = MessageLevel.ERROR, text = "The renewal limit for the token ({0}) has been exceeded.")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not maintain state for revoked tokens. 

## How was this patch tested?

This patch was manually tested.


Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
