### PR TITLE
KNOX-2351 - Catching any errors while monitoring CM configuration changes

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -126,6 +126,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.DEBUG, text = "Checking {0} @ {1} for configuration changes...")
   void checkingClusterConfiguration(String clusterName, String discoveryAddress);
 
+  @Message(level = MessageLevel.ERROR, text = "Error while monitoring ClouderaManager configuration changes: {0}")
+  void clouderaManagerConfigurationChangesMonitoringError(@StackTrace(level = MessageLevel.DEBUG) Exception e);
+
   @Message(level = MessageLevel.ERROR,
       text = "Error getting service configuration details from ClouderaManager: {0}")
   void clouderaManagerConfigurationAPIError(@StackTrace(level = MessageLevel.DEBUG) ApiException e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Surrounding the CM configuration check logic with a `try/catch` block and logging if any issue occurred during the operation.

## How was this patch tested?

Manually tested:

1. deployed Knox w/o the in #319 and deployed a descriptor pointing to a CM cluster where I made a configuration change in one the services
2. waited until CM configuration change monitoring occurred
3. as expected, the monitoring failed. This time the monitoring thread did not get suspended and the appropriate log message was shown:

```
2020-04-21 15:38:00,270 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:run(169)) - Checking Cluster 1 @ http://$CM_HOST:7180 for configuration changes...
2020-04-21 15:38:00,274 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(373)) - Querying restart events from Cluster 1 @ http://$CM_HOST:7180 since 2020-04-21T13:37:00.010Z
2020-04-21 15:38:45,440 ERROR discovery.cm (PollingConfigurationAnalyzer.java:run(201)) - Error while monitoring ClouderaManager configuration changes: java.lang.NullPointerException
java.lang.NullPointerException
	at org.apache.knox.gateway.topology.discovery.cm.monitor.PollingConfigurationAnalyzer.isRelevantEvent(PollingConfigurationAnalyzer.java:398)
	at org.apache.knox.gateway.topology.discovery.cm.monitor.PollingConfigurationAnalyzer.getRelevantEvents(PollingConfigurationAnalyzer.java:383)
	at org.apache.knox.gateway.topology.discovery.cm.monitor.PollingConfigurationAnalyzer.run(PollingConfigurationAnalyzer.java:180)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
