### PR TITLE
KNOX-2263 - Docker - make sure not to put anything except version in the tag

### DIFF
--- a/gateway-docker/pom.xml
+++ b/gateway-docker/pom.xml
@@ -94,7 +94,6 @@
                         <version>${dockerfile-maven-plugin.version}</version>
                         <configuration>
                             <contextDirectory>${project.build.outputDirectory}/docker</contextDirectory>
-                            <repository>apache/knox</repository>
                             <buildArgs>
                                 <RELEASE_FILE>knox-${project.version}.zip</RELEASE_FILE>
                             </buildArgs>
@@ -108,7 +107,8 @@
                                     <goal>tag</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>gateway-${project.version}</tag>
+                                    <repository>apache/knox-gateway</repository>
+                                    <tag>${project.version}</tag>
                                     <buildArgs>
                                         <ENTRYPOINT>gateway-entrypoint.sh</ENTRYPOINT>
                                         <EXPOSE_PORT>8443</EXPOSE_PORT>
@@ -123,7 +123,8 @@
                                     <goal>tag</goal>
                                 </goals>
                                 <configuration>
-                                    <tag>ldap-${project.version}</tag>
+                                    <repository>apache/knox-demo-ldap</repository>
+                                    <tag>${project.version}</tag>
                                     <buildArgs>
                                         <ENTRYPOINT>ldap-entrypoint.sh</ENTRYPOINT>
                                         <EXPOSE_PORT>33389</EXPOSE_PORT>

--- a/gateway-docker/src/main/resources/docker-compose.yml
+++ b/gateway-docker/src/main/resources/docker-compose.yml
@@ -16,13 +16,13 @@
 version: '3'
 services:
   ldap:
-    image: apache/knox:ldap-1.4.0-SNAPSHOT
+    image: apache/knox-demo-ldap:1.4.0-SNAPSHOT
     ports:
     - "33389:33389"
 
   gateway:
     depends_on:
       - ldap
-    image: apache/knox:gateway-1.4.0-SNAPSHOT
+    image: apache/knox-gateway:1.4.0-SNAPSHOT
     ports:
     - "8443:8443"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure that only the version is in the docker image tag.

## How was this patch tested?

* `mvn -T.75C package -Ppackage,release,docker -Dshellcheck -DskipTests`
* Checked created image
```
docker images | grep -F apache/
apache/knox-demo-ldap                                                              1.4.0-SNAPSHOT                             714adc69aef4        17 seconds ago      533MB
apache/knox-gateway                                                                1.4.0-SNAPSHOT                             1e6f961b86f0        34 seconds ago      533MB
```