### PR TITLE
KNOX-2296 - Passing down the service URL field when building up a service model

### DIFF
--- a/gateway-service-definitions/pom.xml
+++ b/gateway-service-definitions/pom.xml
@@ -47,7 +47,10 @@
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>

--- a/gateway-service-definitions/src/main/java/org/apache/knox/gateway/service/definition/Metadata.java
+++ b/gateway-service-definitions/src/main/java/org/apache/knox/gateway/service/definition/Metadata.java
@@ -20,6 +20,11 @@ package org.apache.knox.gateway.service.definition;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 @XmlType(name = "metadata")
 public class Metadata {
 
@@ -62,6 +67,21 @@ public class Metadata {
 
   public void setDescription(String description) {
     this.description = description;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return EqualsBuilder.reflectionEquals(obj, this);
+  }
+
+  @Override
+  public int hashCode() {
+    return HashCodeBuilder.reflectionHashCode(this);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
   }
 
 }

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>
         </dependency>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformation.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformation.java
@@ -17,7 +17,7 @@
  */
 package org.apache.knox.gateway.service.metadata;
 
-import java.util.List;
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
@@ -31,11 +31,11 @@ public class TopologyInformation {
 
   @XmlElement(name = "service")
   @XmlElementWrapper(name = "apiServices")
-  private List<ServiceModel> apiServices;
+  private Set<ServiceModel> apiServices;
 
   @XmlElement(name = "service")
   @XmlElementWrapper(name = "uiServices")
-  private List<ServiceModel> uiServices;
+  private Set<ServiceModel> uiServices;
 
   public String getTopologyName() {
     return topologyName;
@@ -45,19 +45,19 @@ public class TopologyInformation {
     this.topologyName = topologyName;
   }
 
-  public List<ServiceModel> getApiServices() {
+  public Set<ServiceModel> getApiServices() {
     return apiServices;
   }
 
-  public void setApiServices(List<ServiceModel> apiServices) {
+  public void setApiServices(Set<ServiceModel> apiServices) {
     this.apiServices = apiServices;
   }
 
-  public List<ServiceModel> getUiServices() {
+  public Set<ServiceModel> getUiServices() {
     return uiServices;
   }
 
-  public void setUiServices(List<ServiceModel> uiServices) {
+  public void setUiServices(Set<ServiceModel> uiServices) {
     this.uiServices = uiServices;
   }
 

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformationWrapper.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformationWrapper.java
@@ -18,7 +18,6 @@
 package org.apache.knox.gateway.service.metadata;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -37,7 +36,7 @@ public class TopologyInformationWrapper {
     return topologies;
   }
 
-  public void addTopology(String name, List<ServiceModel> apiServices, List<ServiceModel> uiServices) {
+  public void addTopology(String name, Set<ServiceModel> apiServices, Set<ServiceModel> uiServices) {
     final TopologyInformation topology = new TopologyInformation();
     topology.setTopologyName(name);
     topology.setApiServices(apiServices);

--- a/gateway-service-metadata/src/test/java/org/apache/knox/gateway/service/metadata/ServiceModelTest.java
+++ b/gateway-service-metadata/src/test/java/org/apache/knox/gateway/service/metadata/ServiceModelTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.metadata;
+
+import static org.apache.knox.gateway.service.metadata.ServiceModel.HIVE_SERVICE_NAME;
+import static org.apache.knox.gateway.service.metadata.ServiceModel.HIVE_SERVICE_URL_TEMPLATE;
+import static org.apache.knox.gateway.service.metadata.ServiceModel.SERVICE_URL_TEMPLATE;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.knox.gateway.service.definition.Metadata;
+import org.apache.knox.gateway.topology.Service;
+import org.apache.knox.gateway.topology.Version;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class ServiceModelTest {
+
+  private static final String SERVER_SCHEME = "https";
+  private static final String SERVER_NAME = "localhost";
+  private static final int SERVER_PORT = 8443;
+
+  @Test
+  public void shouldReturnEmptyStringAsServiceNameIfServiceNotSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    assertEquals("", serviceModel.getServiceName());
+  }
+
+  @Test
+  public void shouldReturnTheGivenServiceRoleWhenFetchingServiceName() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    final String roleName = "sampleRole";
+    EasyMock.expect(service.getRole()).andReturn(roleName).anyTimes();
+    EasyMock.replay(service);
+    assertEquals(roleName, serviceModel.getServiceName());
+  }
+
+  @Test
+  public void shouldReturnEmptyStringAsServiceVersionIfServiceNotSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    assertEquals("", serviceModel.getVersion());
+  }
+
+  @Test
+  public void shouldReturnEmptyStringAsServiceVersionIfServiceVersionIsNotSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    assertEquals("", serviceModel.getVersion());
+  }
+
+  @Test
+  public void shouldReturnTheGivenServiceVersionWhenFetchingVersion() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    final Version version = new Version(1, 2, 3);
+    EasyMock.expect(service.getVersion()).andReturn(version).anyTimes();
+    EasyMock.replay(service);
+    assertEquals(version.toString(), serviceModel.getVersion());
+  }
+
+  @Test
+  public void shouldReturnServiceRoleAsShortDescriptionIfMetadataIsNotSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    EasyMock.expect(service.getRole()).andReturn("sampleRole").anyTimes();
+    EasyMock.replay(service);
+    assertEquals("Samplerole", serviceModel.getShortDescription());
+  }
+
+  @Test
+  public void shouldReturnShortDescriptionFromMetadataIfMetadataIsSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Metadata metadata = EasyMock.createNiceMock(Metadata.class);
+    serviceModel.setServiceMetadata(metadata);
+    final String shortDesc = "shortDescription";
+    EasyMock.expect(metadata.getShortDesc()).andReturn(shortDesc).anyTimes();
+    EasyMock.replay(metadata);
+    assertEquals(shortDesc, serviceModel.getShortDescription());
+  }
+
+  @Test
+  public void shouldReturnUnknownTypeIfMetadataIsNotSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    assertEquals(ServiceModel.Type.UNKNOWN, serviceModel.getType());
+  }
+
+  @Test
+  public void shouldReturnTypeFromMetadataIfMetadataIsSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Metadata metadata = EasyMock.createNiceMock(Metadata.class);
+    serviceModel.setServiceMetadata(metadata);
+    final ServiceModel.Type type = ServiceModel.Type.API;
+    EasyMock.expect(metadata.getType()).andReturn(type.name()).anyTimes();
+    EasyMock.replay(metadata);
+    assertEquals(type, serviceModel.getType());
+  }
+
+  @Test
+  public void shouldUseServiceNameAsContextIfMetadataIsNotSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    EasyMock.expect(service.getRole()).andReturn("sampleRole").anyTimes();
+    EasyMock.replay(service);
+    assertEquals("/samplerole/", serviceModel.getContext());
+  }
+
+  @Test
+  public void shouldReturnContextFromMetadataIfMetadataIsSet() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final Metadata metadata = EasyMock.createNiceMock(Metadata.class);
+    serviceModel.setServiceMetadata(metadata);
+    final String context = "/testContext";
+    EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
+    EasyMock.replay(metadata);
+    assertEquals(context + "/", serviceModel.getContext());
+  }
+
+  @Test
+  public void shouldReturnProperHiveServiceUrl() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final String gatewayPath = "gateway";
+    final String topologyName = "sandbox";
+    serviceModel.setGatewayPath(gatewayPath);
+    serviceModel.setTopologyName(topologyName);
+    serviceModel.setRequest(setUpHttpRequestMock());
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    EasyMock.expect(service.getRole()).andReturn(HIVE_SERVICE_NAME).anyTimes();
+    EasyMock.replay(service);
+    assertEquals(String.format(Locale.ROOT, HIVE_SERVICE_URL_TEMPLATE, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, "/hive/"), serviceModel.getServiceUrl());
+  }
+
+  public HttpServletRequest setUpHttpRequestMock() {
+    final HttpServletRequest httpServletRequestMock = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(httpServletRequestMock.getScheme()).andReturn(SERVER_SCHEME).anyTimes();
+    EasyMock.expect(httpServletRequestMock.getServerName()).andReturn(SERVER_NAME).anyTimes();
+    EasyMock.expect(httpServletRequestMock.getServerPort()).andReturn(SERVER_PORT).anyTimes();
+    EasyMock.replay(httpServletRequestMock);
+    return httpServletRequestMock;
+  }
+
+  @Test
+  public void shouldReturnSimpleServiceUrl() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final String gatewayPath = "gateway";
+    final String topologyName = "sandbox";
+    serviceModel.setGatewayPath(gatewayPath);
+    serviceModel.setTopologyName(topologyName);
+    serviceModel.setRequest(setUpHttpRequestMock());
+    final Metadata metadata = EasyMock.createNiceMock(Metadata.class);
+    serviceModel.setServiceMetadata(metadata);
+    final String context = "/testContext";
+    EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
+    EasyMock.replay(metadata);
+    assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, context + "/"), serviceModel.getServiceUrl());
+  }
+
+  @Test
+  public void shouldReturnServiceUrlWithBackendHostPlaceholder() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final String gatewayPath = "gateway";
+    final String topologyName = "sandbox";
+    serviceModel.setGatewayPath(gatewayPath);
+    serviceModel.setTopologyName(topologyName);
+    serviceModel.setRequest(setUpHttpRequestMock());
+
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    EasyMock.expect(service.getRole()).andReturn("service").anyTimes();
+    final String backendHost = "https://localhost:5555";
+    EasyMock.expect(service.getUrl()).andReturn(backendHost); // backend host comes from the service object
+    final Metadata metadata = EasyMock.createNiceMock(Metadata.class);
+    serviceModel.setServiceMetadata(metadata);
+    final String context = "/testContext?backendHost={{BACKEND_HOST}}";
+    EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
+    EasyMock.replay(service, metadata);
+    assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName,
+        context.replace("{{BACKEND_HOST}}", backendHost) + "/"), serviceModel.getServiceUrl());
+
+    final String serviceUrl = "https://serviceHost:8888";
+    serviceModel.setServiceUrl(serviceUrl); // backend host comes from the given service URL
+    assertEquals(
+        String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, context.replace("{{BACKEND_HOST}}", serviceUrl) + "/"),
+        serviceModel.getServiceUrl());
+  }
+
+  @Test
+  public void shouldReturnServiceUrlWithSchemeHostAndPortPlaceholders() throws Exception {
+    final ServiceModel serviceModel = new ServiceModel();
+    final String gatewayPath = "gateway";
+    final String topologyName = "sandbox";
+    serviceModel.setGatewayPath(gatewayPath);
+    serviceModel.setTopologyName(topologyName);
+    serviceModel.setRequest(setUpHttpRequestMock());
+
+    final Service service = EasyMock.createNiceMock(Service.class);
+    serviceModel.setService(service);
+    EasyMock.expect(service.getRole()).andReturn("service").anyTimes();
+    EasyMock.expect(service.getUrl()).andReturn("https://localhost:5555");
+
+    final Metadata metadata = EasyMock.createNiceMock(Metadata.class);
+    serviceModel.setServiceMetadata(metadata);
+    final String context = "/testContext?scheme={{SCHEME}}&host={{HOST}}&port={{PORT}}";
+    EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
+
+    EasyMock.replay(service, metadata);
+    assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName,
+        context.replace("{{SCHEME}}", "https").replace("{{HOST}}", "localhost").replace("{{PORT}}", "5555") + "/"), serviceModel.getServiceUrl());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Returning a `Set` of service models instead of a `List` for both UI and API services. This results in displaying only one service logo/URL with multiple service URLs in case the service URLs do not contain service-specific host/port parts.

## How was this patch tested?

Manually tested:

- added a topology (`cdp-proxy`) with IMPALA and IMPALAUI services
- both services had 2 service URLs defined
- redeployed Knox and confirmed the following using the Metadata API:
  - Impala UI logo appeared twice pointing to two different instances as the service URL of IMPALA UI contains `{{HOST}}` and `{{PORT}}` placeholders
  - Impala API link appeared only once

<img width="1668" alt="Screen Shot 2020-03-17 at 8 24 05 PM" src="https://user-images.githubusercontent.com/34065904/76894201-fba82680-688d-11ea-86dd-39b7fc1f8629.png">

<img width="1672" alt="Screen Shot 2020-03-17 at 8 27 03 PM" src="https://user-images.githubusercontent.com/34065904/76894235-08c51580-688e-11ea-9de5-884ad09da194.png">