### PR TITLE
KNOX-2389 - AliasBasedTokenStateService stops processing persisted jo…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -74,17 +74,21 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService {
       List<JournalEntry> entries = journal.get();
       for (JournalEntry entry : entries) {
         String id = entry.getTokenId();
-        long issueTime = Long.parseLong(entry.getIssueTime());
-        long expiration = Long.parseLong(entry.getExpiration());
-        long maxLifetime = Long.parseLong(entry.getMaxLifetime());
+        try {
+          long issueTime   = Long.parseLong(entry.getIssueTime());
+          long expiration  = Long.parseLong(entry.getExpiration());
+          long maxLifetime = Long.parseLong(entry.getMaxLifetime());
 
-        // Add the token state to memory
-        super.addToken(id, issueTime, expiration, maxLifetime);
+          // Add the token state to memory
+          super.addToken(id, issueTime, expiration, maxLifetime);
 
-        synchronized (unpersistedState) {
-          // The max lifetime entry is added by way of the call to super.addToken(),
-          // so only need to add the expiration entry here.
-          unpersistedState.add(new TokenExpiration(id, expiration));
+          synchronized (unpersistedState) {
+            // The max lifetime entry is added by way of the call to super.addToken(),
+            // so only need to add the expiration entry here.
+            unpersistedState.add(new TokenExpiration(id, expiration));
+          }
+        } catch (Exception e) {
+          log.failedToLoadJournalEntry(id, e);
         }
       }
     } catch (IOException e) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -118,6 +118,12 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.DEBUG, text = "Persisting token state journal entry as {0}")
   void persistingJournalEntry(String journalEntryFilename);
 
+  @Message(level = MessageLevel.ERROR, text = "Failed to load persisted token state journal entry for {0} : {1}")
+  void failedToLoadJournalEntry(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to load persisted token state journal entry : {0}")
+  void failedToLoadJournalEntry(@StackTrace(level = MessageLevel.DEBUG) Exception e);
+
   @Message(level = MessageLevel.ERROR, text = "Failed to persisting token state journal entry for {0} : {1}")
   void failedToPersistJournalEntry(String tokenId, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournal.java
@@ -108,7 +108,11 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
             BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
             String line;
             while ((line = reader.readLine()) != null) {
-                entries.add(FileJournalEntry.parse(line));
+                try {
+                    entries.add(FileJournalEntry.parse(line));
+                } catch (Exception e) {
+                    log.failedToLoadJournalEntry(e);
+                }
             }
         }
 


### PR DESCRIPTION
…urnal entries if one is malformed

## What changes were proposed in this pull request?

Added some defensive logic to prevent skipping processing valid token state journal entries due one or more invalid entries.

## How was this patch tested?

_mvn -T1.5C -Ppackage,release clean install_,  augmented AliasBasedTokenStateServiceTest to include a specific test for this, and performed manual testing.