### PR TITLE
KNOX-2359 - Knox src zip should not include node_modules folder

### DIFF
--- a/src/assembly.xml
+++ b/src/assembly.xml
@@ -32,6 +32,7 @@
                 <exclude>**/.settings/**</exclude>
                 <exclude>**/.idea/**</exclude>
                 <exclude>**/*.iml</exclude>
+                <exclude>**/node_modules/**</exclude>
             </excludes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the node_modules folder from the src zip file.

## How was this patch tested?

* `mvn -U -T.75C clean verify -Ppackage,release -Dshellcheck`
* Checked that src zip doesn't have node_modules folders anymore
