### PR TITLE
KNOX-2385 Flink Dashboard (History Server) Support

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/flink/1.10.1/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/flink/1.10.1/rewrite.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule name="FLINK/flink/inbound/root" pattern="*://*:*/**/flink/">
+        <rewrite template="{$serviceUrl[FLINK]}/"/>
+    </rule>
+    <rule name="FLINK/flink/inbound/path" pattern="*://*:*/**/flink/{**}">
+        <rewrite template="{$serviceUrl[FLINK]}/{**}"/>
+    </rule>
+    <rule name="FLINK/flink/inbound/query" pattern="*://*:*/**/flink/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[FLINK]}/{path=**}?{**}"/>
+    </rule>
+    <rule dir="OUT" name="FLINK/flink/outbound/links">
+        <match pattern="*://*:*/proxy/{**}"/>
+        <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}/"/>
+    </rule>
+    <filter name="FLINK/flink/outbound/json">
+        <content type="*/json">
+            <apply path="$.jobs[*].cluster.url" rule="FLINK/flink/outbound/links"/>
+        </content>
+    </filter>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/flink/1.10.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/flink/1.10.1/service.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service name="flink" role="FLINK" version="1.10.1">
+    <metadata>
+        <context>/flink</context>
+        <description>The Flink Dashboard acts as a single UI for all the Flink jobs running on the YARN cluster.</description>
+        <shortDesc>Flink Dashboard</shortDesc>
+        <type>UI</type>
+    </metadata>
+    <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch" use-two-way-ssl="false">
+        <param>
+            <name>responseExcludeHeaders</name>
+            <value>CONTENT-LENGTH</value>
+        </param>
+    </dispatch>
+    <routes>
+        <route path="/flink/"/>
+        <route path="/flink/**"/>
+        <route path="/flink/**?**"/>
+        <route path="/flink/jobs/overview">
+            <rewrite apply="FLINK/flink/outbound/json" to="response.body"/>
+        </route>
+    </routes>
+</service>


### PR DESCRIPTION
This change provides support for Apache Flink Dashboard (a.k.a Flink History Server )
## How was this patch tested?
Manual Testing

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
