### PR TITLE
KNOX-2249 Add Spark 3 History Server definition

### DIFF
--- a/gateway-admin-ui/admin-ui/app/new-desc-wizard/new-desc-wizard.component.ts
+++ b/gateway-admin-ui/admin-ui/app/new-desc-wizard/new-desc-wizard.component.ts
@@ -64,6 +64,7 @@ export class NewDescWizardComponent implements OnInit {
         'RESOURCEMANAGER',
         'SOLR',
         'SPARKHISTORYUI',
+        'SPARK3HISTORYUI',
         'STORM',
         'STORM-LOGVIEWER',
         'SUPERSET',

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/Spark3HistoryUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/Spark3HistoryUIServiceModelGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.model.spark;
+
+public class Spark3HistoryUIServiceModelGenerator extends SparkHistoryUIServiceModelGenerator {
+  public static final String SERVICE = "SPARK3HISTORYUI";
+  public static final String SERVICE_TYPE = "SPARK3_ON_YARN";
+  public static final String ROLE_TYPE = "SPARK3_YARN_HISTORY_SERVER";
+
+  @Override
+  public String getService() {
+    return SERVICE;
+  }
+
+  @Override
+  public String getServiceType() {
+    return SERVICE_TYPE;
+  }
+
+  @Override
+  public String getRoleType() {
+    return ROLE_TYPE;
+  }
+}

--- a/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
+++ b/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
@@ -40,6 +40,7 @@ org.apache.knox.gateway.topology.discovery.cm.model.ranger.RangerServiceModelGen
 org.apache.knox.gateway.topology.discovery.cm.model.ranger.RangerUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.solr.SolrServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.spark.SparkHistoryUIServiceModelGenerator
+org.apache.knox.gateway.topology.discovery.cm.model.spark.Spark3HistoryUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.yarn.JobHistoryUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.yarn.ResourceManagerUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.yarn.YarnUIServiceModelGenerator

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -51,6 +51,7 @@ import org.apache.knox.gateway.topology.discovery.cm.model.oozie.OozieServiceMod
 import org.apache.knox.gateway.topology.discovery.cm.model.phoenix.PhoenixServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.ranger.RangerServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.solr.SolrServiceModelGenerator;
+import org.apache.knox.gateway.topology.discovery.cm.model.spark.Spark3HistoryUIServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.spark.SparkHistoryUIServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.zeppelin.ZeppelinServiceModelGenerator;
 import org.easymock.EasyMock;
@@ -461,6 +462,16 @@ public class ClouderaManagerServiceDiscoveryTest {
   @Test
   public void testSparkHistoryUIDiscoverySSL() {
     doTestSparkHistoryUIDiscovery("spark-history-host", "18088", "18083", true);
+  }
+
+  @Test
+  public void testSpark3HistoryUIDiscovery() {
+    doTestSpark3HistoryUIDiscovery("spark-history-host", "18089", "18489", false);
+  }
+
+  @Test
+  public void testSpark3HistoryUIDiscoverySSL() {
+    doTestSpark3HistoryUIDiscovery("spark-history-host", "18089", "18489", true);
   }
 
   @Test
@@ -875,11 +886,7 @@ public class ClouderaManagerServiceDiscoveryTest {
                                                                  final String  port,
                                                                  final String  sslPort,
                                                                  final boolean isSSL) {
-    // Configure the role
-    Map<String, String> roleProperties = new HashMap<>();
-    roleProperties.put("ssl_enabled", String.valueOf(isSSL));
-    roleProperties.put("history_server_web_port", port);
-    roleProperties.put("ssl_server_port", sslPort);
+    Map<String, String> roleProperties = sparkHistoryUIRoleProperties(port, sslPort, isSSL);
 
     return doTestDiscovery(hostName,
                            "SPARK_ON_YARN-1",
@@ -890,6 +897,31 @@ public class ClouderaManagerServiceDiscoveryTest {
                            roleProperties);
   }
 
+  private ServiceDiscovery.Cluster doTestSpark3HistoryUIDiscovery(final String  hostName,
+                                                                  final String  port,
+                                                                  final String  sslPort,
+                                                                  final boolean isSSL) {
+    Map<String, String> roleProperties = sparkHistoryUIRoleProperties(port, sslPort, isSSL);
+
+    return doTestDiscovery(hostName,
+                           "SPARK3_ON_YARN-1",
+                           Spark3HistoryUIServiceModelGenerator.SERVICE_TYPE,
+                           "SPAR4fcf419a-SPARK3_YARN_HISTORY_SERVER-12345",
+                           Spark3HistoryUIServiceModelGenerator.ROLE_TYPE,
+                           Collections.emptyMap(),
+                           roleProperties);
+  }
+
+  private Map<String, String> sparkHistoryUIRoleProperties(final String  port,
+                                                           final String  sslPort,
+                                                           final boolean isSSL) {
+    Map<String, String> roleProperties = new HashMap<>();
+    roleProperties.put("ssl_enabled", String.valueOf(isSSL));
+    roleProperties.put("history_server_web_port", port);
+    roleProperties.put("ssl_server_port", sslPort);
+
+    return roleProperties;
+  }
 
   private ServiceDiscovery.Cluster doTestAtlasDiscovery(final String  atlasHost,
                                                         final String  port,

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/Spark3HistoryUIServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/Spark3HistoryUIServiceModelGeneratorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.model.spark;
+
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator;
+import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGeneratorTest;
+import org.junit.Test;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Spark3HistoryUIServiceModelGeneratorTest extends AbstractServiceModelGeneratorTest {
+
+  @Test
+  public void testServiceModelMetadata() {
+    final Map<String, String> serviceConfig = Collections.emptyMap();
+    final Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(Spark3HistoryUIServiceModelGenerator.SSL_ENABLED, "false");
+    roleConfig.put(Spark3HistoryUIServiceModelGenerator.HISTORY_SERVER_PORT, "18089");
+    roleConfig.put(Spark3HistoryUIServiceModelGenerator.SSL_SERVER_PORT, "18489");
+
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+  }
+
+  @Override
+  protected String getServiceType() {
+    return Spark3HistoryUIServiceModelGenerator.SERVICE_TYPE;
+  }
+
+  @Override
+  protected String getRoleType() {
+    return Spark3HistoryUIServiceModelGenerator.ROLE_TYPE;
+  }
+
+  @Override
+  protected ServiceModelGenerator newGenerator() {
+    return new Spark3HistoryUIServiceModelGenerator();
+  }
+
+}

--- a/gateway-service-definitions/src/main/resources/services/spark3historyui/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/spark3historyui/3.0.0/rewrite.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/inbound/root" pattern="*://*:*/**/spark3history/">
+    <rewrite template="{$serviceUrl[SPARK3HISTORYUI]}/"/>
+  </rule>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/inbound/path" pattern="*://*:*/**/spark3history/{**}">
+    <rewrite template="{$serviceUrl[SPARK3HISTORYUI]}/{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/inbound/simpleQuery" pattern="*://*:*/**/spark3history/?{**}">
+    <rewrite template="{$serviceUrl[SPARK3HISTORYUI]}/?{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/inbound/query" pattern="*://*:*/**/spark3history/{**}?{**}">
+    <rewrite template="{$serviceUrl[SPARK3HISTORYUI]}/{**}?{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/inbound/history" pattern="*://*:*/**/spark3history/history/{**}/?{**}">
+    <rewrite template="{$serviceUrl[SPARK3HISTORYUI]}/history/{**}/?{**}"/>
+  </rule>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/inbound/apps" pattern="*://*:*/**/spark3history/?{page}?{showIncomplete}">
+    <rewrite template="{$serviceUrl[SPARK3HISTORYUI]}/?{page}?{showIncomplete}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/history" pattern="/history/{**}">
+    <rewrite template="{$frontend[url]}/spark3history/history/{**}"/>
+  </rule>
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/history/job" pattern="/history/{**}?{**}">
+    <rewrite template="{$frontend[url]}/spark3history/history/{**}?{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/apps" pattern="/?{page}?{showIncomplete}">
+    <rewrite template="{$frontend[url]}/spark3history/?{page}?{showIncomplete}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/headers/location">
+    <match pattern="*://*:*/history/{**}/?{**}"/>
+    <rewrite template="{$frontend[url]}/spark3history/history/{**}/?{**}"/>
+  </rule>
+  <rule flow="OR" dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/headers/jobs/location">
+    <match pattern="*://*:*/history/{**}/jobs">
+      <rewrite template="{$frontend[url]}/spark3history/history/{**}/jobs"/>
+    </match>
+    <match pattern="*://*:*/history/{**}/jobs/">
+      <rewrite template="{$frontend[url]}/spark3history/history/{**}/jobs/"/>
+    </match>
+  </rule>
+  <rule dir="IN" name="SPARK3HISTORYUI/spark3history/outbound/rqheaders/xfc">
+    <match pattern="{**}"/>
+    <rewrite template="/{**}/spark3history" />
+  </rule>
+
+  <filter name="SPARK3HISTORYUI/spark3history/outbound/headers">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="SPARK3HISTORYUI/spark3history/outbound/headers/location"/>
+    </content>
+  </filter>
+  <filter name="SPARK3HISTORYUI/spark3history/outbound/headers/jobs">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="SPARK3HISTORYUI/spark3history/outbound/headers/jobs/location"/>
+    </content>
+  </filter>
+  <filter name="SPARK3HISTORYUI/spark3history/outbound/rqheaders">
+    <content type="application/x-http-headers">
+      <apply path="X-Forwarded-Context" rule="SPARK3HISTORYUI/spark3history/outbound/rqheaders/xfc"/>
+    </content>
+  </filter>
+
+  <!-- re-write rule for location when SHS redirects to Knox SSO login page -->
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/headers/location/sso">
+    <match pattern="{scheme}://{host}:{port}/{gateway}/{knoxsso}/{api}/{v}/websso?originalUrl={**}"/>
+    <rewrite template="{scheme}://{host}:{port}/{gateway}/{knoxsso}/{api}/{v}/websso?originalUrl={$postfix[url,/spark3history/]}"/>
+  </rule>
+  <filter name="SPARK3HISTORYUI/spark3history/outbound/headers/sso/filter">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="SPARK3HISTORYUI/spark3history/outbound/headers/location/sso"/>
+    </content>
+  </filter>
+
+  <!-- re-write rules for yarn container logs -->
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/yarn/containerlogs" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}">
+    <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{scheme}?{host}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="SPARK3HISTORYUI/spark3history/outbound/yarn/containerlogs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
+    <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
+  </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/spark3historyui/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/spark3historyui/3.0.0/service.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="SPARK3HISTORYUI" name="spark3history" version="3.0.0">
+    <routes>
+        <route path="/spark3history/">
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/rqheaders" to="request.headers"/>
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/headers/sso/filter" to="response.headers"/>
+        </route>
+        <route path="/spark3history/**">
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/rqheaders" to="request.headers"/>
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/headers/sso/filter" to="response.headers"/>
+        </route>
+        <route path="/spark3history/**?**"/>
+        <route path="/spark3history/history/**?**">
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/headers" to="response.headers"/>
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/rqheaders" to="request.headers"/>
+        </route>
+        <route path="/spark3history/history/**/?**">
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/headers/jobs" to="response.headers"/>
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/rqheaders" to="request.headers"/>
+        </route>
+        <route path="/spark3history/history/**/jobs/**?**">
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/headers/jobs" to="response.headers"/>
+            <rewrite apply="SPARK3HISTORYUI/spark3history/outbound/rqheaders" to="request.headers"/>
+        </route>
+    </routes>
+</service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Spark 3 History Server definition. Spark 3 HS could be run alongside Spark 2 HS, so separate service definition is required.

## How was this patch tested?

Manually and with unit tests.
