### PR TITLE
KNOX-2350 - Handling event types w/o COMMAND and/or COMMAND_STATUS attributes when polling CM events

### DIFF
--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -172,6 +172,16 @@ public class PollingConfigurationAnalyzerTest {
     ApiEvent failedStartEvent = createApiEvent(ApiEventCategory.AUDIT_EVENT, startEventAttrs);
     pca.addRestartEvent(clusterName, failedStartEvent);
 
+    // Simulate an event w/o COMMAND and/or COMMAND_STATUS attributes
+    final List<ApiEventAttribute> revisionEventAttrs = new ArrayList<>();
+    revisionEventAttrs.add(createEventAttribute("CLUSTER", clusterName));
+    revisionEventAttrs.add(createEventAttribute("SERVICE_TYPE", HiveOnTezServiceModelGenerator.SERVICE_TYPE));
+    revisionEventAttrs.add(createEventAttribute("SERVICE", HiveOnTezServiceModelGenerator.SERVICE));
+    revisionEventAttrs.add(createEventAttribute("REVISION", "215"));
+    revisionEventAttrs.add(createEventAttribute("EVENTCODE", "EV_REVISION_CREATED"));
+    final ApiEvent revisionEvent = createApiEvent(ApiEventCategory.AUDIT_EVENT, revisionEventAttrs);
+    pca.addRestartEvent(clusterName, revisionEvent);
+
     try {
       pollingThreadExecutor.awaitTermination(10, TimeUnit.SECONDS);
     } catch (InterruptedException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Checking if the given CM event has either `COMMAND` or `COMMAND_STATUS` attribute before calling `.get(0)` on the attribute map entry (which is `null` if the above condition is not true).

## How was this patch tested?

Updated and ran JUnit tests as well as executing the following manual test steps in a cluster with 2 Knox instances with CM configuration monitoring enabled:
- redeployed Knox with my changes in place
- changed Atlas's HTTPS server port from 31445 to 31446 and restarted Atlas
- confirmed that CM configuration monitor picked up the change (in both Knox instances) and re-deployed the affected topologies:

```
2020-04-20 22:11:49,606 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:run(171)) - Checking Cluster 1 @ https://$CM_HOST:7183 for configuration changes...
2020-04-20 22:11:49,615 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(371)) - Querying restart events from Cluster 1 @ https://$CM_HOST:7183 since 2020-04-20T22:10:49.529213Z
2020-04-20 22:11:49,686 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getCurrentServiceConfiguration(455)) - Getting current configuration for ATLAS-1 from Cluster 1 @ https://$CM_HOST:7183
2020-04-20 22:11:49,899 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:run(211)) - Analyzing current ATLAS-1 configuration for changes...
2020-04-20 22:11:49,899 INFO  discovery.cm (PollingConfigurationAnalyzer.java:hasConfigurationChanged(524)) - Role property atlas_server_https_port value has changed from 31445 to 31446
2020-04-20 22:11:49,899 INFO  knox.gateway (DefaultTopologyService.java:onConfigurationChange(968)) - A cluster configuration change was noticed for Cluster 1 @ https://$CM_HOST:7183
2020-04-20 22:11:49,905 INFO  knox.gateway (DefaultTopologyService.java:onConfigurationChange(976)) - Triggering topology regeneration for descriptor /var/lib/knox/gateway/conf/descriptors/cdp-proxy-api.json because of change to the Cluster 1 @ https://$CM_HOST:7183 configuration.
2020-04-20 22:11:49,917 INFO  knox.gateway (DefaultTopologyService.java:onConfigurationChange(976)) - Triggering topology regeneration for descriptor /var/lib/knox/gateway/conf/descriptors/cdp-proxy.json because of change to the Cluster 1 @ https://$CM_HOST:7183 configuration.
```