### PR TITLE
KNOX-2377 - Address potential loss of token state

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -97,4 +97,34 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.INFO, text = "Removed token state aliases for {0}")
   void removedTokenStateAliases(String tokenId);
 
+  @Message(level = MessageLevel.INFO, text = "Loading peristed token state journal entries")
+  void loadingPersistedJournalEntries();
+
+  @Message(level = MessageLevel.DEBUG, text = "Loaded peristed token state journal entry for {0}")
+  void loadedPersistedJournalEntry(String tokenId);
+
+  @Message(level = MessageLevel.ERROR, text = "The peristed token state journal entry {0} is empty")
+  void emptyJournalEntry(String journalEntryName);
+
+  @Message(level = MessageLevel.INFO, text = "Added token state journal entry for {0}")
+  void addedJournalEntry(String tokenId);
+
+  @Message(level = MessageLevel.INFO, text = "Removed token state journal entry for {0}")
+  void removedJournalEntry(String tokenId);
+
+  @Message(level = MessageLevel.INFO, text = "Token state journal entry not found for {0}")
+  void journalEntryNotFound(String tokenId);
+
+  @Message(level = MessageLevel.DEBUG, text = "Persisting token state journal entry as {0}")
+  void persistingJournalEntry(String journalEntryFilename);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to persisting token state journal entry for {0} : {1}")
+  void failedToPersistJournalEntry(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to add a token state journal entry for {0} : {1}")
+  void failedToAddJournalEntry(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to remove the token state journal entry for {0} : {1}")
+  void failedToRemoveJournalEntry(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournal.java
@@ -1,0 +1,221 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.impl.state;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.token.state.JournalEntry;
+import org.apache.knox.gateway.services.token.state.TokenStateJournal;
+import org.apache.knox.gateway.services.token.impl.TokenStateServiceMessages;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Base class for TokenStateJournal implementations that employ files for persistence.
+ */
+abstract class FileTokenStateJournal implements TokenStateJournal {
+
+    protected static final int INDEX_TOKEN_ID     = 0;
+    protected static final int INDEX_ISSUE_TIME   = 1;
+    protected static final int INDEX_EXPIRATION   = 2;
+    protected static final int INDEX_MAX_LIFETIME = 3;
+
+    protected static final TokenStateServiceMessages log = MessagesFactory.get(TokenStateServiceMessages.class);
+
+    // The name of the journal directory
+    protected static final String JOURNAL_DIR_NAME = "token-state";
+
+    /**
+     * The journal directory path
+     */
+    protected final Path journalDir;
+
+    protected FileTokenStateJournal(GatewayConfig config) throws IOException {
+        journalDir = Paths.get(config.getGatewaySecurityDir(), JOURNAL_DIR_NAME);
+        if (!Files.exists(journalDir)) {
+            Files.createDirectories(journalDir);
+        }
+    }
+
+    @Override
+    public abstract void add(String tokenId, long issueTime, long expiration, long maxLifetime) throws IOException;
+
+    @Override
+    public void add(JournalEntry entry) throws IOException {
+        add(Collections.singletonList(entry));
+    }
+
+    @Override
+    public abstract void add(List<JournalEntry> entries) throws IOException;
+
+    @Override
+    public List<JournalEntry> get() throws IOException {
+        return loadJournal();
+    }
+
+    @Override
+    public abstract JournalEntry get(String tokenId) throws IOException;
+
+    @Override
+    public void remove(final String tokenId) throws IOException {
+        remove(Collections.singleton(tokenId));
+    }
+
+    @Override
+    public abstract void remove(Collection<String> tokenIds) throws IOException;
+
+    @Override
+    public void remove(final JournalEntry entry) throws IOException {
+        remove(entry.getTokenId());
+    }
+
+    protected abstract List<JournalEntry> loadJournal() throws IOException;
+
+    protected List<FileJournalEntry> loadJournal(FileChannel channel) throws IOException {
+        List<FileJournalEntry> entries = new ArrayList<>();
+
+        try (InputStream input = Channels.newInputStream(channel)) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                entries.add(FileJournalEntry.parse(line));
+            }
+        }
+
+        return entries;
+    }
+
+    /**
+     * Parse the String representation of an entry.
+     *
+     * @param entry A journal file entry line
+     *
+     * @return A FileJournalEntry object created from the specified entry.
+     */
+    protected FileJournalEntry parse(final String entry) {
+        return FileJournalEntry.parse(entry);
+    }
+
+    /**
+     * A JournalEntry implementation for File-based TokenStateJournal implementations
+     */
+    static final class FileJournalEntry implements JournalEntry {
+        private final String tokenId;
+        private final String issueTime;
+        private final String expiration;
+        private final String maxLifetime;
+
+        FileJournalEntry(final String tokenId, long issueTime, long expiration, long maxLifetime) {
+            this(tokenId, String.valueOf(issueTime), String.valueOf(expiration), String.valueOf(maxLifetime));
+        }
+
+        FileJournalEntry(final String tokenId,
+                         final String issueTime,
+                         final String expiration,
+                         final String maxLifetime) {
+            this.tokenId = tokenId;
+            this.issueTime = issueTime;
+            this.expiration = expiration;
+            this.maxLifetime = maxLifetime;
+        }
+
+        @Override
+        public String getTokenId() {
+            return tokenId;
+        }
+
+        @Override
+        public String getIssueTime() {
+            return issueTime;
+        }
+
+        @Override
+        public String getExpiration() {
+            return expiration;
+        }
+
+        @Override
+        public String getMaxLifetime() {
+            return maxLifetime;
+        }
+
+        @Override
+        public String toString() {
+            String[] elements = new String[4];
+
+            elements[INDEX_TOKEN_ID] = getTokenId();
+
+            String issueTime = getIssueTime();
+            elements[INDEX_ISSUE_TIME] = (issueTime != null) ? issueTime : "";
+
+            String expiration = getExpiration();
+            elements[INDEX_EXPIRATION] = (expiration != null) ? expiration : "";
+
+            String maxLifetime = getMaxLifetime();
+            elements[INDEX_MAX_LIFETIME] = (maxLifetime != null) ? maxLifetime : "";
+
+            return String.format(Locale.ROOT,
+                                 "%s,%s,%s,%s",
+                                 elements[INDEX_TOKEN_ID],
+                                 elements[INDEX_ISSUE_TIME],
+                                 elements[INDEX_EXPIRATION],
+                                 elements[INDEX_MAX_LIFETIME]);
+        }
+
+        /**
+          * Parse the String representation of an entry.
+          *
+          * @param entry A journal file entry line
+          *
+          * @return A FileJournalEntry object created from the specified entry.
+          */
+        static FileJournalEntry parse(final String entry) {
+            String[] elements = entry.split(",");
+            if (elements.length < 4) {
+                throw new IllegalArgumentException("Invalid journal entry: " + entry);
+            }
+
+            String tokenId     = elements[INDEX_TOKEN_ID].trim();
+            String issueTime   = elements[INDEX_ISSUE_TIME].trim();
+            String expiration  = elements[INDEX_EXPIRATION].trim();
+            String maxLifetime = elements[INDEX_MAX_LIFETIME].trim();
+
+            return new FileJournalEntry(tokenId.isEmpty() ? null : tokenId,
+                                        issueTime.isEmpty() ? null : issueTime,
+                                        expiration.isEmpty() ? null : expiration,
+                                        maxLifetime.isEmpty() ? null : maxLifetime);
+        }
+
+    }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournal.java
@@ -1,0 +1,142 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.impl.state;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.token.state.JournalEntry;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A TokenStateJournal implementation that manages separate files for token state.
+ */
+class MultiFileTokenStateJournal extends FileTokenStateJournal {
+
+    // File extension for journal entry files
+    static final String ENTRY_FILE_EXT = ".ts";
+
+    // Filter used when listing all journal entry files in the journal directory
+    static final String ENTRY_FILE_EXT_FILTER = "*" + ENTRY_FILE_EXT;
+
+    MultiFileTokenStateJournal(GatewayConfig config) throws IOException {
+        super(config);
+    }
+
+    @Override
+    public void add(final String tokenId, long issueTime, long expiration, long maxLifetime) throws IOException {
+        add(Collections.singletonList(new FileJournalEntry(tokenId, issueTime, expiration, maxLifetime)));
+    }
+
+    @Override
+    public void add(final List<JournalEntry> entries) throws IOException {
+        // Persist each journal entry as an individual file in the journal directory
+        for (JournalEntry entry : entries) {
+            final Path entryFile = journalDir.resolve(entry.getTokenId() + ENTRY_FILE_EXT);
+            log.persistingJournalEntry(entryFile.toString());
+            try (FileChannel fileChannel = FileChannel.open(entryFile, StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                fileChannel.lock();
+                try (OutputStream out = Channels.newOutputStream(fileChannel)) {
+                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+                    writer.write(entry.toString());
+                    writer.newLine();
+                    writer.flush();
+                }
+                log.addedJournalEntry(entry.getTokenId());
+            } catch (IOException e){
+                log.failedToPersistJournalEntry(entry.getTokenId(), e);
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public JournalEntry get(final String tokenId) throws IOException {
+        JournalEntry result = null;
+
+        Path entryFilePath = journalDir.resolve(tokenId + ENTRY_FILE_EXT);
+        if (Files.exists(entryFilePath)) {
+            try (FileChannel fileChannel = FileChannel.open(entryFilePath, StandardOpenOption.READ)) {
+                fileChannel.lock(0L, Long.MAX_VALUE, true);
+                List<FileJournalEntry> entries = loadJournal(fileChannel);
+                if (entries.isEmpty()) {
+                    log.journalEntryNotFound(tokenId);
+                } else {
+                    result = entries.get(0);
+                }
+            }
+        } else {
+            log.journalEntryNotFound(tokenId);
+        }
+
+        return result;
+    }
+
+    @Override
+    public void remove(final Collection<String> tokenIds) throws IOException {
+        // Remove the journal entry files corresponding to the specified token identifiers
+        for (String tokenId : tokenIds) {
+            Path entryFilePath = journalDir.resolve(tokenId + ENTRY_FILE_EXT);
+            if (Files.exists(entryFilePath)) {
+                Files.delete(entryFilePath);
+                log.removedJournalEntry(tokenId);
+            }
+        }
+    }
+
+    @Override
+    protected List<JournalEntry> loadJournal() throws IOException {
+        List<JournalEntry> entries = new ArrayList<>();
+
+        // List all the journal entry files in the directory, and create journal entries for them
+        if (Files.exists(journalDir)) {
+            log.loadingPersistedJournalEntries();
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(journalDir, ENTRY_FILE_EXT_FILTER)) {
+                for (Path entryFilePath : stream ) {
+                    try (FileChannel fileChannel = FileChannel.open(entryFilePath, StandardOpenOption.READ)) {
+                        fileChannel.lock(0L, Long.MAX_VALUE, true);
+                        entries.addAll(loadJournal(fileChannel));
+                        if (entries.isEmpty()) {
+                            log.emptyJournalEntry(entryFilePath.toString());
+                        } else {
+                            // Should only be a single entry for this implementation
+                            log.loadedPersistedJournalEntry(entries.get(0).getTokenId());
+                        }
+                    }
+                }
+            }
+        }
+
+        return entries;
+    }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/TokenStateJournalFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/TokenStateJournalFactory.java
@@ -1,0 +1,32 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.impl.state;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.token.state.TokenStateJournal;
+
+import java.io.IOException;
+
+public class TokenStateJournalFactory {
+
+    public static TokenStateJournal create(GatewayConfig config) throws IOException {
+        return new MultiFileTokenStateJournal(config);
+    }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/JournalEntry.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/JournalEntry.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements. See the NOTICE file distributed with this
+ *  * work for additional information regarding copyright ownership. The ASF
+ *  * licenses this file to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.state;
+
+/**
+ * An entry in the TokenStateJournal
+ */
+public interface JournalEntry {
+
+    /**
+     *
+     * @return The unique token identifier for which this entry is defined.
+     */
+    String getTokenId();
+
+    /**
+     *
+     * @return The token's issue time (milliseconds since the epoch) as a String.
+     */
+    String getIssueTime();
+
+    /**
+     *
+     * @return The token's expiration time (milliseconds since the epoch) as a String.
+     */
+    String getExpiration();
+
+    /**
+     * The token's maximum allowed lifetime, beyond which its expiration cannot be extended,
+     * (milliseconds since the epoch) as a String.
+     *
+     * @return The token's maximum allowed lifetime
+     */
+    String getMaxLifetime();
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/TokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/TokenStateJournal.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements. See the NOTICE file distributed with this
+ *  * work for additional information regarding copyright ownership. The ASF
+ *  * licenses this file to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.state;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ *
+ */
+public interface TokenStateJournal {
+
+    /**
+     * Persist the token state to the journal.
+     *
+     * @param tokenId     The unique token identifier
+     * @param issueTime   The issue timestamp
+     * @param expiration  The expiration time
+     * @param maxLifetime The maximum allowed lifetime
+     */
+    void add(String tokenId, long issueTime, long expiration, long maxLifetime)
+        throws IOException;
+
+    /**
+     * Persist the token state to the journal.
+     *
+     * @param entry The entry to persist
+     */
+    void add(JournalEntry entry) throws IOException;
+
+    /**
+     * Persist the token state to the journal.
+     *
+     * @param entries The entries to persist
+     */
+    void add(List<JournalEntry> entries) throws IOException;
+
+    /**
+     * Get the journaled state for the specified token identifier.
+     *
+     * @param tokenId The unique token identifier.
+     *
+     * @return A JournalEntry with the specified token's journaled state.
+     */
+    JournalEntry get(String tokenId) throws IOException;
+
+    /**
+     * Get all the the journaled tokens' state.
+     *
+     * @return A List of JournalEntry objects.
+     */
+    List<JournalEntry> get() throws IOException;
+
+    /**
+     * Remove the token state for the specified token from the journal
+     *
+     * @param tokenId The unique token identifier
+     */
+    void remove(String tokenId) throws IOException;
+
+    /**
+     * Remove the token state for the specified tokens from the journal
+     *
+     * @param tokenIds A set of unique token identifiers
+     */
+    void remove(Collection<String> tokenIds) throws IOException;
+
+    /**
+     * Remove the token state for the specified journal entry
+     *
+     * @param entry A JournalEntry for the token for which the state should be removed
+     */
+    void remove(JournalEntry entry) throws IOException;
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/AbstractFileTokenStateJournalTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/AbstractFileTokenStateJournalTest.java
@@ -1,0 +1,230 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.impl.state;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
+import org.apache.knox.gateway.services.token.state.JournalEntry;
+import org.apache.knox.gateway.services.token.state.TokenStateJournal;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public abstract class AbstractFileTokenStateJournalTest {
+
+    @Rule
+    public final TemporaryFolder testFolder = new TemporaryFolder();
+
+    abstract TokenStateJournal createTokenStateJournal(GatewayConfig config) throws IOException;
+
+    protected JournalEntry createTestJournalEntry(final String tokenId,
+                                                        long issueTime,
+                                                        long expiration,
+                                                        long maxLifetime) {
+        return new FileTokenStateJournal.FileJournalEntry(tokenId, issueTime, expiration, maxLifetime);
+    }
+
+    protected GatewayConfig getGatewayConfig() throws IOException {
+        final Path dataDir = testFolder.newFolder().toPath();
+        System.out.println("dataDir : " + dataDir.toString());
+        Files.createDirectories(dataDir.resolve("security")); // Make sure the security directory exists
+
+        GatewayConfigImpl config = new GatewayConfigImpl();
+        config.set("gateway.data.dir", dataDir.toString());
+        return config;
+    }
+
+    @Test
+    public void testSingleTokenRoundTrip() throws Exception {
+        GatewayConfig config = getGatewayConfig();
+
+        TokenStateJournal journal = createTokenStateJournal(config);
+
+        final String tokenId = String.valueOf(UUID.randomUUID());
+
+        // Verify that the token state has not yet been journaled
+        assertNull(journal.get(tokenId));
+
+        long issueTime = System.currentTimeMillis();
+        long expiration = issueTime + TimeUnit.MINUTES.toMillis(5);
+        long maxLifetime = issueTime + (5 * TimeUnit.MINUTES.toMillis(5));
+        journal.add(tokenId, issueTime, expiration, maxLifetime);
+
+        // Get the token state from the journal, and validate its contents
+        JournalEntry entry = journal.get(tokenId);
+        assertNotNull(entry);
+        assertEquals(tokenId, entry.getTokenId());
+        assertEquals(issueTime, Long.parseLong(entry.getIssueTime()));
+        assertEquals(expiration, Long.parseLong(entry.getExpiration()));
+        assertEquals(maxLifetime, Long.parseLong(entry.getMaxLifetime()));
+
+        journal.remove(tokenId);
+
+        // Verify that the token state can no longer be gotten from the journal
+        assertNull(journal.get(tokenId));
+    }
+
+    @Test
+    public void testUpdateTokenState() throws Exception {
+        GatewayConfig config = getGatewayConfig();
+
+        TokenStateJournal journal = createTokenStateJournal(config);
+
+        final String tokenId = String.valueOf(UUID.randomUUID());
+
+        // Verify that the token state has not yet been journaled
+        assertNull(journal.get(tokenId));
+
+        long issueTime = System.currentTimeMillis();
+        long expiration = issueTime + TimeUnit.MINUTES.toMillis(5);
+        long maxLifetime = issueTime + (5 * TimeUnit.MINUTES.toMillis(5));
+        journal.add(tokenId, issueTime, expiration, maxLifetime);
+
+        // Get the token state from the journal, and validate its contents
+        JournalEntry entry = journal.get(tokenId);
+        assertNotNull(entry);
+        assertEquals(tokenId, entry.getTokenId());
+        assertEquals(issueTime, Long.parseLong(entry.getIssueTime()));
+        assertEquals(expiration, Long.parseLong(entry.getExpiration()));
+        assertEquals(maxLifetime, Long.parseLong(entry.getMaxLifetime()));
+
+        long updatedExpiration = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
+        journal.add(tokenId, issueTime, updatedExpiration, maxLifetime);
+
+        // Get and validate the updated token state
+        entry = journal.get(tokenId);
+        assertNotNull(entry);
+        assertEquals(tokenId, entry.getTokenId());
+        assertEquals(issueTime, Long.parseLong(entry.getIssueTime()));
+        assertEquals(updatedExpiration, Long.parseLong(entry.getExpiration()));
+        assertEquals(maxLifetime, Long.parseLong(entry.getMaxLifetime()));
+
+        // Verify that the token state can no longer be gotten from the journal
+        journal.remove(tokenId);
+        assertNull(journal.get(tokenId));
+    }
+
+    @Test
+    public void testSingleJournalEntryRoundTrip() throws Exception {
+        GatewayConfig config = getGatewayConfig();
+
+        TokenStateJournal journal = createTokenStateJournal(config);
+
+        final String tokenId = String.valueOf(UUID.randomUUID());
+
+        // Verify that the token state has not yet been journaled
+        assertNull(journal.get(tokenId));
+
+        long issueTime = System.currentTimeMillis();
+        long expiration = issueTime + TimeUnit.MINUTES.toMillis(5);
+        long maxLifetime = issueTime + (5 * TimeUnit.MINUTES.toMillis(5));
+        JournalEntry original = createTestJournalEntry(tokenId, issueTime, expiration, maxLifetime);
+        journal.add(original);
+
+        // Get the token state from the journal, and validate its contents
+        JournalEntry entry = journal.get(tokenId);
+        assertNotNull(entry);
+        assertEquals(original.getTokenId(), entry.getTokenId());
+        assertEquals(original.getIssueTime(), entry.getIssueTime());
+        assertEquals(original.getExpiration(), entry.getExpiration());
+        assertEquals(original.getMaxLifetime(), entry.getMaxLifetime());
+
+        journal.remove(entry);
+
+        // Verify that the token state can no longer be gotten from the journal
+        assertNull(journal.get(tokenId));
+    }
+
+    @Test
+    public void testMultipleTokensRoundTrip() throws Exception {
+        GatewayConfig config = getGatewayConfig();
+
+        TokenStateJournal journal = createTokenStateJournal(config);
+
+        final List<String> tokenIds = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            tokenIds.add(String.valueOf(UUID.randomUUID()));
+        }
+
+        Map<String, JournalEntry> journalEntries = new HashMap<>();
+
+        // Verify that the token state has not yet been journaled, and create a JournalEntry for it
+        for (String tokenId : tokenIds) {
+            assertNull(journal.get(tokenId));
+
+            long issueTime = System.currentTimeMillis();
+            long expiration = issueTime + TimeUnit.MINUTES.toMillis(5);
+            long maxLifetime = issueTime + (5 * TimeUnit.MINUTES.toMillis(5));
+            journalEntries.put(tokenId, createTestJournalEntry(tokenId, issueTime, expiration, maxLifetime));
+        }
+
+        for (JournalEntry entry : journalEntries.values()) {
+            journal.add(entry);
+        }
+
+        for (Map.Entry<String, JournalEntry> journalEntry : journalEntries.entrySet()) {
+            final String tokenId = journalEntry.getKey();
+            // Get the token state from the journal, and validate its contents
+            JournalEntry entry = journal.get(tokenId);
+            assertNotNull(entry);
+
+            JournalEntry original = journalEntry.getValue();
+            assertEquals(original.getTokenId(), entry.getTokenId());
+            assertEquals(original.getIssueTime(), entry.getIssueTime());
+            assertEquals(original.getExpiration(), entry.getExpiration());
+            assertEquals(original.getMaxLifetime(), entry.getMaxLifetime());
+        }
+
+        // Test loading of persisted token state
+        List<JournalEntry> loadedEntries = journal.get();
+        assertNotNull(loadedEntries);
+        assertFalse(loadedEntries.isEmpty());
+        assertEquals(10, loadedEntries.size());
+        for (JournalEntry loaded : loadedEntries) {
+            JournalEntry original = journalEntries.get(loaded.getTokenId());
+            assertNotNull(original);
+            assertEquals(original.getTokenId(), loaded.getTokenId());
+            assertEquals(original.getIssueTime(), loaded.getIssueTime());
+            assertEquals(original.getExpiration(), loaded.getExpiration());
+            assertEquals(original.getMaxLifetime(), loaded.getMaxLifetime());
+        }
+
+        for (String tokenId : tokenIds) {
+            journal.remove(tokenId);
+            // Verify that the token state can no longer be gotten from the journal
+            assertNull(journal.get(tokenId));
+        }
+    }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournalTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournalTest.java
@@ -1,0 +1,133 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.impl.state;
+
+import org.apache.knox.gateway.services.token.state.JournalEntry;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class FileTokenStateJournalTest {
+
+    @Test
+    public void testParseJournalEntry() {
+        final String tokenId     = UUID.randomUUID().toString();
+        final Long   issueTime   = System.currentTimeMillis();
+        final Long   expiration  = issueTime + TimeUnit.HOURS.toMillis(1);
+        final Long   maxLifetime = TimeUnit.HOURS.toMillis(7);
+
+        doTestParseJournalEntry(tokenId, issueTime, expiration, maxLifetime);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseJournalEntry_MissingMaxLifetime() {
+        final String tokenId     = UUID.randomUUID().toString();
+        final Long   issueTime   = System.currentTimeMillis();
+        final Long   expiration  = issueTime + TimeUnit.HOURS.toMillis(1);
+        final Long   maxLifetime = null;
+
+        doTestParseJournalEntry(tokenId, issueTime, expiration, maxLifetime);
+    }
+
+    @Test
+    public void testParseJournalEntry_MissingIssueTime() {
+        final String tokenId     = UUID.randomUUID().toString();
+        final Long   issueTime   = System.currentTimeMillis();
+        final Long   expiration  = issueTime + TimeUnit.HOURS.toMillis(1);
+        final Long   maxLifetime = TimeUnit.HOURS.toMillis(7);
+
+        doTestParseJournalEntry(tokenId, null, expiration, maxLifetime);
+    }
+
+    @Test
+    public void testParseJournalEntry_MissingIssueAndExpirationTimes() {
+        final String tokenId = UUID.randomUUID().toString();
+        final Long   maxLifetime = TimeUnit.HOURS.toMillis(7);
+
+        doTestParseJournalEntry(tokenId, null, null, maxLifetime);
+    }
+
+    @Test
+    public void testParseJournalEntry_OnlyMaxLifetime() {
+        final Long maxLifetime = TimeUnit.HOURS.toMillis(7);
+
+        doTestParseJournalEntry(null, null, null, maxLifetime);
+    }
+
+    @Test
+    public void testParseJournalEntry_AllMissing() {
+        doTestParseJournalEntry(null, null, null, " ");
+    }
+
+    private void doTestParseJournalEntry(final String tokenId,
+                                         final Long   issueTime,
+                                         final Long   expiration,
+                                         final Long   maxLifetime) {
+        doTestParseJournalEntry(tokenId,
+                                (issueTime != null ? issueTime.toString() : null),
+                                (expiration != null ? expiration.toString() : null),
+                                (maxLifetime != null ? maxLifetime.toString() : null));
+    }
+
+    private void doTestParseJournalEntry(final String tokenId,
+                                         final String issueTime,
+                                         final String expiration,
+                                         final String maxLifetime) {
+        StringBuilder entryStringBuilder =
+            new StringBuilder(tokenId != null ? tokenId : "").append(',')
+                                                             .append(issueTime != null ? issueTime : "")
+                                                             .append(',')
+                                                             .append(expiration != null ? expiration : "")
+                                                             .append(',')
+                                                             .append(maxLifetime != null ? maxLifetime : "");
+
+        JournalEntry entry = FileTokenStateJournal.FileJournalEntry.parse(entryStringBuilder.toString());
+        assertNotNull(entry);
+        if (tokenId != null && !tokenId.trim().isEmpty()) {
+            assertEquals(tokenId, entry.getTokenId());
+        } else {
+            assertNull(entry.getTokenId());
+        }
+
+        if (issueTime != null && !issueTime.trim().isEmpty()) {
+            assertEquals(issueTime, entry.getIssueTime());
+        } else {
+            assertNull(entry.getIssueTime());
+        }
+
+        if (expiration != null && !expiration.trim().isEmpty()) {
+            assertEquals(expiration, entry.getExpiration());
+        } else {
+            assertNull(entry.getExpiration());
+        }
+
+        if (maxLifetime != null && !maxLifetime.trim().isEmpty()) {
+            assertEquals(maxLifetime, entry.getMaxLifetime());
+        } else {
+            assertNull(entry.getMaxLifetime());
+        }
+    }
+
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournalTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournalTest.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements. See the NOTICE file distributed with this
+ *  * work for additional information regarding copyright ownership. The ASF
+ *  * licenses this file to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+package org.apache.knox.gateway.services.token.impl.state;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.token.state.TokenStateJournal;
+
+import java.io.IOException;
+
+public class MultiFileTokenStateJournalTest extends AbstractFileTokenStateJournalTest {
+
+    @Override
+    TokenStateJournal createTokenStateJournal(GatewayConfig config) throws IOException {
+        return new MultiFileTokenStateJournal(config);
+    }
+
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -154,12 +154,15 @@ public interface TokenStateService extends Service {
   long getTokenExpiration(String tokenId) throws UnknownTokenException;
 
   /**
-    *
-    * @param tokenId  The token unique identifier.
-    * @param validate Flag indicating whether the token needs to be validated.
-    *
-    * @return The token's expiration time in milliseconds.
-    */
+   * Get the expiration for the specified token, optionally validating the token prior to accessing its expiration.
+   * In some cases, the token has already been validated, and skipping an additional unnecessary validation improves
+   * performance.
+   *
+   * @param tokenId  The token unique identifier.
+   * @param validate Flag indicating whether the token needs to be validated.
+   *
+   * @return The token's expiration time in milliseconds.
+   */
   long getTokenExpiration(String tokenId, boolean validate) throws UnknownTokenException;
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the resolution of KNOX-2375, the potential for token state to be lost between the issuance of a token and its persistence to the keystore. To address this risk, this patchset introduces a TokenStateJournal, the default implementation of which persists small individual files for each token's state until it is persisted in the keystore. This new facility has been integrated into the AliasBasedTokenStateService, which is the driver behind creating it. When token state it added, an entry (file) is added to the journal; Then, once that state has been persisted in the keystore, the journal entry (file) is removed since the risk of loss is no longer present.

Part of the integration includes loading all the persisted token state journal entries when the AliasBasedTokenStateService is initialized, which effectively allows it to resume processing from where it has left off if the gateway was stopped or crashed after the addition of one or more tokens but before the state for those tokens could be persisted.

## How was this patch tested?

- 'mvn -T1.5C -Ppackage,release clean install'
- Added FileTokenStateJournalTest and MultiFileTokenStateJournalTest unit test classes
- Augmented AliasBasedTokenStateServiceTest to test the integration of the TokenStateJournal with the AliasBasedTokenStateService, the intended (and only) consumer.
- Manual testing involving two clients concurrently requesting tokens, and allowing this type of test to run through multiple token state eviction cycles, such that I feel there is no additional issue wrt thread-safety or performance.