### PR TITLE
KNOX-2386 - Added CM service discovery support for Apache Flink

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGenerator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.model.flink;
+
+import java.util.Locale;
+
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel.Type;
+import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGenerator;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+
+public class FlinkServiceModelGenerator extends AbstractServiceModelGenerator {
+
+  static final String SERVICE = "FLINK";
+  static final String SERVICE_TYPE = "FLINK";
+  static final String ROLE_TYPE = "FLINK_HISTORY_SERVER";
+
+  static final String SSL_ENABLED = "ssl_enabled";
+  static final String WEB_PORT = "historyserver_web_port";
+
+  @Override
+  public String getService() {
+    return SERVICE;
+  }
+
+  @Override
+  public String getServiceType() {
+    return SERVICE_TYPE;
+  }
+
+  @Override
+  public String getRoleType() {
+    return ROLE_TYPE;
+  }
+
+  @Override
+  public Type getModelType() {
+    return ServiceModel.Type.UI;
+  }
+
+  @Override
+  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException {
+    final String hostname = role.getHostRef().getHostname();
+    final String port = getRoleConfigValue(roleConfig, WEB_PORT);
+    final boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));
+    final String scheme = sslEnabled ? "https" : "http";
+
+    final ServiceModel model = createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s", scheme, hostname, port));
+    model.addRoleProperty(getRoleType(), SSL_ENABLED, Boolean.toString(sslEnabled));
+    model.addRoleProperty(getRoleType(), WEB_PORT, port);
+
+    return model;
+  }
+
+}

--- a/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
+++ b/gateway-discovery-cm/src/main/resources/META-INF/services/org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator
@@ -18,6 +18,7 @@
 
 org.apache.knox.gateway.topology.discovery.cm.model.atlas.AtlasServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.atlas.AtlasAPIServiceModelGenerator
+org.apache.knox.gateway.topology.discovery.cm.model.flink.FlinkServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hbase.HBaseUIServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hbase.WebHBaseServiceModelGenerator
 org.apache.knox.gateway.topology.discovery.cm.model.hdfs.NameNodeServiceModelGenerator

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGeneratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.model.flink;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGeneratorTest;
+import org.junit.Test;
+
+public class FlinkServiceModelGeneratorTest extends AbstractServiceModelGeneratorTest {
+  @Test
+  public void testServiceModelMetadata() {
+    final Map<String, String> serviceConfig = Collections.emptyMap();
+    final Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(FlinkServiceModelGenerator.SSL_ENABLED, "true");
+    roleConfig.put(FlinkServiceModelGenerator.WEB_PORT, "8082");
+
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+  }
+
+  @Override
+  protected String getServiceType() {
+    return FlinkServiceModelGenerator.SERVICE_TYPE;
+  }
+
+  @Override
+  protected String getRoleType() {
+    return FlinkServiceModelGenerator.ROLE_TYPE;
+  }
+
+  @Override
+  protected FlinkServiceModelGenerator newGenerator() {
+    return new FlinkServiceModelGenerator();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added CM service discovery support for Apache Flink

## How was this patch tested?

Unit testing:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18:09 min (Wall Clock)
[INFO] Finished at: 2020-06-11T14:17:20+02:00
[INFO] Final Memory: 429M/2075M
[INFO] ------------------------------------------------------------------------
```

Manual testing:
1. deployed Knox with my changes in a running CM cluster
2. updated `Flink Dashboard Port` from 8082 to 9999 and restarted Flink
3. Confirmed that Knox picked-up the change:
```
2020-06-11 04:55:39,891 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getCurrentServiceConfiguration(470)) - Getting current configuration for FLINK-1 from Cluster 1 @ https://MY_CM__HOST:7183
2020-06-11 04:55:40,059 DEBUG discovery.cm (PollingConfigurationAnalyzer.java:hasConfigChanged(250)) - Analyzing current FLINK-1 configuration for changes...
2020-06-11 04:55:40,059 INFO  discovery.cm (PollingConfigurationAnalyzer.java:hasConfigurationChanged(539)) - Role property historyserver_web_port value has changed from 8082 to 9999
2020-06-11 04:55:40,059 INFO  knox.gateway (DefaultTopologyService.java:onConfigurationChange(968)) - A cluster configuration change was noticed for Cluster 1 @ https://MY_CM__HOST:7183
2020-06-11 04:55:40,066 INFO  knox.gateway (DefaultTopologyService.java:onConfigurationChange(976)) - Triggering topology regeneration for descriptor /var/lib/knox/gateway/conf/descriptors/cdp-proxy.json because of change to the Cluster 1 @ https://MY_CM__HOST:7183 configuration.
```
4. Confirmed that Flink Dashboard was reachable from `cdp-proxy`:
<img width="1678" alt="Screen Shot 2020-06-11 at 1 56 50 PM" src="https://user-images.githubusercontent.com/34065904/84387449-4a4a3000-abf3-11ea-958f-6434dcbac1de.png">


