### PR TITLE
KNOX-2305 - Blacklist Maven 3.6.2 and move cloudera repository to child pom

### DIFF
--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -27,6 +27,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gateway-discovery-cm</artifactId>
+
+    <repositories>
+        <repository>
+            <id>Cloudera</id>
+            <name>Cloudera</name>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.knox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,11 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[3.0.2,)</version>
+                                    <!--
+                                    Maven 3.6.2 has issues
+                                    https://issues.apache.org/jira/browse/KNOX-2305
+                                    -->
+                                    <version>[3.1.0,3.6.2),(3.6.2,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[1.8,)</version>
@@ -2414,17 +2418,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>Cloudera</id>
-            <name>Cloudera</name>
-            <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-    </repositories>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Blacklist Maven 3.6.2 and move cloudera repository to child pom

## How was this patch tested?

* `mvn -U -T.75C clean verify -Ppackage,release -Dshellcheck`
