### PR TITLE
KNOX-2189 - KnoxShellTable.select() must handle whitespace

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -356,6 +356,7 @@ public class KnoxShellTable {
   public KnoxShellTable select(String cols) {
     KnoxShellTable table = new KnoxShellTable();
     List<List<Comparable<? extends Object>>> columns = new ArrayList<>();
+    cols = cols.trim();
     String[] colnames = cols.split(",\\s*");
     for (String colName : colnames) {
       table.header(colName);

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -357,7 +357,7 @@ public class KnoxShellTable {
     KnoxShellTable table = new KnoxShellTable();
     List<List<Comparable<? extends Object>>> columns = new ArrayList<>();
     cols = cols.trim();
-    String[] colnames = cols.split(",\\s*");
+    String[] colnames = cols.split("\\s*,\\s*");
     for (String colName : colnames) {
       table.header(colName);
       columns.add(values(headers.indexOf(colName)));

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -356,7 +356,7 @@ public class KnoxShellTable {
   public KnoxShellTable select(String cols) {
     KnoxShellTable table = new KnoxShellTable();
     List<List<Comparable<? extends Object>>> columns = new ArrayList<>();
-    String[] colnames = cols.split(",");
+    String[] colnames = cols.split(",\\s*");
     for (String colName : colnames) {
       table.header(colName);
       columns.add(values(headers.indexOf(colName)));

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -121,11 +121,6 @@ public class KnoxShellTableTest {
         + "|    123     |    456     |  344444444   |\n"
         + "|    789     |    012     |  844444444   |\n" + "+------------+------------+--------------+\n";
 
-    String expectedResult2 = "+------------+--------------+\n"
-        + "|  Column A  |   Column C   |\n" + "+------------+--------------+\n"
-        + "|    123     |  344444444   |\n"
-        + "|    789     |  844444444   |\n" + "+------------+--------------+\n";
-
     KnoxShellTable table = new KnoxShellTable();
 
     table.header("Column A").header("Column B").header("Column C");
@@ -135,8 +130,8 @@ public class KnoxShellTableTest {
 
     assertEquals(expectedResult, table.toString());
 
-    table = table.select("      Column A,       Column C      ");
-    assertEquals(expectedResult2, table.toString());
+    table = table.select(" Column A   ,   Column B ,  Column C  ");
+    assertEquals(expectedResult, table.toString());
   }
 
   @Test

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -135,7 +135,7 @@ public class KnoxShellTableTest {
 
     assertEquals(expectedResult, table.toString());
 
-    table = table.select("Column A,       Column C");
+    table = table.select("      Column A,       Column C      ");
     assertEquals(expectedResult2, table.toString());
   }
 

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -135,7 +135,7 @@ public class KnoxShellTableTest {
 
     assertEquals(expectedResult, table.toString());
 
-    table = table.select("Column A,Column C");
+    table = table.select("Column A,       Column C");
     assertEquals(expectedResult2, table.toString());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ability to use whitespace as a delimiter in the select method

## How was this patch tested?

Manual and unit tests
