### PR TITLE
KNOX-2316 - Knox Token State Eviction Must Consider Maximum Token Lif…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -308,13 +308,18 @@ public class DefaultTokenStateService implements TokenStateService {
   }
 
   /**
-   * Method that checks if an expired token is ready to be evicted
-   * by adding configured grace period to the expiry time.
-   * @param tokenId
-   * @return
+   * Method that checks if a token's state is a candidate for eviction.
+   *
+   * @param tokenId A unique token identifier
+   *
+   * @return true, if the associated token state can be evicted; Otherwise, false.
    */
   protected boolean needsEviction(final String tokenId) throws UnknownTokenException {
-    return ((getTokenExpiration(tokenId) + TimeUnit.SECONDS.toMillis(tokenEvictionGracePeriod)) <= System.currentTimeMillis());
+    long maxLifetime = getMaxLifetime(tokenId);
+    if (maxLifetime <= 0) {
+      throw new UnknownTokenException(tokenId);
+    }
+    return ((maxLifetime + TimeUnit.SECONDS.toMillis(tokenEvictionGracePeriod)) <= System.currentTimeMillis());
   }
 
   /**

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -61,7 +61,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to evict expired token {0} : {1}")
   void failedExpiredTokenEviction(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
-  @Message(level = MessageLevel.DEBUG, text = "Evicting expired token {0}")
+  @Message(level = MessageLevel.INFO, text = "Evicting expired token {0}")
   void evictToken(String tokenId);
 
   @Message(level = MessageLevel.ERROR, text = "Error occurred evicting token {0}")


### PR DESCRIPTION
…etime

## What changes were proposed in this pull request?

Modified the logic to decide if the state associated with a token should be evicted from storage, such that token state won't be evicted before the maximum token lifetime is exceeded.

## How was this patch tested?

Manual testing, and modified DefaultTokenStateServiceTest methods.