### PR TITLE
KNOX-2210 - Gateway-level configuration for server-managed Knox token…

### DIFF
--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/CommonJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/CommonJWTFilterTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.provider.federation;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CommonJWTFilterTest {
+
+  private AbstractJWTFilter handler;
+
+  @Before
+  public void setUp() {
+    handler = new TestHandler();
+  }
+
+  @After
+  public void tearDown() {
+    handler = null;
+  }
+
+  @Test
+  public void testServerManagedTokenStateEnabledByProviderOverride() throws Exception {
+    // Provider param should override gateway config
+    assertTrue(doTestServerManagedTokenState(false, "true"));
+  }
+
+  @Test
+  public void testServerManagedTokenStateDisabledByProviderOverride() throws Exception {
+    // Provider param should override gateway config
+    assertFalse(doTestServerManagedTokenState(true, "false"));
+  }
+
+  @Test
+  public void testServerManagedTokenStateDisabledWithoutProviderOverride() throws Exception {
+    // Missing provider param override should apply gateway config
+    assertFalse(doTestServerManagedTokenState(false, null));
+  }
+
+  @Test
+  public void testServerManagedTokenStateEnabledWithoutProviderOverride() throws Exception {
+    // Missing provider param override should apply gateway config
+    assertTrue(doTestServerManagedTokenState(true, null));
+  }
+
+  @Test
+  public void testServerManagedTokenStateDisabledWitEmptyProviderOverride() throws Exception {
+    // Empty provider param override should apply gateway config
+    assertFalse(doTestServerManagedTokenState(false, ""));
+  }
+
+  @Test
+  public void testServerManagedTokenStateEnabledWithEmptyProviderOverride() throws Exception {
+    // Empty provider param override should apply gateway config
+    assertTrue(doTestServerManagedTokenState(true, ""));
+  }
+
+  private boolean doTestServerManagedTokenState(final Boolean isEnabledAtGateway, final String providerParamValue)
+      throws Exception {
+
+    GatewayConfig gwConf = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gwConf.isServerManagedTokenStateEnabled()).andReturn(isEnabledAtGateway).anyTimes();
+    EasyMock.replay(gwConf);
+
+    ServletContext sc = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(sc.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gwConf).anyTimes();
+    EasyMock.replay(sc);
+
+    FilterConfig fc = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(fc.getInitParameter(TokenStateService.CONFIG_SERVER_MANAGED)).andReturn(providerParamValue).anyTimes();
+    EasyMock.expect(fc.getServletContext()).andReturn(sc).anyTimes();
+    EasyMock.replay(fc);
+
+    Method m = AbstractJWTFilter.class.getDeclaredMethod("isServerManagedTokenStateEnabled", FilterConfig.class);
+    m.setAccessible(true);
+    return (Boolean) m.invoke(handler, fc);
+  }
+
+
+  static final class TestHandler extends AbstractJWTFilter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+    }
+
+    @Override
+    protected void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status, String error) throws IOException {
+
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -240,6 +240,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   /* property that specifies list of services for which we need to append service name to the X-Forward-Context header */
   public static final String X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".xforwarded.header.context.append.servicename";
 
+  private static final String TOKEN_STATE_SERVER_MANAGED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.exp.server-managed";
+
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
   private static final long DEFAULT_CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = 30000L;
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
@@ -1109,4 +1111,10 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval() {
     return getLong(CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL, DEFAULT_CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL);
   }
+
+  @Override
+  public boolean isServerManagedTokenStateEnabled() {
+    return getBoolean(TOKEN_STATE_SERVER_MANAGED, false);
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -652,4 +652,10 @@ public interface GatewayConfig {
    * @return the monitoring interval (in milliseconds) of Cloudera Manager advanced service discovery configuration
    */
   long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval();
+
+  /**
+   * @return true, if state for tokens issued by the Knox Token service should be managed by Knox.
+   */
+  boolean isServerManagedTokenStateEnabled();
+
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -774,4 +774,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval() {
     return 0;
   }
+
+  @Override
+  public boolean isServerManagedTokenStateEnabled() {
+    return false;
+  }
 }


### PR DESCRIPTION
… state

## What changes were proposed in this pull request?

Added gateway-level default configuration for the server-managed token state, which can be overridden by service and provider level params.

## How was this patch tested?

Added tests for the AbstractJWTFilter functionality and augmented TokenServiceResourceTest.