### PR TITLE
KNOX-2340 - Fix DefaultTokenStateServiceTest timeouts

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -252,7 +252,7 @@ public class DefaultTokenStateService implements TokenStateService {
 
   protected boolean hasRemainingRenewals(final String tokenId, long renewInterval) {
     // Is the current time + 30-second buffer + the renewal interval is less than the max lifetime for the token?
-    return ((System.currentTimeMillis() + 30000 + renewInterval) < getMaxLifetime(tokenId));
+    return ((System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30) + renewInterval) < getMaxLifetime(tokenId));
   }
 
   protected long getMaxLifetime(final String tokenId) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix DefaultTokenStateServiceTest timeouts to be more reasonable. I used TimeUnit every where to ensure we are doing things with the correct unit of time. Previously there were issues where milliseconds and seconds were being mixed. This caused race conditions in AliasBasedTokenStateServiceTest which extends DefaultTokenStateServiceTest.

## How was this patch tested?

* Ran `AliasBasedTokenStateServiceTest` and `DefaultTokenStateServiceTest` repeatedly in IDE
* `mvn -T.5C clean verify -U -Ppackage,release -Dshellcheck`
