### PR TITLE
KNOX-2300 - Livy and Solr handled as both API and UI services

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
@@ -17,7 +17,7 @@
 -->
 <service role="LIVYSERVER" name="livy" version="0.4.0">
     <metadata>
-        <type>API</type>
+        <type>API_AND_UI</type>
         <context>/livy</context>
         <shortDesc>Livy Server</shortDesc>
         <description>Apache Livy is a service that enables easy interaction with a Spark cluster over a REST interface.</description>

--- a/gateway-service-definitions/src/main/resources/services/solr/5.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/solr/5.5.0/service.xml
@@ -17,7 +17,7 @@
 -->
 <service role="SOLRAPI" name="solr" version="5.5.0">
     <metadata>
-        <type>API</type>
+        <type>API_AND_UI</type>
         <context>/solr</context>
         <shortDesc>SOLR</shortDesc>
         <description>Solr is a popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.</description>

--- a/gateway-service-definitions/src/main/resources/services/solr/6.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/solr/6.0.0/service.xml
@@ -17,7 +17,7 @@
 -->
 <service role="SOLR" name="solr" version="6.0.0">
     <metadata>
-        <type>API</type>
+        <type>API_AND_UI</type>
         <context>/solr</context>
         <shortDesc>SOLR</shortDesc>
         <description>Solr is a popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.</description>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -201,6 +201,9 @@ public class KnoxMetadataResource {
                   serviceUrl);
               if (ServiceModel.Type.UI == serviceModel.getType()) {
                 uiServices.add(serviceModel);
+              } else if (ServiceModel.Type.API_AND_UI == serviceModel.getType()) {
+                uiServices.add(serviceModel);
+                apiServices.add(serviceModel);
               } else {
                 apiServices.add(serviceModel);
               }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
@@ -44,7 +44,7 @@ public class ServiceModel implements Comparable<ServiceModel> {
   static final String HIVE_SERVICE_URL_TEMPLATE = "jdbc:hive2://%s:%d/;?hive.server2.transport.mode=http;hive.server2.thrift.http.path=/%s/%s%s";
 
   public enum Type {
-    API, UI, UNKNOWN
+    API, UI, API_AND_UI, UNKNOWN
   };
 
   private HttpServletRequest request;


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on Livy Server's and Solr's logo will be displayed in the UI services section as well as listed in the API services table.

## How was this patch tested?

Manually tested:

<img width="1662" alt="Screen Shot 2020-03-18 at 9 31 55 AM" src="https://user-images.githubusercontent.com/34065904/76941298-0ef1db00-68fc-11ea-8c9d-0685ea55ff19.png">
