### PR TITLE
KNOX-2240 - KnoxShell Custom Command for WEBHDFS Use

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
@@ -653,7 +653,7 @@ public class KnoxSession implements Closeable {
   }
 
   public static void persistMountPoints(Map<String, String> mounts) {
-    persistDataSourcesToKnoxShell(KNOXMOUNTPOINTS_JSON, mounts);
+    persistMapToKnoxShell(KNOXMOUNTPOINTS_JSON, mounts);
   }
 
   /**
@@ -677,7 +677,7 @@ public class KnoxSession implements Closeable {
   }
 
   public static Map<String, String> loadMountPoints() throws IOException {
-    Map<String, String> mounts = null;
+    Map<String, String> mounts = new HashMap<>();
     String home = System.getProperty("user.home");
 
     File mountFile = new File(

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
@@ -141,6 +141,7 @@ public class KnoxSession implements Closeable {
 
   private static final String KNOXSQLHISTORIES_JSON = "knoxsqlhistories.json";
   private static final String KNOXDATASOURCES_JSON = "knoxdatasources.json";
+  private static final String KNOXMOUNTPOINTS_JSON = "knoxmountpoints.json";
 
   public Map<String, String> getHeaders() {
     return headers;
@@ -607,6 +608,16 @@ public class KnoxSession implements Closeable {
    * @param map to persist
    */
   public static <T> void persistDataSourcesToKnoxShell(String fileName, Map<String, T> map) {
+    persistMapToKnoxShell(fileName, map);
+  }
+
+  /**
+   * Persist provided Map to a file within the {user.home}/.knoxshell directory
+   * @param <T> type of the value in the map
+   * @param fileName of persisted file
+   * @param map to persist
+   */
+  public static <T> void persistMapToKnoxShell(String fileName, Map<String, T> map) {
     String s = JsonUtils.renderAsJsonString(map);
     String home = System.getProperty("user.home");
     try {
@@ -641,6 +652,10 @@ public class KnoxSession implements Closeable {
     persistDataSourcesToKnoxShell(KNOXDATASOURCES_JSON, datasources);
   }
 
+  public static void persistMountPoints(Map<String, String> mounts) {
+    persistDataSourcesToKnoxShell(KNOXMOUNTPOINTS_JSON, mounts);
+  }
+
   /**
    * Load and return a map of datasource names to sql commands
    * from the {user.home}/.knoxshell/knoxsqlhistories.json file.
@@ -659,6 +674,20 @@ public class KnoxSession implements Closeable {
       sqlHistories = getMapOfStringArrayListsFromJsonString(json);
     }
     return sqlHistories;
+  }
+
+  public static Map<String, String> loadMountPoints() throws IOException {
+    Map<String, String> mounts = null;
+    String home = System.getProperty("user.home");
+
+    File mountFile = new File(
+        home + File.separator +
+        ".knoxshell" + File.separator + KNOXMOUNTPOINTS_JSON);
+    if (mountFile.exists()) {
+      String json = readFileToString(mountFile);
+      mounts = getMapFromJsonString(json);
+    }
+    return mounts;
   }
 
   private static String readFileToString(File file) throws IOException {
@@ -701,6 +730,15 @@ public class KnoxSession implements Closeable {
     JsonFactory factory = new JsonFactory();
     ObjectMapper mapper = new ObjectMapper(factory);
     TypeReference<Map<String, List<String>>> typeRef = new TypeReference<Map<String, List<String>>>() {};
+    obj = mapper.readValue(json, typeRef);
+    return obj;
+  }
+
+  public static <T> Map<String, T> getMapFromJsonString(String json) throws IOException {
+    Map<String, T> obj;
+    JsonFactory factory = new JsonFactory();
+    ObjectMapper mapper = new ObjectMapper(factory);
+    TypeReference<Map<String, T>> typeRef = new TypeReference<Map<String, T>>() {};
     obj = mapper.readValue(json, typeRef);
     return obj;
   }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.shell.commands.AbstractSQLCommandSupport;
 import org.apache.knox.gateway.shell.commands.CSVCommand;
 import org.apache.knox.gateway.shell.commands.DataSourceCommand;
 import org.apache.knox.gateway.shell.commands.SelectCommand;
+import org.apache.knox.gateway.shell.commands.WebHDFSCommand;
 import org.apache.knox.gateway.shell.hbase.HBase;
 import org.apache.knox.gateway.shell.hdfs.Hdfs;
 import org.apache.knox.gateway.shell.job.Job;
@@ -96,6 +97,7 @@ public class Shell {
       shell.register(new SelectCommand(shell));
       shell.register(new DataSourceCommand(shell));
       shell.register(new CSVCommand(shell));
+      shell.register(new WebHDFSCommand(shell));
       shell.run( null );
     }
   }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractKnoxShellCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractKnoxShellCommand.java
@@ -18,6 +18,9 @@
 package org.apache.knox.gateway.shell.commands;
 
 import java.util.List;
+
+import org.apache.knox.gateway.shell.CredentialCollectionException;
+import org.apache.knox.gateway.shell.CredentialCollector;
 import org.codehaus.groovy.tools.shell.CommandSupport;
 import org.codehaus.groovy.tools.shell.Groovysh;
 
@@ -42,5 +45,11 @@ public abstract class AbstractKnoxShellCommand extends CommandSupport {
       }
     }
     return variableName;
+  }
+
+  protected CredentialCollector login() throws CredentialCollectionException {
+    KnoxLoginDialog dlg = new KnoxLoginDialog();
+    dlg.collect();
+    return dlg;
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractSQLCommandSupport.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractSQLCommandSupport.java
@@ -25,8 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.knox.gateway.shell.CredentialCollectionException;
-import org.apache.knox.gateway.shell.CredentialCollector;
 import org.apache.knox.gateway.shell.KnoxDataSource;
 import org.apache.knox.gateway.shell.KnoxSession;
 import org.apache.knox.gateway.shell.jdbc.JDBCUtils;
@@ -201,11 +199,5 @@ public abstract class AbstractSQLCommandSupport extends AbstractKnoxShellCommand
         // nop
       }
     });
-  }
-
-  protected CredentialCollector login() throws CredentialCollectionException {
-    KnoxLoginDialog dlg = new KnoxLoginDialog();
-    dlg.collect();
-    return dlg;
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/CSVCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/CSVCommand.java
@@ -49,10 +49,24 @@ public class CSVCommand extends AbstractKnoxShellCommand {
 
     try {
       if (withHeaders) {
-        table = KnoxShellTable.builder().csv().withHeaders().url(url);
+        if (url.startsWith("$")) {
+          // a knoxshell variable is a csv file as a string
+          String csvString = (String) getVariables().get(url.substring(1));
+          table = KnoxShellTable.builder().csv().withHeaders().string(csvString);
+        }
+        else {
+          table = KnoxShellTable.builder().csv().withHeaders().url(url);
+        }
       }
       else {
-        table = KnoxShellTable.builder().csv().url(url);
+        if (url.startsWith("$")) {
+          // a knoxshell variable is a csv file as a string
+          String csvString = (String) getVariables().get(url.substring(1));
+          table = KnoxShellTable.builder().csv().string(csvString);
+        }
+        else {
+          table = KnoxShellTable.builder().csv().url(url);
+        }
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.shell.commands;
 
 import java.io.Console;
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -54,9 +55,7 @@ public class WebHDFSCommand extends AbstractKnoxShellCommand {
                    "  :fs get {from-path} {to-path} \n" +
                    "  :fs put {from-path} {tp-path} \n" +
                    "  :fs rm {target-path} \n" +
-                   "  :fs mkdir {dir-path} \n" +
-                   "  :fs chown {owner} {target-path} \n" +
-                   "  :fs chmod {permissions} {target-path} \n";
+                   "  :fs mkdir {dir-path} \n";
     return usage;
   }
 
@@ -236,6 +235,10 @@ public class WebHDFSCommand extends AbstractKnoxShellCommand {
         String to = null;
         if (args.size() > 2) {
           to = args.get(2);
+        }
+        else {
+          to = System.getProperty("user.home") + File.separator +
+              path.substring(path.lastIndexOf(File.separator));
         }
         try {
           Hdfs.get(sessions.get(mountPoint)).from(from).file(to).now().getString();

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
@@ -41,7 +41,6 @@ import org.apache.knox.gateway.util.JsonUtils;
 import org.codehaus.groovy.tools.shell.Groovysh;
 
 public class WebHDFSCommand extends AbstractKnoxShellCommand {
-  private static final String KNOXMOUNTPOINTS = "__knoxmountpoints";
   private Map<String, KnoxSession> sessions = new HashMap<>();
 
   public WebHDFSCommand(Groovysh shell) {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell.commands;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.apache.knox.gateway.shell.CredentialCollectionException;
+import org.apache.knox.gateway.shell.CredentialCollector;
+import org.apache.knox.gateway.shell.KnoxSession;
+import org.apache.knox.gateway.shell.KnoxShellException;
+import org.apache.knox.gateway.shell.hdfs.Hdfs;
+import org.apache.knox.gateway.shell.table.KnoxShellTable;
+import org.apache.knox.gateway.util.JsonUtils;
+import org.codehaus.groovy.tools.shell.Groovysh;
+
+public class WebHDFSCommand extends AbstractKnoxShellCommand {
+  private Map<String, KnoxSession> sessions = new HashMap<>();
+  private String currentDir = "";
+
+  public WebHDFSCommand(Groovysh shell) {
+    super(shell, ":filesystem", ":fs");
+  }
+
+  @Override
+  public String getUsage() {
+    String usage = "Usage: \n" +
+                   "  :fs ls {target-path} \n" +
+                   "  :fs cat {target-path} \n" +
+                   "  :fs get {from-path} {to-path} \n" +
+                   "  :fs put {from-path} {tp-path} \n" +
+                   "  :fs rm {target-path} \n" +
+                   "  :fs mkdir {dir-path} \n" +
+                   "  :fs chown {owner} {target-path} \n" +
+                   "  :fs chmod {permissions} {target-path} \n";
+    return usage;
+  }
+
+  @Override
+  public Object execute(List<String> args) {
+    if (args.isEmpty()) {
+      args.add("ls");
+    }
+    if (args.get(0).equalsIgnoreCase("mount")) {
+      String url = args.get(1);
+      String mountPoint = args.get(2);
+      CredentialCollector dlg;
+      try {
+        dlg = login();
+      } catch (CredentialCollectionException e) {
+        e.printStackTrace();
+        return "Error: Credential collection failure.";
+      }
+      String username = dlg.name();
+      String password = new String(dlg.chars());
+      KnoxSession session;
+      try {
+        session = KnoxSession.login(url, username, password);
+        sessions.put(mountPoint, session);
+      } catch (URISyntaxException e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
+
+      return url + " mounted as " + mountPoint;
+    }
+    else if (args.get(0).equalsIgnoreCase("ls")) {
+      if (args.size() == 1 && currentDir != null) {
+        args.add(currentDir);
+      }
+      String path = args.get(1);
+      try {
+        String directory;
+        String mountPoint = determineMountPoint(path);
+        if (mountPoint != null) {
+          directory = determineTargetPath(path, mountPoint);
+          String json = Hdfs.ls(sessions.get(mountPoint)).dir(directory).now().getString();
+          Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> map =
+              JsonUtils.getFileStatusesAsMap(json);
+          if (map != null) {
+            ArrayList<HashMap<String, String>> list = map.get("FileStatuses").get("FileStatus");
+            KnoxShellTable table = buildTableFromListStatus(directory, list);
+            return table;
+          }
+        }
+        else {
+          System.out.println("No mountpoint found. Use ':fs mount {topologyURL} {mountpoint}'.");
+        }
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("put")) {
+      // Hdfs.put( session ).file( dataFile ).to( dataDir + "/" + dataFile ).now()
+      // :fs put from-path to-path
+      String localFile = args.get(1);
+      String path = args.get(2);
+
+      String mountPoint = determineMountPoint(path);
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        Hdfs.put(sessions.get(mountPoint)).file(localFile).to(targetPath).now().getString();
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("rm")) {
+      // Hdfs.rm( session ).file( dataFile ).now()
+      // :fs rm target-path
+      String path = args.get(1);
+
+      String mountPoint = determineMountPoint(path);
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        Hdfs.rm(sessions.get(mountPoint)).file(targetPath).now().getString();
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("cat")) {
+      // println Hdfs.get( session ).from( dataDir + "/" + dataFile ).now().string
+      // :fs cat target-path
+      String path = args.get(1);
+
+      String mountPoint = determineMountPoint(path);
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        String contents = Hdfs.get(sessions.get(mountPoint)).from(targetPath).now().getString();
+        return contents;
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("mkdir")) {
+      // println Hdfs.mkdir( session ).dir( directoryPath ).perm( "777" ).now().string
+      // :fs mkdir target-path [perms]
+      String path = args.get(1);
+      String perms = null;
+      if (args.size() == 3) {
+        perms = args.get(2);
+      }
+
+      String mountPoint = determineMountPoint(path);
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        if (perms != null) {
+          Hdfs.mkdir(sessions.get(mountPoint)).dir(targetPath).now().getString();
+        }
+        else {
+          Hdfs.mkdir(sessions.get(mountPoint)).dir(targetPath).perm(perms).now().getString();
+        }
+        return "Successfully created directory: " + targetPath;
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("get")) {
+      // println Hdfs.get( session ).from( dataDir + "/" + dataFile ).now().string
+      // :fs get from-path [to-path]
+      String path = args.get(1);
+
+      String mountPoint = determineMountPoint(path);
+      String from = determineTargetPath(path, mountPoint);
+      String to = null;
+      if (args.size() > 2) {
+        to = args.get(2);
+      }
+      try {
+        Hdfs.get(sessions.get(mountPoint)).from(from).file(to).now().getString();
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("pwd")) {
+      if (currentDir != null && !currentDir.isEmpty()) {
+        System.out.println(currentDir);
+      }
+    }
+    else if (args.get(0).equalsIgnoreCase("cd")) {
+      String tmp;
+      String path = args.get(1);
+      if (path.startsWith("/")) {
+        // if user supplied path starts at the root then
+        // this is a possible switch to a new mount point
+        String mountPoint = determineMountPoint(path);
+        if (mountPoint != null) {
+          // mountPoint found so check that the path is valid
+          // within the mounted filesystem
+          tmp = stripMountPoint(path, mountPoint);
+          validateChangeDirectory(tmp, "", mountPoint);
+        }
+      }
+      else if (!currentDir.isEmpty()) {
+        tmp = currentDir;
+        if (!tmp.endsWith("/")) {
+          tmp += "/";
+        }
+        validateChangeDirectory(tmp, path, determineMountPoint(tmp));
+      }
+    }
+    else {
+      System.out.println("Unknown filesystem command");
+      System.out.println(getUsage());
+    }
+    return "";
+  }
+
+  private String determineTargetPath(String path, String mountPoint) {
+    String directory;
+    if (path.startsWith("/")) {
+      directory = stripMountPoint(path, mountPoint);
+    }
+    else {
+      directory = "/" + currentDir + path;
+    }
+    return directory;
+  }
+
+  private void validateChangeDirectory(String tmp, String path, String mountPoint) {
+    try {
+      int status = Hdfs.status(sessions.get(mountPoint))
+          .file(stripMountPoint(tmp + path, mountPoint))
+          .now()
+          .getStatusCode();
+      if (status == 200) {
+        currentDir = tmp + path;
+      }
+      else if (status == 404) {
+        System.out.println("cd: " + path + ": No such file or directory");
+      }
+      else {
+        System.out.println("cd: " + path + ": Unsuccessful status:" + status);
+      }
+    } catch (KnoxShellException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private String stripMountPoint(String path, String mountPoint) {
+    String newPath = path.replace("/" + mountPoint, "");
+    return newPath;
+  }
+
+  private String determineMountPoint(String path) {
+    String mountPoint = null;
+    if (path.startsWith("/")) {
+      // does the user supplied path starts at a root
+      // if so check for a mountPoint based on the first element of the path
+      String[] pathElements = path.split("/");
+      mountPoint = pathElements[1];
+    }
+    else if (!currentDir.isEmpty()) {
+      // if the user supplied path is relative then it is relative
+      // to the current directory with included mountPoint
+      String[] pathElements = currentDir.split("/");
+      mountPoint = pathElements[1];
+    }
+    return mountPoint;
+  }
+
+  private KnoxShellTable buildTableFromListStatus(String directory, List<HashMap<String, String>> list) {
+    Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault());
+    KnoxShellTable table = new KnoxShellTable();
+    table.title(directory);
+    table.header("permission")
+      .header("owner")
+      .header("group")
+      .header("length")
+      .header("modtime")
+      .header("name");
+
+    for (Map<String, String> map : list) {
+      cal.setTimeInMillis(Long.parseLong(map.get("modificationTime")));
+      table.row()
+        .value(map.get("permission"))
+        .value(map.get("owner"))
+        .value(map.get("group"))
+        .value(map.get("length"))
+        .value(cal.getTime())
+        .value(map.get("pathSuffix"));
+    }
+
+    return table;
+  }
+
+  public static void main(String[] args) {
+    WebHDFSCommand cmd = new WebHDFSCommand(new Groovysh());
+    List<String> args2 = new ArrayList<>();
+    cmd.execute(args2);
+  }
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Ls.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Ls.java
@@ -26,7 +26,7 @@ import org.apache.http.client.utils.URIBuilder;
 
 import java.util.concurrent.Callable;
 
-class Ls {
+public class Ls {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Mkdir.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Mkdir.java
@@ -26,7 +26,7 @@ import org.apache.http.client.utils.URIBuilder;
 
 import java.util.concurrent.Callable;
 
-class Mkdir {
+public class Mkdir {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Put.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Put.java
@@ -34,7 +34,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.File;
 import java.util.concurrent.Callable;
 
-class Put {
+public class Put {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Rm.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Rm.java
@@ -27,7 +27,7 @@ import org.apache.http.client.utils.URIBuilder;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-class Rm {
+public class Rm {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -18,7 +18,9 @@
 package org.apache.knox.gateway.shell.table;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
@@ -39,33 +41,47 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable url(String url) throws IOException {
-    int rowIndex = 0;
     URL urlToCsv = new URL(url);
     URLConnection connection = urlToCsv.openConnection();
     try (Reader urlConnectionStreamReader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(urlConnectionStreamReader);) {
-      if (title != null) {
-        this.table.title(title);
-      }
-      String row = null;
-      while ((row = csvReader.readLine()) != null) {
-        boolean addingHeaders = (withHeaders && rowIndex == 0);
-        if (!addingHeaders) {
-          this.table.row();
-        }
-        String[] data = row.split(",");
-
-        for (String value : data) {
-          if (addingHeaders) {
-            this.table.header(value);
-          } else {
-            this.table.value(value);
-          }
-        }
-        rowIndex++;
-      }
+      buildTableFromCSVReader(csvReader);
     }
     return this.table;
+  }
+
+  public KnoxShellTable string(String csvString) throws IOException {
+    InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8));
+
+    try (Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+        BufferedReader csvReader = new BufferedReader(stringStreamReader);) {
+      buildTableFromCSVReader(csvReader);
+    }
+    return this.table;
+  }
+
+  private void buildTableFromCSVReader(BufferedReader csvReader) throws IOException {
+    int rowIndex = 0;
+    if (title != null) {
+      this.table.title(title);
+    }
+    String row = null;
+    while ((row = csvReader.readLine()) != null) {
+      boolean addingHeaders = (withHeaders && rowIndex == 0);
+      if (!addingHeaders) {
+        this.table.row();
+      }
+      String[] data = row.split(",", -1);
+
+      for (String value : data) {
+        if (addingHeaders) {
+          this.table.header(value);
+        } else {
+          this.table.value(value);
+        }
+      }
+      rowIndex++;
+    }
   }
 
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -51,9 +51,7 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable string(String csvString) throws IOException {
-    InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8));
-
-    try (Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+    try (InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8)); Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(stringStreamReader);) {
       buildTableFromCSVReader(csvReader);
     }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -137,8 +137,8 @@ public class KnoxShellTable {
     double[] colArray = new double[col.size()];
     Conversions conversionMethod = null;
     for (int i = 0; i < col.size(); i++) {
-      String v = (String) col.get(i);
-      if (v.trim().isEmpty()) {
+      Object v = col.get(i);
+      if (v instanceof String && ((String) v).trim().isEmpty()) {
         col.set(i, "0");
       }
       if (i == 0) {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -435,6 +435,10 @@ public class KnoxShellTable {
   }
 
   public String toCSV() {
-    return new KnoxShellTableRenderer(this).toCSV();
+    return toCSV(null);
+  }
+
+  public String toCSV(String filePath) {
+    return new KnoxShellTableRenderer(this).toCSV(filePath);
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -137,6 +137,10 @@ public class KnoxShellTable {
     double[] colArray = new double[col.size()];
     Conversions conversionMethod = null;
     for (int i = 0; i < col.size(); i++) {
+      String v = (String) col.get(i);
+      if (v.trim().isEmpty()) {
+        col.set(i, "0");
+      }
       if (i == 0) {
         conversionMethod = getConversion(col.get(i));
       }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFileUtils.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFileUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell.table;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class KnoxShellTableFileUtils {
+  public static void persistToFile(String filePath, final String content) throws IOException {
+    final Path jsonFilePath = Paths.get(filePath);
+    if (!Files.exists(jsonFilePath.getParent())) {
+      Files.createDirectories(jsonFilePath.getParent());
+    }
+    Files.deleteIfExists(jsonFilePath);
+    Files.createFile(jsonFilePath);
+    setPermissions(jsonFilePath);
+    Files.write(jsonFilePath, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void setPermissions(Path path) throws IOException {
+    // clear all flags for everybody
+    path.toFile().setReadable(false, false);
+    path.toFile().setWritable(false, false);
+    path.toFile().setExecutable(false, false);
+    // allow owners to read/write
+    path.toFile().setReadable(true, true);
+    path.toFile().setWritable(true, true);
+  }
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableJSONSerializer.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableJSONSerializer.java
@@ -18,10 +18,6 @@
 package org.apache.knox.gateway.shell.table;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -87,27 +83,10 @@ class KnoxShellTableJSONSerializer {
       } else {
         jsonResult = JsonUtils.renderAsJsonString(KnoxShellTableCallHistory.getInstance().getCallHistory(table.id), null, JSON_DATE_FORMAT.get());
       }
-      final Path jsonFilePath = Paths.get(filePath);
-      if (!Files.exists(jsonFilePath.getParent())) {
-        Files.createDirectories(jsonFilePath.getParent());
-      }
-      Files.deleteIfExists(jsonFilePath);
-      Files.createFile(jsonFilePath);
-      setPermissions(jsonFilePath);
-      Files.write(jsonFilePath, jsonResult.getBytes(StandardCharsets.UTF_8));
+      KnoxShellTableFileUtils.persistToFile(filePath, jsonResult);
       return "Successfully saved into " + filePath;
     } catch (IOException e) {
       throw new KnoxShellException("Error while saving KnoxShellTable JSON into " + filePath, e);
     }
-  }
-
-  private static void setPermissions(Path path) throws IOException {
-    // clear all flags for everybody
-    path.toFile().setReadable(false, false);
-    path.toFile().setWritable(false, false);
-    path.toFile().setExecutable(false, false);
-    // allow owners to read/write
-    path.toFile().setReadable(true, true);
-    path.toFile().setWritable(true, true);
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableRenderer.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableRenderer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.shell.table;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -38,6 +39,10 @@ class KnoxShellTableRenderer {
   }
 
   String toCSV() {
+    return toCSV(null);
+  }
+
+  String toCSV(String filePath) {
     final StringBuilder csv = new StringBuilder();
     String header;
     for (int i = 0; i < tableToRender.headers.size(); i++) {
@@ -59,8 +64,17 @@ class KnoxShellTableRenderer {
         }
       }
     }
+    String content = csv.toString();
+    if (filePath != null) {
+      try {
+        KnoxShellTableFileUtils.persistToFile(filePath, content);
+      } catch (IOException e) {
+        System.out.println("Persistence of CSV file has failed. " + e.getMessage());
+        e.printStackTrace();
+      }
+    }
 
-    return csv.toString();
+    return content;
   }
 
   @Override

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -191,6 +191,14 @@ public class KnoxShellTableTest {
   }
 
   @Test
+  public void testCSVStringToTable() throws IOException {
+    String initialString = "colA, colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
+
+    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
+    assertEquals(table.rows.size(), 2);
+  }
+
+  @Test
   public void testToAndFromJSON() throws IOException {
     KnoxShellTable table = new KnoxShellTable();
 

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.util;
 
 import java.io.IOException;
 import java.text.DateFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -94,6 +95,20 @@ public class JsonUtils {
       map = mapper.readValue(json, typeRef);
     } catch (IOException e) {
       LOG.failedToGetMapFromJsonString( json, e );
+    }
+    return map;
+  }
+
+  public static Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> getFileStatusesAsMap(String json) {
+    Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> map = null;
+    JsonFactory factory = new JsonFactory();
+    ObjectMapper mapper = new ObjectMapper(factory);
+    TypeReference<HashMap<String,HashMap<String, ArrayList<HashMap<String, String>>>>> typeRef
+      = new TypeReference<HashMap<String,HashMap<String, ArrayList<HashMap<String, String>>>>>() {};
+    try {
+      map = mapper.readValue(json, typeRef);
+    } catch (IOException e) {
+      //LOG.failedToGetMapFromJsonString( json, e );
     }
     return map;
   }

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
@@ -17,15 +17,16 @@
  */
 package org.apache.knox.gateway.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
 
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class JsonUtilsTest {
   private String expiresIn = "\"expires_in\":\"1364487943100\"";
@@ -53,5 +54,47 @@ public class JsonUtilsTest {
     assertEquals("ksdfh3489tyiodhfjk", map.get("access_token"));
     assertEquals("Bearer", map.get("token_type"));
     assertEquals("1364487943100", map.get("expires_in"));
+  }
+
+  @Test
+  public void testFileStatusesAsMap() {
+    String json = "{\n" +
+      "   \"FileStatuses\":{\n" +
+      "      \"FileStatus\":[\n" +
+      "         {\n" +
+      "            \"accessTime\":0,\n" +
+      "            \"blockSize\":0,\n" +
+      "            \"childrenNum\":3,\n" +
+      "            \"fileId\":16389,\n" +
+      "            \"group\":\"supergroup\",\n" +
+      "            \"length\":0,\n" +
+      "            \"modificationTime\":1581578495905,\n" +
+      "            \"owner\":\"hdfs\",\n" +
+      "            \"pathSuffix\":\"tmp\",\n" +
+      "            \"permission\":\"1777\",\n" +
+      "            \"replication\":0,\n" +
+      "            \"storagePolicy\":0,\n" +
+      "            \"type\":\"DIRECTORY\"\n" +
+      "         },\n" +
+      "         {\n" +
+      "            \"accessTime\":0,\n" +
+      "            \"blockSize\":0,\n" +
+      "            \"childrenNum\":658,\n" +
+      "            \"fileId\":16386,\n" +
+      "            \"group\":\"supergroup\",\n" +
+      "            \"length\":0,\n" +
+      "            \"modificationTime\":1581578527580,\n" +
+      "            \"owner\":\"hdfs\",\n" +
+      "            \"pathSuffix\":\"user\",\n" +
+      "            \"permission\":\"755\",\n" +
+      "            \"replication\":0,\n" +
+      "            \"storagePolicy\":0,\n" +
+      "            \"type\":\"DIRECTORY\"\n" +
+      "          } \n" +
+      "       ]\n" +
+      "   }\n" +
+      "}";
+    Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> map = JsonUtils.getFileStatusesAsMap(json);
+    assertNotNull(map);
   }
 }


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

This PR introduces a new custom groovy command for KnoxShell for interaction with hadoop filesystems through the WebHDFS API. This includes the ability to mount filesystems, unmount them and list mounts. Mounts are persisted in the user's home directory for knoxshell so that they live across KnoxShell sessions.

It is limited to the hdfs client classes that are provided in KnoxShell today but with follow up patches to both the client classes and the command will cover more of the Hadoop filesystem capabilities - such as chown and chmod.

## How was this patch tested?

Primarily tested through manual use of the KnoxShell environment. Minor improvements in CSV builder have added unit tests as well.

`knox:000> **:fs mounts**
===> +----------------+------------------------------------------------------------------------+
|  Mount Point   |                              Topology URL                              |
+----------------+------------------------------------------------------------------------+
|     sandor     |  https://knox-host1:8443/gateway/cdp-proxy-api  |
+----------------+------------------------------------------------------------------------+

knox:000> **:fs mount https://knox-host1:8443/gateway/cdp-proxy-api sando**r
===> https://knox-host1:8443/gateway/cdp-proxy-api mounted as sandor
knox:000> 
knox:000> **:fs ls /sandor/tmp**
===> /tmp
+--------------+----------+--------------+----------+--------------------------------+--------------------------------------------+
|  permission  |  owner   |    group     |  length  |            modtime             |                    name                    |
+--------------+----------+--------------+----------+--------------------------------+--------------------------------------------+
|      0       |   hdfs   |  supergroup  |    0     |  Thu Mar 19 20:39:30 EDT 2020  |  .cloudera_health_monitoring_canary_files  |
|     733      |   hive   |  supergroup  |    0     |  Mon Mar 16 12:09:18 EDT 2020  |                    hive                    |
|     1777     |  mapred  |    hadoop    |    0     |  Mon Mar 16 12:09:30 EDT 2020  |                    logs                    |
+--------------+----------+--------------+----------+--------------------------------+--------------------------------------------+

knox:000> **:fs ls /sandor/user/knoxui/**
===> /user/knoxui/
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|  permission  |  owner   |  group   |  length  |            modtime             |                name                |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|     755      |  knoxui  |  knoxui  |  62979   |  Thu Mar 19 13:36:18 EDT 2020  |            covid19.csv             |
|     755      |  knoxui  |  knoxui  |  73822   |  Thu Mar 19 15:30:00 EDT 2020  |  hopkins-confirmed-3-18-2020.csv   |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+

knox:000> **:fs cat /sandor/user/knoxui/hopkins-confirmed-3-18-2020.csv**
===> Province/State,Country/Region,Lat,Long,1/22/20,1/23/20,1/24/20,1/25/20,1/26/20,1/27/20,1/28/20,1/29/20,1/30/20,1/31/20,2/1/20,2/2/20,2/3/20,2/4/20,2/5/20,2/6/20,2/7/20,2/8/20,2/9/20,2/10/20,2/11/20,2/12/20,2/13/20,2/14/20,2/15/20,2/16/20,2/17/20,2/18/20,2/19/20,2/20/20,2/21/20,2/22/20,2/23/20,2/24/20,2/25/20,2/26/20,2/27/20,2/28/20,2/29/20,3/1/20,3/2/20,3/3/20,3/4/20,3/5/20,3/6/20,3/7/20,3/8/20,3/9/20,3/10/20,3/11/20,3/12/20,3/13/20,3/14/20,3/15/20,3/16/20,3/17/20,3/18/20
,Thailand,15,101,2,3,5,7,8,8,14,14,14,19,19,19,19,25,25,25,25,32,32,32,33,33,33,33,33,34,35,35,35,35,35,35,35,35,37,40,40,41,42,42,43,43,43,47,48,50,50,50,53,59,70,75,82,114,147,177,212
,Japan,36,138,2,1,2,2,4,4,7,7,11,15,20,20,20,22,22,45,25,25,26,26,26,28,28,29,43,59,66,74,84,94,105,122,147,159,170,189,214,228,241,256,274,293,331,360,420,461,502,511,581,639,639,701,773,839,825,878,889
,Singapore,1.2833,103.8333,0,1,3,3,4,5,7,7,10,13,16,18,18,24,28,28,30,33,40,45,47,50,58,67,72,75,77,81,84,84,85,85,89,89,91,93,93,93,102,106,108,110,110,117,130,138,150,150,160,178,178,200,212,226,243,266,313
,Nepal,28.1667,84.25,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1
,Malaysia,2.5,112.5,0,0,0,3,4,4,4,7,8,8,8,8,8,10,12,12,12,16,16,18,18,18,19,19,22,22,22,22,22,22,22,22,22,22,22,22,23,23,25,29,29,36,50,50,83,93,99,117,129,149,149,197,238,428,566,673,790
British Columbia,Canada,49.2827,-123.1207,0,0,0,0,0,0,1,1,1,1,1,1,1,1,2,2,4,4,4,4,4,4,4,4,4,4,5,5,5,5,6,6,6,6,7,7,7,7,8,8,8,9,12,13,21,21,27,32,32,39,46,64,64,73,103,103,186
New South Wales,Australia,-33.8688,151.2093,0,0,0,0,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,6,6,13,22,22,26,28,38,48,55,65,65,92,112,134,171,210,267
Victoria,Australia,-37.8136,144.9631,0,0,0,0,1,1,1,1,2,3,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,7,7,9,9,10,10,10,11,11,15,18,21,21,36,49,57,71,94,121
Queensland,Australia,-28.0167,153.4,0,0,0,0,0,0,0,1,3,2,3,2,2,3,3,4,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,9,9,9,11,11,13,13,13,15,15,18,20,20,35,46,61,68,78,94
,Cambodia,11.55,104.9167,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,3,3,5,7,7,7,33,35
,Sri Lanka,7,81,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,6,10,18,28,44,51
,Germany,51,9,0,0,0,0,0,1,4,4,4,5,8,10,12,12,12,12,13,13,14,14,16,16,16,16,16,16,16,16,16,16,16,16,16,16,17,27,46,48,79,130,159,196,262,482,670,799,1040,1176,1457,1908,2078,3675,4585,5795,7272,9257,12327
,Finland,64,26,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2,2,2,3,6,6,6,6,12,15,15,23,30,40,59,59,155,225,244,277,321,336
,United Arab Emirates,24,54,0,0,0,0,0,0,0,4,4,4,4,5,5,5,5,5,5,7,7,8,8,8,8,8,8,9,9,9,9,9,9,13,13,13,13,13,13,19,21,21,21,27,27,29,29,45,45,45,74,74,85,85,85,98,98,98,113
,Philippines,13,122,0,0,0,0,0,0,0,0,1,1,1,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,5,6,10,20,33,49,52,64,111,140,142,187,202
,India,21,78,0,0,0,0,0,0,0,0,1,1,1,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,5,5,28,30,31,34,39,43,56,62,73,82,102,113,119,142,156
,Italy,43,12,0,0,0,0,0,0,0,0,0,2,2,2,2,2,2,2,3,3,3,3,3,3,3,3,3,3,3,3,3,3,20,62,155,229,322,453,655,888,1128,1694,2036,2502,3089,3858,4636,5883,7375,9172,10149,12462,12462,17660,21157,24747,27980,31506,35713



knox:000> **:csv withHeaders $_ assign hopkins**
===> +--------------------------------+------------------------------------+------------+--------------+--------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+------------+------------+------------+------------+------------+------------+------------+------------+------------+
|         Province/State         |           Country/Region           |    Lat     |     Long     |   1/22/20    |  1/23/20   |  1/24/20   |  1/25/20   |  1/26/20   |  1/27/20   |  1/28/20   |  1/29/20   |  1/30/20   |  1/31/20   |  2/1/20  |  2/2/20  |  2/3/20  |  2/4/20  |  2/5/20  |  2/6/20  |  2/7/20  |  2/8/20  |  2/9/20  |  2/10/20   |  2/11/20   |  2/12/20   |  2/13/20   |  2/14/20   |  2/15/20   |  2/16/20   |  2/17/20   |  2/18/20   |  2/19/20   |  2/20/20   |  2/21/20   |  2/22/20   |  2/23/20   |  2/24/20   |  2/25/20   |  2/26/20   |  2/27/20   |  2/28/20   |  2/29/20   |  3/1/20  |  3/2/20  |  3/3/20  |  3/4/20  |  3/5/20  |  3/6/20  |  3/7/20  |  3/8/20  |  3/9/20  |  3/10/20   |  3/11/20   |  3/12/20   |  3/13/20   |  3/14/20   |  3/15/20   |  3/16/20   |  3/17/20   |  3/18/20   |
+--------------------------------+------------------------------------+------------+--------------+--------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+------------+----------+----------+----------+----------+----------+----------+----------+----------+----------+------------+------------+------------+------------+------------+------------+------------+------------+------------+
|                                |              Thailand              |     15     |     101      |      2       |     3      |     5      |     7      |     8      |     8      |     14     |     14     |     14     |     19     |    19    |    19    |    19    |    25    |    25    |    25    |    25    |    32    |    32    |     32     |     33     |     33     |     33     |     33     |     33     |     34     |     35     |     35     |     35     |     35     |     35     |     35     |     35     |     35     |     37     |     40     |     40     |     41     |     42     |    42    |    43    |    43    |    43    |    47    |    48    |    50    |    50    |    50    |     53     |     59     |     70     |     75     |     82     |    114     |    147     |    177     |    212     |
|                                |               Japan                |     36     |     138      |      2       |     1      |     2      |     2      |     4      |     4      |     7      |     7      |     11     |     15     |    20    |    20    |    20    |    22    |    22    |    45    |    25    |    25    |    26    |     26     |     26     |     28     |     28     |     29     |     43     |     59     |     66     |     74     |     84     |     94     |    105     |    122     |    147     |    159     |    170     |    189     |    214     |    228     |    241     |   256    |   274    |   293    |   331    |   360    |   420    |   461    |   502    |   511    |    581     |    639     |    639     |    701     |    773     |    839     |    825     |    878     |    889     |
|                                |             Singapore              |   1.2833   |   103.8333   |      0       |     1      |     3      |     3      |     4      |     5      |     7      |     7      |     10     |     13     |    16    |    18    |    18    |    24    |    28    |    28    |    30    |    33    |    40    |     45     |     47     |     50     |     58     |     67     |     72     |  


knox:000> **:fs put /home/lmccay/hopkins-confirmed-3-18-2020.csv /sandor/user/knoxui/hopkins.csv**
/user/knoxui/hopkins.csv already exists would you like to overwrite (Y/n)===> 
knox:000> 
knox:000> **:fs ls /sandor/user/knoxui/**
===> /user/knoxui/
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|  permission  |  owner   |  group   |  length  |            modtime             |                name                |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|     755      |  knoxui  |  knoxui  |  62979   |  Thu Mar 19 13:36:18 EDT 2020  |            covid19.csv             |
|     755      |  knoxui  |  knoxui  |  73822   |  Thu Mar 19 15:30:00 EDT 2020  |  hopkins-confirmed-3-18-2020.csv   |
|     755      |  knoxui  |  knoxui  |  73822   |  Thu Mar 19 20:43:38 EDT 2020  |            hopkins.csv             |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+

knox:000> **:fs mkdir /sandor/user/knoxui/test**
===> Successfully created directory: /user/knoxui/test
knox:000> **:fs ls /sandor/user/knoxui/**
===> /user/knoxui/
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|  permission  |  owner   |  group   |  length  |            modtime             |                name                |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|     755      |  knoxui  |  knoxui  |  62979   |  Thu Mar 19 13:36:18 EDT 2020  |            covid19.csv             |
|     755      |  knoxui  |  knoxui  |  73822   |  Thu Mar 19 15:30:00 EDT 2020  |  hopkins-confirmed-3-18-2020.csv   |
|     755      |  knoxui  |  knoxui  |  73822   |  Thu Mar 19 20:43:38 EDT 2020  |            hopkins.csv             |
|     755      |  knoxui  |  knoxui  |    0     |  Thu Mar 19 20:45:07 EDT 2020  |                test                |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+


knox:000> **:fs get /sandor/user/knoxui/hopkins.cs**v
===> 

lmccay@system76-pc:~/Projects/knox$ ls -l ~/hopkins.csv
-rw-r--r-- 1 lmccay lmccay 73822 Mar 19 20:46 /home/lmccay/hopkins.csv

knox:000> **:fs rm /sandor/user/knoxui/hopkins.csv**
===> 
knox:000> **:fs ls /sandor/user/knoxui/**
===> /user/knoxui/
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|  permission  |  owner   |  group   |  length  |            modtime             |                name                |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+
|     755      |  knoxui  |  knoxui  |  62979   |  Thu Mar 19 13:36:18 EDT 2020  |            covid19.csv             |
|     755      |  knoxui  |  knoxui  |  73822   |  Thu Mar 19 15:30:00 EDT 2020  |  hopkins-confirmed-3-18-2020.csv   |
|     755      |  knoxui  |  knoxui  |    0     |  Thu Mar 19 20:45:07 EDT 2020  |                test                |
+--------------+----------+----------+----------+--------------------------------+------------------------------------+



`

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
