### PR TITLE
KNOX-2238 CM discovery - Add TLS support to Phoenix auto discovery

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
@@ -31,7 +31,8 @@ public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator 
   public static final String SERVICE_TYPE = "PHOENIX";
   public static final String ROLE_TYPE    = "PHOENIX_QUERY_SERVER";
 
-  static final String QUERY_SERVER_PORT = "phoenix_query_server_port";
+  static final String SSL_ENABLED         = "ssl_enabled";
+  static final String QUERY_SERVER_PORT   = "phoenix_query_server_port";
 
   @Override
   public String getService() {
@@ -58,14 +59,24 @@ public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator 
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
                                       ApiConfigList    roleConfig) {
+
     String hostname = role.getHostRef().getHostname();
-    // Phoenix Query Server does not support https
+    String sslEnabledRaw = getRoleConfigValue(roleConfig, SSL_ENABLED);
     String scheme = "http";
+
+    if (sslEnabledRaw != null) {
+      if (Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED))) {
+        scheme = "https";
+      }
+    }
+
     String port = getRoleConfigValue(roleConfig, QUERY_SERVER_PORT);
 
     ServiceModel model = createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s", scheme, hostname, port));
     model.addRoleProperty(getRoleType(), QUERY_SERVER_PORT, port);
-
+    if (sslEnabledRaw != null) {
+        model.addRoleProperty(getRoleType(), SSL_ENABLED, sslEnabledRaw);
+    }
     return model;
   }
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
@@ -64,10 +64,8 @@ public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator 
     String sslEnabledRaw = getRoleConfigValue(roleConfig, SSL_ENABLED);
     String scheme = "http";
 
-    if (sslEnabledRaw != null) {
-      if (Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED))) {
-        scheme = "https";
-      }
+    if (Boolean.parseBoolean(sslEnabledRaw)) {
+      scheme = "https";
     }
 
     String port = getRoleConfigValue(roleConfig, QUERY_SERVER_PORT);

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -367,6 +367,18 @@ public class ClouderaManagerServiceDiscoveryTest {
   }
 
   @Test
+  public void testPhoenixDiscoverySSL() {
+    final String hostName    = "phoenix-host";
+    final String port        = "8765";
+    ServiceDiscovery.Cluster cluster = doTestPhoenixDiscovery(hostName, port, true);
+    assertNotNull(cluster);
+    List<String> phoenixURLs = cluster.getServiceURLs("AVATICA");
+    assertNotNull(phoenixURLs);
+    assertEquals(1, phoenixURLs.size());
+    assertEquals("https://" + hostName + ":" + port, phoenixURLs.get(0));
+  }
+
+  @Test
   public void testWebHCatDiscovery() {
     final String hostName = "webhcat-host";
     final String port     = "22222";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add TLS support for Phoenix Query Server for the CM service discovery module

The TLS support was omitted from the original discovery module, as PQS didn't have TLS support yet. 
Now I have re-added the TLS support. The code is a little different from most similar modules, because the ssl_enabled property is not present in older CM releases, and we have to handle that as well.

## How was this patch tested?

* Wrote and run new unit test
* Tested against live Cloudera Manager instance which had the the TLS for PQS support
* Tested against live older Cloudera Manager instance which did not have the TLS for PQS support

In both cases I was able to connect to the auto discovered PQS service.