### PR TITLE
KNOX-2353 - Disabled CM descriptor monitoring and advanced service discovery changes monitoring by default

### DIFF
--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -27,6 +27,9 @@ public interface ClouderaManagerIntegrationMessages {
   @Message(level = MessageLevel.INFO, text = "Monitoring Cloudera Manager descriptors in {0} ...")
   void monitoringClouderaManagerDescriptor(String path);
 
+  @Message(level = MessageLevel.INFO, text = "Monitoring Cloudera Manager descriptors is disabled.")
+  void disableMonitoringClouderaManagerDescriptor();
+
   @Message(level = MessageLevel.INFO, text = "Parsing Cloudera Manager descriptor {0}. Looking up {1}...")
   void parseClouderaManagerDescriptor(String path, String topologyName);
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorMonitor.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorMonitor.java
@@ -64,6 +64,8 @@ public class ClouderaManagerDescriptorMonitor implements AdvancedServiceDiscover
       final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(new BasicThreadFactory.Builder().namingPattern("ClouderaManagerDescriptorMonitor-%d").build());
       executorService.scheduleAtFixedRate(() -> monitorClouderaManagerDescriptors(null), 0, monitoringInterval, TimeUnit.MILLISECONDS);
       LOG.monitoringClouderaManagerDescriptor(descriptorsDir);
+    } else {
+      LOG.disableMonitoringClouderaManagerDescriptor();
     }
   }
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
@@ -27,6 +27,9 @@ public interface AdvanceServiceDiscoveryConfigurationMessages {
   @Message(level = MessageLevel.INFO, text = "Monitoring {0}/{1}* for advanced service discovery configuration changes.")
   void monitorStarted(String directory, String prefix);
 
+  @Message(level = MessageLevel.INFO, text = "Monitoring advanced service discovery configuration changes is disabled.")
+  void disableMonitoring();
+
   @Message(level = MessageLevel.ERROR, text = "Error while monitoring CM advanced configuration: {1}")
   void failedToMonitorClouderaManagerAdvancedConfiguration(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigurationMonitor.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvancedServiceDiscoveryConfigurationMonitor.java
@@ -71,6 +71,8 @@ public class AdvancedServiceDiscoveryConfigurationMonitor {
       final ScheduledExecutorService executorService = newSingleThreadScheduledExecutor(new BasicThreadFactory.Builder().namingPattern("AdvancedServiceDiscoveryConfigurationMonitor-%d").build());
       executorService.scheduleAtFixedRate(() -> monitorAdvancedServiceConfigurations(), 0, monitoringInterval, TimeUnit.MILLISECONDS);
       LOG.monitorStarted(gatewayConfigurationDir, ADVANCED_CONFIGURATION_FILE_NAME_PREFIX);
+    } else {
+      LOG.disableMonitoring();
     }
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -243,9 +243,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String TOKEN_STATE_SERVER_MANAGED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.exp.server-managed";
 
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
-  private static final long DEFAULT_CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = 30000L;
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
-  private static final long DEFAULT_CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = 30000L;
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
@@ -1114,12 +1112,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public long getClouderaManagerDescriptorsMonitoringInterval() {
-    return getLong(CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL, DEFAULT_CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL);
+    return getLong(CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL, -1L);
   }
 
   @Override
   public long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval() {
-    return getLong(CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL, DEFAULT_CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL);
+    return getLong(CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL, -1L);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default, the following features are disabled:

- CM Descriptor Monitor
- Advance Service Discovery Monitor

## How was this patch tested?

Manually tested:
```
2020-04-21 21:04:41,741 INFO  discovery.advanced (AdvancedServiceDiscoveryConfigurationMonitor.java:setupMonitor(75)) - Monitoring advanced service discovery configuration changes is disabled.
2020-04-21 21:04:41,743 INFO  knox.gateway (ClouderaManagerDescriptorMonitor.java:setupMonitor(68)) - Monitoring Cloudera Manager descriptors is disabled.
```