### PR TITLE
KNOX-2376 Ensure all HBASEJARS IN rules are for /hbase/jars and not /…

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/rewrite.xml
@@ -15,17 +15,8 @@
    limitations under the License.
 -->
 <rules>
-  <!-- jetty-dir.css is special in that it's not so much a CSS file, but the ResourceHandler
-       will always link to it in the current directory. We can refer to it at the static path though. -->
-  <rule dir="IN" name="HBASEJARS/path/in/css" pattern="*://*:*/**/hbase/maven/jetty-dir.css">
-    <rewrite template="{$serviceUrl[HBASEJARS]}/jetty-dir.css"/>
-  </rule>
-  <rule dir="OUT" name="HBASEJARS/path/out/css" pattern="jetty-dir.css">
-    <rewrite template="{$frontend[url]}/hbase/maven/jetty-dir.css"/>
-  </rule>
-
   <!-- Root location -->
-  <rule dir="IN" name="HBASEJARS/inbound/jars" pattern="*://*:*/**/hbase/maven">
+  <rule dir="IN" name="HBASEJARS/inbound/jars" pattern="*://*:*/**/hbase/jars">
     <rewrite template="{$serviceUrl[HBASEJARS]}/"/>
   </rule>
   <!-- Jetty ResourceHandler issues HTTP/302 redirects to the same path with trailing slash
@@ -37,13 +28,13 @@
   </filter>
   <rule dir="OUT" name="HBASEJARS/outbound/jars/headers-redirect">
     <match pattern="*://*:*/static/maven/{path=**}?{**}"/>
-    <rewrite template="{$frontend[url]}/hbase/maven/{path=**}/"/>
+    <rewrite template="{$frontend[url]}/hbase/jars/{path=**}/"/>
   </rule>
   <!-- Regex to match everything -->
-  <rule dir="IN" name="HBASEJARS/inbound/jars/path" pattern="*://*:*/**/hbase/maven/{**}">
+  <rule dir="IN" name="HBASEJARS/inbound/jars/path" pattern="*://*:*/**/hbase/jars/{**}">
     <rewrite template="{$serviceUrl[HBASEJARS]}/{**}"/>
   </rule>
   <rule dir="OUT" name="HBASEJARS/outbound/jars" pattern="/static/maven/{**}">
-    <rewrite template="{$frontend[url]}/hbase/maven/{**}"/>
+    <rewrite template="{$frontend[url]}/hbase/jars/{**}"/>
   </rule>
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbasejars/2.2.0/service.xml
@@ -17,22 +17,20 @@
 <service role="HBASEJARS" name="hbasejars" version="2.2.0">
     <metadata>
         <type>API</type>
-        <context>/hbase/maven</context>
+        <context>/hbase/jars</context>
         <shortDesc>Jar hosting for HBase</shortDesc>
         <description>Static hosting of HBase client jars from the backend HBase UI.</description>
     </metadata>
+    <!-- This service assumes that HBase UI is hosting a "mini" maven repo at
+      http://<hbase-master>:16010/static/maven and we expose this via Knox
+      at https://<knox>/sandbox/topology/hbase/jars -->
     <routes>
-        <!-- Jetty static resources won't come with the query string -->
-        <route path="/hbase/maven/jetty-dir.css">
-            <rewrite apply="HBASEJARS/path/in/css" to="request.url"/>
-            <rewrite apply="HBASEJARS/path/out/css" to="response.body"/>
-        </route>
         <!-- Define routes for our embedded maven repo -->
-        <route path="/hbase/maven">
+        <route path="/hbase/jars">
            <rewrite apply="HBASEJARS/inbound/jars" to="request.url"/>
            <rewrite apply="HBASEJARS/outbound/jars" to="response.body"/>
         </route>
-        <route path="/hbase/maven/**">
+        <route path="/hbase/jars/**">
           <rewrite apply="HBASEJARS/inbound/jars/path" to="request.url"/>
           <rewrite apply="HBASEJARS/outbound/jars" to="response.body"/>
           <!-- For the Jetty HTTP/302 redirects -->


### PR DESCRIPTION
…hbase/maven

## What changes were proposed in this pull request?

Looks like I was getting turned around the first time, confusing what is
an internal path (HBase UI) and what is an external path (Knox gateway path).
This fixes the service such that we're always coming in to Knox at /hbase/jars
and always going "out" (to hbase ui) as /static/maven.

Further, because we expect this to be deployed as an API (rather than a
UI), we can do away with the rules to render the quirky jetty-dir.css.

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## How was this patch tested?

Modified a Knox installation that has this set up, touched the topology and restarted the gateway to ensure it was redeployed. Validated that a maven application could pull the jar(s) required through Knox.