### PR TITLE
KNOX-2266 - Tokens Should Include a Unique Identifier

### DIFF
--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/CommonJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/CommonJWTFilterTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.provider.federation;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.easymock.EasyMock;
@@ -109,9 +110,7 @@ public class CommonJWTFilterTest {
     EasyMock.expect(fc.getServletContext()).andReturn(sc).anyTimes();
     EasyMock.replay(fc);
 
-    Method m = AbstractJWTFilter.class.getDeclaredMethod("isServerManagedTokenStateEnabled", FilterConfig.class);
-    m.setAccessible(true);
-    return (Boolean) m.invoke(handler, fc);
+    return TokenUtils.isServerManagedTokenStateEnabled(fc);
   }
 
   @Test
@@ -129,7 +128,7 @@ public class CommonJWTFilterTest {
   @Test(expected = UnknownTokenException.class)
   public void testIsStillValidUnknownToken() throws Exception {
     TokenStateService tss = EasyMock.createNiceMock(TokenStateService.class);
-    EasyMock.expect(tss.getTokenExpiration(anyObject()))
+    EasyMock.expect(tss.getTokenExpiration(anyObject(JWT.class)))
             .andThrow(new UnknownTokenException("eyjhbgcioi1234567890neg"))
             .anyTimes();
     EasyMock.replay(tss);
@@ -139,7 +138,7 @@ public class CommonJWTFilterTest {
 
   private boolean doTestIsStillValid(final Long expiration) throws Exception {
     TokenStateService tss = EasyMock.createNiceMock(TokenStateService.class);
-    EasyMock.expect(tss.getTokenExpiration(anyObject()))
+    EasyMock.expect(tss.getTokenExpiration(anyObject(JWT.class)))
             .andReturn(expiration)
             .anyTimes();
     EasyMock.replay(tss);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -25,48 +25,46 @@ import org.apache.knox.gateway.i18n.messages.StackTrace;
 public interface TokenStateServiceMessages {
 
   @Message(level = MessageLevel.DEBUG, text = "Added token {0}, expiration {1}")
-  void addedToken(String tokenDisplayText, String expiration);
+  void addedToken(String tokenId, String expiration);
 
   @Message(level = MessageLevel.DEBUG, text = "Renewed token {0}, expiration {1}")
-  void renewedToken(String tokenDisplayText, String expiration);
+  void renewedToken(String tokenId, String expiration);
 
   @Message(level = MessageLevel.DEBUG, text = "Revoked token {0}")
-  void revokedToken(String tokenDisplayText);
+  void revokedToken(String tokenId);
 
   @Message(level = MessageLevel.DEBUG, text = "Removed state for token {0}")
-  void removedTokenState(String tokenDisplayText);
+  void removedTokenState(String tokenId);
 
-  @Message(level = MessageLevel.DEBUG, text = "Unknown token {0}")
-  void unknownToken(String tokenDisplayText);
+  @Message(level = MessageLevel.ERROR, text = "Unknown token {0}")
+  void unknownToken(String tokenId);
 
   @Message(level = MessageLevel.ERROR, text = "The renewal limit for the token ({0}) has been exceeded.")
-  void renewalLimitExceeded(String tokenDisplayText);
+  void renewalLimitExceeded(String tokenId);
 
   @Message(level = MessageLevel.ERROR, text = "Failed to save state for token {0} : {1}")
-  void failedToSaveTokenState(String tokenDisplayText, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+  void failedToSaveTokenState(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR, text = "Error accessing state for token {0} : {1}")
-  void errorAccessingTokenState(String tokenDisplayText, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+  void errorAccessingTokenState(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.INFO,
+           text = "Referencing the expiration in the token ({0}) because no state could not be found: {1}")
+  void permissiveTokenHandling(String tokenId, String errorMessage);
 
   @Message(level = MessageLevel.ERROR, text = "Failed to update expiration for token {1} : {1}")
-  void failedToUpdateTokenExpiration(String tokenDisplayText, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+  void failedToUpdateTokenExpiration(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR, text = "Failed to remove state for token {0} : {1}")
-  void failedToRemoveTokenState(String tokenDisplayText, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+  void failedToRemoveTokenState(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR, text = "Failed to evict expired token {0} : {1}")
-  void failedExpiredTokenEviction(String tokenDisplayText, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+  void failedExpiredTokenEviction(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.DEBUG, text = "Evicting expired token {0}")
-  void evictToken(String tokenDisplayText);
+  void evictToken(String tokenId);
 
   @Message(level = MessageLevel.ERROR, text = "Error occurred evicting token {0}")
   void errorEvictingTokens(@StackTrace(level = MessageLevel.DEBUG) Exception e);
-
-  @Message(level = MessageLevel.ERROR, text = "Error occurred while parsing JWT token, cause: {0}")
-  void errorParsingToken(String cause);
-
-  @Message(level = MessageLevel.DEBUG, text = "Permissive validation for token is enabled, expiration for token {0} is {1}")
-  void jwtTokenExpiry(String tokenDisplayText, String expiration);
 
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -22,8 +22,19 @@ import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
 import org.apache.knox.gateway.i18n.messages.StackTrace;
 
+import java.text.ParseException;
+
 @Messages(logger="org.apache.knox.gateway.service.knoxtoken")
 public interface TokenServiceMessages {
+
+  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) issued token {1} ({2})")
+  void issuedToken(String topologyName, String tokenDisplayText, String tokenId);
+
+  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) renewed the expiration for token {1} ({2})")
+  void renewedToken(String topologyName, String tokenDisplayText, String tokenId);
+
+  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) revoked token {1} ({2})")
+  void revokedToken(String topologyName, String tokenDisplayText, String tokenId);
 
   @Message( level = MessageLevel.ERROR, text = "Unable to issue token.")
   void unableToIssueToken(@StackTrace( level = MessageLevel.DEBUG) Exception e);
@@ -45,15 +56,22 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.INFO, text = "Server management of token state is enabled for the \"{0}\" topology.")
   void serverManagedTokenStateEnabled(String topologyName);
 
+  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) could not parse token {1}: {2}")
+  void invalidToken(String topologyName,
+                    String tokenDisplayText,
+                    @StackTrace( level = MessageLevel.DEBUG ) ParseException e);
+
   @Message( level = MessageLevel.WARN,
             text = "There are no token renewers white-listed in the \"{0}\" topology.")
   void noRenewersConfigured(String topologyName);
 
-  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad token renewal request: {1}")
-  void badRenewalRequest(String topologyName, String error);
+  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad renewal request for token {1}: {2}")
+  void badRenewalRequest(String topologyName, String tokenDisplayText, String error);
 
-  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad token revocation request: {1}")
-  void badRevocationRequest(String topologyName, String error);
+  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad revocation request for token {1}: {2}")
+  void badRevocationRequest(String topologyName, String tokenDisplayText, String error);
 
+  @Message( level = MessageLevel.DEBUG, text = "Knox Token service ({0}) stored state for token {1} ({2})")
+  void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -17,6 +17,7 @@
 package org.apache.knox.gateway.services.security.token;
 
 import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 
 
@@ -44,24 +45,25 @@ public interface TokenStateService extends Service {
    * @param issueTime The time the token was issued.
    */
   void addToken(JWTToken token, long issueTime);
-  /**
-   * Add state for the specified token.
-   *
-   * @param token      The token.
-   * @param issueTime  The time the token was issued.
-   * @param expiration The token expiration time.
-   */
-  void addToken(String token, long issueTime, long expiration);
 
   /**
    * Add state for the specified token.
    *
-   * @param token               The token.
+   * @param tokenId    The token unique identifier.
+   * @param issueTime  The time the token was issued.
+   * @param expiration The token expiration time.
+   */
+  void addToken(String tokenId, long issueTime, long expiration);
+
+  /**
+   * Add state for the specified token.
+   *
+   * @param tokenId             The token unique identifier.
    * @param issueTime           The time the token was issued.
    * @param expiration          The token expiration time.
    * @param maxLifetimeDuration The maximum allowed lifetime for the token.
    */
-  void addToken(String token, long issueTime, long expiration, long maxLifetimeDuration);
+  void addToken(String tokenId, long issueTime, long expiration, long maxLifetimeDuration);
 
   /**
    *
@@ -70,14 +72,6 @@ public interface TokenStateService extends Service {
    * @return true, if the token has expired; Otherwise, false.
    */
   boolean isExpired(JWTToken token) throws UnknownTokenException;
-
-  /**
-   *
-   * @param token The token.
-   *
-   * @return true, if the token has expired; Otherwise, false.
-   */
-  boolean isExpired(String token) throws UnknownTokenException;
 
   /**
    * Disable any subsequent use of the specified token.
@@ -89,9 +83,9 @@ public interface TokenStateService extends Service {
   /**
    * Disable any subsequent use of the specified token.
    *
-   * @param token The token.
+   * @param tokenId The token unique identifier.
    */
-  void revokeToken(String token) throws UnknownTokenException;
+  void revokeToken(String tokenId) throws UnknownTokenException;
 
   /**
    * Extend the lifetime of the specified token by the default amount of time.
@@ -115,21 +109,21 @@ public interface TokenStateService extends Service {
   /**
    * Extend the lifetime of the specified token by the default amount of time.
    *
-   * @param token The token.
+   * @param tokenId The token unique identifier.
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(String token) throws UnknownTokenException;
+  long renewToken(String tokenId) throws UnknownTokenException;
 
   /**
    * Extend the lifetime of the specified token by the specified amount of time.
    *
-   * @param token The token.
+   * @param tokenId The token unique identifier.
    * @param renewInterval The amount of time that should be added to the token's lifetime.
    *
    * @return The token's updated expiration time in milliseconds.
    */
-  long renewToken(String token, long renewInterval) throws UnknownTokenException;
+  long renewToken(String tokenId, long renewInterval) throws UnknownTokenException;
 
   /**
    *
@@ -137,6 +131,14 @@ public interface TokenStateService extends Service {
    *
    * @return The token's expiration time in milliseconds.
    */
-  long getTokenExpiration(String token) throws UnknownTokenException;
+  long getTokenExpiration(JWT token) throws UnknownTokenException;
+
+  /**
+   *
+   * @param tokenId The token unique identifier.
+   *
+   * @return The token's expiration time in milliseconds.
+   */
+  long getTokenExpiration(String tokenId) throws UnknownTokenException;
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenUtils.java
@@ -16,12 +16,68 @@
  */
 package org.apache.knox.gateway.services.security.token;
 
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
 import java.util.Locale;
+
 
 public class TokenUtils {
 
+  /**
+   * Get a String derived from a JWT String, which is suitable for presentation (e.g., logging) without compromising
+   * security.
+   *
+   * @param token A BASE64-encoded JWT String.
+   *
+   * @return An abbreviated form of the specified JWT String.
+   */
   public static String getTokenDisplayText(final String token) {
-    return String.format(Locale.ROOT, "%s...%s", token.substring(0, 10), token.substring(token.length() - 3));
+    return String.format(Locale.ROOT, "%s...%s", token.substring(0, 6), token.substring(token.length() - 6));
+  }
+
+  /**
+   * Extract the unique Knox token identifier from the specified JWT's claim set.
+   *
+   * @param token A JWT
+   *
+   * @return The unique identifier, or null.
+   */
+  public static String getTokenId(final JWT token) {
+    return token.getClaim(JWTToken.KNOX_ID_CLAIM);
+  }
+
+  /**
+   * Determine if server-managed token state is enabled for a provider, based on configuration.
+   * The analysis includes checking the provider params and the gateway configuration.
+   *
+   * @param filterConfig A FilterConfig object.
+   *
+   * @return true, if server-managed state is enabled; Otherwise, false.
+   */
+  public static boolean isServerManagedTokenStateEnabled(FilterConfig filterConfig) {
+    boolean isServerManaged = false;
+
+    // First, check for explicit provider-level configuration
+    String providerParamValue = filterConfig.getInitParameter(TokenStateService.CONFIG_SERVER_MANAGED);
+
+    // If there is no provider-level configuration
+    if (providerParamValue == null || providerParamValue.isEmpty()) {
+      // Fall back to the gateway-level default
+      ServletContext context = filterConfig.getServletContext();
+      if (context != null) {
+        GatewayConfig config = (GatewayConfig) context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+        isServerManaged = (config != null) && config.isServerManagedTokenStateEnabled();
+      }
+    } else {
+      // Otherwise, apply the provider-level configuration
+      isServerManaged = Boolean.valueOf(providerParamValue);
+    }
+
+    return isServerManaged;
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/UnknownTokenException.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/UnknownTokenException.java
@@ -18,19 +18,23 @@ package org.apache.knox.gateway.services.security.token;
 
 public class UnknownTokenException extends Exception {
 
-  private String token;
+  private String tokenId;
 
-  public UnknownTokenException(final String token) {
-    this.token = token;
+  /**
+   *
+   * @param tokenId The token unique identifier
+   */
+  public UnknownTokenException(final String tokenId) {
+    this.tokenId = tokenId;
   }
 
-  public String getToken() {
-    return token;
+  public String getTokenId() {
+    return tokenId;
   }
 
   @Override
   public String getMessage() {
-    return "Unknown token: " + TokenUtils.getTokenDisplayText(token);
+    return "Unknown token: " + tokenId;
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -20,6 +20,7 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
@@ -35,6 +36,8 @@ import com.nimbusds.jwt.SignedJWT;
 
 public class JWTToken implements JWT {
   private static JWTProviderMessages log = MessagesFactory.get( JWTProviderMessages.class );
+
+  public static final String KNOX_ID_CLAIM = "knox.id";
 
   SignedJWT jwt;
 
@@ -72,6 +75,9 @@ public class JWTToken implements JWT {
     if(claimsArray[3] != null) {
       builder = builder.expirationTime(new Date(Long.parseLong(claimsArray[3])));
     }
+
+    // Add a private UUID claim for uniqueness
+    builder.claim(KNOX_ID_CLAIM, String.valueOf(UUID.randomUUID()));
 
     claims = builder.build();
 

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
@@ -25,6 +25,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -78,6 +79,25 @@ public class JWTTokenTest {
     assertEquals("KNOXSSO", token.getIssuer());
     assertEquals("john.doe@example.com", token.getSubject());
     assertEquals("https://login.example.com", token.getAudience());
+  }
+
+  @Test
+  public void testPrivateUUIDClaim() throws Exception {
+    String[] claims = new String[4];
+    claims[0] = "KNOXSSO";
+    claims[1] = "john.doe@example.com";
+    claims[2] = "https://login.example.com";
+    claims[3] = Long.toString( ( System.currentTimeMillis()/1000 ) + 300);
+    JWT token = new JWTToken("RS256", claims);
+
+    assertEquals("KNOXSSO", token.getIssuer());
+    assertEquals("john.doe@example.com", token.getSubject());
+    assertEquals("https://login.example.com", token.getAudience());
+
+    String uuidString = token.getClaim(JWTToken.KNOX_ID_CLAIM);
+    assertNotNull(uuidString);
+    UUID uuid = UUID.fromString(uuidString);
+    assertNotNull(uuid);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

JWTs issued and validated by Knox now include a unique identifier as a private claim. This is mostly to guarantee token uniqueness, even for multiple requests within the same second.
Further, the TokenStateService has been updated to leverage this unique identifier as the key for handling token state. This identifier is less susceptible to the nuances of some storage mechanisms.

## How was this patch tested?

Mulitple existing tests were modified to accommodate this change while ensuring the maintenance of existing behavior. TokenServiceResourceTest#testConcurrentGetToken was added to validate these changes. I've also done a bit of manual testing.