### PR TITLE
KNOX-2222 - Fix HBase UI Proxying for HBCK Report page

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/rewrite.xml
@@ -138,6 +138,9 @@
   <rule dir="OUT" name="HBASEUI/hbase/outbound/master/children" pattern="/processMaster.jsp?{**}">
     <rewrite template="{$frontend[url]}/hbase/webui/master/processMaster.jsp?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
   </rule>
+  <rule dir="OUT" name="HBASEUI/hbase/outbound/master/children" pattern="/hbck.jsp?{**}">
+    <rewrite template="{$frontend[url]}/hbase/webui/master/hbck.jsp?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
+  </rule>
 
   <!-- RegionServer UI proxying -->
   <rule dir="IN" name="HBASEUI/hbase/inbound/regionserver/root/qualified" pattern="*://*:*/**/hbase/webui/regionserver?{host}?port}">


### PR DESCRIPTION
Tested against HBase 2.2.4-SNAPSHOT and HBCK Report page was accessible

## What changes were proposed in this pull request?

This change fixes HBase UI such that the HBCK Report page is accessible via Knox.

## How was this patch tested?
<img width="1084" alt="Screen Shot 2020-02-04 at 6 23 52 PM" src="https://user-images.githubusercontent.com/17375439/73805458-8ec44b80-477b-11ea-9330-3273eb3897c3.png">

Deployed KNOX-1.4.0-SNAPSHOT locally and tested HBase-2.2.4-SNAPSHOT along with it. I was able to access the HBCK Report page via UI. Have uploaded a sample image of the UI for reference.
