### PR TITLE
KNOX-2307 - CSVKnoxShellTableBuilder must support quoted strings and …

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -17,8 +17,6 @@
  */
 package org.apache.knox.gateway.services.topology.impl;
 
-import org.apache.commons.digester3.Digester;
-import org.apache.commons.digester3.binder.DigesterLoader;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
@@ -54,7 +52,6 @@ import org.apache.knox.gateway.topology.TopologyListener;
 import org.apache.knox.gateway.topology.TopologyMonitor;
 import org.apache.knox.gateway.topology.TopologyProvider;
 import org.apache.knox.gateway.topology.Version;
-import org.apache.knox.gateway.topology.builder.TopologyBuilder;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.monitor.RemoteConfigurationMonitor;
@@ -62,9 +59,8 @@ import org.apache.knox.gateway.topology.monitor.RemoteConfigurationMonitorFactor
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorFactory;
 import org.apache.knox.gateway.topology.validation.TopologyValidator;
-import org.apache.knox.gateway.topology.xml.AmbariFormatXmlTopologyRules;
-import org.apache.knox.gateway.topology.xml.KnoxFormatXmlTopologyRules;
 import org.apache.knox.gateway.util.ServiceDefinitionsLoader;
+import org.apache.knox.gateway.util.TopologyUtils;
 import org.eclipse.persistence.jaxb.JAXBContextProperties;
 import org.xml.sax.SAXException;
 
@@ -74,6 +70,7 @@ import javax.xml.bind.Marshaller;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,8 +84,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
-
 public class DefaultTopologyService extends FileAlterationListenerAdaptor implements TopologyService, TopologyMonitor,
     TopologyProvider, FileFilter, FileAlterationListener, ServiceDefinitionChangeListener {
 
@@ -101,8 +96,6 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
   public static final List<String> SUPPORTED_TOPOLOGY_FILE_EXTENSIONS = Collections.unmodifiableList(Arrays.asList("xml", "conf"));
 
   private static GatewayMessages log = MessagesFactory.get(GatewayMessages.class);
-  private static DigesterLoader digesterLoader = newLoader(new KnoxFormatXmlTopologyRules(),
-      new AmbariFormatXmlTopologyRules());
   private Map<String, FileAlterationMonitor> monitors = new ConcurrentHashMap<>();
   private File topologiesDirectory;
   private File sharedProvidersDirectory;
@@ -153,17 +146,21 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
     return topology;
   }
 
+  @Override
+  public Topology parse(final InputStream content) throws IOException, SAXException {
+    return TopologyUtils.parse(content);
+  }
+
   private Topology loadTopologyAttempt(File file) throws IOException, SAXException {
     Topology topology;
-    Digester digester = digesterLoader.newDigester();
-    TopologyBuilder topologyBuilder = digester.parse(FileUtils.openInputStream(file));
-    if (null == topologyBuilder) {
-      return null;
+    try (InputStream in = FileUtils.openInputStream(file)) {
+      topology = parse(in);
+      if (topology != null) {
+        topology.setUri(file.toURI());
+        topology.setName(FilenameUtils.removeExtension(file.getName()));
+        topology.setTimestamp(file.lastModified());
+      }
     }
-    topology = topologyBuilder.build();
-    topology.setUri(file.toURI());
-    topology.setName(FilenameUtils.removeExtension(file.getName()));
-    topology.setTimestamp(file.lastModified());
     return topology;
   }
 
@@ -556,6 +553,15 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         log.remoteConfigurationMonitorStartFailure(remoteMonitor.getClass().getTypeName(), e.getLocalizedMessage());
       }
     }
+
+    // Trigger descriptor discovery (KNOX-2301)
+    triggerDescriptorDiscovery();
+  }
+
+  private void triggerDescriptorDiscovery() {
+    for (File descriptor : getDescriptors()) {
+      descriptorsMonitor.onFileChange(descriptor);
+    }
   }
 
   @Override
@@ -606,7 +612,6 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
 
   @Override
   public void start() {
-
   }
 
   @Override
@@ -652,50 +657,10 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
       initListener("shared provider configurations", sharedProvidersDirectory, spm, spm);
       log.configuredMonitoringProviderConfigChangesInDirectory(sharedProvidersDirectory.getAbsolutePath());
 
-      // For all the descriptors currently in the descriptors dir at start-up time, determine if topology regeneration
-      // is required.
-      // This happens prior to the start-up loading of the topologies.
-      String[] descriptorFilenames =  descriptorsDirectory.list();
-      if (descriptorFilenames != null) {
-        for (String descriptorFilename : descriptorFilenames) {
-          if (DescriptorsMonitor.SUPPORTED_EXTENSIONS.contains(FilenameUtils.getExtension(descriptorFilename))) {
-            String topologyName = FilenameUtils.getBaseName(descriptorFilename);
-            File existingDescriptorFile = getExistingFile(descriptorsDirectory, topologyName);
-            if (existingDescriptorFile != null) {
-              // If there isn't a corresponding topology file, or if the descriptor has been modified since the
-              // corresponding topology file was generated, then trigger generation of one
-              File matchingTopologyFile = getExistingFile(topologiesDirectory, topologyName);
-              if (matchingTopologyFile == null || matchingTopologyFile.lastModified() < existingDescriptorFile.lastModified()) {
-                descriptorsMonitor.onFileChange(existingDescriptorFile);
-              } else {
-                // If regeneration is NOT required, then we at least need to report the provider configuration
-                // reference relationship (KNOX-1144)
-                String normalizedDescriptorPath = FilenameUtils.normalize(existingDescriptorFile.getAbsolutePath());
-
-                // Parse the descriptor to determine the provider config reference
-                SimpleDescriptor sd = SimpleDescriptorFactory.parse(normalizedDescriptorPath);
-                if (sd != null) {
-                  File referencedProviderConfig =
-                             getExistingFile(sharedProvidersDirectory, FilenameUtils.getBaseName(sd.getProviderConfig()));
-                  if (referencedProviderConfig != null) {
-                    List<String> references =
-                           descriptorsMonitor.getReferencingDescriptors(referencedProviderConfig.getAbsolutePath());
-                    if (!references.contains(normalizedDescriptorPath)) {
-                      references.add(normalizedDescriptorPath);
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
       // Initialize the remote configuration monitor, if it has been configured
       remoteMonitor = RemoteConfigurationMonitorFactory.get(config);
-
-    } catch (IOException io) {
-      throw new ServiceLifecycleException(io.getMessage(), io);
+    } catch (Exception e) {
+      throw new ServiceLifecycleException(e.getMessage(), e);
     }
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/TopologyUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/TopologyUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.apache.commons.digester3.binder.DigesterLoader;
+import org.apache.knox.gateway.topology.Topology;
+import org.apache.knox.gateway.topology.builder.TopologyBuilder;
+import org.apache.knox.gateway.topology.xml.AmbariFormatXmlTopologyRules;
+import org.apache.knox.gateway.topology.xml.KnoxFormatXmlTopologyRules;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+
+import static org.apache.commons.digester3.binder.DigesterLoader.newLoader;
+
+public final class TopologyUtils {
+
+  private static final DigesterLoader digesterLoader = newLoader(new KnoxFormatXmlTopologyRules(),
+                                                                 new AmbariFormatXmlTopologyRules());
+
+
+  public static Topology parse(final String content) throws IOException, SAXException {
+    Topology result;
+
+    TopologyBuilder builder = digesterLoader.newDigester().parse(new StringReader(content));
+    result = builder.build();
+
+    return result;
+  }
+
+  public static Topology parse(final InputStream content) throws IOException, SAXException {
+    Topology result;
+
+    TopologyBuilder builder = digesterLoader.newDigester().parse(content);
+    result = builder.build();
+
+    return result;
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -21,7 +21,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.monitor.FileAlterationListener;
+import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
 import org.apache.knox.gateway.services.topology.monitor.DescriptorsMonitor;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -38,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -177,6 +181,17 @@ public class DefaultTopologyServiceTest {
     }
   }
 
+  /**
+   * Set the static GatewayServices field to the specified value.
+   *
+   * @param gws A GatewayServices object, or null.
+   */
+  private void setGatewayServices(final GatewayServices gws) throws Exception {
+    Field gwsField = GatewayServer.class.getDeclaredField("services");
+    gwsField.setAccessible(true);
+    gwsField.set(null, gws);
+  }
+
   /*
    * KNOX-1014
    *
@@ -212,6 +227,12 @@ public class DefaultTopologyServiceTest {
       provider.init(config, c);
       provider.addTopologyChangeListener(topoListener);
       provider.reloadTopologies();
+
+      // GatewayServices mock
+      GatewayServices gws = EasyMock.createNiceMock(GatewayServices.class);
+      EasyMock.expect(gws.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(provider).anyTimes();
+      EasyMock.replay(gws);
+      setGatewayServices(gws);
 
       // Add a simple descriptor to the descriptors dir to verify topology generation and loading (KNOX-1006)
       AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
@@ -292,6 +313,7 @@ public class DefaultTopologyServiceTest {
       }
     } finally {
       FileUtils.deleteQuietly(dir);
+      setGatewayServices(null);
     }
   }
 
@@ -329,6 +351,12 @@ public class DefaultTopologyServiceTest {
       ts.init(config, c);
       ts.addTopologyChangeListener(topoListener);
       ts.reloadTopologies();
+
+      // GatewayServices mock
+      GatewayServices gws = EasyMock.createNiceMock(GatewayServices.class);
+      EasyMock.expect(gws.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
+      EasyMock.replay(gws);
+      setGatewayServices(gws);
 
       java.lang.reflect.Field dmField = ts.getClass().getDeclaredField("descriptorsMonitor");
       dmField.setAccessible(true);
@@ -389,6 +417,7 @@ public class DefaultTopologyServiceTest {
 
     } finally {
       FileUtils.deleteQuietly(dir);
+      setGatewayServices(null);
     }
   }
 
@@ -421,6 +450,12 @@ public class DefaultTopologyServiceTest {
       ts.init(config, c);
       ts.addTopologyChangeListener(topoListener);
       ts.reloadTopologies();
+
+      // GatewayServices mock
+      GatewayServices gws = EasyMock.createNiceMock(GatewayServices.class);
+      EasyMock.expect(gws.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
+      EasyMock.replay(gws);
+      setGatewayServices(gws);
 
       java.lang.reflect.Field dmField = ts.getClass().getDeclaredField("descriptorsMonitor");
       dmField.setAccessible(true);
@@ -534,6 +569,7 @@ public class DefaultTopologyServiceTest {
 
     } finally {
       FileUtils.deleteQuietly(dir);
+      setGatewayServices(null);
     }
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxSession.java
@@ -141,6 +141,7 @@ public class KnoxSession implements Closeable {
 
   private static final String KNOXSQLHISTORIES_JSON = "knoxsqlhistories.json";
   private static final String KNOXDATASOURCES_JSON = "knoxdatasources.json";
+  private static final String KNOXMOUNTPOINTS_JSON = "knoxmountpoints.json";
 
   public Map<String, String> getHeaders() {
     return headers;
@@ -607,6 +608,16 @@ public class KnoxSession implements Closeable {
    * @param map to persist
    */
   public static <T> void persistDataSourcesToKnoxShell(String fileName, Map<String, T> map) {
+    persistMapToKnoxShell(fileName, map);
+  }
+
+  /**
+   * Persist provided Map to a file within the {user.home}/.knoxshell directory
+   * @param <T> type of the value in the map
+   * @param fileName of persisted file
+   * @param map to persist
+   */
+  public static <T> void persistMapToKnoxShell(String fileName, Map<String, T> map) {
     String s = JsonUtils.renderAsJsonString(map);
     String home = System.getProperty("user.home");
     try {
@@ -641,6 +652,10 @@ public class KnoxSession implements Closeable {
     persistDataSourcesToKnoxShell(KNOXDATASOURCES_JSON, datasources);
   }
 
+  public static void persistMountPoints(Map<String, String> mounts) {
+    persistMapToKnoxShell(KNOXMOUNTPOINTS_JSON, mounts);
+  }
+
   /**
    * Load and return a map of datasource names to sql commands
    * from the {user.home}/.knoxshell/knoxsqlhistories.json file.
@@ -659,6 +674,20 @@ public class KnoxSession implements Closeable {
       sqlHistories = getMapOfStringArrayListsFromJsonString(json);
     }
     return sqlHistories;
+  }
+
+  public static Map<String, String> loadMountPoints() throws IOException {
+    Map<String, String> mounts = new HashMap<>();
+    String home = System.getProperty("user.home");
+
+    File mountFile = new File(
+        home + File.separator +
+        ".knoxshell" + File.separator + KNOXMOUNTPOINTS_JSON);
+    if (mountFile.exists()) {
+      String json = readFileToString(mountFile);
+      mounts = getMapFromJsonString(json);
+    }
+    return mounts;
   }
 
   private static String readFileToString(File file) throws IOException {
@@ -701,6 +730,15 @@ public class KnoxSession implements Closeable {
     JsonFactory factory = new JsonFactory();
     ObjectMapper mapper = new ObjectMapper(factory);
     TypeReference<Map<String, List<String>>> typeRef = new TypeReference<Map<String, List<String>>>() {};
+    obj = mapper.readValue(json, typeRef);
+    return obj;
+  }
+
+  public static <T> Map<String, T> getMapFromJsonString(String json) throws IOException {
+    Map<String, T> obj;
+    JsonFactory factory = new JsonFactory();
+    ObjectMapper mapper = new ObjectMapper(factory);
+    TypeReference<Map<String, T>> typeRef = new TypeReference<Map<String, T>>() {};
     obj = mapper.readValue(json, typeRef);
     return obj;
   }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/Shell.java
@@ -23,6 +23,7 @@ import org.apache.knox.gateway.shell.commands.AbstractSQLCommandSupport;
 import org.apache.knox.gateway.shell.commands.CSVCommand;
 import org.apache.knox.gateway.shell.commands.DataSourceCommand;
 import org.apache.knox.gateway.shell.commands.SelectCommand;
+import org.apache.knox.gateway.shell.commands.WebHDFSCommand;
 import org.apache.knox.gateway.shell.hbase.HBase;
 import org.apache.knox.gateway.shell.hdfs.Hdfs;
 import org.apache.knox.gateway.shell.job.Job;
@@ -96,6 +97,7 @@ public class Shell {
       shell.register(new SelectCommand(shell));
       shell.register(new DataSourceCommand(shell));
       shell.register(new CSVCommand(shell));
+      shell.register(new WebHDFSCommand(shell));
       shell.run( null );
     }
   }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractKnoxShellCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractKnoxShellCommand.java
@@ -18,6 +18,9 @@
 package org.apache.knox.gateway.shell.commands;
 
 import java.util.List;
+
+import org.apache.knox.gateway.shell.CredentialCollectionException;
+import org.apache.knox.gateway.shell.CredentialCollector;
 import org.codehaus.groovy.tools.shell.CommandSupport;
 import org.codehaus.groovy.tools.shell.Groovysh;
 
@@ -42,5 +45,11 @@ public abstract class AbstractKnoxShellCommand extends CommandSupport {
       }
     }
     return variableName;
+  }
+
+  protected CredentialCollector login() throws CredentialCollectionException {
+    KnoxLoginDialog dlg = new KnoxLoginDialog();
+    dlg.collect();
+    return dlg;
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractSQLCommandSupport.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/AbstractSQLCommandSupport.java
@@ -25,8 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.knox.gateway.shell.CredentialCollectionException;
-import org.apache.knox.gateway.shell.CredentialCollector;
 import org.apache.knox.gateway.shell.KnoxDataSource;
 import org.apache.knox.gateway.shell.KnoxSession;
 import org.apache.knox.gateway.shell.jdbc.JDBCUtils;
@@ -201,11 +199,5 @@ public abstract class AbstractSQLCommandSupport extends AbstractKnoxShellCommand
         // nop
       }
     });
-  }
-
-  protected CredentialCollector login() throws CredentialCollectionException {
-    KnoxLoginDialog dlg = new KnoxLoginDialog();
-    dlg.collect();
-    return dlg;
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/CSVCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/CSVCommand.java
@@ -49,10 +49,24 @@ public class CSVCommand extends AbstractKnoxShellCommand {
 
     try {
       if (withHeaders) {
-        table = KnoxShellTable.builder().csv().withHeaders().url(url);
+        if (url.startsWith("$")) {
+          // a knoxshell variable is a csv file as a string
+          String csvString = (String) getVariables().get(url.substring(1));
+          table = KnoxShellTable.builder().csv().withHeaders().string(csvString);
+        }
+        else {
+          table = KnoxShellTable.builder().csv().withHeaders().url(url);
+        }
       }
       else {
-        table = KnoxShellTable.builder().csv().url(url);
+        if (url.startsWith("$")) {
+          // a knoxshell variable is a csv file as a string
+          String csvString = (String) getVariables().get(url.substring(1));
+          table = KnoxShellTable.builder().csv().string(csvString);
+        }
+        else {
+          table = KnoxShellTable.builder().csv().url(url);
+        }
       }
     } catch (IOException e) {
       e.printStackTrace();

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/commands/WebHDFSCommand.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell.commands;
+
+import java.io.Console;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.apache.knox.gateway.shell.CredentialCollectionException;
+import org.apache.knox.gateway.shell.CredentialCollector;
+import org.apache.knox.gateway.shell.KnoxSession;
+import org.apache.knox.gateway.shell.KnoxShellException;
+import org.apache.knox.gateway.shell.hdfs.Hdfs;
+import org.apache.knox.gateway.shell.hdfs.Status.Response;
+import org.apache.knox.gateway.shell.table.KnoxShellTable;
+import org.apache.knox.gateway.util.JsonUtils;
+import org.codehaus.groovy.tools.shell.Groovysh;
+
+public class WebHDFSCommand extends AbstractKnoxShellCommand {
+  private Map<String, KnoxSession> sessions = new HashMap<>();
+
+  public WebHDFSCommand(Groovysh shell) {
+    super(shell, ":filesystem", ":fs");
+  }
+
+  @Override
+  public String getUsage() {
+    String usage = "Usage: \n" +
+                   "  :fs ls {target-path} \n" +
+                   "  :fs cat {target-path} \n" +
+                   "  :fs get {from-path} {to-path} \n" +
+                   "  :fs put {from-path} {tp-path} \n" +
+                   "  :fs rm {target-path} \n" +
+                   "  :fs mkdir {dir-path} \n";
+    return usage;
+  }
+
+  @Override
+  public Object execute(List<String> args) {
+    Map<String, String> mounts = getMountPoints();
+    if (args.isEmpty()) {
+      args.add("ls");
+    }
+    if (args.get(0).equalsIgnoreCase("mount")) {
+      String url = args.get(1);
+      String mountPoint = args.get(2);
+      return mount(mounts, url, mountPoint);
+    }
+    else if (args.get(0).equalsIgnoreCase("unmount")) {
+      String mountPoint = args.get(1);
+      unmount(mounts, mountPoint);
+    }
+    else if (args.get(0).equalsIgnoreCase("mounts")) {
+      return listMounts(mounts);
+    }
+    else if (args.get(0).equalsIgnoreCase("ls")) {
+      String path = args.get(1);
+      return listStatus(mounts, path);
+    }
+    else if (args.get(0).equalsIgnoreCase("put")) {
+      // Hdfs.put( session ).file( dataFile ).to( dataDir + "/" + dataFile ).now()
+      // :fs put from-path to-path
+      String localFile = args.get(1);
+      String path = args.get(2);
+      int permission = 755;
+      if (args.size() >= 4) {
+        permission = Integer.parseInt(args.get(3));
+      }
+
+      return put(mounts, localFile, path, permission);
+    }
+    else if (args.get(0).equalsIgnoreCase("rm")) {
+      // Hdfs.rm( session ).file( dataFile ).now()
+      // :fs rm target-path
+      String path = args.get(1);
+      return remove(mounts, path);
+    }
+    else if (args.get(0).equalsIgnoreCase("cat")) {
+      // println Hdfs.get( session ).from( dataDir + "/" + dataFile ).now().string
+      // :fs cat target-path
+      String path = args.get(1);
+      return cat(mounts, path);
+    }
+    else if (args.get(0).equalsIgnoreCase("mkdir")) {
+      // println Hdfs.mkdir( session ).dir( directoryPath ).perm( "777" ).now().string
+      // :fs mkdir target-path [perms]
+      String path = args.get(1);
+      String perms = null;
+      if (args.size() == 3) {
+        perms = args.get(2);
+      }
+
+      return mkdir(mounts, path, perms);
+    }
+    else if (args.get(0).equalsIgnoreCase("get")) {
+      // println Hdfs.get( session ).from( dataDir + "/" + dataFile ).now().string
+      // :fs get from-path [to-path]
+      String path = args.get(1);
+
+      String mountPoint = determineMountPoint(path);
+      KnoxSession session = getSessionForMountPoint(mounts, mountPoint);
+      if (session != null) {
+        String from = determineTargetPath(path, mountPoint);
+        String to = null;
+        if (args.size() > 2) {
+          to = args.get(2);
+        }
+        else {
+          to = System.getProperty("user.home") + File.separator +
+              path.substring(path.lastIndexOf(File.separator));
+        }
+        return get(mountPoint, from, to);
+      }
+      else {
+        return "No session established for mountPoint: " + mountPoint + " Use :fs mount {topology-url} {mountpoint-name}";
+      }
+    }
+    else {
+      System.out.println("Unknown filesystem command");
+      System.out.println(getUsage());
+    }
+    return "";
+  }
+
+  private String get(String mountPoint, String from, String to) {
+    String result = null;
+    try {
+      Hdfs.get(sessions.get(mountPoint)).from(from).file(to).now().getString();
+      result = "Successfully copied: " + from + " to: " + to;
+    } catch (KnoxShellException | IOException e) {
+      e.printStackTrace();
+      result = "Exception ocurred: " + e.getMessage();
+    }
+    return result;
+  }
+
+  private String mkdir(Map<String, String> mounts, String path, String perms) {
+    String result = null;
+    String mountPoint = determineMountPoint(path);
+    KnoxSession session = getSessionForMountPoint(mounts, mountPoint);
+    if (session != null) {
+      String targetPath = determineTargetPath(path, mountPoint);
+      if (!exists(session, targetPath)) {
+        try {
+          if (perms != null) {
+            Hdfs.mkdir(sessions.get(mountPoint)).dir(targetPath).now().getString();
+          }
+          else {
+            Hdfs.mkdir(session).dir(targetPath).perm(perms).now().getString();
+          }
+          result = "Successfully created directory: " + targetPath;
+        } catch (KnoxShellException | IOException e) {
+          e.printStackTrace();
+          result = "Exception ocurred: " + e.getMessage();
+        }
+      }
+      else {
+        result = targetPath + " already exists";
+      }
+    }
+    else {
+      result = "No session established for mountPoint: " + mountPoint + " Use :fs mount {topology-url} {mountpoint-name}";
+    }
+    return result;
+  }
+
+  private String cat(Map<String, String> mounts, String path) {
+    String response = null;
+    String mountPoint = determineMountPoint(path);
+    KnoxSession session = getSessionForMountPoint(mounts, mountPoint);
+    if (session != null) {
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        String contents = Hdfs.get(session).from(targetPath).now().getString();
+        response = contents;
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+        response = "Exception ocurred: " + e.getMessage();
+      }
+    }
+    else {
+      response = "No session established for mountPoint: " + mountPoint + " Use :fs mount {topology-url} {mountpoint-name}";
+    }
+    return response;
+  }
+
+  private String remove(Map<String, String> mounts, String path) {
+    String mountPoint = determineMountPoint(path);
+    KnoxSession session = getSessionForMountPoint(mounts, mountPoint);
+    if (session != null) {
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        Hdfs.rm(session).file(targetPath).now().getString();
+      } catch (KnoxShellException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+    else {
+      return "No session established for mountPoint: " + mountPoint + " Use :fs mount {topology-url} {mountpoint-name}";
+    }
+    return "Successfully removed: " + path;
+  }
+
+  private String put(Map<String, String> mounts, String localFile, String path, int permission) {
+    String mountPoint = determineMountPoint(path);
+    KnoxSession session = getSessionForMountPoint(mounts, mountPoint);
+    if (session != null) {
+      String targetPath = determineTargetPath(path, mountPoint);
+      try {
+        boolean overwrite = false;
+        if (exists(session, targetPath)) {
+          if (collectClearInput(targetPath + " already exists would you like to overwrite (Y/n)").equalsIgnoreCase("y")) {
+            overwrite = true;
+          }
+        }
+        Hdfs.put(session).file(localFile).to(targetPath).overwrite(overwrite).permission(permission).now().getString();
+      } catch (IOException e) {
+        e.printStackTrace();
+        return "Exception ocurred: " + e.getMessage();
+      }
+    }
+    else {
+      return "No session established for mountPoint: " + mountPoint + " Use :fs mount {topology-url} {mountpoint-name}";
+    }
+    return "Successfully put: " + localFile + " to: " + path;
+  }
+
+  private boolean exists(KnoxSession session, String path) {
+    boolean rc = false;
+    try {
+      Response response = Hdfs.status(session).file(path).now();
+      rc = response.exists();
+    } catch (KnoxShellException e) {
+      // NOP
+    }
+    return rc;
+  }
+
+  private Object listStatus(Map<String, String> mounts, String path) {
+    Object response = null;
+    try {
+      String directory;
+      String mountPoint = determineMountPoint(path);
+      if (mountPoint != null) {
+        KnoxSession session = getSessionForMountPoint(mounts, mountPoint);
+        if (session != null) {
+          directory = determineTargetPath(path, mountPoint);
+          String json = Hdfs.ls(session).dir(directory).now().getString();
+          Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> map =
+              JsonUtils.getFileStatusesAsMap(json);
+          if (map != null) {
+            ArrayList<HashMap<String, String>> list = map.get("FileStatuses").get("FileStatus");
+            KnoxShellTable table = buildTableFromListStatus(directory, list);
+            response = table;
+          }
+        }
+        else {
+          response = "No session established for mountPoint: " + mountPoint + " Use :fs mount {topology-url} {mountpoint-name}";
+        }
+      }
+      else {
+        response = "No mountpoint found. Use ':fs mount {topologyURL} {mountpoint}'.";
+      }
+    } catch (KnoxShellException | IOException e) {
+      response = "Exception ocurred: " + e.getMessage();
+      e.printStackTrace();
+    }
+    return response;
+  }
+
+  private KnoxShellTable listMounts(Map<String, String> mounts) {
+    KnoxShellTable table = new KnoxShellTable();
+    table.header("Mount Point").header("Topology URL");
+    for (String mountPoint : mounts.keySet()) {
+      table.row().value(mountPoint).value(mounts.get(mountPoint));
+    }
+    return table;
+  }
+
+  private void unmount(Map<String, String> mounts, String mountPoint) {
+    sessions.remove(mountPoint);
+    mounts.remove(mountPoint);
+    KnoxSession.persistMountPoints(mounts);
+  }
+
+  private String mount(Map<String, String> mounts, String url, String mountPoint) {
+    KnoxSession session = establishSession(mountPoint, url);
+    if (session != null) {
+      mounts.put(mountPoint, url);
+      KnoxSession.persistMountPoints(mounts);
+      return url + " mounted as " + mountPoint;
+    }
+    return "Failed to mount " + url + " as " + mountPoint;
+  }
+
+  private KnoxSession getSessionForMountPoint(Map<String, String> mounts, String mountPoint) {
+    KnoxSession session = sessions.get(mountPoint);
+    if (session == null) {
+      String url = mounts.get(mountPoint);
+      if (url != null) {
+        session = establishSession(mountPoint, url);
+      }
+    }
+    return session;
+  }
+
+  private KnoxSession establishSession(String mountPoint, String url) {
+    CredentialCollector dlg;
+    try {
+      dlg = login();
+    } catch (CredentialCollectionException e) {
+      e.printStackTrace();
+      return null;
+    }
+    String username = dlg.name();
+    String password = new String(dlg.chars());
+    KnoxSession session = null;
+    try {
+      session = KnoxSession.login(url, username, password);
+      sessions.put(mountPoint, session);
+    } catch (URISyntaxException e) {
+      e.printStackTrace();
+    }
+    return session;
+  }
+
+  private String collectClearInput(String prompt) {
+    Console c = System.console();
+    if (c == null) {
+      System.err.println("No console.");
+      System.exit(1);
+    }
+
+    String value = c.readLine(prompt);
+
+    return value;
+  }
+
+  private String determineTargetPath(String path, String mountPoint) {
+    String directory = null;
+    if (path.startsWith("/")) {
+      directory = stripMountPoint(path, mountPoint);
+    }
+    return directory;
+  }
+
+  private String stripMountPoint(String path, String mountPoint) {
+    String newPath = path.replace("/" + mountPoint, "");
+    return newPath;
+  }
+
+  private String determineMountPoint(String path) {
+    String mountPoint = null;
+    if (path.startsWith("/")) {
+      // does the user supplied path starts at a root
+      // if so check for a mountPoint based on the first element of the path
+      String[] pathElements = path.split("/");
+      mountPoint = pathElements[1];
+    }
+    return mountPoint;
+  }
+
+  private KnoxShellTable buildTableFromListStatus(String directory, List<HashMap<String, String>> list) {
+    Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.getDefault());
+    KnoxShellTable table = new KnoxShellTable();
+    table.title(directory);
+    table.header("permission")
+      .header("owner")
+      .header("group")
+      .header("length")
+      .header("modtime")
+      .header("name");
+
+    for (Map<String, String> map : list) {
+      cal.setTimeInMillis(Long.parseLong(map.get("modificationTime")));
+      table.row()
+        .value(map.get("permission"))
+        .value(map.get("owner"))
+        .value(map.get("group"))
+        .value(map.get("length"))
+        .value(cal.getTime())
+        .value(map.get("pathSuffix"));
+    }
+
+    return table;
+  }
+
+  protected Map<String, String> getMountPoints() {
+    Map<String, String> mounts = null;
+    try {
+      mounts = KnoxSession.loadMountPoints();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return mounts;
+  }
+
+  public static void main(String[] args) {
+    WebHDFSCommand cmd = new WebHDFSCommand(new Groovysh());
+    cmd.execute(new ArrayList<>(Arrays.asList(args)));
+  }
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Ls.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Ls.java
@@ -26,7 +26,7 @@ import org.apache.http.client.utils.URIBuilder;
 
 import java.util.concurrent.Callable;
 
-class Ls {
+public class Ls {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Mkdir.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Mkdir.java
@@ -26,7 +26,7 @@ import org.apache.http.client.utils.URIBuilder;
 
 import java.util.concurrent.Callable;
 
-class Mkdir {
+public class Mkdir {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Put.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Put.java
@@ -34,7 +34,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.File;
 import java.util.concurrent.Callable;
 
-class Put {
+public class Put {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Rm.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/hdfs/Rm.java
@@ -27,7 +27,7 @@ import org.apache.http.client.utils.URIBuilder;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-class Rm {
+public class Rm {
 
   public static class Request extends AbstractRequest<Response> {
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -18,9 +18,7 @@
 package org.apache.knox.gateway.shell.table;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
@@ -41,47 +39,34 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable url(String url) throws IOException {
+    int rowIndex = 0;
     URL urlToCsv = new URL(url);
     URLConnection connection = urlToCsv.openConnection();
     try (Reader urlConnectionStreamReader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(urlConnectionStreamReader);) {
-      buildTableFromCSVReader(csvReader);
-    }
-    return this.table;
-  }
-
-  public KnoxShellTable string(String csvString) throws IOException {
-    InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8));
-
-    try (Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
-        BufferedReader csvReader = new BufferedReader(stringStreamReader);) {
-      buildTableFromCSVReader(csvReader);
-    }
-    return this.table;
-  }
-
-  private void buildTableFromCSVReader(BufferedReader csvReader) throws IOException {
-    int rowIndex = 0;
-    if (title != null) {
-      this.table.title(title);
-    }
-    String row = null;
-    while ((row = csvReader.readLine()) != null) {
-      boolean addingHeaders = (withHeaders && rowIndex == 0);
-      if (!addingHeaders) {
-        this.table.row();
+      if (title != null) {
+        this.table.title(title);
       }
-      // handle comma's within quoted string values for single col
-      String[] data = row.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", -1);
-
-      for (String value : data) {
-        if (addingHeaders) {
-          this.table.header(value);
-        } else {
-          this.table.value(value);
+      String row = null;
+      while ((row = csvReader.readLine()) != null) {
+        boolean addingHeaders = (withHeaders && rowIndex == 0);
+        if (!addingHeaders) {
+          this.table.row();
         }
+        // handle comma's within quoted string values for single col
+        String[] data = row.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", -1);
+
+        for (String value : data) {
+          if (addingHeaders) {
+            this.table.header(value);
+          } else {
+            this.table.value(value);
+          }
+        }
+        rowIndex++;
       }
-      rowIndex++;
     }
+    return this.table;
   }
+
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -51,7 +51,8 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable string(String csvString) throws IOException {
-    try (InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8)); Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+    try (InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8));
+        Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(stringStreamReader);) {
       buildTableFromCSVReader(csvReader);
     }
@@ -82,4 +83,5 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
       rowIndex++;
     }
   }
+
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -18,7 +18,9 @@
 package org.apache.knox.gateway.shell.table;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
@@ -39,33 +41,47 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable url(String url) throws IOException {
-    int rowIndex = 0;
     URL urlToCsv = new URL(url);
     URLConnection connection = urlToCsv.openConnection();
     try (Reader urlConnectionStreamReader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(urlConnectionStreamReader);) {
-      if (title != null) {
-        this.table.title(title);
-      }
-      String row = null;
-      while ((row = csvReader.readLine()) != null) {
-        boolean addingHeaders = (withHeaders && rowIndex == 0);
-        if (!addingHeaders) {
-          this.table.row();
-        }
-        String[] data = row.split(",");
-
-        for (String value : data) {
-          if (addingHeaders) {
-            this.table.header(value);
-          } else {
-            this.table.value(value);
-          }
-        }
-        rowIndex++;
-      }
+      buildTableFromCSVReader(csvReader);
     }
     return this.table;
   }
 
+  public KnoxShellTable string(String csvString) throws IOException {
+    InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8));
+
+    try (Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+        BufferedReader csvReader = new BufferedReader(stringStreamReader);) {
+      buildTableFromCSVReader(csvReader);
+    }
+    return this.table;
+  }
+
+  private void buildTableFromCSVReader(BufferedReader csvReader) throws IOException {
+    int rowIndex = 0;
+    if (title != null) {
+      this.table.title(title);
+    }
+    String row = null;
+    while ((row = csvReader.readLine()) != null) {
+      boolean addingHeaders = (withHeaders && rowIndex == 0);
+      if (!addingHeaders) {
+        this.table.row();
+      }
+      // handle comma's within quoted string values for single col
+      String[] data = row.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", -1);
+
+      for (String value : data) {
+        if (addingHeaders) {
+          this.table.header(value);
+        } else {
+          this.table.value(value);
+        }
+      }
+      rowIndex++;
+    }
+  }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -137,6 +137,10 @@ public class KnoxShellTable {
     double[] colArray = new double[col.size()];
     Conversions conversionMethod = null;
     for (int i = 0; i < col.size(); i++) {
+      Object v = col.get(i);
+      if (v instanceof String && ((String) v).trim().isEmpty()) {
+        col.set(i, "0");
+      }
       if (i == 0) {
         conversionMethod = getConversion(col.get(i));
       }
@@ -435,6 +439,10 @@ public class KnoxShellTable {
   }
 
   public String toCSV() {
-    return new KnoxShellTableRenderer(this).toCSV();
+    return toCSV(null);
+  }
+
+  public String toCSV(String filePath) {
+    return new KnoxShellTableRenderer(this).toCSV(filePath);
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFileUtils.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableFileUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell.table;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class KnoxShellTableFileUtils {
+  public static void persistToFile(String filePath, final String content) throws IOException {
+    final Path jsonFilePath = Paths.get(filePath);
+    if (!Files.exists(jsonFilePath.getParent())) {
+      Files.createDirectories(jsonFilePath.getParent());
+    }
+    Files.deleteIfExists(jsonFilePath);
+    Files.createFile(jsonFilePath);
+    setPermissions(jsonFilePath);
+    Files.write(jsonFilePath, content.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void setPermissions(Path path) throws IOException {
+    // clear all flags for everybody
+    path.toFile().setReadable(false, false);
+    path.toFile().setWritable(false, false);
+    path.toFile().setExecutable(false, false);
+    // allow owners to read/write
+    path.toFile().setReadable(true, true);
+    path.toFile().setWritable(true, true);
+  }
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableJSONSerializer.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableJSONSerializer.java
@@ -18,10 +18,6 @@
 package org.apache.knox.gateway.shell.table;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -87,27 +83,10 @@ class KnoxShellTableJSONSerializer {
       } else {
         jsonResult = JsonUtils.renderAsJsonString(KnoxShellTableCallHistory.getInstance().getCallHistory(table.id), null, JSON_DATE_FORMAT.get());
       }
-      final Path jsonFilePath = Paths.get(filePath);
-      if (!Files.exists(jsonFilePath.getParent())) {
-        Files.createDirectories(jsonFilePath.getParent());
-      }
-      Files.deleteIfExists(jsonFilePath);
-      Files.createFile(jsonFilePath);
-      setPermissions(jsonFilePath);
-      Files.write(jsonFilePath, jsonResult.getBytes(StandardCharsets.UTF_8));
+      KnoxShellTableFileUtils.persistToFile(filePath, jsonResult);
       return "Successfully saved into " + filePath;
     } catch (IOException e) {
       throw new KnoxShellException("Error while saving KnoxShellTable JSON into " + filePath, e);
     }
-  }
-
-  private static void setPermissions(Path path) throws IOException {
-    // clear all flags for everybody
-    path.toFile().setReadable(false, false);
-    path.toFile().setWritable(false, false);
-    path.toFile().setExecutable(false, false);
-    // allow owners to read/write
-    path.toFile().setReadable(true, true);
-    path.toFile().setWritable(true, true);
   }
 }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableRenderer.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableRenderer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.shell.table;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -38,6 +39,10 @@ class KnoxShellTableRenderer {
   }
 
   String toCSV() {
+    return toCSV(null);
+  }
+
+  String toCSV(String filePath) {
     final StringBuilder csv = new StringBuilder();
     String header;
     for (int i = 0; i < tableToRender.headers.size(); i++) {
@@ -59,8 +64,17 @@ class KnoxShellTableRenderer {
         }
       }
     }
+    String content = csv.toString();
+    if (filePath != null) {
+      try {
+        KnoxShellTableFileUtils.persistToFile(filePath, content);
+      } catch (IOException e) {
+        System.out.println("Persistence of CSV file has failed. " + e.getMessage());
+        e.printStackTrace();
+      }
+    }
 
-    return csv.toString();
+    return content;
   }
 
   @Override

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -191,19 +191,31 @@ public class KnoxShellTableTest {
   }
 
   @Test
-  public void testCSVStringToTable() throws IOException {
-    String initialString = "colA, colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
-
-    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
-    assertEquals(table.rows.size(), 2);
-  }
-
-  @Test
   public void testCSVQuotedEmbeddedCommaStringToTable() throws IOException {
-    String initialString = "\"colA, colA1\", colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
+    KnoxShellTable table = new KnoxShellTable();
+    table.title("From URL");
 
-    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
-    assertEquals(table.headers.get(0), "\"colA, colA1\"");
+    table.header("\"Column A, Column A1\"").header("Column B").header("Column C");
+
+    table.row().value("123").value("456").value("344444444");
+    table.row().value("789").value("012").value("844444444");
+
+    String csv = table.toCSV();
+    try {
+      // write file to /tmp to read back in
+      FileUtils.writeStringToFile(new File("/tmp/testtable.csv"), csv, StandardCharsets.UTF_8);
+
+      KnoxShellTable urlTable = KnoxShellTable.builder().csv()
+          .withHeaders()
+          .url("file:///tmp/testtable.csv");
+      urlTable.title("From URL");
+      assertEquals(urlTable.toString(), table.toString());
+
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    assertEquals(table.headers.get(0), "\"Column A, Column A1\"");
   }
 
   @Test

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -219,6 +219,14 @@ public class KnoxShellTableTest {
   }
 
   @Test
+  public void testCSVQuotedEmbeddedCommaStringToTable() throws IOException {
+    String initialString = "\"colA, colA1\", colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
+
+    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
+    assertEquals(table.headers.get(0), "\"colA, colA1\"");
+  }
+
+  @Test
   public void testToAndFromJSON() throws IOException {
     KnoxShellTable table = new KnoxShellTable();
 

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -196,7 +196,6 @@ public class KnoxShellTableTest {
     table.title("From URL");
 
     table.header("\"Column A, Column A1\"").header("Column B").header("Column C");
-
     table.row().value("123").value("456").value("344444444");
     table.row().value("789").value("012").value("844444444");
 
@@ -216,14 +215,6 @@ public class KnoxShellTableTest {
     }
 
     assertEquals(table.headers.get(0), "\"Column A, Column A1\"");
-  }
-
-  @Test
-  public void testCSVQuotedEmbeddedCommaStringToTable() throws IOException {
-    String initialString = "\"colA, colA1\", colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
-
-    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
-    assertEquals(table.headers.get(0), "\"colA, colA1\"");
   }
 
   @Test

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -191,6 +191,22 @@ public class KnoxShellTableTest {
   }
 
   @Test
+  public void testCSVStringToTable() throws IOException {
+    String initialString = "colA, colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
+
+    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
+    assertEquals(table.rows.size(), 2);
+  }
+
+  @Test
+  public void testCSVQuotedEmbeddedCommaStringToTable() throws IOException {
+    String initialString = "\"colA, colA1\", colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
+
+    KnoxShellTable table = KnoxShellTable.builder().csv().withHeaders().string(initialString);
+    assertEquals(table.headers.get(0), "\"colA, colA1\"");
+  }
+
+  @Test
   public void testToAndFromJSON() throws IOException {
     KnoxShellTable table = new KnoxShellTable();
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
@@ -22,8 +22,11 @@ import org.apache.knox.gateway.service.definition.ServiceDefinitionChangeListene
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.topology.TopologyListener;
+import org.xml.sax.SAXException;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -62,5 +65,17 @@ public interface TopologyService extends Service, ServiceDefinitionChangeListene
   boolean deleteProviderConfiguration(String name, boolean force);
 
   Map<String, List<String>> getServiceTestURLs(Topology t, GatewayConfig config);
+
+  /**
+   * Parse the specified XML topology content to produce a Topology object.
+   *
+   * @param content The XML content of the topology.
+   *
+   * @return A Topology object based on the specified content.
+   *
+   * @throws IOException
+   * @throws SAXException
+   */
+  Topology parse(InputStream content) throws IOException, SAXException;
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Provider.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Provider.java
@@ -17,6 +17,9 @@
  */
 package org.apache.knox.gateway.topology;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -80,6 +83,33 @@ public class Provider {
 
   public void setRole( String role ) {
     this.role = role;
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder().append(name)
+                                .append(role)
+                                .append(params)
+                                .append(enabled)
+                                .build();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Provider)) {
+      return false;
+    }
+
+    Provider other = (Provider) obj;
+    return (new EqualsBuilder()).append(name, other.name)
+                                .append(role, other.role)
+                                .append(params, other.params)
+                                .append(enabled, other.enabled)
+                                .build();
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Service.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Service.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.topology;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.knox.gateway.service.definition.CustomDispatch;
 
 import java.util.ArrayList;
@@ -24,6 +26,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Service {
 
@@ -122,35 +125,22 @@ public class Service {
       return false;
     }
     Service that = (Service) object;
-    String thatName = that.getName();
-    if (thatName != null && !(thatName.equals(name))) {
-        return false;
-    }
-    String thatRole = that.getRole();
-    if (thatRole != null && !thatRole.equals(role)) {
-        return false;
-    }
-    Version thatVersion = that.getVersion();
-    if (thatVersion != null && !(thatVersion.equals(version))) {
-        return false;
-    }
-    return true;
+    return (new EqualsBuilder()).append(name, that.name)
+                                .append(role, that.role)
+                                .append(version, that.version)
+                                .append(urls.stream().sorted().collect(Collectors.toList()),
+                                        that.urls.stream().sorted().collect(Collectors.toList()))
+                                .append(params, that.params)
+                                .build();
   }
 
   @Override
   public int hashCode() {
-    int hashCode = 17;
-    if (getName() != null) {
-      hashCode *= 31 * getName().hashCode();
-    }
-    if (getRole() != null) {
-      hashCode *= 31 * getRole().hashCode();
-    }
-    if (getVersion() != null) {
-      hashCode *= 31 * getVersion().hashCode();
-    }
-
-    return hashCode;
+    return (new HashCodeBuilder(17, 31)).append(name)
+                                        .append(role)
+                                        .append(version)
+                                        .append(urls)
+                                        .append(params).build();
   }
 
   /**
@@ -172,4 +162,5 @@ public class Service {
   public void addDispatch(CustomDispatch dispatch) {
     this.dispatch = dispatch;
   }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Topology.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Topology.java
@@ -19,13 +19,17 @@ package org.apache.knox.gateway.topology;
 
 import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.collections.map.MultiKeyMap;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class Topology {
 
@@ -38,8 +42,12 @@ public class Topology {
   private Map<String,Map<String,Provider>> providerMap = new HashMap<>();
   public List<Service> services = new ArrayList<>();
   private MultiKeyMap serviceMap;
-  private List<Application> applications = new ArrayList<>();
+  List<Application> applications = new ArrayList<>();
   private Map<String,Application> applicationMap = new HashMap<>();
+
+  private ProviderComparator providerComparator = new ProviderComparator();
+  private ServiceComparator serviceComparator = new ServiceComparator();
+  private ApplicationComparator appComparator = new ApplicationComparator();
 
   public Topology() {
     serviceMap = MultiKeyMap.decorate(new HashedMap());
@@ -151,6 +159,108 @@ public class Topology {
     String role = provider.getRole();
     Map<String, Provider> nameMap = providerMap.computeIfAbsent(role, k -> new HashMap<>());
     nameMap.put( provider.getName(), provider );
+  }
+
+  @Override
+  public int hashCode() {
+    return (new HashCodeBuilder(17, 31)).append(name)
+                                .append(providerList.stream().sorted(providerComparator).collect(Collectors.toList()))
+                                .append(services.stream().sorted(serviceComparator).collect(Collectors.toList()))
+                                .append(applications.stream().sorted(appComparator).collect(Collectors.toList()))
+                                .build();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+
+    // Has to be a Topology
+    if (!(obj instanceof Topology)) {
+      return false;
+    }
+
+    Topology other = (Topology) obj;
+    if (Objects.equals(this.name,other.name)) {
+      // Order is NOT significant for providers, services, and applications
+
+      if (equalProviders(other)) {  // Providers
+        if (equalServices(other)) { // Services
+          if (equalApplications(other)) { // Applications
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private boolean equalProviders(Topology other) {
+    if (providerList != null) {
+      if (other.providerList == null) {
+        return false;
+      }
+
+      List<Provider> mySorted = providerList.stream().sorted(providerComparator).collect(Collectors.toList());
+      List<Provider> otherSorted = other.providerList.stream().sorted(providerComparator).collect(Collectors.toList());
+      return mySorted.equals(otherSorted);
+    } else {
+      return (other.providerList == null);
+    }
+  }
+
+  private boolean equalServices(Topology other) {
+    if (services != null) {
+      if (other.services == null) {
+        return false;
+      }
+
+      List<Service> mySorted = services.stream().sorted(serviceComparator).collect(Collectors.toList());
+      List<Service> otherSorted = other.services.stream().sorted(serviceComparator).collect(Collectors.toList());
+      return mySorted.equals(otherSorted);
+    } else {
+      return (other.services == null);
+    }
+  }
+
+  private boolean equalApplications(Topology other) {
+    if (applications != null) {
+      if (other.applications == null) {
+        return false;
+      }
+
+      List<Application> mySorted = applications.stream().sorted(appComparator).collect(Collectors.toList());
+      List<Application> otherSorted = other.applications.stream().sorted(appComparator).collect(Collectors.toList());
+      return mySorted.equals(otherSorted);
+    } else {
+      return (other.applications == null);
+    }
+  }
+
+  private static final class ProviderComparator implements Comparator<Provider> {
+    @Override
+    public int compare(Provider o1, Provider o2) {
+      String name1 = o1.getName();
+      return name1 != null ? name1.compareToIgnoreCase(o2.getName()) : 0;
+    }
+  }
+
+  private static final class ServiceComparator implements Comparator<Service> {
+    @Override
+    public int compare(Service o1, Service o2) {
+      String name1 = o1.getName();
+      return name1 != null ? name1.compareToIgnoreCase(o2.getName()) : 0;
+    }
+  }
+
+  private static final class ApplicationComparator implements Comparator<Application> {
+    @Override
+    public int compare(Application o1, Application o2) {
+      String name1 = o1.getName();
+      return name1 != null ? name1.compareToIgnoreCase(o2.getName()) : 0;
+    }
   }
 
 }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/topology/TopologyTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/topology/TopologyTest.java
@@ -1,0 +1,742 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TopologyTest {
+
+
+  @Test
+  public void testIdenticalTopologyObjectsAreEqual() {
+    Topology t1 = new Topology();
+    Topology t2 = t1;
+    assertEquals(t1, t2);
+  }
+
+  @Test
+  public void testNullProviders() {
+    Topology t1 = new Topology();
+    Topology t2 = new Topology();
+
+    t1.providerList = null;
+    assertNotEquals(t1, t2);
+
+    t1.providerList = Collections.emptyList();
+    t2.providerList = null;
+    assertNotEquals(t1, t2);
+
+    t1.providerList = null;
+    assertEquals(t1, t2);
+  }
+
+  @Test
+  public void testNullServices() {
+    Topology t1 = new Topology();
+    Topology t2 = new Topology();
+
+    t1.services = null;
+    assertNotEquals(t1, t2);
+
+    t1.services = Collections.emptyList();
+    t2.services = null;
+    assertNotEquals(t1, t2);
+
+    t1.services = null;
+    assertEquals(t1, t2);
+  }
+
+  @Test
+  public void testNullApplications() {
+    Topology t1 = new Topology();
+    Topology t2 = new Topology();
+
+    t1.applications = null;
+    assertNotEquals(t1, t2);
+
+    t1.applications = Collections.emptyList();
+    t2.applications = null;
+    assertNotEquals(t1, t2);
+
+    t1.applications = null;
+    assertEquals(t1, t2);
+  }
+
+  @Test
+  public void testEmptyTopologiesWithSameName() {
+    final String name = "tName";
+    Topology t1 = createTopology(name, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    Topology t2 = createTopology(name, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    assertEquals(t1, t2);
+    assertEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+  }
+
+  @Test
+  public void testEmptyTopologiesWithDifferentName() {
+    Topology t1 = createTopology("tName1", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    Topology t2 = createTopology("tName2", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    assertNotEquals(t1, t2);
+    assertNotEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+  }
+
+  @Test
+  public void testTopologiesWithSameServicesInDifferentOrder() {
+    final String name = "topologyX";
+
+    final String serviceName1 = "service1";
+    final String serviceRole1 = "role1";
+    Service service1 = createService(serviceName1, serviceRole1, Collections.emptyList(), Collections.emptyMap());
+
+    final String serviceName2 = "service2";
+    final String serviceRole2 = "role2";
+    Service service2 = createService(serviceName2, serviceRole2, Collections.emptyList(), Collections.emptyMap());
+
+    final String serviceName3 = "service3";
+    final String serviceRole3 = "role3";
+    Service service3 = createService(serviceName3, serviceRole3, Collections.emptyList(), Collections.emptyMap());
+
+    List<Service> services1 = Arrays.asList(service1, service2, service3);
+    List<Service> services2 = Arrays.asList(service2, service3, service1);
+
+    Topology t1 = createTopology(name, Collections.emptyList(), services1, Collections.emptyList());
+    Topology t2 = createTopology(name, Collections.emptyList(), services2, Collections.emptyList());
+
+    assertEquals(t1, t2);
+    assertEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+  }
+
+  @Test
+  public void testTopologiesWithSameServicesWithDifferentURLOrder() {
+    final String name = "topologyX";
+
+    final String url1 = "http://host:1234/path1";
+    final String url2 = "http://host:1234/path2";
+    final String url3 = "http://host:1234/path3";
+
+    final String serviceName1 = "service1";
+    final String serviceRole1 = "role1";
+    Service service1 =
+                  createService(serviceName1, serviceRole1, Arrays.asList(url1, url2, url3), Collections.emptyMap());
+
+    final String serviceName2 = "service2";
+    final String serviceRole2 = "role2";
+    Service service2 =
+                  createService(serviceName2, serviceRole2, Arrays.asList(url2, url3, url1), Collections.emptyMap());
+
+    final String serviceName3 = "service3";
+    final String serviceRole3 = "role3";
+    Service service3 =
+                  createService(serviceName3, serviceRole3, Arrays.asList(url3, url2, url1), Collections.emptyMap());
+
+    List<Service> services1 = Arrays.asList(service1, service2, service3);
+    List<Service> services2 = Arrays.asList(service2, service3, service1);
+
+    Topology t1 = createTopology(name, Collections.emptyList(), services1, Collections.emptyList());
+    Topology t2 = createTopology(name, Collections.emptyList(), services2, Collections.emptyList());
+
+    assertEquals(t1, t2);
+    assertEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+  }
+
+  @Test
+  public void testTopologiesWithSameProvidersInDifferentOrder() {
+    final String name = "topologyX";
+
+    final String name1 = "provider1";
+    final String role1 = "role1";
+    Provider provider1 = createProvider(name1, role1, Collections.emptyMap());
+
+    final String name2 = "provider1";
+    final String role2 = "role1";
+    Provider provider2 = createProvider(name2, role2, Collections.emptyMap());
+
+    final String name3 = "provider1";
+    final String role3 = "role1";
+    Provider provider3 = createProvider(name3, role3, Collections.emptyMap());
+
+    List<Provider> providers1 = Arrays.asList(provider1, provider2, provider3);
+    List<Provider> providers2 = Arrays.asList(provider3, provider2, provider1);
+
+    Topology t1 = createTopology(name, providers1, Collections.emptyList(), Collections.emptyList());
+    Topology t2 = createTopology(name, providers2, Collections.emptyList(), Collections.emptyList());
+
+    assertEquals(t1, t2);
+    assertEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+  }
+
+
+  @Test
+  public void testTopologiesWithSameAppsInDifferentOrder() {
+    final String name = "topologyX";
+
+    final String name1 = "app1";
+    final String role1 = "role1";
+    Application app1 = createApplication(name1, role1, Collections.emptyList(), Collections.emptyMap());
+
+    final String name2 = "app2";
+    final String role2 = "role2";
+    Application app2 = createApplication(name2, role2, Collections.emptyList(), Collections.emptyMap());
+
+    final String name3 = "app3";
+    final String role3 = "role3";
+    Application app3 = createApplication(name3, role3, Collections.emptyList(), Collections.emptyMap());
+
+    List<Application> apps1 = Arrays.asList(app1, app2, app3);
+    List<Application> apps2 = Arrays.asList(app3, app1, app2);
+
+    Topology t1 = createTopology(name, Collections.emptyList(), Collections.emptyList(), apps1);
+    Topology t2 = createTopology(name, Collections.emptyList(), Collections.emptyList(), apps2);
+
+    assertEquals(t1, t2);
+    assertEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+  }
+
+
+  @Test
+  public void testTopologiesAreEqual() {
+    doTestSameTopologies(2, 2, 2);
+  }
+
+  @Test
+  public void testSameTopologiesNoApps() {
+    doTestSameTopologies(2, 2, 0);
+  }
+
+  @Test
+  public void testSameTopologiesNoProviders() {
+    doTestSameTopologies(0, 2, 2);
+  }
+
+  @Test
+  public void testSameTopologiesNoServices() {
+    doTestSameTopologies(2, 0, 2);
+  }
+
+  @Test
+  public void testDifferentAppCount() {
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appParamName  = "a_key_one";
+    final String appParamValue = "a_value_one";
+    final String appURL        = "http://host:1234/app";
+    List<List<Application>> apps = createAppLists(appName, appRole, appParamName, appParamValue, appURL, 2);
+
+    List<Application> modifiedApps = apps.get(1);
+    modifiedApps.add(createApplication("app2", "app2Role", Collections.emptyList(), Collections.emptyMap()));
+
+    assertFalse("Expected inequality because there are a different number of applications.",
+                doTestApplicationEquality(apps.get(0), modifiedApps));
+  }
+
+  @Test
+  public void testDifferentAppNames() {
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appURL        = "http://host:1234/app";
+    Map<String, String> params = Collections.emptyMap();
+
+    // Since applications' roles get set as the name, vary the role for this test
+    Application a1 = createApplication(appName, appRole, Collections.singletonList(appURL), params);
+    Application a2 = createApplication(appName, "differentRole", Collections.singletonList(appURL), params);
+
+    assertFalse("Expected inequality because there are different application names.",
+                doTestApplicationEquality(a1, a2));
+  }
+
+  @Test
+  public void testDifferentAppURLCount() {
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appURL        = "http://host:1234/app";
+    Map<String, String> params = Collections.emptyMap();
+
+    Application a1 = createApplication(appName, appRole, Collections.singletonList(appURL), params);
+
+    List<String> urls = Arrays.asList(appURL, appURL + "/other");
+    Application a2 = createApplication(appName, appRole, urls, params);
+
+    assertFalse("Expected inequality because there are different number of application URLs.",
+                doTestApplicationEquality(a1, a2));
+  }
+
+  @Test
+  public void testDifferentAppURLValues() {
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appURL        = "http://host:1234/app";
+    Map<String, String> params = Collections.emptyMap();
+
+    Application a1 = createApplication(appName, appRole, Collections.singletonList(appURL), params);
+    Application a2 = createApplication(appName, appRole, Collections.singletonList(appURL + "/other"), params);
+
+    assertFalse("Expected inequality because there are different application URL values.",
+                doTestApplicationEquality(a1, a2));
+  }
+
+
+  @Test
+  public void testDifferentAppParamCount() {
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appParamName  = "a_key_one";
+    final String appParamValue = "a_value_one";
+    final List<String> urls = Collections.emptyList();
+
+    Map<String, String> params = new HashMap<>();
+    params.put(appParamName, appParamValue);
+    Application a1 = createApplication(appName, appRole, urls, params);
+
+    Map<String, String> params2 = new HashMap<>();
+    params.put(appParamName, appParamValue);
+    params.put("anotherName", "anotherValue");
+    Application a2 = createApplication(appName, appRole, urls, params2);
+
+    assertFalse("Expected inequality because there are different number of application params.",
+                doTestApplicationEquality(a1, a2));
+  }
+
+  @Test
+  public void testDifferentAppParamValues() {
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appParamName  = "a_key_one";
+    final String appParamValue = "a_value_one";
+    final List<String> urls = Collections.emptyList();
+
+    Map<String, String> params = new HashMap<>();
+    params.put(appParamName, appParamValue);
+    Application a1 = createApplication(appName, appRole, urls, params);
+
+    Map<String, String> params2 = new HashMap<>();
+    params.put(appParamName, "anotherValue");
+    Application a2 = createApplication(appName, appRole, urls, params2);
+
+    assertFalse("Expected inequality because there are different application param values.",
+                doTestApplicationEquality(a1, a2));
+  }
+
+  @Test
+  public void testDifferentServiceNames() {
+    final String serviceName = "sName";
+    final String serviceRole = "sRole";
+    final String serviceURL = "http://host:1234/service";
+
+    Service s1 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), Collections.emptyMap());
+    Service s2 = createService("another", serviceRole, Collections.singletonList(serviceURL), Collections.emptyMap());
+
+    assertFalse("Expected inequality because there are different service names.",
+                doTestServiceEquality(s1, s2));
+  }
+
+  @Test
+  public void testDifferentServiceCount() {
+    final String serviceName = "sName";
+    final String serviceRole = "sRole";
+    final String serviceURL = "http://host:1234/service";
+
+    Service s1 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), Collections.emptyMap());
+    Service s2 = createService("another", serviceRole, Collections.singletonList(serviceURL), Collections.emptyMap());
+
+    assertFalse("Expected inequality because there are different number of services.",
+                doTestServiceEquality(s1, s2));
+  }
+
+
+  @Test
+  public void testDifferentServiceURLCount() {
+    final String serviceName = "sName";
+    final String serviceRole = "sRole";
+    final String serviceURL = "http://host:1234/service";
+
+    Service s1 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), Collections.emptyMap());
+    Service s2 =
+      createService(serviceName, serviceRole, Arrays.asList(serviceURL, serviceURL + "/other"), Collections.emptyMap());
+
+    assertFalse("Expected inequality because there are a different number of service URLs.",
+                doTestServiceEquality(s1, s2));
+  }
+
+  @Test
+  public void testDifferentServiceURLValues() {
+    final String serviceName = "sName";
+    final String serviceRole = "sRole";
+    final String serviceURL = "http://host:1234/service";
+
+    Service s1 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), Collections.emptyMap());
+    Service s2 =
+      createService(serviceName, serviceRole, Collections.singletonList(serviceURL + "/other"), Collections.emptyMap());
+
+    assertFalse("Expected inequality because there are different service URL values.",
+                doTestServiceEquality(s1, s2));
+  }
+
+  @Test
+  public void testDifferentServiceParamCount() {
+    final String serviceName = "sName";
+    final String serviceRole = "sRole";
+    final String serviceURL = "http://host:1234/service";
+
+
+    Map<String, String> params = new HashMap<>();
+    params.put("paramOne", "paramOneValue");
+    Service s1 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), params);
+
+    Map<String, String> params2 = new HashMap<>();
+    params2.put("paramOne", "paramOneValue");
+    params2.put("paramTwo", "paramTwoValue");
+    Service s2 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), params2);
+
+    assertFalse("Expected inequality because there are different number of service params.",
+                doTestServiceEquality(s1, s2));
+  }
+
+  @Test
+  public void testDifferentServiceParamValues() {
+    final String serviceName = "sName";
+    final String serviceRole = "sRole";
+    final String serviceURL  = "http://host:1234/service";
+    final String paramName   = "paramOne";
+
+
+    Map<String, String> params = new HashMap<>();
+    params.put(paramName, "paramValue");
+    Service s1 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), params);
+
+    Map<String, String> params2 = new HashMap<>();
+    params2.put(paramName, "paramValue" + "DIFFERENT");
+    Service s2 = createService(serviceName, serviceRole, Collections.singletonList(serviceURL), params2);
+
+    assertFalse("Expected inequality because there are different service param values.",
+                doTestServiceEquality(s1, s2));
+  }
+
+  @Test
+  public void testDifferentProviderCount() {
+    final String name = "pName";
+    final String role = "pRole";
+
+    Provider p1 = createProvider(name, role, Collections.emptyMap());
+    Provider p2 = createProvider(name, role, Collections.emptyMap());
+
+    assertFalse("Expected inequality because there are a different number of providers.",
+                doTestProviderEquality(Collections.singletonList(p1), Arrays.asList(p2, p1)));
+  }
+
+  @Test
+  public void testDifferentProviderNames() {
+    final String role = "pRole";
+
+    Provider p1 = createProvider("p1", role, Collections.emptyMap());
+    Provider p2 = createProvider("p2", role, Collections.emptyMap());
+
+    assertFalse("Expected inequality because there are different provider names.",
+                doTestProviderEquality(p1, p2));
+  }
+
+  @Test
+  public void testDifferentProviderParamCount() {
+    final String name = "pName";
+    final String role = "pRole";
+
+    Map<String, String> params = new HashMap<>();
+    params.put("paramOne", "p1Value");
+    Provider p1 = createProvider(name, role, params);
+
+    Map<String, String> params2 = new HashMap<>();
+    params2.put("paramOne", "p1Value");
+    params2.put("paramTwo", "p2Value");
+    Provider p2 = createProvider(name, role, params2);
+
+    assertFalse("Expected inequality because there are a different number of provider params.",
+                doTestProviderEquality(p1, p2));
+  }
+
+  @Test
+  public void testDifferentProviderParamValues() {
+    final String name      = "pName";
+    final String role      = "pRole";
+    final String paramName = "paramOne";
+
+    Map<String, String> params = new HashMap<>();
+    params.put(paramName, "p1Value");
+    Provider p1 = createProvider(name, role, params);
+
+    Map<String, String> params2 = new HashMap<>();
+    params2.put(paramName, "somethingelse");
+    Provider p2 = createProvider(name, role, params2);
+
+    assertFalse("Expected inequality because there are a different provider param values.",
+                doTestProviderEquality(p1, p2));
+  }
+
+  private void doTestSameTopologies(int providerCount, int serviceCount, int appCount) {
+    final String providerName       = "pName";
+    final String providerRole       = "pRole";
+    final String providerParamName  = "p_key_one";
+    final String providerParamValue = "p_value_one";
+    List<List<Provider>> providers =
+        createProviderLists(providerName, providerRole, providerParamName, providerParamValue, providerCount);
+
+    final String serviceName       = "sName";
+    final String serviceRole       = "sRole";
+    final String serviceParamName  = "s_key_one";
+    final String serviceParamValue = "s_value_one";
+    final String serviceURL        = "http://host:1234/service";
+    final List<List<Service>> services =
+        createServiceLists(serviceName, serviceRole, serviceParamName, serviceParamValue, serviceURL, serviceCount);
+
+    final String appName       = "aName";
+    final String appRole       = "aRole";
+    final String appParamName  = "a_key_one";
+    final String appParamValue = "a_value_one";
+    final String appURL        = "http://host:1234/app";
+    List<List<Application>> apps = createAppLists(appName, appRole, appParamName, appParamValue, appURL, appCount);
+
+    boolean isEqual = doTestEquals(!providers.isEmpty() ? providers.get(0) : Collections.emptyList(),
+                                   providers.size() > 1 ? providers.get(1) : Collections.emptyList(),
+                                   !services.isEmpty()  ? services.get(0)  : Collections.emptyList(),
+                                   services.size()  > 1 ? services.get(1)  : Collections.emptyList(),
+                                   !apps.isEmpty()      ? apps.get(0)      : Collections.emptyList(),
+                                   apps.size()      > 1 ? apps.get(1)      : Collections.emptyList());
+    assertTrue("Expected topologies to be equal.", isEqual);
+  }
+
+  private boolean doTestApplicationEquality(Application app1, Application app2) {
+    return doTestApplicationEquality(Collections.singletonList(app1), Collections.singletonList(app2));
+  }
+
+  private boolean doTestApplicationEquality(List<Application> apps1, List<Application> apps2) {
+    return doTestEquals(Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        apps1,
+                        apps2);
+  }
+
+
+  private boolean doTestServiceEquality(Service s1, Service s2) {
+    return doTestServiceEquality(Collections.singletonList(s1), Collections.singletonList(s2));
+  }
+
+
+  private boolean doTestServiceEquality(List<Service> svcs1, List<Service> svcs2) {
+    return doTestEquals(Collections.emptyList(),
+                        Collections.emptyList(),
+                        svcs1,
+                        svcs2,
+                        Collections.emptyList(),
+                        Collections.emptyList());
+  }
+
+
+  private boolean doTestProviderEquality(Provider p1, Provider p2) {
+    return doTestProviderEquality(Collections.singletonList(p1), Collections.singletonList(p2));
+  }
+
+  private boolean doTestProviderEquality(List<Provider> p1, List<Provider> p2) {
+    return doTestEquals(p1,
+                        p2,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList());
+  }
+
+
+  /**
+   *
+   * @param provs1
+   * @param provs2
+   * @param svcs1
+   * @param svcs2
+   * @param apps1
+   * @param apps2
+   *
+   * @return true if the topologies are equal; Otherwise, false.
+   */
+  private boolean doTestEquals(final List<Provider>    provs1,
+                               final List<Provider>    provs2,
+                               final List<Service>     svcs1,
+                               final List<Service>     svcs2,
+                               final List<Application> apps1,
+                               final List<Application> apps2) {
+    final String topoName = "testTopology";
+    return doTestEquals(topoName, topoName, provs1, provs2, svcs1, svcs2, apps1, apps2);
+  }
+
+  /**
+   *
+   * @param name1
+   * @param name2
+   * @param provs1
+   * @param provs2
+   * @param svcs1
+   * @param svcs2
+   * @param apps1
+   * @param apps2
+   *
+   * @return true if the topologies are equal; Otherwise, false.
+   */
+  private boolean doTestEquals(final String            name1,
+                               final String            name2,
+                               final List<Provider>    provs1,
+                               final List<Provider>    provs2,
+                               final List<Service>     svcs1,
+                               final List<Service>     svcs2,
+                               final List<Application> apps1,
+                               final List<Application> apps2) {
+
+    Topology t1 = createTopology(name1, provs1, svcs1, apps1);
+    Topology t2 = createTopology(name2, provs2, svcs2, apps2);
+
+    boolean result = t1.equals(t2);
+    if (result) {
+      assertEquals("hashcode must be equal if objects are equal.", t1.hashCode(), t2.hashCode());
+    }
+    return result;
+  }
+
+  private static Topology createTopology(final String            name,
+                                         final List<Provider>    providers,
+                                         final List<Service>     services,
+                                         final List<Application> applications) {
+
+    return createTopology(name, providers, services, applications, null);
+  }
+
+  private static Topology createTopology(final String            name,
+                                         final List<Provider>    providers,
+                                         final List<Service>     services,
+                                         final List<Application> applications,
+                                         final URI               uri) {
+
+    Topology t = new Topology();
+    t.providerList = providers;
+    t.services = services;
+    t.applications = applications;
+    t.setName(name);
+    t.setUri(uri);
+    return t;
+  }
+
+  private List<List<Provider>> createProviderLists(final String providerName,
+                                                   final String providerRole,
+                                                   final String providerParamName,
+                                                   final String providerParamValue,
+                                                   int          count) {
+    List<List<Provider>> result = new ArrayList<>();
+
+    for (int i=0; i < count ; i++) {
+      List<Provider> providers = new ArrayList<>();
+      Map<String, String> providerParams = new HashMap<>();
+      providerParams.put(providerParamName, providerParamValue);
+      providers.add(createProvider(providerName, providerRole, providerParams));
+      result.add(providers);
+    }
+
+    return result;
+  }
+
+  private List<List<Service>> createServiceLists(final String serviceName,
+                                                 final String serviceRole,
+                                                 final String serviceParamName,
+                                                 final String serviceParamValue,
+                                                 final String serviceURL,
+                                                 int          count) {
+    List<List<Service>> result = new ArrayList<>();
+
+    for (int i=0; i < count ; i++) {
+      List<Service> svcs = new ArrayList<>();
+      Map<String, String> svcParams = new HashMap<>();
+      svcParams.put(serviceParamName, serviceParamValue);
+      svcs.add(createService(serviceName, serviceRole, Collections.singletonList(serviceURL), svcParams));
+      result.add(svcs);
+    }
+
+    return result;
+  }
+
+  private List<List<Application>> createAppLists(final String appName,
+                                                 final String appRole,
+                                                 final String appParamName,
+                                                 final String appParamValue,
+                                                 final String appURL,
+                                                 int          count) {
+    List<List<Application>> result = new ArrayList<>();
+
+    for (int i=0; i < count ; i++) {
+      List<Application> apps = new ArrayList<>();
+      Map<String, String> appParams = new HashMap<>();
+      appParams.put(appParamName, appParamValue);
+      apps.add(createApplication(appName, appRole, Collections.singletonList(appURL), appParams));
+      result.add(apps);
+    }
+
+    return result;
+  }
+
+  private Service createService(final String              name,
+                                final String              role,
+                                final List<String>        urls,
+                                final Map<String, String> params) {
+    Service s = new Service();
+    s.setName(name);
+    s.setRole(role);
+    s.setUrls(urls);
+    s.setParams(params);
+    return s;
+  }
+
+  private Provider createProvider(final String              name,
+                                  final String              role,
+                                  final Map<String, String> params) {
+    Provider p = new Provider();
+    p.setName(name);
+    p.setRole(role);
+    p.setParams(params);
+
+    return p;
+  }
+
+  private Application createApplication(final String              name,
+                                        final String              role,
+                                        final List<String>        urls,
+                                        final Map<String, String> params) {
+    Application a = new Application();
+    a.setName(name);
+    a.setRole(role);
+    a.setUrls(urls);
+    a.setParams(params);
+
+    return a;
+  }
+
+}

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -652,12 +652,12 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
 
   @Override
   public String getGatewayProvidersConfigDir() {
-    return null;
+    return getGatewayConfPath().resolve("shared-providers").toString();
   }
 
   @Override
   public String getGatewayDescriptorsDir() {
-    return null;
+    return getGatewayConfPath().resolve("descriptors").toString();
   }
 
   @Override

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestDriver.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestDriver.java
@@ -140,6 +140,12 @@ public class GatewayTestDriver {
     File topoDir = new File( config.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( config.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( config.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( config.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/AmbariServiceDefinitionTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/AmbariServiceDefinitionTest.java
@@ -114,6 +114,12 @@ public class AmbariServiceDefinitionTest {
     File deployDir = new File( config.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 
+    File descDir = new File( config.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File providerConfigDir = new File( config.getGatewayProvidersConfigDir() );
+    providerConfigDir.mkdirs();
+
     setupMockServers();
     startGatewayServer();
   }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminFuncTest.java
@@ -81,6 +81,12 @@ public class GatewayAdminFuncTest {
     File topoDir = new File( testConfig.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( testConfig.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( testConfig.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( testConfig.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
@@ -115,6 +115,12 @@ public class GatewayAppFuncTest {
     File topoDir = new File( config.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( config.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( config.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( config.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayCorrelationIdTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayCorrelationIdTest.java
@@ -97,6 +97,12 @@ public class GatewayCorrelationIdTest {
     File topoDir = new File( testConfig.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( testConfig.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( testConfig.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( testConfig.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayDeployFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayDeployFuncTest.java
@@ -95,6 +95,12 @@ public class GatewayDeployFuncTest {
     File topoDir = new File( testConfig.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( testConfig.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( testConfig.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( testConfig.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayHealthFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayHealthFuncTest.java
@@ -104,6 +104,12 @@ public class GatewayHealthFuncTest {
     File topoDir = new File(testConfig.getGatewayTopologyDir());
     topoDir.mkdirs();
 
+    File descDir = new File( testConfig.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( testConfig.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File(testConfig.getGatewayDeploymentDir());
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLocalServiceFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLocalServiceFuncTest.java
@@ -90,6 +90,12 @@ public class GatewayLocalServiceFuncTest {
     File topoDir = new File( testConfig.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( testConfig.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( testConfig.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( testConfig.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayMultiFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayMultiFuncTest.java
@@ -118,6 +118,12 @@ public class GatewayMultiFuncTest {
     File topoDir = new File( config.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( config.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( config.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( config.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewaySampleFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewaySampleFuncTest.java
@@ -81,6 +81,12 @@ public class GatewaySampleFuncTest {
     File topoDir = new File( testConfig.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( testConfig.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( testConfig.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( testConfig.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewaySslFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewaySslFuncTest.java
@@ -130,6 +130,12 @@ public class GatewaySslFuncTest {
     File topoDir = new File( config.getGatewayTopologyDir() );
     topoDir.mkdirs();
 
+    File descDir = new File( config.getGatewayDescriptorsDir() );
+    descDir.mkdirs();
+
+    File provConfDir = new File( config.getGatewayProvidersConfigDir() );
+    provConfDir.mkdirs();
+
     File deployDir = new File( config.getGatewayDeploymentDir() );
     deployDir.mkdirs();
 

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
@@ -28,7 +28,7 @@ public interface SimpleDescriptorMessages {
             text = "Unable to complete service discovery for cluster {0}.")
     void failedToDiscoverClusterServices(String descriptorName);
 
-    @Message(level = MessageLevel.ERROR,
+    @Message(level = MessageLevel.WARN,
             text = "No valid URLs were discovered for {0} in the {1} cluster.")
     void failedToDiscoverClusterServiceURLs(String serviceName, String clusterName);
 
@@ -60,5 +60,18 @@ public interface SimpleDescriptorMessages {
     @Message(level = MessageLevel.ERROR,
             text = "Failed to create a password for query string encryption for {0}." )
     void unableCreatePasswordForEncryption(String topologyName);
+
+    @Message(level = MessageLevel.ERROR,
+        text = "Error comparing the generated {0} topology with the existing version: {1}" )
+    void errorComparingGeneratedTopology(String topologyName,
+                                         @StackTrace( level = MessageLevel.DEBUG) Exception e);
+
+    @Message(level = MessageLevel.INFO,
+            text = "Persisting the generated {0} topology because it either does not exist or it has changed." )
+    void persistingGeneratedTopology(String topologyName);
+
+    @Message(level = MessageLevel.INFO,
+            text = "Skipping redeployment of the {0} topology because it already exists and has not changed." )
+    void skippingDeploymentOfGeneratedTopology(String topologyName);
 
 }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.util;
 
 import java.io.IOException;
 import java.text.DateFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -94,6 +95,20 @@ public class JsonUtils {
       map = mapper.readValue(json, typeRef);
     } catch (IOException e) {
       LOG.failedToGetMapFromJsonString( json, e );
+    }
+    return map;
+  }
+
+  public static Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> getFileStatusesAsMap(String json) {
+    Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> map = null;
+    JsonFactory factory = new JsonFactory();
+    ObjectMapper mapper = new ObjectMapper(factory);
+    TypeReference<HashMap<String,HashMap<String, ArrayList<HashMap<String, String>>>>> typeRef
+      = new TypeReference<HashMap<String,HashMap<String, ArrayList<HashMap<String, String>>>>>() {};
+    try {
+      map = mapper.readValue(json, typeRef);
+    } catch (IOException e) {
+      //LOG.failedToGetMapFromJsonString( json, e );
     }
     return map;
   }

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
@@ -17,15 +17,16 @@
  */
 package org.apache.knox.gateway.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
 
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class JsonUtilsTest {
   private String expiresIn = "\"expires_in\":\"1364487943100\"";
@@ -53,5 +54,47 @@ public class JsonUtilsTest {
     assertEquals("ksdfh3489tyiodhfjk", map.get("access_token"));
     assertEquals("Bearer", map.get("token_type"));
     assertEquals("1364487943100", map.get("expires_in"));
+  }
+
+  @Test
+  public void testFileStatusesAsMap() {
+    String json = "{\n" +
+      "   \"FileStatuses\":{\n" +
+      "      \"FileStatus\":[\n" +
+      "         {\n" +
+      "            \"accessTime\":0,\n" +
+      "            \"blockSize\":0,\n" +
+      "            \"childrenNum\":3,\n" +
+      "            \"fileId\":16389,\n" +
+      "            \"group\":\"supergroup\",\n" +
+      "            \"length\":0,\n" +
+      "            \"modificationTime\":1581578495905,\n" +
+      "            \"owner\":\"hdfs\",\n" +
+      "            \"pathSuffix\":\"tmp\",\n" +
+      "            \"permission\":\"1777\",\n" +
+      "            \"replication\":0,\n" +
+      "            \"storagePolicy\":0,\n" +
+      "            \"type\":\"DIRECTORY\"\n" +
+      "         },\n" +
+      "         {\n" +
+      "            \"accessTime\":0,\n" +
+      "            \"blockSize\":0,\n" +
+      "            \"childrenNum\":658,\n" +
+      "            \"fileId\":16386,\n" +
+      "            \"group\":\"supergroup\",\n" +
+      "            \"length\":0,\n" +
+      "            \"modificationTime\":1581578527580,\n" +
+      "            \"owner\":\"hdfs\",\n" +
+      "            \"pathSuffix\":\"user\",\n" +
+      "            \"permission\":\"755\",\n" +
+      "            \"replication\":0,\n" +
+      "            \"storagePolicy\":0,\n" +
+      "            \"type\":\"DIRECTORY\"\n" +
+      "          } \n" +
+      "       ]\n" +
+      "   }\n" +
+      "}";
+    Map<String,HashMap<String, ArrayList<HashMap<String, String>>>> map = JsonUtils.getFileStatusesAsMap(json);
+    assertNotNull(map);
   }
 }


### PR DESCRIPTION
…embedded commas

Change-Id: I3d2e0dc8144e79c73df2067a7b6320e5d0a84266

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Embedded commas within a quoted string/col in CSV files result in separate cols currently. This patch allows for them to be ignored during the split() call via regex for identifying such patterns.

## How was this patch tested?

New unit test added and existing unit tests run.
Manually tested with dataset with such embedded commas in quoted strings.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
