### PR TITLE
KNOX-2237 - CM service discovery should default the http path of Hive…

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -41,6 +41,8 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
   static final String HTTP_PORT      = "hive.server2.thrift.http.port";
   static final String HTTP_PATH      = "hive.server2.thrift.http.path";
 
+  static final String DEFAULT_HTTP_PATH = "cliservice";
+
   @Override
   public String getService() {
     return SERVICE;
@@ -81,6 +83,9 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
 
     String port     = getHttpPort(roleConfig);
     String httpPath = getHttpPath(roleConfig);
+    if (httpPath == null) {
+      httpPath = DEFAULT_HTTP_PATH;
+    }
 
     ServiceModel model =
         createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/%s", scheme, hostname, port, httpPath));

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -145,22 +146,31 @@ public class ClouderaManagerServiceDiscoveryTest {
   }
 
   @Test
+  public void testHiveServiceDiscoveryCustomThriftPath() {
+    doTestHiveServiceDiscovery("testPath", false);
+  }
+
+  @Test
   public void testHiveServiceDiscoverySSL() {
     doTestHiveServiceDiscovery(true);
   }
 
   private void doTestHiveServiceDiscovery(final boolean enableSSL) {
+    doTestHiveServiceDiscovery(null, enableSSL);
+  }
+
+  private void doTestHiveServiceDiscovery(final String thriftPath, final boolean enableSSL) {
     final String hostName       = "test-host-1";
     final String thriftPort     = "10001";
-    final String thriftPath     = "cliService";
     final String expectedScheme = (enableSSL ? "https" : "http");
+    final String expectedThriftPath = thriftPath != null ? thriftPath : "cliservice";
 
     ServiceDiscovery.Cluster cluster =
         doTestHiveServiceDiscovery(hostName, thriftPort, thriftPath, enableSSL);
     List<String> hiveURLs = cluster.getServiceURLs("HIVE");
     assertNotNull(hiveURLs);
     assertEquals(1, hiveURLs.size());
-    assertEquals((expectedScheme + "://" + hostName + ":" +thriftPort + "/" + thriftPath), hiveURLs.get(0));
+    assertEquals((expectedScheme + "://" + hostName + ":" + thriftPort + "/" + expectedThriftPath), hiveURLs.get(0));
   }
 
   @Test
@@ -169,23 +179,33 @@ public class ClouderaManagerServiceDiscoveryTest {
   }
 
   @Test
+  public void testHiveOnTezDiscoveryCustomThriftPath() {
+    doTestHiveOnTezServiceDiscovery("customPath", false);
+  }
+
+  @Test
   public void testHiveOnTezDiscoverySSL() {
     doTestHiveOnTezServiceDiscovery(true);
   }
 
   private void doTestHiveOnTezServiceDiscovery(final boolean enableSSL) {
+    doTestHiveOnTezServiceDiscovery(null, enableSSL);
+  }
+
+  private void doTestHiveOnTezServiceDiscovery(final String thriftPath, final boolean enableSSL) {
     final String hostName       = "test-host-1";
     final String thriftPort     = "10001";
-    final String thriftPath     = "cliService";
     final String expectedScheme = (enableSSL ? "https" : "http");
+    final String expectedThriftPath = thriftPath != null ? thriftPath : "cliservice";
 
     ServiceDiscovery.Cluster cluster =
         doTestHiveOnTezServiceDiscovery(hostName, thriftPort, thriftPath, enableSSL);
     List<String> hiveURLs = cluster.getServiceURLs("HIVE");
     assertNotNull(hiveURLs);
     assertEquals(1, hiveURLs.size());
-    assertEquals((expectedScheme + "://" + hostName + ":" +thriftPort + "/" + thriftPath), hiveURLs.get(0));
+    assertEquals((expectedScheme + "://" + hostName + ":" + thriftPort + "/" + expectedThriftPath), hiveURLs.get(0));
   }
+
 
   @Test
   public void testWebHDFSServiceDiscovery() {
@@ -883,10 +903,16 @@ public class ClouderaManagerServiceDiscoveryTest {
                                                               final String  thriftPort,
                                                               final String  thriftPath,
                                                               final boolean enableSSL) {
+    final String safetyValveThriftPathFormat =
+        "<property><name>hive.server2.thrift.http.path</name><value>%s</value></property>";
+
+    final String safetyValveThriftPathConfig =
+        thriftPath != null ? String.format(Locale.ROOT, safetyValveThriftPathFormat, thriftPath) : "";
+
     final String hs2SafetyValveValue =
           "<property><name>hive.server2.transport.mode</name><value>http</value></property>\n" +
           "<property><name>hive.server2.thrift.http.port</name><value>" + thriftPort + "</value></property>\n" +
-          "<property><name>hive.server2.thrift.http.path</name><value>" + thriftPath + "</value></property>";
+          safetyValveThriftPathConfig;
 
     // Configure the role
     Map<String, String> roleProperties = new HashMap<>();
@@ -907,8 +933,11 @@ public class ClouderaManagerServiceDiscoveryTest {
                                                                    final String  thriftPort,
                                                                    final String  thriftPath,
                                                                    final boolean enableSSL) {
+
+    final String safetyValveFormat = "<property><name>hive.server2.thrift.http.path</name><value>%s</value></property>";
+
     final String hs2SafetyValveValue =
-        "<property><name>hive.server2.thrift.http.path</name><value>" + thriftPath + "</value></property>";
+        thriftPath != null ? String.format(Locale.ROOT, safetyValveFormat, thriftPath) : null;
 
     // Configure the role
     Map<String, String> roleProperties = new HashMap<>();


### PR DESCRIPTION
… URLs when the associated property is not set

## What changes were proposed in this pull request?

When the hive configuration property hive.server2.thrift.http.path is not explicitly set, then service discovery will default to cliservice for the path element of the Hive URLs.

## How was this patch tested?

Added/modified tests in ClouderaManagerServiceDiscoveryTest