### PR TITLE
KNOX-2317 - Open UI services from Knox Home page on new tabs

### DIFF
--- a/knox-homepage-ui/home/app/topologies/topology.information.component.html
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.html
@@ -27,10 +27,10 @@
         <!-- UI services -->
         <mat-grid-list cols="4" rowHeight="130px">
             <mat-grid-tile *ngFor="let service of topology.uiServices.service" [colspan]="1" [rowspan]="1">
-                 <a href="{{service.serviceUrl}}" target="blank" *ngIf="!this['enableServiceText_' + service.serviceName.toLowerCase()]">
+                 <a href="{{service.serviceUrl}}" target="_blank" *ngIf="!this['enableServiceText_' + service.serviceName.toLowerCase()]">
                     <img src="assets/service-logos/{{service.serviceName.toLowerCase()}}.png" height="50px" (error)="enableServiceText('enableServiceText_' + service.serviceName.toLowerCase())"/>
                 </a>
-                 <a href="{{service.serviceUrl}}" target="blank" *ngIf="this['enableServiceText_' + service.serviceName.toLowerCase()]">
+                 <a href="{{service.serviceUrl}}" target="_blank" *ngIf="this['enableServiceText_' + service.serviceName.toLowerCase()]">
                     {{service.shortDesc}}
                 </a>
                 <mat-grid-tile-footer class="tile-shortDesc">


### PR DESCRIPTION
## What changes were proposed in this pull request?

All UI service links were open on the same tab (separate from the Home page tab though). With this fix, all links are open on their own tabs.

## How was this patch tested?

Manually tested.