### PR TITLE
KNOX-2378 - AliasBasedTokenStateService log message is misleading

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -100,7 +100,10 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService {
     for (TokenState state : processing) {
       tokenIds.add(state.getTokenId());
       aliases.put(state.getAlias(), state.getAliasValue());
-      log.creatingTokenStateAliases(state.getTokenId());
+    }
+
+    for (String tokenId: tokenIds) {
+      log.creatingTokenStateAliases(tokenId);
     }
 
     // Write aliases in a batch


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logging change to be more accurate. As it was, the same log message was being emitted twice for every token.

## How was this patch tested?

Full build/tests, and then manually verified the logging change.