### PR TITLE
KNOX-2307 - CSVKnoxShellTableBuilder must support quoted strings and …

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/CSVKnoxShellTableBuilder.java
@@ -51,7 +51,8 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
   }
 
   public KnoxShellTable string(String csvString) throws IOException {
-    try (InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8)); Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
+    try (InputStream is = new ByteArrayInputStream(csvString.getBytes(StandardCharsets.UTF_8));
+        Reader stringStreamReader = new InputStreamReader(is, StandardCharsets.UTF_8);
         BufferedReader csvReader = new BufferedReader(stringStreamReader);) {
       buildTableFromCSVReader(csvReader);
     }
@@ -69,7 +70,8 @@ public class CSVKnoxShellTableBuilder extends KnoxShellTableBuilder {
       if (!addingHeaders) {
         this.table.row();
       }
-      String[] data = row.split(",", -1);
+      // handle comma's within quoted string values for single col
+      String[] data = row.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", -1);
 
       for (String value : data) {
         if (addingHeaders) {

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -191,6 +191,33 @@ public class KnoxShellTableTest {
   }
 
   @Test
+  public void testCSVQuotedEmbeddedCommaStringToTable() throws IOException {
+    KnoxShellTable table = new KnoxShellTable();
+    table.title("From URL");
+
+    table.header("\"Column A, Column A1\"").header("Column B").header("Column C");
+    table.row().value("123").value("456").value("344444444");
+    table.row().value("789").value("012").value("844444444");
+
+    String csv = table.toCSV();
+    try {
+      // write file to /tmp to read back in
+      FileUtils.writeStringToFile(new File("/tmp/testtable.csv"), csv, StandardCharsets.UTF_8);
+
+      KnoxShellTable urlTable = KnoxShellTable.builder().csv()
+          .withHeaders()
+          .url("file:///tmp/testtable.csv");
+      urlTable.title("From URL");
+      assertEquals(urlTable.toString(), table.toString());
+
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    assertEquals(table.headers.get(0), "\"Column A, Column A1\"");
+  }
+
+  @Test
   public void testCSVStringToTable() throws IOException {
     String initialString = "colA, colB, colC\nvalue1, value2. value3\nvalue4, value5, value6";
 


### PR DESCRIPTION
…embedded commas

Change-Id: I82e096d204accc0ba6a334b18d6287eb67adf74c

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?
Embedded commas within a quoted string/col in CSV files result in separate cols currently. This patch allows for them to be ignored during the split() call via regex for identifying such patterns.

It will result in the value - either header or cell value - as retaining the quotes currently. If this is not desired we can revisit and make configurable or just removed.


## How was this patch tested?

New unit test added and existing unit tests ran.
Manually tested against datasets with and without such quoted strings and embedded commas.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
