### PR TITLE
KNOX-2223 - HS2 cookie not stored in HadoopAuthCookieStore

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/HadoopAuthCookieStore.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/HadoopAuthCookieStore.java
@@ -41,6 +41,7 @@ public class HadoopAuthCookieStore extends BasicCookieStore {
   private static final String IMPALA_AUTH_COOKIE_NAME = "impala.auth";
 
   private static String knoxPrincipal;
+  private static String shortKnoxPrincipal;
 
   HadoopAuthCookieStore(GatewayConfig config) {
     // Read knoxPrincipal from krb5 login jaas config file
@@ -56,6 +57,8 @@ public class HadoopAuthCookieStore extends BasicCookieStore {
               configuredKnoxPrincipal.length() - 1);
         }
         knoxPrincipal = configuredKnoxPrincipal;
+        // Break out the short principal name from the principal
+        shortKnoxPrincipal = knoxPrincipal.split("/", 2)[0];
       } catch (IOException e) {
         LOG.errorReadingKerberosLoginConfig(krb5Config, e);
       }
@@ -87,7 +90,8 @@ public class HadoopAuthCookieStore extends BasicCookieStore {
     // somewhere in the cookie value.
     if (cookie != null) {
       String value = cookie.getValue();
-      if (value != null && value.contains(knoxPrincipal)) {
+      if (value != null &&
+              (value.contains('=' + knoxPrincipal) || value.contains('=' + shortKnoxPrincipal))) {
         result = true;
       }
     }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/HadoopAuthCookieStoreTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/HadoopAuthCookieStoreTest.java
@@ -92,7 +92,7 @@ public class HadoopAuthCookieStoreTest {
 
   @Test
   public void testKnoxCookieInclusionDefaultUser() {
-    doTestKnoxCookieExclusion("u=knox&p=anotherUser/myhost.example.com@EXAMPLE.COM&t=kerberos&e=1517900515610&s=HpSXUOhoXR/2wXrsgPz5lSbNuf8=");
+    doTestKnoxCookieInclusion("u=knox&p=anotherUser/myhost.example.com@EXAMPLE.COM&t=kerberos&e=1517900515610&s=HpSXUOhoXR/2wXrsgPz5lSbNuf8=");
   }
 
   @Test
@@ -126,7 +126,7 @@ public class HadoopAuthCookieStoreTest {
 
   @Test
   public void testKnoxCookieInclusionDefaultUserAndMissingPrincipal() {
-    doTestKnoxCookieExclusion("u=knox&t=kerberos&e=1517900515610&s=HpSXUOhoXR/2wXrsgPz5lSbNuf8=");
+    doTestKnoxCookieInclusion("u=knox&t=kerberos&e=1517900515610&s=HpSXUOhoXR/2wXrsgPz5lSbNuf8=");
   }
 
   private void doTestKnoxCookieInclusion(final String cookieValue) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This ensures that Knox principal both short
and long will be compared against the cookie
returned. This will match the HS2 cookie.

## How was this patch tested?

* `mvn -T.75C verify -Ppackage,release -Dshellcheck`
