### PR TITLE
KNOX-2239 - Websocket use the configured truststore in gateway-site config file

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -324,6 +324,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1953,6 +1953,16 @@
 
             <!-- Websocket support -->
             <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.websocket</groupId>
                 <artifactId>javax.websocket-api</artifactId>
                 <version>${javax.websocket-api.version}</version>


### PR DESCRIPTION

## What changes were proposed in this pull request?

In Knox wss support was broken, the jetty implementation was picking up system keystore and not the keystore configured in gateway-site.xml file. This PR fixes it.

## How was this patch tested?
This was tested locally with ws and wss protocols.