### PR TITLE
KNOX-2381 racking UI of flink session is broken in YARNUIV2

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -259,7 +259,7 @@
   </rule>
 
   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/proxy" pattern="*://*:*/proxy/{**}">
-    <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}"/>
+    <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}/"/>
   </rule>
 
   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/cluster/apps" pattern="*://*:*/cluster/app/{**}">


### PR DESCRIPTION
A fix for a missing trailing '/' issue in YARNUIV2 that already fixed in YARNUI see [KNOX-2074](https://issues.apache.org/jira/browse/KNOX-2074)

## How was this patch tested?
Manually see the attached screenshot
![image](https://user-images.githubusercontent.com/53612764/84054978-775ccf80-a9b4-11ea-92be-a022ae27470b.png)
