### PR TITLE
KNOX-2250 - maven-antrun-plugin use target instead of tasks

### DIFF
--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -85,7 +85,7 @@
                                 <phase>package</phase>
                                 <goals><goal>run</goal></goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <checksum algorithm="SHA-256" fileext=".sha256">
                                             <fileset dir="../target/${project.version}">
                                                 <include name="*.zip" />
@@ -98,7 +98,7 @@
                                                 <include name="*.tar.gz" />
                                             </fileset>
                                         </checksum>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -109,7 +109,7 @@
                                 <phase>package</phase>
                                 <goals><goal>run</goal></goals>
                                 <configuration>
-                                    <tasks>
+                                    <target>
                                         <checksum algorithm="SHA-256" fileext=".sha256">
                                             <fileset dir="../target/${project.version}">
                                                 <include name="knoxshell-${project.version}.zip" />
@@ -122,7 +122,7 @@
                                                 <include name="knoxshell-${project.version}.tar.gz" />
                                             </fileset>
                                         </checksum>
-                                    </tasks>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove deprecated tasks and switch to target for maven-antrun-plugin.

## How was this patch tested?

* `mvn -T.5C clean verify -U -Ppackage,release -Dshellcheck`