### PR TITLE
KNOX-2230 - Token State Service should throw UnknownTokenException in…

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -50,6 +50,7 @@ import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.util.JsonUtils;
 
@@ -287,7 +288,7 @@ public class TokenResource {
       if (allowedRenewers.contains(renewer)) {
         try {
           tokenStateService.revokeToken(token);
-        } catch (IllegalArgumentException e) {
+        } catch (UnknownTokenException e) {
           error = e.getMessage();
         }
       } else {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -69,7 +69,7 @@ public interface TokenStateService extends Service {
    *
    * @return true, if the token has expired; Otherwise, false.
    */
-  boolean isExpired(JWTToken token);
+  boolean isExpired(JWTToken token) throws UnknownTokenException;
 
   /**
    *
@@ -77,21 +77,21 @@ public interface TokenStateService extends Service {
    *
    * @return true, if the token has expired; Otherwise, false.
    */
-  boolean isExpired(String token);
+  boolean isExpired(String token) throws UnknownTokenException;
 
   /**
    * Disable any subsequent use of the specified token.
    *
    * @param token The token.
    */
-  void revokeToken(JWTToken token);
+  void revokeToken(JWTToken token) throws UnknownTokenException;
 
   /**
    * Disable any subsequent use of the specified token.
    *
    * @param token The token.
    */
-  void revokeToken(String token);
+  void revokeToken(String token) throws UnknownTokenException;
 
   /**
    * Extend the lifetime of the specified token by the default amount of time.
@@ -100,7 +100,7 @@ public interface TokenStateService extends Service {
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(JWTToken token);
+  long renewToken(JWTToken token) throws UnknownTokenException;
 
   /**
    * Extend the lifetime of the specified token by the specified amount of time.
@@ -110,7 +110,7 @@ public interface TokenStateService extends Service {
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(JWTToken token, long renewInterval);
+  long renewToken(JWTToken token, long renewInterval) throws UnknownTokenException;
 
   /**
    * Extend the lifetime of the specified token by the default amount of time.
@@ -119,7 +119,7 @@ public interface TokenStateService extends Service {
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(String token);
+  long renewToken(String token) throws UnknownTokenException;
 
   /**
    * Extend the lifetime of the specified token by the specified amount of time.
@@ -129,7 +129,7 @@ public interface TokenStateService extends Service {
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(String token, long renewInterval);
+  long renewToken(String token, long renewInterval) throws UnknownTokenException;
 
   /**
    *
@@ -137,6 +137,6 @@ public interface TokenStateService extends Service {
    *
    * @return The token's expiration time in milliseconds.
    */
-  long getTokenExpiration(String token);
+  long getTokenExpiration(String token) throws UnknownTokenException;
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+import java.util.Locale;
+
+public class TokenUtils {
+
+  public static String getTokenDisplayText(final String token) {
+    return String.format(Locale.ROOT, "%s...%s", token.substring(0, 10), token.substring(token.length() - 3));
+  }
+
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/UnknownTokenException.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/UnknownTokenException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+public class UnknownTokenException extends Exception {
+
+  private String token;
+
+  public UnknownTokenException(final String token) {
+    this.token = token;
+  }
+
+  public String getToken() {
+    return token;
+  }
+
+  @Override
+  public String getMessage() {
+    return "Unknown token: " + TokenUtils.getTokenDisplayText(token);
+  }
+
+}


### PR DESCRIPTION
…stead of IllegalArgumentException

## What changes were proposed in this pull request?

Added UnknownTokenException so this condition can be handled more appropriately by clients of the TokenStateService and related.

## How was this patch tested?

Modified existing tests, which were checking for IllegalStateException results when tokens are unknown by the TokenStateService.