### PR TITLE
KNOX-2161 - CM generated descriptors are read-only on Admin UI

### DIFF
--- a/gateway-admin-ui/admin-ui/app/resource-detail/descriptor.ts
+++ b/gateway-admin-ui/admin-ui/app/resource-detail/descriptor.ts
@@ -23,6 +23,7 @@ export class Descriptor {
     discoveryPassAlias: string;
     discoveryCluster: string;
     providerConfig: string;
+    readOnly: boolean;
     services: Service[];
 
     private dirty = false;

--- a/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.html
+++ b/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.html
@@ -1,8 +1,9 @@
 <div *ngIf="resourceType && resourceType !== 'Topologies' && resourceType !== 'Service Definitions'" class="panel panel-default">
     <div class="panel-heading">
         <h4 class="panel-title">
-            {{ getTitleSubject() }} Detail <span *ngIf="hasSelectedResource()"
-                                                 class="pull-right">{{resourceService.getResourceDisplayName(resource)}}</span>
+            {{ getTitleSubject() }} Detail
+            <span *ngIf="showEditOptions() == false" style="padding-left: 15%;" class="text-danger text-center"> Read Only (generated file) </span>
+            <span *ngIf="hasSelectedResource()" class="pull-right">{{resourceService.getResourceDisplayName(resource)}}</span>
         </h4>
     </div>
 
@@ -479,7 +480,8 @@
                     title="Remove Descriptor"
                     class="btn btn-default btn-sm pull-left"
                     (click)="deleteConfirmModal.open('md')"
-                    data-toggle="tooltip">
+                    data-toggle="tooltip"
+                    *ngIf="showEditOptions()">
                 <span class="glyphicon glyphicon-trash"></span>
             </button>
             <span class="pull-right">
@@ -488,7 +490,8 @@
                 class="btn btn-default btn-sm"
                 [disabled]="!descriptor.isDirty()"
                 (click)="discardConfirmModal.open('md')"
-                data-toggle="tooltip">
+                data-toggle="tooltip"
+                *ngIf="showEditOptions()">
           <span class="glyphicon glyphicon-refresh"></span>
         </button>
         <span>&nbsp;</span>
@@ -497,7 +500,8 @@
                 class="btn btn-default btn-sm"
                 [disabled]="!descriptor.isDirty()"
                 (click)="persistChanges()"
-                data-toggle="tooltip">
+                data-toggle="tooltip"
+                *ngIf="showEditOptions()">
           <span class="glyphicon glyphicon-floppy-disk"></span>
         </button>
       </span>

--- a/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.ts
+++ b/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.ts
@@ -175,6 +175,7 @@ export class ResourceDetailComponent implements OnInit {
                     tempDesc.discoveryPassAlias = contentObj['discovery-pwd-alias'];
                     tempDesc.discoveryCluster = contentObj['cluster'];
                     tempDesc.providerConfig = contentObj['provider-config-ref'];
+                    tempDesc.readOnly = contentObj['read-only'];
                     tempDesc.services = contentObj['services'];
                 }
                 this.descriptor = tempDesc;
@@ -556,5 +557,12 @@ export class ResourceDetailComponent implements OnInit {
                 return 'Resource';
             }
         }
+    }
+
+    showEditOptions(): boolean {
+        if (this.resourceType === 'Descriptors' && this.descriptor.readOnly) {
+            return !Boolean(this.descriptor.readOnly);
+        }
+        return true;
     }
 }

--- a/gateway-admin-ui/admin-ui/app/resource/resource.service.ts
+++ b/gateway-admin-ui/admin-ui/app/resource/resource.service.ts
@@ -247,6 +247,9 @@ export class ResourceService {
         if (desc.discoveryCluster) {
             tmp['cluster'] = desc.discoveryCluster;
         }
+        if (desc.readOnly) {
+            tmp['read-only'] = desc.readOnly;
+        }
         tmp['provider-config-ref'] = desc.providerConfig;
         tmp['services'] = desc.services;
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParser.java
@@ -106,6 +106,7 @@ public class ClouderaManagerDescriptorParser implements AdvancedServiceDiscovery
   private SimpleDescriptor parseXmlDescriptor(String name, String xmlValue) {
     try {
       final SimpleDescriptorImpl descriptor = new SimpleDescriptorImpl();
+      descriptor.setReadOnly(true);
       descriptor.setName(name);
       final String[] configurationPairs = xmlValue.split(";");
       for (String configurationPair : configurationPairs) {

--- a/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
+++ b/gateway-cm-integration/src/test/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserTest.java
@@ -150,6 +150,7 @@ public class ClouderaManagerDescriptorParserTest {
   }
 
   private void validateTopology1(SimpleDescriptor descriptor) {
+    assertTrue(descriptor.isReadOnly());
     assertEquals("topology1", descriptor.getName());
     assertEquals("ClouderaManager", descriptor.getDiscoveryType());
     assertEquals("http://host:123", descriptor.getDiscoveryAddress());
@@ -168,6 +169,7 @@ public class ClouderaManagerDescriptorParserTest {
   }
 
   private void validateTopology2(SimpleDescriptor descriptor, boolean nifiExpected) {
+    assertTrue(descriptor.isReadOnly());
     assertEquals("topology2", descriptor.getName());
     assertEquals("Ambari", descriptor.getDiscoveryType());
     assertEquals("http://host:456", descriptor.getDiscoveryAddress());

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptor.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptor.java
@@ -38,6 +38,8 @@ public interface SimpleDescriptor {
 
     String getProviderConfig();
 
+    boolean isReadOnly();
+
     List<Service> getServices();
 
     Service getService(String serviceName);

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorImpl.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorImpl.java
@@ -42,6 +42,9 @@ public class SimpleDescriptorImpl implements SimpleDescriptor {
     @JsonProperty("provider-config-ref")
     private String providerConfig;
 
+    @JsonProperty("read-only")
+    private boolean readOnly;
+
     @JsonProperty("cluster")
     private String cluster;
 
@@ -114,6 +117,15 @@ public class SimpleDescriptorImpl implements SimpleDescriptor {
     @Override
     public String getProviderConfig() {
         return providerConfig;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+      return readOnly;
+    }
+
+    public void setReadOnly(boolean readOnly) {
+      this.readOnly = readOnly;
     }
 
     public void addService(Service service) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

#236  introduces a new descriptor type (using on Hadoop XML structure). Descriptors generated out of those XML configurations are read-only on Admin UI from now on.

## How was this patch tested?

Updated and executed JUnit tests.

Additionally, the following manual test steps were executed:

1. built and deployed Knox with my changes
2. logged into Admin UI
3. created a descriptor called `testDescriptor` on Admin UI
4. placed the following CM-type descriptor in Knox's descriptor directory:

```
<configuration>
  <property>
    <name>topology1</name>
    <value>
        providerConfigRef=default-providers;
        app:knoxauth:param1.name=param1.value;
        HIVE:url=http://localhost:456;
        HIVE:version=1.0;
        HIVE:httpclient.connectionTimeout=5m;
        HIVE:httpclient.socketTimeout=100m
    </value>
  </property>
  <property>
    <name>topology2</name>
    <value>
        providerConfigRef=default-providers;
        HDFS:url=http://localhost:456;
        HDFS:httpclient.connectionTimeout=5m;
        HDFS:httpclient.socketTimeout=100m
    </value>
  </property>
</configuration>
```
5. confirmed that:
`testDescriptor` is not read-only; it can be updated/removed
`topology1` and `topology2` descriptors are read-only: they cannot be removed/updted (no icons displayed)
<img width="1666" alt="Screen Shot 2020-02-18 at 2 25 29 PM" src="https://user-images.githubusercontent.com/34065904/74740505-49178080-525b-11ea-9bd8-becb55624d37.png">
<img width="1668" alt="Screen Shot 2020-02-18 at 2 25 45 PM" src="https://user-images.githubusercontent.com/34065904/74740511-4c127100-525b-11ea-93aa-505761ec16c8.png">
