### PR TITLE
KNOX-2265 - Checking CM configs by their related names and read hive.server2.use.SSL from the service configuration

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
@@ -54,7 +54,7 @@ public abstract class AbstractServiceModelGenerator implements ServiceModelGener
 
   protected String getConfigValue(String key, List<ApiConfig> items) {
     for (ApiConfig config : items) {
-      if (key.equals(config.getName())) {
+      if (key.equals(config.getName()) || key.equals(config.getRelatedName())) {
         String value = config.getValue();
         if (value != null) {
           return value;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -78,7 +78,7 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
                                       ApiRole          role,
                                       ApiConfigList    roleConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
-    boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));
+    boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));
     String scheme = sslEnabled ? "https" : "http";
 
     String port     = getHttpPort(roleConfig);
@@ -89,7 +89,7 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
 
     ServiceModel model =
         createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/%s", scheme, hostname, port, httpPath));
-    model.addRoleProperty(getRoleType(), SSL_ENABLED, getRoleConfigValue(roleConfig, SSL_ENABLED));
+    model.addRoleProperty(getRoleType(), SSL_ENABLED, Boolean.toString(sslEnabled));
     model.addRoleProperty(getRoleType(), SAFETY_VALVE, getRoleConfigValue(roleConfig, SAFETY_VALVE));
 
     return model;

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -961,14 +961,15 @@ public class ClouderaManagerServiceDiscoveryTest {
     // Configure the role
     Map<String, String> roleProperties = new HashMap<>();
     roleProperties.put("hive_hs2_config_safety_valve", hs2SafetyValveValue);
-    roleProperties.put("hive.server2.use.SSL", String.valueOf(enableSSL));
+
+    final Map<String, String> serviceProperties = Collections.singletonMap("hive.server2.use.SSL", String.valueOf(enableSSL));
 
     return doTestDiscovery(hostName,
                            "HIVE-1",
                            HiveServiceModelGenerator.SERVICE_TYPE,
                            "HIVE-1-HIVESERVER2-12345",
                            HiveServiceModelGenerator.ROLE_TYPE,
-                           Collections.emptyMap(),
+                           serviceProperties,
                            roleProperties);
   }
 
@@ -988,14 +989,15 @@ public class ClouderaManagerServiceDiscoveryTest {
     roleProperties.put("hive_server2_thrift_http_port", thriftPort);
     roleProperties.put("hive_server2_transport_mode", "http");
     roleProperties.put("hive_hs2_config_safety_valve", hs2SafetyValveValue);
-    roleProperties.put("hive.server2.use.SSL", String.valueOf(enableSSL));
+
+    final Map<String, String> serviceProperties = Collections.singletonMap("hive.server2.use.SSL", String.valueOf(enableSSL));
 
     return doTestDiscovery(hostName,
                            "HIVE_ON_TEZ-1",
                            HiveOnTezServiceModelGenerator.SERVICE_TYPE,
                            "HIVE_ON_TEZ-1-HIVESERVER2-12345",
                            HiveServiceModelGenerator.ROLE_TYPE,
-                           Collections.emptyMap(),
+                           serviceProperties,
                            roleProperties);
   }
 
@@ -1215,9 +1217,14 @@ public class ClouderaManagerServiceDiscoveryTest {
     ApiServiceConfig serviceConfig = EasyMock.createNiceMock(ApiServiceConfig.class);
     List<ApiConfig> serviceConfigs = new ArrayList<>();
 
+    int i = 0;
     for (Map.Entry<String, String> property : properties.entrySet()) {
       ApiConfig config = EasyMock.createNiceMock(ApiConfig.class);
-      EasyMock.expect(config.getName()).andReturn(property.getKey()).anyTimes();
+      if (i++ % 2 == 0) {
+        EasyMock.expect(config.getName()).andReturn(property.getKey()).anyTimes();
+      } else {
+        EasyMock.expect(config.getRelatedName()).andReturn(property.getKey()).anyTimes();
+      }
       EasyMock.expect(config.getValue()).andReturn(property.getValue()).anyTimes();
       EasyMock.replay(config);
       serviceConfigs.add(config);
@@ -1232,9 +1239,14 @@ public class ClouderaManagerServiceDiscoveryTest {
     ApiConfigList configList = EasyMock.createNiceMock(ApiConfigList.class);
     List<ApiConfig> roleConfigs = new ArrayList<>();
 
+    int i = 0;
     for (Map.Entry<String, String> property : properties.entrySet()) {
       ApiConfig config = EasyMock.createNiceMock(ApiConfig.class);
-      EasyMock.expect(config.getName()).andReturn(property.getKey()).anyTimes();
+      if (i++ % 2 == 0) {
+        EasyMock.expect(config.getName()).andReturn(property.getKey()).anyTimes();
+      } else {
+        EasyMock.expect(config.getRelatedName()).andReturn(property.getKey()).anyTimes();
+      }
       EasyMock.expect(config.getValue()).andReturn(property.getValue()).anyTimes();
       EasyMock.replay(config);
       roleConfigs.add(config);


### PR DESCRIPTION
## What changes were proposed in this pull request?

CM configuration's related name is used when looking up service/role configurations.
Moreover, it turned out that `hive.server2.use.SSL` is a service configuration rather than being a role configuration.

## How was this patch tested?

Updated and ran JUnit tests and tested manually:

1. had a secure remote cluster (i.e. SSL enabled) with Hive/Hive on TEZ
2. redeployed Knox locally and added a descriptor with HIVE
3. set the remote cluster's attributes in this descriptor's `Service Discovery` details
4. confirmed that
  - service discovery worked
  - Hive URLs start with the `https` scheme