### PR TITLE
KNOX-2308 - Add sortNumeric to KnoxShellTable for Cols that are numer…

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -375,11 +375,25 @@ public class KnoxShellTable {
     return sort(colName, SortOrder.ASCENDING);
   }
 
+  public KnoxShellTable sortNumeric(String colName) {
+    double[] col = toDoubleArray(colName);
+    ArrayList<Comparable<? extends Object>> column = new ArrayList<>();
+    for(double v : col) {
+      column.add(v);
+   }
+    return sort(column, SortOrder.ASCENDING);
+  }
+
   public KnoxShellTable sort(String colName, SortOrder order) {
+    List<Comparable<? extends Object>> col = values(colName);
+    return sort(col, order);
+  }
+
+  public KnoxShellTable sort(List<Comparable<? extends Object>> col,
+      SortOrder order) {
     KnoxShellTable table = new KnoxShellTable();
 
     Comparable<? extends Object> value;
-    List<Comparable<? extends Object>> col = values(colName);
     List<RowIndex> index = new ArrayList<>();
     for (int i = 0; i < col.size(); i++) {
       value = col.get(i);

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -249,6 +249,20 @@ public class KnoxShellTableTest {
   }
 
   @Test
+  public void testSortStringValuesNumerically() throws IOException {
+    KnoxShellTable table = new KnoxShellTable();
+
+    table.header("Column A").header("Column B").header("Column C");
+
+    table.row().value("2").value("012").value("844444444");
+    table.row().value("10").value("456").value("344444444");
+
+    KnoxShellTable table2 = table.sortNumeric("Column A");
+    assertEquals(table2.getRows().get(0).get(0), "2");
+    assertEquals(table2.getRows().get(1).get(0), "10");
+  }
+
+  @Test
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public void testCells() throws IOException {
     KnoxShellTable table = new KnoxShellTable();


### PR DESCRIPTION
…ic but values are String

Change-Id: I773e5ee9805347de36d5e4921a026f91b35c54b7

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Tables that are created from CSV files contain cols with only String types even though cols can be created with specific types. Sorting numeric values as Strings result in improper sorts. This patch provides a sortNumeric which internally converts the col to doubles and then does the sort. It sorts the table properly but leaves the col unchanged within the table itself.

## How was this patch tested?
Unit test added, existing unit tests run.
Manually tested with dataset with a col of strings that are numeric values.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
