### PR TITLE
KNOX-2384 - Token Service should return expiration from token when re…

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -74,4 +74,7 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.DEBUG, text = "Knox Token service ({0}) stored state for token {1} ({2})")
   void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 
+  @Message( level = MessageLevel.WARN,
+          text = "Renewal is disabled for the Knox Token service ({0}). Responding with the expiration from the token {1} ({2})")
+  void renewalDisabled(String topologyName, String tokenDisplayText, String tokenId);
 }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -704,20 +704,54 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRenewal_ServerManagedStateEnabledAtGatewayWithServiceOverride() throws Exception {
     final String caller = "yarn";
-    Response renewalResponse = doTestTokenRenewal(false, true, caller, null, createTestSubject(caller)).getValue();
-    validateRenewalResponse(renewalResponse, 400, false, "Token renewal support is not configured");
+    Map.Entry<TestTokenStateService, Response> result =
+            doTestTokenRenewal(false, true, caller, null, createTestSubject(caller));
+
+    // Make sure the expiration was not recorded by the TokenStateService, since it is disabled for this test
+    TestTokenStateService tss = result.getKey();
+    assertEquals("TokenStateService should be disabled for this test.", 0, tss.expirationData.size());
+
+    Response renewalResponse = result.getValue();
+    validateSuccessfulRenewalResponse(renewalResponse);
+    String responseContent = (String) renewalResponse.getEntity();
+    assertNotNull(responseContent);
+    Map<String, String> json = parseJSONResponse(responseContent);
+    assertTrue(Boolean.parseBoolean(json.get("renewed")));
+    assertNotNull(json.get("expires")); // Should get back the original expiration from the token itself
   }
 
   @Test
   public void testTokenRenewal_ServerManagedStateNotConfiguredAtAll() throws Exception {
-    Response renewalResponse = doTestTokenRenewal(null, null, null, null, null).getValue();
-    validateRenewalResponse(renewalResponse, 400, false, "Token renewal support is not configured");
+    Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(null, null, null, null, null);
+
+    // Make sure the expiration was not recorded by the TokenStateService, since it is disabled for this test
+    TestTokenStateService tss = result.getKey();
+    assertEquals("TokenStateService should be disabled for this test.", 0, tss.expirationData.size());
+
+    Response renewalResponse = result.getValue();
+    validateSuccessfulRenewalResponse(renewalResponse);
+    String responseContent = (String) renewalResponse.getEntity();
+    assertNotNull(responseContent);
+    Map<String, String> json = parseJSONResponse(responseContent);
+    assertTrue(Boolean.parseBoolean(json.get("renewed")));
+    assertNotNull(json.get("expires")); // Should get back the original expiration from the token itself
   }
 
   @Test
   public void testTokenRenewal_Disabled() throws Exception {
-    Response renewalResponse = doTestTokenRenewal(false, null, null);
-    validateRenewalResponse(renewalResponse, 400, false, "Token renewal support is not configured");
+    Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(false, null, null, null);
+
+    // Make sure the expiration was not recorded by the TokenStateService, since it is disabled for this test
+    TestTokenStateService tss = result.getKey();
+    assertEquals("TokenStateService should be disabled for this test.", 0, tss.expirationData.size());
+
+    Response renewalResponse = result.getValue();
+    validateSuccessfulRenewalResponse(renewalResponse);
+    String responseContent = (String) renewalResponse.getEntity();
+    assertNotNull(responseContent);
+    Map<String, String> json = parseJSONResponse(responseContent);
+    assertTrue(Boolean.parseBoolean(json.get("renewed")));
+    assertNotNull(json.get("expires")); // Should get back the original expiration from the token itself
   }
 
   @Test


### PR DESCRIPTION
…newal disabled

## What changes were proposed in this pull request?

Rather than responding with a 400 Bad Request when server-managed token state is disabled, renewal requests should respond with the expiration from the token being renewed.

## How was this patch tested?

Updated existing tests, and perfomed manual testing.