### PR TITLE
KNOX-2258 - Add new rewrite rule in Livy service for handling redirect requests to /ui

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/rewrite.xml
@@ -45,4 +45,8 @@
     <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{scheme}?host={$hostmap(host)}?{port}"/>
   </rule>
 
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/headers/ui" pattern="{scheme}://{host}:{port}/ui">
+    <rewrite template="{$frontend[url]}/livy/ui"/>
+  </rule>
+
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/rewrite.xml
@@ -45,8 +45,8 @@
     <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{scheme}?host={$hostmap(host)}?{port}"/>
   </rule>
 
-  <rule dir="OUT" name="LIVYSERVER/livy/outbound/headers/ui" pattern="{scheme}://{host}:{port}/ui">
-    <rewrite template="{$frontend[url]}/livy/ui"/>
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/headers/ui" pattern="{scheme}://{host}:{port}/ui/">
+    <rewrite template="{$frontend[url]}/livy/ui/"/>
   </rule>
 
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
@@ -27,7 +27,9 @@
     <route path="/livy">
         <rewrite apply="LIVYSERVER/livy/outbound/headers/ui" to="response.headers"/>
     </route>
-    <route path="/livy/"/>
+    <route path="/livy/">
+        <rewrite apply="LIVYSERVER/livy/outbound/headers/ui" to="response.headers"/>
+    </route>
   </routes>
   <dispatch classname="org.apache.knox.gateway.livy.LivyDispatch"/>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
@@ -24,7 +24,9 @@
     </metadata>
   <routes>
     <route path="/livy/**?**"/>
-    <route path="/livy"/>
+    <route path="/livy">
+        <rewrite apply="LIVYSERVER/livy/outbound/headers/ui" to="response.headers"/>
+    </route>
     <route path="/livy/"/>
   </routes>
   <dispatch classname="org.apache.knox.gateway.livy.LivyDispatch"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new rewrite rule in Livy service for handling redirects to /ui endpoint

## How was this patch tested?

Manually tested in a Cluster with Knox and Livy Services.
1. Edited the rewrite/service.xml for Livy service with the changes.
2. Verified that `https://<KNOX_HOST:KNOX_PORT>/gateway/default/livy` gets redirected to `https://<KNOX_HOST:KNOX_PORT>/gateway/default/livy/ui`