### PR TITLE
KNOX-2289 - Passing GatewayServer.getGatewayServices() to SimpleDescriptorHandler.handle() as it needs it to provision encryption query string password

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -789,10 +789,6 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
 
 
   /**
-   * Change handler for simple descriptors
-   */
-
-  /**
    * Listener for Ambari config change events, which will trigger re-generation (including re-discovery) of the
    * affected topologies.
    */

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/monitor/DescriptorsMonitor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/monitor/DescriptorsMonitor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -92,7 +93,7 @@ public class DescriptorsMonitor extends FileAlterationListenerAdaptor implements
   public void onFileChange(File file) {
     try {
       // When a simple descriptor has been created or modified, generate the new topology descriptor
-      Map<String, File> result = SimpleDescriptorHandler.handle(gatewayConfig, file, topologiesDir, aliasService);
+      Map<String, File> result = SimpleDescriptorHandler.handle(gatewayConfig, file, topologiesDir, aliasService, GatewayServer.getGatewayServices());
       LOG.generatedTopologyForDescriptorChange(result.get(SimpleDescriptorHandler.RESULT_TOPOLOGY).getName(), file.getName());
 
       // Add the provider config reference relationship for handling updates to the provider config


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

Manually tested:

- redeployed Knox with my changes
- had a CM descriptor with two topologies: `topology1` and `topology2`
- started Knox: the CM descriptor got picked up and generated into toplogies
- confirmed that:
  - the previous ERROR message - `Failed to create a password for query string encryption for` - did not show up in the log
  - the password was created

```
$ bin/knoxcli.sh list-alias --cluster topology2
Listing aliases for: topology2
encryptquerystring

1 items.

$ bin/knoxcli.sh list-alias --cluster topology1
Listing aliases for: topology1
encryptquerystring

1 items.
```