### PR TITLE
KNOX-2267 - Ambari/CM discovery - Needs to point to configured truststore

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariClientCommon.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariClientCommon.java
@@ -20,6 +20,7 @@ import net.minidev.json.JSONArray;
 import net.minidev.json.JSONObject;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
 import java.util.HashMap;
@@ -40,8 +41,8 @@ class AmbariClientCommon {
     private RESTInvoker restClient;
 
 
-    AmbariClientCommon(GatewayConfig config, AliasService aliasService) {
-        this(new RESTInvoker(config, aliasService));
+    AmbariClientCommon(GatewayConfig config, AliasService aliasService, KeystoreService keystoreService) {
+        this(new RESTInvoker(config, aliasService, keystoreService));
     }
 
 

--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariClusterConfigurationMonitorProvider.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariClusterConfigurationMonitorProvider.java
@@ -18,6 +18,7 @@ package org.apache.knox.gateway.topology.discovery.ambari;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitorProvider;
 
@@ -30,7 +31,8 @@ public class AmbariClusterConfigurationMonitorProvider implements
     }
 
     @Override
-    public ClusterConfigurationMonitor newInstance(GatewayConfig config, AliasService aliasService) {
-        return new AmbariConfigurationMonitor(config, aliasService);
+    public ClusterConfigurationMonitor newInstance(GatewayConfig config, AliasService aliasService,
+                                                   KeystoreService keystoreService) {
+        return new AmbariConfigurationMonitor(config, aliasService, keystoreService);
     }
 }

--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariConfigurationMonitor.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariConfigurationMonitor.java
@@ -20,6 +20,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
@@ -80,9 +81,9 @@ class AmbariConfigurationMonitor implements ClusterConfigurationMonitor {
         return TYPE;
     }
 
-    AmbariConfigurationMonitor(GatewayConfig config, AliasService aliasService) {
+    AmbariConfigurationMonitor(GatewayConfig config, AliasService aliasService, KeystoreService keystoreService) {
         this.gatewayConfig   = config;
-        this.ambariClient    = new AmbariClientCommon(config, aliasService);
+        this.ambariClient    = new AmbariClientCommon(config, aliasService, keystoreService);
         this.internalMonitor = new PollingConfigAnalyzer(this);
 
         // Override the default polling interval if it has been configured

--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.GatewayService;
@@ -76,6 +77,9 @@ class AmbariServiceDiscovery implements ServiceDiscovery {
 
     @GatewayService
     private AliasService aliasService;
+
+    @GatewayService
+    private KeystoreService keystoreService;
 
     private RESTInvoker restClient;
     private AmbariClientCommon ambariClient;
@@ -146,7 +150,7 @@ class AmbariServiceDiscovery implements ServiceDiscovery {
     private void init(GatewayConfig config) {
         if (!isInitialized) {
             if (this.restClient == null) {
-                this.restClient = new RESTInvoker(config, aliasService);
+                this.restClient = new RESTInvoker(config, aliasService, keystoreService);
             }
             this.ambariClient = new AmbariClientCommon(restClient);
             this.configChangeMonitor = getConfigurationChangeMonitor();

--- a/gateway-discovery-ambari/src/test/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariConfigurationMonitorTest.java
+++ b/gateway-discovery-ambari/src/test/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariConfigurationMonitorTest.java
@@ -279,7 +279,7 @@ public class AmbariConfigurationMonitorTest {
         Map<String, Map<String, Map<String, String>>> configVersionData = new HashMap<>();
 
         TestableAmbariConfigurationMonitor(GatewayConfig config) {
-            super(config, null);
+            super(config, null, null);
         }
 
         void addTestConfigVersion(String address, String clusterName, String configType, String configVersion) {

--- a/gateway-discovery-ambari/src/test/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryTest.java
+++ b/gateway-discovery-ambari/src/test/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryTest.java
@@ -323,7 +323,7 @@ public class AmbariServiceDiscoveryTest {
         private Map<String, JSONObject> cannedResponses = new HashMap<>();
 
         TestRESTInvoker(String clusterName) {
-            super(null);
+            super(null, null);
 
             cannedResponses.put(AmbariServiceDiscovery.AMBARI_CLUSTERS_URI,
                     (JSONObject) JSONValue.parse(CLUSTERS_JSON_TEMPLATE.replaceAll(CLUSTER_PLACEHOLDER,

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -34,6 +34,7 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
@@ -85,6 +86,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
   private boolean debug;
 
   private AliasService aliasService;
+  private KeystoreService keystoreService;
 
   private ClouderaManagerClusterConfigurationMonitor configChangeMonitor;
 
@@ -97,6 +99,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
     GatewayServices gwServices = GatewayServer.getGatewayServices();
     if (gwServices != null) {
       this.aliasService = gwServices.getService(ServiceType.ALIAS_SERVICE);
+      this.keystoreService = gwServices.getService(ServiceType.KEYSTORE_SERVICE);
     }
     this.debug = debug;
     this.configChangeMonitor = getConfigurationChangeMonitor();
@@ -114,9 +117,8 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
       throw new IllegalArgumentException("Missing or invalid discovery address.");
     }
 
-    DiscoveryApiClient client = new DiscoveryApiClient(discoveryConfig, aliasService);
+    DiscoveryApiClient client = new DiscoveryApiClient(discoveryConfig, aliasService, keystoreService);
     client.setDebugging(debug);
-    client.setVerifyingSsl(false);
     return client;
   }
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -187,4 +187,6 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.WARN, text = "Failed to create persistence directory {0}")
   void failedToCreatePersistenceDirectory(String path);
 
+  @Message(level = MessageLevel.ERROR, text = "Failed to configure truststore")
+  void failedToConfigureTruststore();
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerCluster;
@@ -71,7 +72,8 @@ public class ClouderaManagerClusterConfigurationMonitor implements ClusterConfig
   }
 
 
-  ClouderaManagerClusterConfigurationMonitor(final GatewayConfig config, final AliasService aliasService) {
+  ClouderaManagerClusterConfigurationMonitor(final GatewayConfig config, final AliasService aliasService,
+                                             final KeystoreService keystoreService) {
     // Initialize the config cache
     configCache = new ClusterConfigurationCache();
 
@@ -85,7 +87,7 @@ public class ClouderaManagerClusterConfigurationMonitor implements ClusterConfig
     this.executorService = Executors.newSingleThreadExecutor(tf);
 
     // Initialize the internal monitor
-    internalMonitor = new PollingConfigurationAnalyzer(configCache, aliasService, this);
+    internalMonitor = new PollingConfigurationAnalyzer(configCache, aliasService, keystoreService, this);
 
     // Override the default polling interval if it has been configured
     // (org.apache.knox.gateway.topology.discovery.cm.monitor.interval)

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitorProvider.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitorProvider.java
@@ -18,6 +18,7 @@ package org.apache.knox.gateway.topology.discovery.cm.monitor;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitorProvider;
 
@@ -29,8 +30,9 @@ public class ClouderaManagerClusterConfigurationMonitorProvider implements Clust
   }
 
   @Override
-  public ClusterConfigurationMonitor newInstance(GatewayConfig config, AliasService aliasService) {
-    return new ClouderaManagerClusterConfigurationMonitor(config, aliasService);
+  public ClusterConfigurationMonitor newInstance(GatewayConfig config, AliasService aliasService,
+                                                 KeystoreService keystoreService) {
+    return new ClouderaManagerClusterConfigurationMonitor(config, aliasService, keystoreService);
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -31,6 +31,7 @@ import com.cloudera.api.swagger.model.ApiRoleList;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscoveryMessages;
 import org.apache.knox.gateway.topology.discovery.cm.DiscoveryApiClient;
@@ -75,6 +76,8 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
   private AliasService aliasService;
 
+  private KeystoreService keystoreService;
+
   // Polling interval in seconds
   private int interval;
 
@@ -92,18 +95,21 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
   PollingConfigurationAnalyzer(final ClusterConfigurationCache   configCache,
                                final AliasService                aliasService,
+                               final KeystoreService             keystoreService,
                                final ConfigurationChangeListener changeListener) {
-    this(configCache, aliasService, changeListener, DEFAULT_POLLING_INTERVAL);
+    this(configCache, aliasService, keystoreService, changeListener, DEFAULT_POLLING_INTERVAL);
   }
 
   PollingConfigurationAnalyzer(final ClusterConfigurationCache   configCache,
                                final AliasService                aliasService,
+                               final KeystoreService             keystoreService,
                                final ConfigurationChangeListener changeListener,
                                int                               interval) {
-    this.configCache    = configCache;
-    this.aliasService   = aliasService;
-    this.changeListener = changeListener;
-    this.interval       = interval;
+    this.configCache     = configCache;
+    this.aliasService    = aliasService;
+    this.keystoreService = keystoreService;
+    this.changeListener  = changeListener;
+    this.interval        = interval;
   }
 
   void setInterval(int interval) {
@@ -229,7 +235,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
    */
   private DiscoveryApiClient getApiClient(final ServiceDiscoveryConfig discoveryConfig) {
     return clients.computeIfAbsent(discoveryConfig.getAddress(),
-                                   c -> new DiscoveryApiClient(discoveryConfig, aliasService));
+                                   c -> new DiscoveryApiClient(discoveryConfig, aliasService, keystoreService));
   }
 
   /**

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -30,6 +30,7 @@ import com.cloudera.api.swagger.model.ApiServiceList;
 import com.squareup.okhttp.Call;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.model.atlas.AtlasAPIServiceModelGenerator;
@@ -1141,7 +1142,7 @@ public class ClouderaManagerServiceDiscoveryTest {
     ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig();
 
     // Create the test client for providing test response content
-    TestDiscoveryApiClient mockClient = new TestDiscoveryApiClient(sdConfig, null);
+    TestDiscoveryApiClient mockClient = new TestDiscoveryApiClient(sdConfig, null, null);
 
     // Prepare the service list response for the cluster
     ApiServiceList serviceList = EasyMock.createNiceMock(ApiServiceList.class);
@@ -1261,8 +1262,9 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     private Map<Type, ApiResponse<?>> responseMap = new HashMap<>();
 
-    TestDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
-      super(sdConfig, aliasService);
+    TestDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService,
+                           KeystoreService keystoreService) {
+      super(sdConfig, aliasService, keystoreService);
     }
 
     void addResponse(Type type, ApiResponse<?> response) {

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -200,13 +200,13 @@ public class PollingConfigurationAnalyzerTest {
 
     TestablePollingConfigAnalyzer(ClusterConfigurationCache   cache,
                                   ConfigurationChangeListener listener) {
-      super(cache, null, listener);
+      super(cache, null, null, listener);
     }
 
     TestablePollingConfigAnalyzer(ClusterConfigurationCache cache,
                                   ConfigurationChangeListener listener,
                                   int interval) {
-      super(cache, null, listener, interval);
+      super(cache, null, null, listener, interval);
     }
 
     void addRestartEvent(final String service, final ApiEvent restartEvent) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -133,6 +133,7 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
 
     DefaultClusterConfigurationMonitorService ccs = new DefaultClusterConfigurationMonitorService();
     ccs.setAliasService(alias);
+    ccs.setKeystoreService(ks);
     ccs.init(config, options);
     addService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, ccs);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultClusterConfigurationMonitorService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultClusterConfigurationMonitorService.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.topology.impl;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitorProvider;
@@ -27,10 +28,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-
 public class DefaultClusterConfigurationMonitorService implements ClusterConfigurationMonitorService {
-
     private AliasService aliasService;
+    private KeystoreService keystoreService;
 
     private Map<String, ClusterConfigurationMonitor> monitors = new HashMap<>();
 
@@ -41,7 +41,7 @@ public class DefaultClusterConfigurationMonitorService implements ClusterConfigu
         for (ClusterConfigurationMonitorProvider provider : providers) {
             // Check the gateway configuration to determine if this type of monitor is enabled
             if (config.isClusterMonitorEnabled(provider.getType())) {
-                ClusterConfigurationMonitor monitor = provider.newInstance(config, aliasService);
+                ClusterConfigurationMonitor monitor = provider.newInstance(config, aliasService, keystoreService);
                 if (monitor != null) {
                     monitors.put(provider.getType(), monitor);
                 }
@@ -86,4 +86,7 @@ public class DefaultClusterConfigurationMonitorService implements ClusterConfigu
         this.aliasService = aliasService;
     }
 
+    public void setKeystoreService(KeystoreService keystoreService) {
+        this.keystoreService = keystoreService;
+    }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -76,4 +76,7 @@ public interface GatewaySpiMessages {
   @Message( level = MessageLevel.ERROR, text = "Topology {0} cannot be manually overwritten because it was generated from a simple descriptor." )
   void disallowedOverwritingGeneratedTopology(String topologyName);
 
+  @Message(level = MessageLevel.ERROR, text = "Failed to load truststore due to {0}")
+  void failedToLoadTruststore(String message, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ClusterConfigurationMonitorProvider.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ClusterConfigurationMonitorProvider.java
@@ -18,10 +18,12 @@ package org.apache.knox.gateway.topology.discovery;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
 
 public interface ClusterConfigurationMonitorProvider {
 
     String getType();
 
-    ClusterConfigurationMonitor newInstance(GatewayConfig config, AliasService aliasService);
+    ClusterConfigurationMonitor newInstance(GatewayConfig config, AliasService aliasService,
+                                            KeystoreService keystoreService);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/TruststoreSSLContextUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/TruststoreSSLContextUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.KeystoreServiceException;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+public class TruststoreSSLContextUtils {
+  private static final GatewaySpiMessages LOGGER = MessagesFactory.get(GatewaySpiMessages.class);
+
+  private TruststoreSSLContextUtils() {
+  }
+
+  public static SSLContext getTruststoreSSLContext(KeystoreService keystoreService) {
+    SSLContext sslContext = null;
+    try {
+      if(keystoreService != null) {
+        KeyStore truststore = keystoreService.getTruststoreForHttpClient();
+        if (truststore != null) {
+          SSLContextBuilder sslContextBuilder = SSLContexts.custom();
+          sslContextBuilder.loadTrustMaterial(truststore, null);
+          sslContext = sslContextBuilder.build();
+        }
+      }
+    } catch (KeystoreServiceException | NoSuchAlgorithmException | KeyStoreException
+                 | KeyManagementException e) {
+      LOGGER.failedToLoadTruststore(e.getMessage(), e);
+    }
+    return sslContext;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Ambari and CM discovery doesn't use the configured HTTP truststore. This change adds the HTTP truststore to both the Ambari and CM discovery HTTP clients.

## How was this patch tested?

* `mvn -U -T.75C clean verify -Ppackage,release -Dshellcheck`
* Spun up a cluster with CM AutoTLS and checked that Knox didn't get handshake errors talking to CM