### PR TITLE
KNOX-2352 - Knox Token State Eviction Should Be Based on Expiration a…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -251,7 +251,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
   private static final String KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.permissive.validation";
   private static final long KNOX_TOKEN_EVICTION_INTERVAL_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
-  private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
+  private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.HOURS.toSeconds(24);
   private static final boolean KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT = false;
 
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
@@ -185,7 +185,7 @@ public class DefaultTokenStateServiceTest {
     // Sleep to allow the eviction evaluation to be performed prior to the maximum token lifetime
     Thread.sleep(evictionInterval + (evictionInterval / 2));
 
-    // Renewal should succeed because there is sufficient time until max lifetime is exceeded
+    // Renewal should succeed because there is sufficient time until expiration + grace period is exceeded
     tss.renewToken(token, TimeUnit.SECONDS.toMillis(10));
     assertFalse("Expected the token to have been renewed.", tss.isExpired(token));
   }
@@ -196,7 +196,7 @@ public class DefaultTokenStateServiceTest {
     final TokenStateService tss = createTokenStateService();
 
     final long evictionInterval = TimeUnit.SECONDS.toMillis(3);
-    final long maxTokenLifetime = evictionInterval / 2;
+    final long maxTokenLifetime = evictionInterval * 3;
 
     try {
       tss.start();

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -253,7 +253,10 @@ public class TokenResource {
           // If renewal fails, it should be an exception
           expiration = tokenStateService.renewToken(jwt,
                                                     renewInterval.orElse(tokenStateService.getDefaultRenewInterval()));
-          log.renewedToken(getTopologyName(), TokenUtils.getTokenDisplayText(token), TokenUtils.getTokenId(jwt));
+          log.renewedToken(getTopologyName(),
+                           TokenUtils.getTokenDisplayText(token),
+                           TokenUtils.getTokenId(jwt),
+                           renewer);
         } catch (ParseException e) {
           log.invalidToken(getTopologyName(), TokenUtils.getTokenDisplayText(token), e);
           error = safeGetMessage(e);
@@ -297,7 +300,10 @@ public class TokenResource {
         try {
           JWTToken jwt = new JWTToken(token);
           tokenStateService.revokeToken(jwt);
-          log.revokedToken(getTopologyName(), TokenUtils.getTokenDisplayText(token), TokenUtils.getTokenId(jwt));
+          log.revokedToken(getTopologyName(),
+                           TokenUtils.getTokenDisplayText(token),
+                           TokenUtils.getTokenId(jwt),
+                           renewer);
         } catch (ParseException e) {
           log.invalidToken(getTopologyName(), TokenUtils.getTokenDisplayText(token), e);
           error = safeGetMessage(e);

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -30,11 +30,11 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) issued token {1} ({2})")
   void issuedToken(String topologyName, String tokenDisplayText, String tokenId);
 
-  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) renewed the expiration for token {1} ({2})")
-  void renewedToken(String topologyName, String tokenDisplayText, String tokenId);
+  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) renewed the expiration for token {1} ({2}) (renewer={3})")
+  void renewedToken(String topologyName, String tokenDisplayText, String tokenId, String renewer);
 
-  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) revoked token {1} ({2})")
-  void revokedToken(String topologyName, String tokenDisplayText, String tokenId);
+  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) revoked token {1} ({2}) (renewer={3})")
+  void revokedToken(String topologyName, String tokenDisplayText, String tokenId, String renewer);
 
   @Message( level = MessageLevel.ERROR, text = "Unable to issue token.")
   void unableToIssueToken(@StackTrace( level = MessageLevel.DEBUG) Exception e);


### PR DESCRIPTION
…nd Extended Default Grace Period

## What changes were proposed in this pull request?

Reverted the token state eviction evaluation to be based on the expiration time and a configurable grace period. Also increased the default grace period to 24 hours to accommodate irregular renewers.

## How was this patch tested?

Automated tests + manual testing