### PR TITLE
KNOX-2368 - CM Cluster Configuration Monitor Does Not Support Rolling…

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -162,10 +162,11 @@ public interface ClouderaManagerServiceDiscoveryMessages {
                                           String clusterName,
                                           String discoveryAddress);
 
-  @Message(level = MessageLevel.DEBUG, text = "Querying restart events from {0} @ {1} since {2}")
-  void queryingRestartEventsFromCluster(String clusterName,
-                                        String discoveryAddress,
-                                        String sinceTimestamp);
+  @Message(level = MessageLevel.DEBUG,
+          text = "Querying configuration activation events from {0} @ {1} since {2}")
+  void queryingConfigActivationEventsFromCluster(String clusterName,
+                                                 String discoveryAddress,
+                                                 String sinceTimestamp);
 
   @Message(level = MessageLevel.DEBUG, text = "Analyzing current {0} configuration for changes...")
   void analyzingCurrentServiceConfiguration(String serviceName);


### PR DESCRIPTION
… Restart Events

## What changes were proposed in this pull request?

Added cluster config monitor support for rolling restarts of individual services and complete clusters. This also fixes a previously-introduced defect whereby the monitor would recognize relevant events whose status is STARTED, which would result in false-positive inclusion of events that would trigger configuration analysis. All the relevant commands have status value of SUCCEEDED once they've successfully completed. Since the "Rolling Restart" option is disabled in the CM cluster against which I've tested, the implementation and associated test of that behavior is entirely based on log content that exposed the need for this PR.

## How was this patch tested?

Refactored and augmented PollingConfigurationAnalyzerTest, and manually tested all the supported scenarios (except rolling CLUSTER restart).