### PR TITLE
KNOX-2212 - Token permissiveness

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -249,10 +249,10 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
-  private static final String KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.permissive.failure.enabled";
+  private static final String KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.permissive.validation";
   private static final long KNOX_TOKEN_EVICTION_INTERVAL_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
   private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
-  private static final boolean KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED_DEFAULT = false;
+  private static final boolean KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT = false;
 
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata"));
@@ -1148,8 +1148,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
    * @return returns whether know token permissive failure is enabled
    */
   @Override
-  public boolean isKnoxTokenPermissiveFailureEnabled() {
-    return getBoolean(KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED,
-        KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED_DEFAULT);
+  public boolean isKnoxTokenPermissiveValidationEnabled() {
+    return getBoolean(KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED,
+        KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT);
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -249,8 +249,10 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
+  private static final String KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.permissive.failure.enabled";
   private static final long KNOX_TOKEN_EVICTION_INTERVAL_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
   private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
+  private static final boolean KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED_DEFAULT = false;
 
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata"));
@@ -1140,5 +1142,14 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public Set<String> getHiddenTopologiesOnHomepage() {
     final Set<String> hiddenTopologies = new HashSet<>(getStringCollection(KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES));
     return hiddenTopologies == null || hiddenTopologies.isEmpty() ? KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT : hiddenTopologies;
+  }
+
+  /**
+   * @return returns whether know token permissive failure is enabled
+   */
+  @Override
+  public boolean isKnoxTokenPermissiveFailureEnabled() {
+    return getBoolean(KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED,
+        KNOX_TOKEN_PERMISSIVE_FAILURE_ENABLED_DEFAULT);
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -16,7 +16,6 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -97,9 +96,8 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService {
       validateToken(token);
     } catch (final UnknownTokenException e) {
       /* if token permissiveness is enabled we check JWT token expiration when the token state is unknown */
-      if (permissiveFailureEnabled && StringUtils
-          .containsIgnoreCase(e.toString(), "Unknown token")) {
-        return getJWTTokenExpiration(token);
+      if (permissiveValidationEnabled &&  getJWTTokenExpiration(token).isPresent()) {
+        return getJWTTokenExpiration(token).getAsLong();
       } else {
         throw e;
       }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -63,4 +63,10 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "Error occurred evicting token {0}")
   void errorEvictingTokens(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.ERROR, text = "Error occurred while parsing JWT token, cause: {0}")
+  void errorParsingToken(String cause);
+
+  @Message(level = MessageLevel.DEBUG, text = "Token permissiveness is enabled, expiration for token {0} is {1}")
+  void jwtTokenExpiry(String tokenDisplayText, String expiration);
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -66,7 +66,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "Error occurred while parsing JWT token, cause: {0}")
   void errorParsingToken(String cause);
 
-  @Message(level = MessageLevel.DEBUG, text = "Token permissiveness is enabled, expiration for token {0} is {1}")
+  @Message(level = MessageLevel.DEBUG, text = "Permissive validation for token is enabled, expiration for token {0} is {1}")
   void jwtTokenExpiry(String tokenDisplayText, String expiration);
 
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
@@ -245,7 +245,7 @@ public class DefaultTokenStateServiceTest {
     /* configure token eviction time to be 5 secs for test */
     EasyMock.expect(config.getKnoxTokenEvictionInterval()).andReturn(EVICTION_INTERVAL).anyTimes();
     EasyMock.expect(config.getKnoxTokenEvictionGracePeriod()).andReturn(0L).anyTimes();
-    EasyMock.expect(config.isKnoxTokenPermissiveFailureEnabled()).andReturn(tokenPermissiveness).anyTimes();
+    EasyMock.expect(config.isKnoxTokenPermissiveValidationEnabled()).andReturn(tokenPermissiveness).anyTimes();
     EasyMock.replay(config);
     return config;
   }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
@@ -16,15 +16,22 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 import org.easymock.EasyMock;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
 import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +45,16 @@ import static org.junit.Assert.fail;
 public class DefaultTokenStateServiceTest {
 
   private static long EVICTION_INTERVAL = 2L;
+  private static RSAPrivateKey privateKey;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(2048);
+
+    KeyPair kp = kpg.genKeyPair();
+    privateKey = (RSAPrivateKey) kp.getPrivate();
+  }
 
   @Test
   public void testGetExpiration() throws Exception {
@@ -185,6 +202,32 @@ public class DefaultTokenStateServiceTest {
     }
   }
 
+  @Test
+  public void testTokenPermissiveness() throws UnknownTokenException {
+    final long expiry = System.currentTimeMillis() + 300000;
+    final JWT token = getJWTToken(expiry);
+    TokenStateService tss = new DefaultTokenStateService();
+    try {
+      tss.init(createMockGatewayConfig(true), Collections.emptyMap());
+    } catch (ServiceLifecycleException e) {
+      fail("Error creating TokenStateService: " + e.getMessage());
+    }
+    assertEquals(expiry/1000, tss.getTokenExpiration(token.toString())/1000);
+  }
+
+  @Test
+  public void testTokenPermissivenessNoExpiry() throws UnknownTokenException {
+    final JWT token = getJWTToken(-1);
+    TokenStateService tss = new DefaultTokenStateService();
+    try {
+      tss.init(createMockGatewayConfig(true), Collections.emptyMap());
+    } catch (ServiceLifecycleException e) {
+      fail("Error creating TokenStateService: " + e.getMessage());
+    }
+
+    assertEquals(-1L, tss.getTokenExpiration(token.toString()));
+  }
+
   protected static JWTToken createMockToken(final long expiration) {
     return createMockToken("abcD1234eFGHIJKLmnoPQRSTUVwXYz", expiration);
   }
@@ -197,18 +240,19 @@ public class DefaultTokenStateServiceTest {
     return token;
   }
 
-  protected static GatewayConfig createMockGatewayConfig() {
+  protected static GatewayConfig createMockGatewayConfig(boolean tokenPermissiveness) {
     GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
     /* configure token eviction time to be 5 secs for test */
     EasyMock.expect(config.getKnoxTokenEvictionInterval()).andReturn(EVICTION_INTERVAL).anyTimes();
     EasyMock.expect(config.getKnoxTokenEvictionGracePeriod()).andReturn(0L).anyTimes();
+    EasyMock.expect(config.isKnoxTokenPermissiveFailureEnabled()).andReturn(tokenPermissiveness).anyTimes();
     EasyMock.replay(config);
     return config;
   }
 
   protected void initTokenStateService(TokenStateService tss) {
     try {
-      tss.init(createMockGatewayConfig(), Collections.emptyMap());
+      tss.init(createMockGatewayConfig(false), Collections.emptyMap());
     } catch (ServiceLifecycleException e) {
       fail("Error creating TokenStateService: " + e.getMessage());
     }
@@ -218,6 +262,22 @@ public class DefaultTokenStateServiceTest {
     TokenStateService tss = new DefaultTokenStateService();
     initTokenStateService(tss);
     return tss;
+  }
+
+  /* create a test JWT token */
+  protected JWT getJWTToken(final long expiry) {
+    String[] claims = new String[4];
+    claims[0] = "KNOXSSO";
+    claims[1] = "john.doe@example.com";
+    claims[2] = "https://login.example.com";
+    if(expiry > 0) {
+      claims[3] = Long.toString(expiry);
+    }
+    JWT token = new JWTToken("RS256", claims);
+    // Sign the token
+    JWSSigner signer = new RSASSASigner(privateKey);
+    token.sign(signer);
+    return token;
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -675,4 +675,9 @@ public interface GatewayConfig {
    * @return the list of topologies that should be hidden on Knox homepage
    */
   Set<String> getHiddenTopologiesOnHomepage();
+
+  /**
+   * @return returns whether know token permissive failure is enabled
+   */
+  boolean isKnoxTokenPermissiveFailureEnabled();
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -677,7 +677,7 @@ public interface GatewayConfig {
   Set<String> getHiddenTopologiesOnHomepage();
 
   /**
-   * @return returns whether know token permissive failure is enabled
+   * @return returns whether know token permissive validation is enabled
    */
-  boolean isKnoxTokenPermissiveFailureEnabled();
+  boolean isKnoxTokenPermissiveValidationEnabled();
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -794,4 +794,12 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public Set<String> getHiddenTopologiesOnHomepage() {
     return Collections.emptySet();
   }
+
+  /**
+   * @return returns whether know token permissive failure is enabled
+   */
+  @Override
+  public boolean isKnoxTokenPermissiveFailureEnabled() {
+    return false;
+  }
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -799,7 +799,7 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
    * @return returns whether know token permissive failure is enabled
    */
   @Override
-  public boolean isKnoxTokenPermissiveFailureEnabled() {
+  public boolean isKnoxTokenPermissiveValidationEnabled() {
     return false;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `gateway.knox.token.permissive.failure.enabled`  property is set to true in gateway-site.xml (by default it is false) **and** `knox.token.exp.server-managed` is set to true in the descriptor (server managed token state is enabled) then, when Knox encounters a valid token which is not stored in it's token state Knox uses the expiry date of the JWT token instead of flagging it as "Unknown Token"

## How was this patch tested?
This patch was locally tested