### PR TITLE
KNOX-2356 - Added a 50px high div before the footer to prevent overflow from resource detail panel

### DIFF
--- a/gateway-admin-ui/admin-ui/index.html
+++ b/gateway-admin-ui/admin-ui/index.html
@@ -50,6 +50,9 @@
     <!-- Content -->
     <app-resource-management></app-resource-management>
 
+    <div class="container-fluid" style="padding-top: 50px !important">
+    </div>
+
     <footer class="footer">
         <div class="container-fluid">
             <div>Knox Manager


### PR DESCRIPTION
## What changes were proposed in this pull request?

The main issue was that the footer covered the bottom of the resource detail panel -> the buttons were not visible.
I added an empty 50px high `div` before the footer to make this issue disappear.

## How was this patch tested?

Before my changes:
<img width="1672" alt="Screen Shot 2020-04-28 at 3 34 02 PM" src="https://user-images.githubusercontent.com/34065904/80495327-129b6780-8968-11ea-8b5e-746c2507eadc.png">

After my changes:
<img width="1679" alt="Screen Shot 2020-04-28 at 3 44 09 PM" src="https://user-images.githubusercontent.com/34065904/80495359-1929df00-8968-11ea-9643-b460d7a81b44.png">
