### PR TITLE
KNOX-2229 - Knox shouldn't exclude Kerby since it is used by Hadoop

### DIFF
--- a/gateway-release/src/assembly.xml
+++ b/gateway-release/src/assembly.xml
@@ -101,7 +101,6 @@
             <excludes>
                 <exclude>org.apache.knox:gateway-*</exclude>
                 <exclude>org.apache.knox:hadoop-examples</exclude>
-                <exclude>org.apache.kerby:*</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Don't exclude Kerby jars since they are used transitive by Knox through Hadoop dependencies like hadoop-auth.

## How was this patch tested?

* `mvn -T.75C verify -Ppackage,release -Dshellcheck`
* Checked that in the release the `deps` folder has the `kerby` jars.
