### PR TITLE
KNOX-2310 - Add aggregate method to KnoxShellTable

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -357,6 +357,10 @@ public class KnoxShellTable {
     return new KnoxShellTableFilter(this);
   }
 
+  public KnoxShellTableAggregator aggregate() {
+    return new KnoxShellTableAggregator(this);
+  }
+
   public KnoxShellTable select(String cols) {
     KnoxShellTable table = new KnoxShellTable();
     List<List<Comparable<? extends Object>>> columns = new ArrayList<>();

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableAggregator.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTableAggregator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell.table;
+
+public class KnoxShellTableAggregator {
+  private KnoxShellTable tableToAggregate;
+  private String[] cols;
+
+  public KnoxShellTableAggregator(KnoxShellTable table) {
+    tableToAggregate = table;
+  }
+
+  public KnoxShellTableAggregator columns(String cols) {
+    this.cols = cols.split("\\s*,\\s*");
+    return this;
+  }
+
+  public KnoxShellTable functions(String funcs) {
+    String[] functions = funcs.split("\\s*,\\s*");
+
+    KnoxShellTable table = new KnoxShellTable();
+    table.header("");
+    for (String col : cols) {
+      table.header(col);
+    }
+
+    for (String func : functions) {
+      table.row();
+      table.value(func);
+      for (String col : cols) {
+        table.value(executeFunction(col, func));
+      }
+    }
+    return table;
+  }
+
+  private Double executeFunction(String col, String func) {
+    Double value = 0.0d;
+    if ("min".equalsIgnoreCase(func)) {
+      value = tableToAggregate.min(col);
+    }
+    else if ("max".equalsIgnoreCase(func)) {
+      value = tableToAggregate.max(col);
+    }
+    else if ("mean".equalsIgnoreCase(func)) {
+      value = tableToAggregate.mean(col);
+    }
+    else if ("mode".equalsIgnoreCase(func)) {
+      value = tableToAggregate.mode(col);
+    }
+    else if ("median".equalsIgnoreCase(func)) {
+      value = tableToAggregate.median(col);
+    }
+    else if ("sum".equalsIgnoreCase(func)) {
+      value = tableToAggregate.sum(col);
+    }
+    return value;
+  }
+}

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -674,6 +674,36 @@ public class KnoxShellTableTest {
       assertEquals(20.9998, TABLE.min(2), 0.1);
   }
 
+  /*
+knox:000> test.aggregate() columns "A,B,C" functions "min, max, mean, median, mode,sum"
+===> +----------+----------------------+----------+----------+
+|          |          A           |    B     |    C     |
++----------+----------------------+----------+----------+
+|   min    |        100.0         |  200.0   |  300.0   |
+|   max    |        200.0         |  400.0   |  500.0   |
+|   mean   |  166.66666666666666  |  300.0   |  400.0   |
+|  median  |        200.0         |  300.0   |  400.0   |
+|   mode   |        200.0         |  200.0   |  300.0   |
+|   sum    |        500.0         |  900.0   |  1200.0  |
++----------+----------------------+----------+----------+
+   */
+  @Test
+  public void testAggregate() throws Exception {
+
+      KnoxShellTable TABLE = new KnoxShellTable();
+      TABLE.header("A").header("B").header("C");
+      TABLE.row().value(100).value("200").value(300);
+      TABLE.row().value(200).value("300").value(400);
+      TABLE.row().value(200).value("400").value(500);
+      KnoxShellTable report = TABLE.aggregate().columns("A,B,C").functions("min,max,mean,median,mode,sum");
+      assertEquals(100.0, report.cell(1,0).value);
+      assertEquals(200.0, report.cell(1,1).value);
+      assertEquals(166.66666666666666, report.cell(1,2).value);
+      assertEquals(200.0, report.cell(1,3).value);
+      assertEquals(200.0, report.cell(1,4).value);
+      assertEquals(500.0, report.cell(1,5).value);
+  }
+
   @Test
   public void shouldReturnDifferentCallHistoryForDifferentTables() throws Exception {
     final KnoxShellTable table1 = new KnoxShellTable();


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

A simple method for producing a meaningful mathematical report of a dataset would allow the user to quickly determine some basic metrics of a dataset.

For instance, given a dataset with time series data across columns, an aggregation of:

    min
    max
    mean
    median
    mode
    sum

for specific columns would provide a way to visualize the changes across time.

knox:000> test.aggregate() columns "A,B,C" functions "min, max, mean, median, mode,sum"
===> +----------+----------------------+----------+----------+
|          |          A           |    B     |    C     |
+----------+----------------------+----------+----------+
|   min    |        100.0         |  200.0   |  300.0   |
|   max    |        200.0         |  400.0   |  500.0   |
|   mean   |  166.66666666666666  |  300.0   |  400.0   |
|  median  |        200.0         |  300.0   |  400.0   |
|   mode   |        200.0         |  200.0   |  300.0   |
|   sum    |        500.0         |  900.0   |  1200.0  |
+----------+----------------------+----------+----------+

## How was this patch tested?

Added new unit test and ran existing unit tests.
Tested manually in KnoxShell.

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
