### PR TITLE
KNOX-2366 - Pinned topologies are expanded and general proxy information section is collapsed on HomePage by default

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -39,6 +39,7 @@ import java.net.UnknownHostException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -252,6 +253,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.HOURS.toSeconds(24);
   private static final boolean KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT = false;
 
+  private static final String KNOX_HOMEPAGE_PINNED_TOPOLOGIES =  "knox.homepage.pinned.topologies";
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata", "homepage"));
 
@@ -1138,8 +1140,14 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public Set<String> getHiddenTopologiesOnHomepage() {
-    final Set<String> hiddenTopologies = new HashSet<>(getStringCollection(KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES));
+    final Set<String> hiddenTopologies = new HashSet<>(getTrimmedStringCollection(KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES));
     return hiddenTopologies == null || hiddenTopologies.isEmpty() ? KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT : hiddenTopologies;
+  }
+
+  @Override
+  public Set<String> getPinnedTopologiesOnHomepage() {
+    final Collection<String> pinnedTopologies = getTrimmedStringCollection(KNOX_HOMEPAGE_PINNED_TOPOLOGIES);
+    return pinnedTopologies == null ? Collections.emptySet() : new HashSet<>(pinnedTopologies);
   }
 
   /**

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -70,5 +70,9 @@
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>eclipselink</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformation.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformation.java
@@ -24,10 +24,13 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "topology")
-public class TopologyInformation {
+public class TopologyInformation implements Comparable<TopologyInformation>{
 
   @XmlElement(name = "topology")
   private String topologyName;
+
+  @XmlElement(name = "pinned")
+  private boolean pinned;
 
   @XmlElement(name = "service")
   @XmlElementWrapper(name = "apiServices")
@@ -45,6 +48,14 @@ public class TopologyInformation {
     this.topologyName = topologyName;
   }
 
+  public boolean isPinned() {
+    return pinned;
+  }
+
+  public void setPinned(boolean pinned) {
+    this.pinned = pinned;
+  }
+
   public Set<ServiceModel> getApiServices() {
     return apiServices;
   }
@@ -59,6 +70,12 @@ public class TopologyInformation {
 
   public void setUiServices(Set<ServiceModel> uiServices) {
     this.uiServices = uiServices;
+  }
+
+  @Override
+  public int compareTo(TopologyInformation other) {
+    final int byPinned =  Boolean.compare(other.pinned, pinned);
+    return byPinned == 0 ? topologyName.compareTo(other.topologyName) : byPinned;
   }
 
 }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformationWrapper.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformationWrapper.java
@@ -17,8 +17,8 @@
  */
 package org.apache.knox.gateway.service.metadata;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -30,15 +30,16 @@ public class TopologyInformationWrapper {
 
   @XmlElement(name = "topologyInformation")
   @XmlElementWrapper(name = "topologyInformations")
-  private Set<TopologyInformation> topologies = new HashSet<>();
+  private Set<TopologyInformation> topologies = new TreeSet<>();
 
   public Set<TopologyInformation> getTopologies() {
     return topologies;
   }
 
-  public void addTopology(String name, Set<ServiceModel> apiServices, Set<ServiceModel> uiServices) {
+  public void addTopology(String name, boolean pinned, Set<ServiceModel> apiServices, Set<ServiceModel> uiServices) {
     final TopologyInformation topology = new TopologyInformation();
     topology.setTopologyName(name);
+    topology.setPinned(pinned);
     topology.setApiServices(apiServices);
     topology.setUiServices(uiServices);
     this.topologies.add(topology);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -679,6 +679,11 @@ public interface GatewayConfig {
   Set<String> getHiddenTopologiesOnHomepage();
 
   /**
+   * @return the list of pinned topologies on Knox homepage
+   */
+  Set<String> getPinnedTopologiesOnHomepage();
+
+  /**
    * @return returns whether know token permissive validation is enabled
    */
   boolean isKnoxTokenPermissiveValidationEnabled();

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -795,6 +795,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return Collections.emptySet();
   }
 
+  @Override
+  public Set<String> getPinnedTopologiesOnHomepage() {
+    return Collections.emptySet();
+  }
+
   /**
    * @return returns whether know token permissive failure is enabled
    */

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
@@ -12,8 +12,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<h4>General Proxy Information</h4>
-<div class="table-responsive">
+<div>
+     <h4 (click)="toggleBoolean('showGeneralProxyInformation')"><span [class]="'clickable inline-glyph glyhpicon glyphicon-' + (this['showGeneralProxyInformation'] ? 'minus' : 'plus')"></span>&nbsp;General Proxy Information</h4>
+</div>
+<div class="table-responsive" *ngIf="this['showGeneralProxyInformation']">
     <table class="table table-striped table-hover">
        <colgroup>
             <col width="30%">

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
@@ -28,7 +28,9 @@ export class GeneralProxyInformationComponent implements OnInit {
 
     generalProxyInformation: GeneralProxyInformation;
 
-    constructor(private homepageService: HomepageService) {}
+    constructor(private homepageService: HomepageService) {
+        this['showGeneralProxyInformation'] = false;
+    }
 
     getVersion() {
         if (this.generalProxyInformation) {
@@ -66,4 +68,7 @@ export class GeneralProxyInformationComponent implements OnInit {
                             .then(generalProxyInformation => this.generalProxyInformation = generalProxyInformation);
     }
 
+    toggleBoolean(propertyName: string) {
+        this[propertyName] = !this[propertyName];
+    }
 }

--- a/knox-homepage-ui/home/app/topologies/topology.information.component.html
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.html
@@ -13,13 +13,22 @@
   limitations under the License.
 -->
 <hr/>
-<h4>Topologies</h4>
+<div>
+     <h4 (click)="toggleBoolean('showTopologies')"><span [class]="'clickable inline-glyph glyhpicon glyphicon-' + (this['showTopologies'] ? 'minus' : 'plus')"></span>&nbsp;Topologies</h4>
+</div>
+<div *ngIf="this['showTopologies']">
 <ng-container *ngFor="let topology of topologies">
     <div>
       <span [class]="'clickable inline-glyph
       glyhpicon glyphicon-' + (this['showTopology_' + topology.topology] ? 'minus' : 'plus')"
       (click)="toggleBoolean('showTopology_' + topology.topology)"></span>
       <span (click)="toggleBoolean('showTopology_' + topology.topology)"><strong>{{topology.topology}}</strong></span>
+      <span class="inline-glyph glyphicon glyphicon-pushpin btn btn-xs" *ngIf="topology.pinned"
+            title="You may unpin this topology in gateway-site.xml by removing it from the list declared in 'knox.homepage.pinned.topologies'"
+            data-toggle="tooltip"></span>
+      <span class="inline-glyph glyphicon glyphicon-cog btn btn-xs" *ngIf="!topology.pinned"
+            title="You may pin this topology in gateway-site.xml using the 'knox.homepage.pinned.topologies' property"
+            data-toggle="tooltip"></span>
     </div>
 
     <div class="table-responsive" *ngIf="this['showTopology_' + topology.topology]">
@@ -76,3 +85,4 @@
     </div>
 </ng-container>
 <hr />
+</div>

--- a/knox-homepage-ui/home/app/topologies/topology.information.component.ts
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.ts
@@ -34,7 +34,7 @@ export class TopologyInformationsComponent implements OnInit {
     setTopologies(topologies: TopologyInformation[]) {
         this.topologies = topologies;
         for (let topology of topologies) {
-            this['showTopology_' + topology.topology] = false;
+            this['showTopology_' + topology.topology] = topology.pinned;
         }
     }
 
@@ -46,7 +46,9 @@ export class TopologyInformationsComponent implements OnInit {
         this[enableServiceText] = true;
     }
 
-    constructor(private homepageService: HomepageService) {}
+    constructor(private homepageService: HomepageService) {
+        this['showTopologies'] = true;
+    }
 
     ngOnInit(): void {
         console.debug('TopologyInformationsComponent --> ngOnInit()');

--- a/knox-homepage-ui/home/app/topologies/topology.information.ts
+++ b/knox-homepage-ui/home/app/topologies/topology.information.ts
@@ -18,6 +18,7 @@ import {Service} from './service';
 
 export class TopologyInformation {
     topology: string;
+    pinned: boolean;
     apiServices: Service[];
     uiServices: Service[];
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduced a new property in `gateway-site.xml` called `knox.homepage.pinned.topologies`. This is a comma-separated list of topology names indicating they should be pinned on the Home Page. If a topology is pinned it's going to be expanded when opening the home page.
The order of the topologies are fixed as follows:
1. pinned topologies come first
2. topologies are sorted in alphabetical order

I made the `General Proxy Information` and `Topologies` sections expandable/collapsable too and made sure the first section is collapsed by default.

On the Home page, you'll see an icon next to the topology name:
- either a pushpin: if the topology is pinned. This is a tooltip icon with a meaningful description of how to make the topology un-pinned.
- or a cog: if the topology is un-pinned. This is a tooltip icon with a meaningful description of how to make the topology pinned.

## How was this patch tested?

Tested manually:
1. re-deployed Knox with my changes
2. added the following property in `gateway-site.xml` before started Knox
```
    <property>
        <name>knox.homepage.pinned.topologies</name>
        <value>sandbox, sandboxSandorPinned</value>
    </property>
```
3. Started Knox and created two new topologies: `sandboxSandorPinned ` and `aTestDescriptorNotPinned `
4. Opened the Home page (the`sandboxSandorPinned ` was expanded by default, I collapsed it to make sure the  `aTestDescriptorNotPinned ` is on the screenshot too):
<img width="1667" alt="Screen Shot 2020-05-06 at 1 51 41 PM" src="https://user-images.githubusercontent.com/34065904/81174356-fe77eb80-8fa1-11ea-8a16-12106717b970.png">
