### PR TITLE
KNOX-2259 KNOX-2260 KNOX-2261 - Fixed Impala/Kudu/HBase UI context path in service metadata

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/service.xml
@@ -18,9 +18,9 @@
 <service role="HBASEUI" name="hbaseui" version="2.1.0">
     <metadata>
         <type>UI</type>
-        <context>/hbase/webui</context>
+        <context>/hbase/webui/master?&amp;host={{HOST}}&amp;port={{PORT}}</context>
         <shortDesc>HBase UI</shortDesc>
-        <description>Th﻿e HBase Master web UI is a simple but useful tool, to get an overview of the current status of the cluster. 
+        <description>The HBase Master web UI is a simple but useful tool, to get an overview of the current status of the cluster. 
             From its page, you can get the version of the running HBase, its basic configuration, including the root HDFS path and ZooKeeper quorum, 
             load average of the cluster, and a table, region, and region server list.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/impalaui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/impalaui/1.0.0/service.xml
@@ -18,7 +18,7 @@ limitations under the License.
 <service role="IMPALAUI" name="impalaui" version="1.0.0">
     <metadata>
         <type>UI</type>
-        <context>/impalaui</context>
+        <context>/impalaui?scheme={{SCHEME}}&amp;host={{HOST}}&amp;port={{PORT}}</context>
         <shortDesc>Impala UI</shortDesc>
         <description>Each of the Impala daemons (impalad, statestored, and catalogd) includes a built-in web server that displays diagnostic and status information.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/kuduui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/kuduui/1.0.0/service.xml
@@ -18,7 +18,7 @@ limitations under the License.
 <service role="KUDUUI" name="kuduui" version="1.0.0">
     <metadata>
         <type>UI</type>
-        <context>/kuduui</context>
+        <context>/kuduui?scheme={{SCHEME}}&amp;host={{HOST}}&amp;port={{PORT}}</context>
         <shortDesc>Kudu UI</shortDesc>
         <description>Kudu is a columnar storage manager developed for the Apache Hadoop platform. Kudu shares the common technical properties of Hadoop ecosystem applications: it runs on commodity hardware, is horizontally scalable, and supports highly available operation.</description>
     </metadata>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -215,7 +215,9 @@ public class KnoxMetadataResource {
 
   private Metadata getServiceMetadata(ServiceDefinitionRegistry serviceDefinitionRegistry, Service service) {
     final Optional<ServiceDefinitionPair> serviceDefinition = serviceDefinitionRegistry.getServiceDefinitions().stream()
-        .filter(serviceDefinitionPair -> serviceDefinitionPair.getService().getRole().equalsIgnoreCase(service.getRole())).findFirst();
+        .filter(serviceDefinitionPair -> serviceDefinitionPair.getService().getRole().equalsIgnoreCase(service.getRole()))
+        .filter(serviceDefinitionPair -> service.getVersion() == null || service.getVersion().toString().equalsIgnoreCase(serviceDefinitionPair.getService().getVersion()))
+        .findFirst();
     return serviceDefinition.isPresent() ? serviceDefinition.get().getService().getMetadata() : null;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Corrected the contexts for Impala/Kudu/HBase UI services and fixed the code which selects the correct service definition when looking for metadata (the version was not considered before).

## How was this patch tested?

Tested manually: added a sample descriptor (with IMPALAUI, KUDUUI, HBASEUI services) pointing to a remote cluster (where valid URLs are found). Knox generated the topology properly and the correct URLs are displayed on the Home page.

<img width="1669" alt="Screen Shot 2020-03-09 at 9 57 13 AM" src="https://user-images.githubusercontent.com/34065904/76199609-73bc7f80-61f0-11ea-8958-4401c5a90c63.png">



