### PR TITLE
KNOX-2365 - Knox parses shared provider configuration from Hadoop XML type configuration files

### DIFF
--- a/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.html
+++ b/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.html
@@ -120,6 +120,7 @@
                     title="Remove Provider Configuration"
                     class="btn btn-default btn-sm pull-left"
                     (click)="deleteConfirmModal.open('md')"
+                    *ngIf="showEditOptions()"
                     data-toggle="tooltip">
                 <span class="glyphicon glyphicon-trash"></span>
             </button>
@@ -129,6 +130,7 @@
                 class="btn btn-default btn-sm"
                 [disabled]="!changedProviders"
                 (click)="discardConfirmModal.open('md')"
+                *ngIf="showEditOptions()"
                 data-toggle="tooltip">
           <span class="glyphicon glyphicon-refresh"></span>
         </button>
@@ -138,6 +140,7 @@
                 class="btn btn-default btn-sm"
                 [disabled]="!changedProviders"
                 (click)="persistChanges()"
+                *ngIf="showEditOptions()"
                 data-toggle="tooltip">
           <span class="glyphicon glyphicon-floppy-disk"></span>
         </button>

--- a/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.ts
+++ b/gateway-admin-ui/admin-ui/app/resource-detail/resource-detail.component.ts
@@ -48,6 +48,7 @@ export class ResourceDetailComponent implements OnInit {
     resourceContent: string;
 
     providers: Array<ProviderConfig>;
+    readOnlyProviderConfig: boolean;
     changedProviders: Array<ProviderConfig>;
 
     descriptor: Descriptor;
@@ -114,11 +115,13 @@ export class ResourceDetailComponent implements OnInit {
                     // Parse the JSON representation
                     contentObj = JSON.parse(this.resourceContent);
                     this.providers = contentObj['providers'];
+                    this.readOnlyProviderConfig = contentObj['readOnly'];
                 } else if (res.name.endsWith('yaml') || res.name.endsWith('yml')) {
                     // Parse the YAML representation
                     let yaml = require('js-yaml');
                     contentObj = yaml.safeLoad(this.resourceContent);
                     this.providers = contentObj['providers'];
+                    this.readOnlyProviderConfig = contentObj['readOnly'];
                 } else if (res.name.endsWith('xml')) {
                     // Parse the XML representation
                     parseString(this.resourceContent,
@@ -146,6 +149,7 @@ export class ResourceDetailComponent implements OnInit {
                                     tempProviders.push(providerConfig);
                                 });
                                 this.providers = tempProviders;
+                                this.readOnlyProviderConfig = result['gateway'].readOnly;
                             }
                         });
                 }
@@ -563,6 +567,11 @@ export class ResourceDetailComponent implements OnInit {
         if (this.resourceType === 'Descriptors' && this.descriptor.readOnly) {
             return !Boolean(this.descriptor.readOnly);
         }
+
+        if (this.resourceType === 'Provider Configurations' && this.readOnlyProviderConfig) {
+          return !this.readOnlyProviderConfig;
+        }
+
         return true;
     }
 }

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/ClouderaManagerIntegrationMessages.java
@@ -36,11 +36,14 @@ public interface ClouderaManagerIntegrationMessages {
   @Message(level = MessageLevel.INFO, text = "Found Knox descriptors {0} in {1}")
   void parsedClouderaManagerDescriptor(String descriptorList, String path);
 
-  @Message(level = MessageLevel.INFO, text = "Saved Knox descriptor {0}")
-  void savedSimpleDescriptorDescriptor(String path);
+  @Message(level = MessageLevel.INFO, text = "Saved Knox {0} into {1}")
+  void savedResource(String resourceType, String path);
 
-  @Message(level = MessageLevel.INFO, text = "Ignoring {0} Knox descriptor update because it did not change.")
-  void descriptorDidNotChange(String descriptorName);
+  @Message(level = MessageLevel.INFO, text = "Ignoring {0} Knox {1} update because it did not change.")
+  void resourceDidNotChange(String resourceName, String resourceType);
+
+  @Message(level = MessageLevel.ERROR, text = "Parsing Knox shared provider configuration {0} failed: {1}")
+  void failedToParseProviderConfiguration(String name, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR, text = "Parsing Knox descriptor {0} failed: {1}")
   void failedToParseDescriptor(String name, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);

--- a/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserResult.java
+++ b/gateway-cm-integration/src/main/java/org/apache/knox/gateway/cm/descriptor/ClouderaManagerDescriptorParserResult.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.cm.descriptor;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.knox.gateway.topology.simple.ProviderConfiguration;
+import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
+
+class ClouderaManagerDescriptorParserResult {
+  final Map<String, ProviderConfiguration> providers;
+  final Set<SimpleDescriptor> descriptors;
+
+  ClouderaManagerDescriptorParserResult() {
+    this(Collections.emptyMap(), Collections.emptySet());
+  }
+
+  ClouderaManagerDescriptorParserResult(Map<String, ProviderConfiguration> providers, Set<SimpleDescriptor> descriptors) {
+    this.providers = providers;
+    this.descriptors = descriptors;
+  }
+
+  public Map<String, ProviderConfiguration> getProviders() {
+    return Collections.unmodifiableMap(providers);
+  }
+
+  public Set<SimpleDescriptor> getDescriptors() {
+    return Collections.unmodifiableSet(descriptors);
+  }
+
+}

--- a/gateway-cm-integration/src/test/resources/testDescriptor.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptor.xml
@@ -18,31 +18,48 @@ limitations under the License.
   <property>
     <name>topology1</name>
     <value>
-        discoveryType=ClouderaManager;
-        discoveryAddress=http://host:123;
-        discoveryUser=user;
-        discoveryPasswordAlias=alias;
-        cluster=Cluster 1;
-        providerConfigRef=topology1-provider;
-        app:knoxauth:param1.name=param1.value;
-        app:admin-ui;
-        HIVE:url=http://localhost:456;
-        HIVE:version=1.0;
-        HIVE:httpclient.connectionTimeout=5m;
+        discoveryType=ClouderaManager#
+        discoveryAddress=http://host:123#
+        discoveryUser=user#
+        discoveryPasswordAlias=alias#
+        cluster=Cluster 1#
+        providerConfigRef=topology1-provider#
+        app:knoxauth:param1.name=param1.value#
+        app:admin-ui#
+        HIVE:url=http://localhost:456#
+        HIVE:version=1.0#
+        HIVE:httpclient.connectionTimeout=5m#
         HIVE:httpclient.socketTimeout=100m
     </value>
   </property>
   <property>
     <name>topology2</name>
     <value>
-        discoveryType=Ambari;
-        discoveryAddress=http://host:456;
-        cluster=Cluster 2;
-        providerConfigRef=topology2-provider;
-        ATLAS-API:url=http://localhost:456;
-        ATLAS-API:httpclient.connectionTimeout=5m;
-        ATLAS-API:httpclient.socketTimeout=100m;
+        discoveryType=Ambari#
+        discoveryAddress=http://host:456#
+        cluster=Cluster 2#
+        providerConfigRef=topology2-provider#
+        ATLAS-API:url=http://localhost:456#
+        ATLAS-API:httpclient.connectionTimeout=5m#
+        ATLAS-API:httpclient.socketTimeout=100m#
         NIFI
     </value>
+  </property>
+  <property>
+      <name>providerConfigs:admin, knoxsso</name>
+      <value>
+          role=authentication#
+          authentication.name=ShiroProvider#
+          authentication.param.sessionTimeout=30#
+          authentication.param.main.ldapRealm=org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm#
+          authentication.param.main.ldapContextFactory=org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory#
+          authentication.param.main.ldapRealm.contextFactory=$ldapContextFactory#
+          authentication.param.main.ldapRealm.contextFactory.authenticationMechanism=simple#
+          authentication.param.main.ldapRealm.contextFactory.url=ldap://localhost:33389#
+          authentication.param.main.ldapRealm.contextFactory.systemUsername=uid=guest,ou=people,dc=hadoop,dc=apache,dc=org#
+          authentication.param.main.ldapRealm.contextFactory.systemPassword=${ALIAS=knoxLdapSystemPassword}#
+          authentication.param.main.ldapRealm.userDnTemplate=uid={0},ou=people,dc=hadoop,dc=apache,dc=org#
+          authentication.param.urls./**=authcBasic
+      </value>
   </property>
 </configuration>

--- a/gateway-cm-integration/src/test/resources/testDescriptorConfigurationWithNonHadoopStyleConfiguration.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptorConfigurationWithNonHadoopStyleConfiguration.xml
@@ -18,17 +18,17 @@ limitations under the License.
   <config> <!-- should be property -->
     <name>topology1</name>
     <value>
-        discoveryType=ClouderaManager;
-        discoveryAddress=http://host:123;
-        discoveryUser=user;
-        discoveryPasswordAlias=alias;
-        cluster=Cluster 1;
-        providerConfigRef=topology1-provider;
-        app:knoxauth:param1.name=param1.value;
-        app:admin-ui;
-        HIVE:url=http://localhost:456;
-        HIVE:version=1.0;
-        HIVE:httpclient.connectionTimeout=5m;
+        discoveryType=ClouderaManager#
+        discoveryAddress=http://host:123#
+        discoveryUser=user#
+        discoveryPasswordAlias=alias#
+        cluster=Cluster 1#
+        providerConfigRef=topology1-provider#
+        app:knoxauth:param1.name=param1.value#
+        app:admin-ui#
+        HIVE:url=http://localhost:456#
+        HIVE:version=1.0#
+        HIVE:httpclient.connectionTimeout=5m#
         HIVE:httpclient.socketTimeout=100m
     </value>
   </config>

--- a/gateway-cm-integration/src/test/resources/testDescriptorWithAdminProviderConfigRemovedUserDnTemplate.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptorWithAdminProviderConfigRemovedUserDnTemplate.xml
@@ -16,31 +16,11 @@ limitations under the License.
 -->
 <configuration>
   <property>
-    <name>topology1</name>
-    <value>
-        discoveryType=ClouderaManager#
-        discoveryAddress=http://host:123#
-        discoveryUser=user#
-        discoveryPasswordAlias=alias#
-        cluster=Cluster 1#
-        providerConfigRef=topology1-provider#
-        app:knoxauth:param1.name=param1.value#
-        app:admin-ui#
-        HIVE:url=http://localhost:456#
-        HIVE:version=1.0#
-        HIVE:httpclient.connectionTimeout=5m#
-        HIVE:httpclient.socketTimeout=100m
-    </value>
-  </property>
-  <property>
-    <name>topology2</name>
-    <value>
-        discoveryType=Ambari#
-        discoveryAddress=http://host:456#
-        cluster=Cluster 2#
-        providerConfigRef=topology2-provider#
-        HDFS:url=http://localhost:456#
-        HDFS:noValueParam <!-- can not be parsed -->
-    </value>
+      <name>providerConfigs:admin</name>
+      <value>
+          role=authentication#
+          authentication.name=ShiroProvider#
+          authentication.param.remove=main.ldapRealm.userDnTemplate
+      </value>
   </property>
 </configuration>

--- a/gateway-cm-integration/src/test/resources/testDescriptorWithAdminProviderConfigUpdatedLdapUrl.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptorWithAdminProviderConfigUpdatedLdapUrl.xml
@@ -16,31 +16,11 @@ limitations under the License.
 -->
 <configuration>
   <property>
-    <name>topology1</name>
-    <value>
-        discoveryType=ClouderaManager#
-        discoveryAddress=http://host:123#
-        discoveryUser=user#
-        discoveryPasswordAlias=alias#
-        cluster=Cluster 1#
-        providerConfigRef=topology1-provider#
-        app:knoxauth:param1.name=param1.value#
-        app:admin-ui#
-        HIVE:url=http://localhost:456#
-        HIVE:version=1.0#
-        HIVE:httpclient.connectionTimeout=5m#
-        HIVE:httpclient.socketTimeout=100m
-    </value>
-  </property>
-  <property>
-    <name>topology2</name>
-    <value>
-        discoveryType=Ambari#
-        discoveryAddress=http://host:456#
-        cluster=Cluster 2#
-        providerConfigRef=topology2-provider#
-        HDFS:url=http://localhost:456#
-        HDFS:noValueParam <!-- can not be parsed -->
-    </value>
+      <name>providerConfigs:admin</name>
+      <value>
+          role=authentication#
+          authentication.name=ShiroProvider#
+          authentication.param.main.ldapRealm.contextFactory.url=ldaps://localhost:33390
+      </value>
   </property>
 </configuration>

--- a/gateway-cm-integration/src/test/resources/testDescriptorWithoutDiscoveryDetails.xml
+++ b/gateway-cm-integration/src/test/resources/testDescriptorWithoutDiscoveryDetails.xml
@@ -18,10 +18,10 @@ limitations under the License.
   <property>
     <name>topology1</name>
     <value>
-        providerConfigRef=topology1-provider;
-        app:knoxauth:param1.name=param1.value;
-        app:admin-ui;
-        HIVE:url=http://localhost:123;
+        providerConfigRef=topology1-provider#
+        app:knoxauth:param1.name=param1.value#
+        app:admin-ui#
+        HIVE:url=http://localhost:123
     </value>
   </property>
 </configuration>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -715,7 +715,7 @@ public class GatewayServer {
   }
 
   private void handleClouderaManagerDescriptors() {
-    final ClouderaManagerDescriptorParser cmDescriptorParser = new ClouderaManagerDescriptorParser();
+    final ClouderaManagerDescriptorParser cmDescriptorParser = new ClouderaManagerDescriptorParser(config);
     final ClouderaManagerDescriptorMonitor cmDescriptorMonitor = new ClouderaManagerDescriptorMonitor(config, cmDescriptorParser);
     final AdvancedServiceDiscoveryConfigurationMonitor advancedServiceDiscoveryConfigurationMonitor = new AdvancedServiceDiscoveryConfigurationMonitor(config);
     advancedServiceDiscoveryConfigurationMonitor.registerListener(cmDescriptorParser);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/ProviderConfigurationParserTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/ProviderConfigurationParserTest.java
@@ -29,8 +29,8 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -84,7 +84,7 @@ public class ProviderConfigurationParserTest {
     ProviderConfiguration pc = doTestParseProviderConfiguration(XML, "my-providers.xml");
     assertNotNull(pc);
 
-    List<ProviderConfiguration.Provider> providers = pc.getProviders();
+    Set<ProviderConfiguration.Provider> providers = pc.getProviders();
     assertNotNull(providers);
     assertFalse(providers.isEmpty());
     assertEquals(3, providers.size());
@@ -130,13 +130,13 @@ public class ProviderConfigurationParserTest {
     "      \"name\":\"ShiroProvider\",\n" +
     "      \"enabled\":\"true\",\n" +
     "      \"params\":{\n" +
-    "        \"sessionTimeout\":\"30\",\n" +
-    "        \"main.ldapRealm\":\"org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm\",\n" +
     "        \"main.ldapContextFactory\":\"org.apache.hadoop.gateway.shirorealm.KnoxLdapContextFactory\",\n" +
+    "        \"main.ldapRealm\":\"org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm\",\n" +
     "        \"main.ldapRealm.contextFactory\":\"$ldapContextFactory\",\n" +
     "        \"main.ldapRealm.userDnTemplate\":\"uid={0},ou=people,dc=hadoop,dc=apache,dc=org\",\n" +
     "        \"main.ldapRealm.contextFactory.url\":\"ldap://localhost:33389\",\n" +
     "        \"main.ldapRealm.contextFactory.authenticationMechanism\":\"simple\",\n" +
+    "        \"sessionTimeout\":\"30\",\n" +
     "        \"urls./**\":\"authcBasic\"\n" +
     "      }\n" +
     "    },\n" +
@@ -158,8 +158,8 @@ public class ProviderConfigurationParserTest {
     "      \"name\":\"HaProvider\",\n" +
     "      \"enabled\":\"false\",\n" +
     "      \"params\":{\n" +
-    "        \"WEBHDFS\":\"maxFailoverAttempts=3;failoverSleep=1000;enabled=true\",\n" +
-    "        \"HIVE\":\"maxFailoverAttempts=3;failoverSleep=1000;enabled=true\"\n" +
+    "        \"HIVE\":\"maxFailoverAttempts=3;failoverSleep=1000;enabled=true\",\n" +
+    "        \"WEBHDFS\":\"maxFailoverAttempts=3;failoverSleep=1000;enabled=true\"\n" +
     "      }\n" +
     "    }\n" +
     "  ]\n" +
@@ -168,7 +168,7 @@ public class ProviderConfigurationParserTest {
     ProviderConfiguration pc = doTestParseProviderConfiguration(JSON, "my-providers." + "json");
     assertNotNull(pc);
 
-    List<ProviderConfiguration.Provider> providers = pc.getProviders();
+    Set<ProviderConfiguration.Provider> providers = pc.getProviders();
     assertNotNull(providers);
     assertFalse(providers.isEmpty());
     assertEquals(4, providers.size());
@@ -225,7 +225,7 @@ public class ProviderConfigurationParserTest {
 
     assertNotNull(pc);
 
-    List<ProviderConfiguration.Provider> providers = pc.getProviders();
+    Set<ProviderConfiguration.Provider> providers = pc.getProviders();
     assertNotNull(providers);
     assertFalse(providers.isEmpty());
     assertEquals(4, providers.size());
@@ -235,7 +235,7 @@ public class ProviderConfigurationParserTest {
   }
 
 
-  private void validateParsedProviders(List<ProviderConfiguration.Provider> providers) throws Exception {
+  private void validateParsedProviders(Set<ProviderConfiguration.Provider> providers) throws Exception {
     // Validate the providers
     for (ProviderConfiguration.Provider provider : providers) {
       String role = provider.getRole();
@@ -255,13 +255,13 @@ public class ProviderConfigurationParserTest {
         assertEquals(params.get("urls./**"), "authcBasic");
 
         // Verify the param order was maintained during parsing (KNOX-1188)
-        String[] expectedParameterOrder = new String[] {"sessionTimeout",
+        String[] expectedParameterOrder = new String[] {"main.ldapContextFactory",
                                                         "main.ldapRealm",
-                                                        "main.ldapContextFactory",
                                                         "main.ldapRealm.contextFactory",
-                                                        "main.ldapRealm.userDnTemplate",
-                                                        "main.ldapRealm.contextFactory.url",
                                                         "main.ldapRealm.contextFactory.authenticationMechanism",
+                                                        "main.ldapRealm.contextFactory.url",
+                                                        "main.ldapRealm.userDnTemplate",
+                                                        "sessionTimeout",
                                                         "urls./**"};
         int index = 0;
         for (String name : params.keySet()) {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -889,8 +890,8 @@ public class SimpleDescriptorHandlerTest {
         assertNotNull(generatedProviderConfiguration);
 
         // Compare the generated ProviderConfiguration to the expected one
-        List<ProviderConfiguration.Provider> expectedProviders = expected.getProviders();
-        List<ProviderConfiguration.Provider> actualProviders = generatedProviderConfiguration.getProviders();
+        Set<ProviderConfiguration.Provider> expectedProviders = expected.getProviders();
+        Set<ProviderConfiguration.Provider> actualProviders = generatedProviderConfiguration.getProviders();
         assertEquals("The number of providers should be the same.", expectedProviders.size(), actualProviders.size());
 
         for (ProviderConfiguration.Provider expectedProvider : expectedProviders) {
@@ -905,7 +906,7 @@ public class SimpleDescriptorHandlerTest {
      * @param expected        A Provider that should be among the specified actual providers
      * @param actualProviders The set of actual providers.
      */
-    private boolean validateProvider(ProviderConfiguration.Provider expected, List<ProviderConfiguration.Provider> actualProviders) {
+    private boolean validateProvider(ProviderConfiguration.Provider expected, Set<ProviderConfiguration.Provider> actualProviders) {
         boolean foundMatch = false;
 
         for (ProviderConfiguration.Provider actual : actualProviders) {

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>jaxb-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/JSONProviderConfiguration.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/JSONProviderConfiguration.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.simple;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonPropertyOrder({ "providers", "readOnly" })
+public class JSONProviderConfiguration implements ProviderConfiguration {
+
+  @JsonProperty("providers")
+  @JsonSerialize(contentAs = JSONProvider.class)
+  @JsonDeserialize(contentAs = JSONProvider.class)
+  private Set<Provider> providers;
+
+  @JsonProperty("readOnly")
+  private boolean readOnly;
+
+  @Override
+  public Set<Provider> getProviders() {
+    return providers == null ? Collections.emptySet() : Collections.unmodifiableSet(new TreeSet<>(providers));
+  }
+
+  @Override
+  public void saveOrUpdateProviders(Set<Provider> providersToReplace) {
+    if (this.providers == null) {
+      this.providers = new TreeSet<>();
+      this.providers.addAll(providersToReplace);
+    } else {
+      providersToReplace.forEach(providerToAdd -> {
+        final Optional<Provider> toBeRemoved = this.providers.stream().filter(provider -> provider.getRole().equals(providerToAdd.getRole())).findFirst();
+        if (toBeRemoved.isPresent()) {
+          this.providers.remove(toBeRemoved.get());
+        }
+        this.providers.add(providerToAdd);
+      });
+    }
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return readOnly;
+  }
+
+  @Override
+  public void setReadOnly(boolean readOnly) {
+    this.readOnly = readOnly;
+  }
+
+  @Override
+  public int hashCode() {
+    return HashCodeBuilder.reflectionHashCode(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return EqualsBuilder.reflectionEquals(this, obj);
+  }
+
+  @JsonPropertyOrder({ "role", "name", "enabled", "params" })
+  public static class JSONProvider implements ProviderConfiguration.Provider, Comparable<JSONProvider> {
+
+    @JsonProperty("role")
+    private String role;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("enabled")
+    private boolean enabled;
+
+    @JsonProperty("params")
+    private Map<String, String> params;
+
+    @Override
+    public String getRole() {
+      return role;
+    }
+
+    public void setRole(String role) {
+      this.role = role;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+      this.enabled = enabled;
+    }
+
+    @Override
+    public Map<String, String> getParams() {
+      Map<String, String> result = new TreeMap<>();
+      if (params != null) {
+        result.putAll(params);
+      }
+      return result;
+    }
+
+    public void addParam(String key, String value) {
+      if (params == null) {
+        params = new TreeMap<>();
+      }
+      params.put(key, value);
+    }
+
+    public void removeParam(String key) {
+      if (params != null) {
+        params.remove(key);
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int compareTo(JSONProvider other) {
+      return Integer.compare(ProviderOrder.getOrdinalForRole(role), ProviderOrder.getOrdinalForRole(other.role));
+    }
+  }
+
+}

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/ProviderConfigurationParser.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/ProviderConfigurationParser.java
@@ -16,28 +16,22 @@
  */
 package org.apache.knox.gateway.topology.simple;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.commons.io.FilenameUtils;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+
+import org.apache.commons.io.FilenameUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class ProviderConfigurationParser {
   private static final JAXBContext jaxbContext = getJAXBContext();
@@ -93,31 +87,25 @@ public class ProviderConfigurationParser {
     return EXT_YAML.equals(extension) || EXT_YML.equals(extension);
   }
 
-
   static ProviderConfiguration parseXML(File file) throws Exception {
     return parseXML(Files.newInputStream(file.toPath()));
   }
 
-
   static ProviderConfiguration parseXML(InputStream in) throws Exception {
-    XMLProviderConfiguration providerConfig;
     Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-    providerConfig = (XMLProviderConfiguration) jaxbUnmarshaller.unmarshal(in);
+    XMLProviderConfiguration providerConfig = (XMLProviderConfiguration) jaxbUnmarshaller.unmarshal(in);
 
     return providerConfig;
   }
-
 
   static ProviderConfiguration parseJSON(File file) throws IOException {
     return parseJSON(Files.newInputStream(file.toPath()));
   }
 
-
   static ProviderConfiguration parseJSON(InputStream in) throws IOException {
     final ObjectMapper mapper = new ObjectMapper();
     return mapper.readValue(in, JSONProviderConfiguration.class);
   }
-
 
   static ProviderConfiguration parseYAML(File file) throws IOException {
     return parseYAML(Files.newInputStream(file.toPath()));
@@ -127,140 +115,5 @@ public class ProviderConfigurationParser {
     final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
     return mapper.readValue(in, JSONProviderConfiguration.class);
   }
-
-
-  // XML Provider Configuration Model
-  @XmlRootElement(name="gateway")
-  private static class XMLProviderConfiguration implements ProviderConfiguration {
-
-    @XmlElement(name="provider")
-    private List<XMLProvider> providers;
-
-    @Override
-    public List<Provider> getProviders() {
-      List<Provider> plist = new ArrayList<>();
-      if (providers != null) {
-        plist.addAll(providers);
-      }
-      return plist;
-    }
-
-    @XmlAccessorType(XmlAccessType.NONE)
-    private static class XMLProvider implements ProviderConfiguration.Provider {
-      @XmlElement
-      private String role;
-
-      @XmlElement
-      private String name;
-
-      @XmlElement
-      private boolean enabled;
-
-      @XmlElement(name = "param")
-      private List<XMLParam> params;
-
-      @Override
-      public String getRole() {
-        return role;
-      }
-
-      @Override
-      public String getName() {
-        return name;
-      }
-
-      @Override
-      public boolean isEnabled() {
-        return enabled;
-      }
-
-      @Override
-      public Map<String, String> getParams() {
-        Map<String, String> result = new LinkedHashMap<>();
-        if (params != null) {
-          for (XMLParam p : params) {
-            result.put(p.name, p.value);
-          }
-        }
-        return result;
-      }
-
-      @XmlAccessorType(XmlAccessType.NONE)
-      private static class XMLParam {
-        @XmlElement
-        private String name;
-
-        @XmlElement
-        private String value;
-
-        String getName() {
-          return name;
-        }
-
-        String getValue() {
-          return value;
-        }
-      }
-    }
-
-  }
-
-
-  // JSON/YAML Provider Configuration Model
-  private static class JSONProviderConfiguration implements ProviderConfiguration {
-
-    @JsonProperty("providers")
-    private List<JSONProvider> providers;
-
-    @Override
-    public List<Provider> getProviders() {
-      List<Provider> plist = new ArrayList<>();
-      if (providers != null) {
-        plist.addAll(providers);
-      }
-      return plist;
-    }
-
-    private static class JSONProvider implements ProviderConfiguration.Provider {
-
-      @JsonProperty("role")
-      private String role;
-
-      @JsonProperty("name")
-      private String name;
-
-      @JsonProperty("enabled")
-      private boolean enabled;
-
-      @JsonProperty("params")
-      private Map<String, String> params;
-
-      @Override
-      public String getRole() {
-        return role;
-      }
-
-      @Override
-      public String getName() {
-        return name;
-      }
-
-      @Override
-      public boolean isEnabled() {
-        return enabled;
-      }
-
-      @Override
-      public Map<String, String> getParams() {
-        Map<String, String> result = new LinkedHashMap<>();
-        if (params != null) {
-          result.putAll(params);
-        }
-        return result;
-      }
-    }
-
-  }
-
 
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/ProviderOrder.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/ProviderOrder.java
@@ -16,29 +16,25 @@
  */
 package org.apache.knox.gateway.topology.simple;
 
+public enum ProviderOrder {
+  WEBAPPSEC(1), AUTHENTICATION(2), FEDERATION(3), IDENTITY_ASSERTION(4), AUTHORIZATION(5), HOSTMAP(6), HA(7);
 
-import java.util.Map;
-import java.util.Set;
+  final int ordinal;
+  final String name;
 
-public interface ProviderConfiguration {
-
-  Set<Provider> getProviders();
-
-  void saveOrUpdateProviders(Set<Provider> providers);
-
-  boolean isReadOnly();
-
-  void setReadOnly(boolean readOnly);
-
-  interface Provider {
-
-    String getRole();
-
-    String getName();
-
-    boolean isEnabled();
-
-    Map<String, String> getParams();
+  ProviderOrder(int ordinal) {
+    this.ordinal = ordinal;
+    this.name = name().replace("_", "-");
   }
 
+  static int getOrdinalForRole(String role) {
+    int count = 0;
+    for (ProviderOrder providerOrder : values()) {
+      count++;
+      if (providerOrder.name.equalsIgnoreCase(role)) {
+        return providerOrder.ordinal;
+      }
+    }
+    return ++count;
+  }
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/XMLProviderConfiguration.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/XMLProviderConfiguration.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.simple;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+@XmlRootElement(name = "gateway")
+@XmlAccessorType(XmlAccessType.FIELD)
+class XMLProviderConfiguration implements ProviderConfiguration {
+
+  @XmlElement(name = "provider", type=XMLProvider.class)
+  private Set<Provider> providers;
+
+  @XmlElement(name = "readOnly")
+  private boolean readOnly;
+
+  @Override
+  public Set<Provider> getProviders() {
+    return Collections.unmodifiableSet(providers);
+  }
+
+  @Override
+  public void saveOrUpdateProviders(Set<Provider> providersToReplace) {
+    if (providers == null) {
+      providers = new TreeSet<>();
+      this.providers.addAll(providersToReplace);
+    } else {
+      providersToReplace.forEach(providerToAdd -> {
+        final Optional<Provider> toBeRemoved = providers.stream().filter(provider -> provider.getRole().equals(providerToAdd.getRole())).findFirst();
+        if (toBeRemoved.isPresent()) {
+          providers.remove(toBeRemoved.get());
+        }
+        providers.add(providerToAdd);
+      });
+    }
+  }
+
+  @Override
+  public boolean isReadOnly() {
+    return readOnly;
+  }
+
+  @Override
+  public void setReadOnly(boolean readOnly) {
+    this.readOnly = readOnly;
+  }
+
+  @Override
+  public int hashCode() {
+    return HashCodeBuilder.reflectionHashCode(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return EqualsBuilder.reflectionEquals(this, obj);
+  }
+
+  @XmlAccessorType(XmlAccessType.NONE)
+  @XmlType(propOrder = { "role", "name", "enabled", "params" })
+  private static class XMLProvider implements ProviderConfiguration.Provider, Comparable<XMLProvider> {
+    @XmlElement
+    private String role;
+
+    @XmlElement
+    private String name;
+
+    @XmlElement
+    private boolean enabled;
+
+    @XmlElement(name = "param")
+    private List<XMLParam> params;
+
+    @Override
+    public String getRole() {
+      return role;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return enabled;
+    }
+
+    @Override
+    public Map<String, String> getParams() {
+      Map<String, String> result = new TreeMap<>();
+      if (params != null) {
+        for (XMLParam p : params) {
+          result.put(p.name, p.value);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public int hashCode() {
+      return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @XmlAccessorType(XmlAccessType.NONE)
+    private static class XMLParam {
+      @XmlElement
+      private String name;
+
+      @XmlElement
+      private String value;
+    }
+
+    @Override
+    public int compareTo(XMLProvider other) {
+      return Integer.compare(ProviderOrder.getOrdinalForRole(role), ProviderOrder.getOrdinalForRole(other.role));
+    }
+  }
+}


### PR DESCRIPTION

Main changes in this commit:
- implemented a language that Knox understands when parsing shared provider configuration(s) in Haddop XML type descriptors
- XML/JSON provider configurations are moved out to their own classes from ProviderConfigurationParser
- XML/JSON provider configuration classes implement hashCode/equals properly
- XML/JSON provider classes implement Comparable (based on a predefined provider order) as well as fixing the order of fields and alphabetical order withing parameters when serializing
- changed the separator in Hadoop XML type descriptors from semicolon (;) to hash (#) to conform new requirements
- shared providers that are generated using this framework are read-only on Admin UI
- end-users can modify/remove any parameters in a provider w/o touching others

## What changes were proposed in this pull request?

- implemented a language that Knox understands when parsing shared provider configuration(s) in Haddop XML type descriptors
- XML/JSON provider configurations are moved out to their own classes from ProviderConfigurationParser
- XML/JSON provider configuration classes implement hashCode/equals properly
- XML/JSON provider classes implement Comparable (based on a predefined provider order) as well as fixing the order of fields and alphabetical order withing parameters when serializing
- changed the separator in Hadoop XML type descriptors from semicolon (;) to hash (#) to conform new requirements
- shared providers that are generated using this framework are read-only on Admin UI
- end-users can modify/remove any parameters in a provider w/o touching others

## How was this patch tested?

Updated an executed JUnit tests:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:45 min (Wall Clock)
[INFO] Finished at: 2020-04-29T11:29:16+02:00
[INFO] Final Memory: 430M/2075M
[INFO] ------------------------------------------------------------------------
```

Additionally, the following manual tests were done:

1. Redeployed Knox with my changes
2. Added a `.cm` resource file in the KNOX_DESCRIPTORS_DIR with some shared-providers and descriptors
3. Started Knox (confirmed that Knox paresed the .cm file)
4. Logged into the Admin UI and confirmed that the resources from the .cm file were read-only
5. Created a new shared-provider on the Admin UI and confirmed it was editable
6. Created a new descriptor on the Admin UI and confirmed it was editable
7. Added the following entry in the `.cm`file:
`role=ha#ha.name=HaProvider#ha.param.remove=SOLR#ha.param.HIVE=enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000;zookeeperNamespace=hiveserver2;zookeeperEnsemble=host1:2181,host2:2181,host3:2181`
8. Confirmed that:
  - SOLR HA parameter got removed from the 'pam' provider
  - HIVE HA parameter got updated in the 'pam' provider
  - the rest of the HA parameters remained the same