### PR TITLE
KNOX-2357 - Descriptor handler should not default discovery type to A…

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
@@ -129,6 +129,70 @@ public class SimpleDescriptorHandlerTest {
             "        </provider>\n" +
             "    </gateway>\n";
 
+
+    @Test
+    public void testSkipDiscovery_NoDiscoveryConfig() throws Exception {
+        // There should be no exception because in this case, discovery should be skipped altogether
+        doTestDiscoveryConfig(null, null, null, null, null);
+    }
+
+    private void doTestDiscoveryConfig(final String discoveryType,
+                                       final String address,
+                                       final String clusterName,
+                                       final String user,
+                                       final String pwdAlias) throws Exception {
+        GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+        EasyMock.replay(gc);
+
+        // Write the externalized provider config to a temp file
+        File providerConfig = new File(System.getProperty("java.io.tmpdir"), "test-providers.xml");
+        FileUtils.write(providerConfig, TEST_PROVIDER_CONFIG, StandardCharsets.UTF_8);
+
+        // Mock out the simple descriptor
+        SimpleDescriptor testDescriptor = EasyMock.createNiceMock(SimpleDescriptor.class);
+        EasyMock.expect(testDescriptor.getName()).andReturn("mysimpledescriptor").anyTimes();
+        EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
+        EasyMock.expect(testDescriptor.getDiscoveryAddress()).andReturn(address).anyTimes();
+        EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn(discoveryType).anyTimes();
+        EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(user).anyTimes();
+        EasyMock.expect(testDescriptor.getDiscoveryPasswordAlias()).andReturn(pwdAlias).anyTimes();
+        EasyMock.expect(testDescriptor.getCluster()).andReturn(clusterName).anyTimes();
+        List<SimpleDescriptor.Service> serviceMocks;
+        SimpleDescriptor.Service svc = EasyMock.createNiceMock(SimpleDescriptor.Service.class);
+        EasyMock.expect(svc.getName()).andReturn("KNOXTOKEN").anyTimes();
+        EasyMock.expect(svc.getVersion()).andReturn(null).anyTimes();
+        EasyMock.expect(svc.getURLs()).andReturn(Collections.emptyList()).anyTimes();
+
+        Map<String, String> serviceParams = new HashMap<>();
+        serviceParams.put("knox.token.ttl", "120000");
+        EasyMock.expect(svc.getParams()).andReturn(serviceParams).anyTimes();
+
+        EasyMock.replay(svc);
+        serviceMocks = Collections.singletonList(svc);
+
+        EasyMock.expect(testDescriptor.getServices()).andReturn(serviceMocks).anyTimes();
+        EasyMock.replay(testDescriptor);
+
+        File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
+        File topologyFile = null;
+
+        try {
+            // Invoke the simple descriptor handler
+            Map<String, File> files =
+                    SimpleDescriptorHandler.handle(gc,
+                            testDescriptor,
+                            providerConfig.getParentFile(), // simple desc co-located with provider config
+                            destDir);
+            topologyFile = files.get("topology");
+            assertTrue(topologyFile.exists());
+        } finally {
+            providerConfig.delete();
+            if (topologyFile != null) {
+                topologyFile.delete();
+            }
+        }
+    }
+
     /*
      * KNOX-1006
      *

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
@@ -21,8 +21,16 @@ import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
 import org.apache.knox.gateway.i18n.messages.StackTrace;
 
-@Messages(logger="org.apache.gateway.topology.simple")
+@Messages(logger="org.apache.knox.gateway.topology.simple")
 public interface SimpleDescriptorMessages {
+
+    @Message(level = MessageLevel.INFO,
+            text = "Skipping service discovery for the \"{0}\" descriptor because its contents do not indicate it is intended.")
+    void discoveryNotConfiguredForDescriptor(String descriptorName);
+
+    @Message(level = MessageLevel.INFO,
+            text = "The \"{0}\" descriptor does not include discovery-type.")
+    void missingDiscoveryTypeInDescriptor(String descriptorName);
 
     @Message(level = MessageLevel.ERROR,
             text = "Unable to complete service discovery for cluster {0}.")


### PR DESCRIPTION
…nd Extended Default Grace Period

## What changes were proposed in this pull request?

Prior to this change, if no discovery properties are present in a descriptor, then Ambari discovery was assumed, which would fail due to the lack of configuration. With this change, discovery attempts are skipped altogether unless at least one discovery configuration property is present in a descriptor. If the discovery-type property is NOT present, but there is at least one other such property, then the type will still be defaulted to Ambari.

## How was this patch tested?

Augmented SimpleDescriptorHandlerTest, and tested manually.