### PR TITLE
KNOX-2354 An HBASEJARS service which can proxy HBase jars hosted by t…

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/rewrite.xml
@@ -1,0 +1,49 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+  <!-- jetty-dir.css is special in that it's not so much a CSS file, but the ResourceHandler
+       will always link to it in the current directory. We can refer to it at the static path though. -->
+  <rule dir="IN" name="HBASEJARS/path/in/css" pattern="*://*:*/**/hbase/maven/jetty-dir.css">
+    <rewrite template="{$serviceUrl[HBASEJARS]}/jetty-dir.css"/>
+  </rule>
+  <rule dir="OUT" name="HBASEJARS/path/out/css" pattern="jetty-dir.css">
+    <rewrite template="{$frontend[url]}/hbase/maven/jetty-dir.css"/>
+  </rule>
+
+  <!-- Root location -->
+  <rule dir="IN" name="HBASEJARS/inbound/jars" pattern="*://*:*/**/hbase/maven">
+    <rewrite template="{$serviceUrl[HBASEJARS]}/"/>
+  </rule>
+  <!-- Jetty ResourceHandler issues HTTP/302 redirects to the same path with trailing slash
+    if there is not one there already -->
+  <filter name="HBASEJARS/outbound/jars/headers">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="HBASEJARS/outbound/jars/headers-redirect"/>
+    </content>
+  </filter>
+  <rule dir="OUT" name="HBASEJARS/outbound/jars/headers-redirect">
+    <match pattern="*://*:*/static/maven/{path=**}?{**}"/>
+    <rewrite template="{$frontend[url]}/hbase/maven/{path=**}/"/>
+  </rule>
+  <!-- Regex to match everything -->
+  <rule dir="IN" name="HBASEJARS/inbound/jars/path" pattern="*://*:*/**/hbase/maven/{**}">
+    <rewrite template="{$serviceUrl[HBASEJARS]}/{**}"/>
+  </rule>
+  <rule dir="OUT" name="HBASEJARS/outbound/jars" pattern="/static/maven/{**}">
+    <rewrite template="{$frontend[url]}/hbase/maven/{**}"/>
+  </rule>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/service.xml
@@ -1,0 +1,43 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="HBASEJARS" name="hbasejars" version="2.2.0">
+    <metadata>
+        <type>API</type>
+        <context>/hbase/maven</context>
+        <shortDesc>Jar hosting for HBase</shortDesc>
+        <description>Static hosting of HBase client jars from the backend HBase UI.</description>
+    </metadata>
+    <routes>
+        <!-- Jetty static resources won't come with the query string -->
+        <route path="/hbase/maven/jetty-dir.css">
+            <rewrite apply="HBASEJARS/path/in/css" to="request.url"/>
+            <rewrite apply="HBASEJARS/path/out/css" to="response.body"/>
+        </route>
+        <!-- Define routes for our embedded maven repo -->
+        <route path="/hbase/maven">
+           <rewrite apply="HBASEJARS/inbound/jars" to="request.url"/>
+           <rewrite apply="HBASEJARS/outbound/jars" to="response.body"/>
+        </route>
+        <route path="/hbase/maven/**">
+          <rewrite apply="HBASEJARS/inbound/jars/path" to="request.url"/>
+          <rewrite apply="HBASEJARS/outbound/jars" to="response.body"/>
+          <!-- For the Jetty HTTP/302 redirects -->
+          <rewrite apply="HBASEJARS/outbound/jars/headers" to="response.headers"/>
+        </route>
+    </routes>
+    <dispatch classname="org.apache.knox.gateway.hbase.HBaseUIDispatch" ha-classname="org.apache.knox.gateway.hbase.HBaseUIHaDispatch"/>
+</service>

--- a/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/service.xml
@@ -39,5 +39,10 @@
           <rewrite apply="HBASEJARS/outbound/jars/headers" to="response.headers"/>
         </route>
     </routes>
+    <!-- This is extremely important yet looks out of place. Knox IN rules ending in {**} will drop a trailing-slash
+         character which will result in the HTTP/302 redirect to a URL with a trailing-slash that Jetty does with
+         the ResourceHandler. Without this custom dispatch to re-add that trailing-slash, Knox will create in
+         redirect-loop when trying to traverse this via the UI. This is only important when traversing the dirlisting
+         via a browser or HTTP client. Maven does not traverse the directory structure when pulling artifacts.-->
     <dispatch classname="org.apache.knox.gateway.hbase.HBaseUIDispatch" ha-classname="org.apache.knox.gateway.hbase.HBaseUIHaDispatch"/>
 </service>


### PR DESCRIPTION
…he HBASEUI

In HBase, we can host a "mini" maven repo in hbase itself which a maven
application can point to.

We want this to be in its own service because it has different semantics
than the normal hbaseUI service has (e.g. one would be hooked up to SSO
login, but SSO won't work against that), and Maven cannot function with
the query-string based backend-routing that we do to make the HBaseUI
look like a normal website (instead of a collection of independent
webservers).

## What changes were proposed in this pull request?

Added a new service HBASEJARS

## How was this patch tested?

* Deployed gateway locally with HBase
* Validated that new IN/OUT rules work to traverse the Jetty
* Validated ability to pull resources via Curl directly
* Validated that I can build a Maven application against this (https://github.com/joshelser/knox-hbasejars-exemplar)
