### PR TITLE
KNOX-2299 - Fixed Hive JDBC URL on Knox Home page

### DIFF
--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
@@ -41,7 +41,7 @@ public class ServiceModel implements Comparable<ServiceModel> {
 
   static final String SERVICE_URL_TEMPLATE = "%s://%s:%s/%s/%s%s";
   static final String HIVE_SERVICE_NAME = "HIVE";
-  static final String HIVE_SERVICE_URL_TEMPLATE = "jdbc:hive2://%s:%d/;?hive.server2.transport.mode=http;hive.server2.thrift.http.path=/%s/%s%s";
+  static final String HIVE_SERVICE_URL_TEMPLATE = "jdbc:hive2://%s:%d/;ssl=true;transportMode=http;httpPath=%s/%s/hive";
 
   public enum Type {
     API, UI, UNKNOWN
@@ -120,7 +120,7 @@ public class ServiceModel implements Comparable<ServiceModel> {
   public String getServiceUrl() {
     String context = getContext();
     if (HIVE_SERVICE_NAME.equals(getServiceName())) {
-      return String.format(Locale.ROOT, HIVE_SERVICE_URL_TEMPLATE, request.getServerName(), request.getServerPort(), gatewayPath, topologyName, context);
+      return String.format(Locale.ROOT, HIVE_SERVICE_URL_TEMPLATE, request.getServerName(), request.getServerPort(), gatewayPath, topologyName);
     } else {
       final String backendUrlString = getBackendServiceUrl();
       if (context.indexOf("{{BACKEND_HOST}}") > -1) {

--- a/gateway-service-metadata/src/test/java/org/apache/knox/gateway/service/metadata/ServiceModelTest.java
+++ b/gateway-service-metadata/src/test/java/org/apache/knox/gateway/service/metadata/ServiceModelTest.java
@@ -151,7 +151,7 @@ public class ServiceModelTest {
     serviceModel.setService(service);
     EasyMock.expect(service.getRole()).andReturn(HIVE_SERVICE_NAME).anyTimes();
     EasyMock.replay(service);
-    assertEquals(String.format(Locale.ROOT, HIVE_SERVICE_URL_TEMPLATE, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, "/hive/"), serviceModel.getServiceUrl());
+    assertEquals(String.format(Locale.ROOT, HIVE_SERVICE_URL_TEMPLATE, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName), serviceModel.getServiceUrl());
   }
 
   public HttpServletRequest setUpHttpRequestMock() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replaced the wrong Hive JDBC URL to a valid one.

## How was this patch tested?

Updated and ran JUnit tests.