### PR TITLE
KNOX-2315 - Fix zookeeper Kerberos Auth

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/service/config/remote/LocalFileSystemRemoteConfigurationRegistryClientService.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/service/config/remote/LocalFileSystemRemoteConfigurationRegistryClientService.java
@@ -266,6 +266,16 @@ public class LocalFileSystemRemoteConfigurationRegistryClientService implements 
             public void removeEntryListener(String path) throws Exception {
                 // N/A
             }
+
+            @Override
+            public String authenticationType() {
+                return null;
+            }
+
+            @Override
+            public boolean isBackwardsCompatible() {
+                return false;
+            }
         };
     }
 

--- a/gateway-service-remoteconfig/pom.xml
+++ b/gateway-service-remoteconfig/pom.xml
@@ -71,6 +71,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/RemoteConfigurationRegistryConfig.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/RemoteConfigurationRegistryConfig.java
@@ -40,4 +40,7 @@ public interface RemoteConfigurationRegistryConfig {
 
     boolean isUseKeyTab();
 
+    /* If true ensures that the auth scheme used to create znodes is `auth` and not `sasl` */
+    boolean isBackwardsCompatible();
+
 }

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/config/DefaultRemoteConfigurationRegistries.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/config/DefaultRemoteConfigurationRegistries.java
@@ -69,7 +69,7 @@ class DefaultRemoteConfigurationRegistries extends RemoteConfigurationRegistries
         result.setKeytab(properties.get(GatewayConfig.REMOTE_CONFIG_REGISTRY_KEYTAB));
         result.setUseKeytab(Boolean.valueOf(properties.get(GatewayConfig.REMOTE_CONFIG_REGISTRY_USE_KEYTAB)));
         result.setUseTicketCache(Boolean.valueOf(properties.get(GatewayConfig.REMOTE_CONFIG_REGISTRY_USE_TICKET_CACHE)));
-
+        result.setBackwardsCompatible(Boolean.valueOf(properties.getOrDefault(GatewayConfig.ZOOKEEPER_REMOTE_CONFIG_REGISTRY_BACKWARDS_COMPATIBLE, "false")));
         return result;
     }
 

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/config/RemoteConfigurationRegistry.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/config/RemoteConfigurationRegistry.java
@@ -32,6 +32,8 @@ class RemoteConfigurationRegistry implements RemoteConfigurationRegistryConfig {
     private String keyTab;
     private boolean useKeyTab;
     private boolean useTicketCache;
+    /* If true ensures that the auth scheme used to create znodes is `auth` and not `sasl` */
+    private boolean isBackwardsCompatible;
 
     RemoteConfigurationRegistry() {
     }
@@ -74,6 +76,10 @@ class RemoteConfigurationRegistry implements RemoteConfigurationRegistryConfig {
 
     public void setKeytab(String keytab) {
         this.keyTab = keytab;
+    }
+
+    public void setBackwardsCompatible(boolean backwardsCompatible) {
+        isBackwardsCompatible = backwardsCompatible;
     }
 
     @Override
@@ -130,6 +136,7 @@ class RemoteConfigurationRegistry implements RemoteConfigurationRegistryConfig {
         return useKeyTab;
     }
 
+
     @Override
     @XmlElement(name="keytab")
     public String getKeytab() {
@@ -141,4 +148,9 @@ class RemoteConfigurationRegistry implements RemoteConfigurationRegistryConfig {
         return (getAuthType() != null);
     }
 
+    @Override
+    @XmlElement(name="backwards-compatible")
+    public boolean isBackwardsCompatible() {
+        return isBackwardsCompatible;
+    }
 }

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfig.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfig.java
@@ -164,8 +164,8 @@ class RemoteConfigurationRegistryJAASConfig extends Configuration {
                 }
                 break;
             case Kerberos:
-                opts.put("isUseTicketCache", String.valueOf(config.isUseTicketCache()));
-                opts.put("isUseKeyTab", String.valueOf(config.isUseKeyTab()));
+                opts.put("useTicketCache", String.valueOf(config.isUseTicketCache()));
+                opts.put("useKeyTab", String.valueOf(config.isUseKeyTab()));
                 opts.put("keyTab", config.getKeytab());
                 opts.put("principal", config.getPrincipal());
             default:

--- a/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/ZooKeeperClientService.java
+++ b/gateway-service-remoteconfig/src/main/java/org/apache/knox/gateway/service/config/remote/zk/ZooKeeperClientService.java
@@ -22,4 +22,6 @@ public interface ZooKeeperClientService extends RemoteConfigurationRegistryClien
 
     String TYPE = "ZooKeeper";
 
+    String AUTH_TYPE_KERBEROS = "Kerberos";
+
 }

--- a/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
+++ b/gateway-service-remoteconfig/src/test/java/org/apache/knox/gateway/service/config/remote/zk/RemoteConfigurationRegistryJAASConfigTest.java
@@ -29,10 +29,6 @@ import org.junit.rules.TemporaryFolder;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
-
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.startsWith;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,6 +36,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -344,7 +342,7 @@ public class RemoteConfigurationRegistryJAASConfigTest {
         Map<String, ?> entryOpts = entry.getOptions();
         assertEquals(principal, entryOpts.get("principal"));
         assertEquals(keyTab, entryOpts.get("keyTab"));
-        assertEquals(useKeyTab, Boolean.valueOf((String)entryOpts.get("isUseKeyTab")));
-        assertEquals(useTicketCache, Boolean.valueOf((String)entryOpts.get("isUseTicketCache")));
+        assertEquals(useKeyTab, Boolean.valueOf((String)entryOpts.get("useKeyTab")));
+        assertEquals(useTicketCache, Boolean.valueOf((String)entryOpts.get("useTicketCache")));
     }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -95,8 +95,10 @@ public interface GatewayConfig {
   String REMOTE_CONFIG_REGISTRY_PRINCIPAL = "principal";
   String REMOTE_CONFIG_REGISTRY_CREDENTIAL_ALIAS = "credentialAlias";
   String REMOTE_CONFIG_REGISTRY_KEYTAB = "keytab";
-  String REMOTE_CONFIG_REGISTRY_USE_KEYTAB = "useKeytab";
+  String REMOTE_CONFIG_REGISTRY_USE_KEYTAB = "useKeyTab";
   String REMOTE_CONFIG_REGISTRY_USE_TICKET_CACHE = "useTicketCache";
+  /* If true ensures that the auth scheme used to create znodes is `auth` and not `sasl` */
+  String ZOOKEEPER_REMOTE_CONFIG_REGISTRY_BACKWARDS_COMPATIBLE = "backwardsCompatible";
 
   String PROXYUSER_SERVICES_IGNORE_DOAS = "gateway.proxyuser.services.ignore.doas";
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/config/client/RemoteConfigurationRegistryClient.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/config/client/RemoteConfigurationRegistryClient.java
@@ -54,6 +54,10 @@ public interface RemoteConfigurationRegistryClient extends AutoCloseable {
 
     void removeEntryListener(String path) throws Exception;
 
+    String authenticationType();
+
+    boolean isBackwardsCompatible();
+
     interface ChildEntryListener {
 
         enum Type {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR fixes issues with Zookeeper Kerberos authentication. This PR contains following changes.

1. Fix issues in code that were causing bad configuration issues, such as typos and wrong variable names.
2. For Znodes created by Knox the permissions are more restricted and only knox users can read and write the data to Znodes owned by Knox.
3. Auth scheme for Kerberos authentication is now "sasl"
4. A configuration boolean parameter "backwardsCompatible" is introduced which falls back to old behavior (likely broken behavior)

## How was this patch tested?
This patch was locally tested on a secure cluster with Kerberos authentication between Knox and Zookeeper.

