### PR TITLE
KNOX-2298 - ClouderaManager cluster config monitor should stop monito…

### DIFF
--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-topology-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-i18n</artifactId>
         </dependency>
         <dependency>

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -119,6 +119,10 @@ public interface ClouderaManagerServiceDiscoveryMessages {
       text = "Stopped ClouderaManager cluster configuration monitor")
   void stoppedClouderaManagerConfigMonitor();
 
+  @Message(level = MessageLevel.INFO,
+           text = "Terminating monitoring of {1} @ {0} for configuration changes because there are no referencing descriptors.")
+  void stoppingConfigMonitoring(String discoverySource, String clusterName);
+
   @Message(level = MessageLevel.DEBUG, text = "Checking {0} @ {1} for configuration changes...")
   void checkingClusterConfiguration(String clusterName, String discoveryAddress);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -789,7 +789,7 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
 
 
   /**
-   * Listener for Ambari config change events, which will trigger re-generation (including re-discovery) of the
+   * Listener for cluster config change events, which will trigger re-generation (including re-discovery) of the
    * affected topologies.
    */
   private static class TopologyDiscoveryTrigger implements ClusterConfigurationMonitor.ConfigurationChangeListener {
@@ -803,14 +803,14 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
     }
 
     @Override
-    public void onConfigurationChange(String source, String clusterName) {
+    public void onConfigurationChange(final String source, final String clusterName) {
       log.noticedClusterConfigurationChange(source, clusterName);
       try {
         boolean affectedDescriptors = false;
         // Identify any descriptors associated with the cluster configuration change
         for (File descriptor : topologyService.getDescriptors()) {
-          String descriptorContent = FileUtils.readFileToString(descriptor, StandardCharsets.UTF_8);
-          if (descriptorContent.contains(source) && descriptorContent.contains(clusterName)) {
+          SimpleDescriptor sd = SimpleDescriptorFactory.parse(descriptor.getAbsolutePath());
+          if (source.equals(sd.getDiscoveryAddress()) && clusterName.equals(sd.getCluster())) {
             affectedDescriptors = true;
             log.triggeringTopologyRegeneration(source, clusterName, descriptor.getAbsolutePath());
             // 'Touch' the descriptor to trigger re-generation of the associated topology


### PR DESCRIPTION
…ring unreferenced clusters

## What changes were proposed in this pull request?

Improved the CM cluster configuration monitoring to stop monitoring clusters that are no longer referenced by any descriptors (e.g., descriptor deleted or modified).

## How was this patch tested?

Added a test to PollingConfigurationAnalyzerTest, performed manual testing, and executed all existing tests.