### PR TITLE
KNOX-2284 - Handling CM descriptors after Knox shared-provider/descriptor/topology monitors are started

### DIFF
--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -33,6 +33,9 @@ public interface ClouderaManagerIntegrationMessages {
   @Message(level = MessageLevel.INFO, text = "Found Knox descriptors {0} in {1}")
   void parsedClouderaManagerDescriptor(String descriptorList, String path);
 
+  @Message(level = MessageLevel.INFO, text = "Saved Knox descriptor {0}")
+  void savedSimpleDescriptorDescriptor(String path);
+
   @Message(level = MessageLevel.INFO, text = "Ignoring {0} Knox descriptor update because it did not change.")
   void descriptorDidNotChange(String descriptorName);
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorMonitor.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorMonitor.java
@@ -97,6 +97,7 @@ public class ClouderaManagerDescriptorMonitor implements AdvancedServiceDiscover
         final String simpleDescriptorJsonString = JsonUtils.renderAsJsonString(simpleDescriptor);
         if (isDescriptorChangedOrNew(knoxDescriptorFile, simpleDescriptorJsonString)) {
           FileUtils.writeStringToFile(knoxDescriptorFile, JsonUtils.renderAsJsonString(simpleDescriptor), StandardCharsets.UTF_8);
+          LOG.savedSimpleDescriptorDescriptor(knoxDescriptorFile.getAbsolutePath());
         } else {
           LOG.descriptorDidNotChange(simpleDescriptor.getName());
         }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -624,14 +624,6 @@ public class GatewayServer {
         "org.eclipse.jetty.webapp.JettyWebXmlConfiguration",
         "org.eclipse.jetty.annotations.AnnotationConfiguration" );
 
-    final ClouderaManagerDescriptorParser cmDescriptorParser = new ClouderaManagerDescriptorParser();
-    final ClouderaManagerDescriptorMonitor cmDescriptorMonitor = new ClouderaManagerDescriptorMonitor(config, cmDescriptorParser);
-    final AdvancedServiceDiscoveryConfigurationMonitor advancedServiceDiscoveryConfigurationMonitor = new AdvancedServiceDiscoveryConfigurationMonitor(config);
-    advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorParser);
-    advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorMonitor);
-    advancedServiceDiscoveryConfigurationMonitor.init();
-    cmDescriptorMonitor.setupMonitor();
-
     // Load the current topologies.
     // Redeploy autodeploy topologies.
     File topologiesDir = calculateAbsoluteTopologiesDir();
@@ -708,6 +700,8 @@ public class GatewayServer {
     log.monitoringTopologyChangesInDirectory(topologiesDir.getAbsolutePath());
     monitor.startMonitor();
 
+    handleClouderaManagerDescriptors();
+
     Runtime.getRuntime().addShutdownHook(new Thread() {
 
       @Override
@@ -719,6 +713,16 @@ public class GatewayServer {
         }
       }
     });
+  }
+
+  private void handleClouderaManagerDescriptors() {
+    final ClouderaManagerDescriptorParser cmDescriptorParser = new ClouderaManagerDescriptorParser();
+    final ClouderaManagerDescriptorMonitor cmDescriptorMonitor = new ClouderaManagerDescriptorMonitor(config, cmDescriptorParser);
+    final AdvancedServiceDiscoveryConfigurationMonitor advancedServiceDiscoveryConfigurationMonitor = new AdvancedServiceDiscoveryConfigurationMonitor(config);
+    advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorParser);
+    advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorMonitor);
+    advancedServiceDiscoveryConfigurationMonitor.init();
+    cmDescriptorMonitor.setupMonitor();
   }
 
   public synchronized void stop() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handling CM descriptors after Knox shared-provider/descriptor/topology monitors are started

## How was this patch tested?

Tested manually:
1. redeployed Knox with my changes in place; brand new installation, only the OOTB topologies existed
2. produced a CM descriptor (cm-topologies.cm) with the following content:
```
<configuration>
  <property>
    <name>topology1</name>
    <value>
        providerConfigRef=default-providers;
        app:knoxauth:param1.name=param1.value;
        HIVE:url=http://localhost:456;
        HIVE:version=1.0;
        HIVE:httpclient.connectionTimeout=5m;
        HIVE:httpclient.socketTimeout=100m
    </value>
  </property>
  <property>
    <name>topology2</name>
    <value>
        providerConfigRef=default-providers;
        HDFS:url=http://localhost:456;
        HDFS:httpclient.connectionTimeout=5m;
        HDFS:httpclient.socketTimeout=100m
    </value>
  </property>
</configuration>
```
3. started Knox and confirmed (from logs and using the Admin UI):
- `$KNOX_HOME/conf/descriptors/topology1.json` and `$KNOX_HOME/conf/descriptors/topology2.json` got persisted
- Knox picked them up and generated `$KNOX_HOME/data/deployments/topology1.topo.170c48f42c0` and `$KNOX_HOME/data/deployments/topology2.topo.170c48f42c0`


Relevant logs:
```
2020-03-10 14:07:50,348 INFO  knox.gateway (DefaultTopologyService.java:init(648)) - Monitoring simple descriptors in directory: /Users/smolnar/test/knoxGateway/conf/descriptors
2020-03-10 14:07:50,577 INFO  knox.gateway (DefaultTopologyService.java:init(653)) - Monitoring shared provider configurations in directory: /Users/smolnar/test/knoxGateway/conf/shared-providers
...
2020-03-10 14:08:02,899 INFO  knox.gateway (GatewayServer.java:start(700)) - Monitoring topologies in directory: /Users/smolnar/test/knoxGateway/conf/topologies
2020-03-10 14:08:02,920 INFO  discovery.advanced (AdvancedServiceDiscoveryConfigurationMonitor.java:setupMonitor(73)) - Monitoring /Users/smolnar/test/knoxGateway/conf/auto-discovery-advanced-configuration-* for advanced service discovery configuration changes.
2020-03-10 14:08:02,925 INFO  knox.gateway (ClouderaManagerDescriptorMonitor.java:setupMonitor(66)) - Monitoring Cloudera Manager descriptors in /Users/smolnar/test/knoxGateway/conf/descriptors ...
2020-03-10 14:08:02,925 INFO  knox.gateway (ClouderaManagerDescriptorParser.java:parse(79)) - Parsing Cloudera Manager descriptor /Users/smolnar/test/knoxGateway/conf/descriptors/cm-topologies.cm. Looking up all topologies...
2020-03-10 14:08:02,925 INFO  knox.gateway (GatewayServer.java:startGateway(392)) - Started gateway on port 8,443.
2020-03-10 14:08:02,936 INFO  knox.gateway (ClouderaManagerDescriptorParser.java:parse(84)) - Found Knox descriptors topology1, topology2 in /Users/smolnar/test/knoxGateway/conf/descriptors/cm-topologies.cm
2020-03-10 14:08:03,125 INFO  knox.gateway (ClouderaManagerDescriptorMonitor.java:lambda$1(100)) - Saved Knox descriptor /Users/smolnar/test/knoxGateway/conf/descriptors/topology1.json
2020-03-10 14:08:03,125 INFO  knox.gateway (ClouderaManagerDescriptorMonitor.java:lambda$1(100)) - Saved Knox descriptor /Users/smolnar/test/knoxGateway/conf/descriptors/topology2.json
2020-03-10 14:08:08,011 INFO  knox.gateway (DefaultTopologyService.java:onFileChange(872)) - Generated topology topology1.xml because the associated descriptor topology1.json changed.
...
2020-03-10 14:08:14,278 INFO  knox.gateway (GatewayServer.java:handleCreateDeployment(1013)) - Deploying topology topology1 to /Users/smolnar/test/knoxGateway/data/deployments/topology1.topo.170c48f42c0
2020-03-10 14:08:14,278 INFO  knox.gateway (GatewayServer.java:internalDeactivateTopology(932)) - Deactivating topology topology1
2020-03-10 14:08:14,450 INFO  knox.gateway (DefaultGatewayServices.java:initializeContribution(161)) - Creating credential store for the cluster: topology1
2020-03-10 14:08:14,753 INFO  knox.gateway (GatewayServer.java:internalActivateTopology(898)) - Activating topology topology1
2020-03-10 14:08:14,753 INFO  knox.gateway (GatewayServer.java:internalActivateArchive(908)) - Activating topology topology1 archive %2Fknoxauth
2020-03-10 14:08:14,833 INFO  knox.gateway (GatewayServer.java:handleCreateDeployment(1013)) - Deploying topology topology2 to /Users/smolnar/test/knoxGateway/data/deployments/topology2.topo.170c48f42c0
2020-03-10 14:08:14,833 INFO  knox.gateway (GatewayServer.java:internalDeactivateTopology(932)) - Deactivating topology topology2
2020-03-10 14:08:14,940 INFO  knox.gateway (GatewayServer.java:internalActivateTopology(898)) - Activating topology topology2
```