### PR TITLE
KNOX-2387 - SameSite fix for hadoop-jwt cookie

### DIFF
--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -350,26 +350,37 @@ public class WebSSOResource {
 
   private void addJWTHadoopCookie(String original, JWT token) {
     LOGGER.addingJWTCookie(token.toString());
-    Cookie c = new Cookie(cookieName,  token.toString());
-    c.setPath("/");
+    /*
+     * In order to account for google chrome changing default value
+     * of SameSite from None to Lax we need to craft Set-Cookie
+     * header to prevent issues with hadoop-jwt cookie.
+     * NOTE: this would have been easier if javax.servlet.http.Cookie supported
+     * SameSite param. Change this back to Cookie impl. after
+     * SameSite header is supported by javax.servlet.http.Cookie.
+     */
+    final StringBuilder setCookie = new StringBuilder(50);
     try {
-      String domain = Urls.getDomainName(original, domainSuffix);
+      setCookie.append(cookieName).append('=').append(token.toString());
+      setCookie.append("; Path=/");
+      final String domain = Urls.getDomainName(original, domainSuffix);
       if (domain != null) {
-        c.setDomain(domain);
+        setCookie.append("; Domain=").append(domain);
       }
-      c.setHttpOnly(true);
+      setCookie.append("; HttpOnly");
       if (secureOnly) {
-        c.setSecure(true);
+        setCookie.append("; Secure");
       }
       if (maxAge != -1) {
-        c.setMaxAge(maxAge);
+        setCookie.append("; Max-Age=").append(maxAge);
       }
-      response.addCookie(c);
+      setCookie.append("; SameSite=None");
+      response.setHeader("Set-Cookie", setCookie.toString());
       LOGGER.addedJWTCookie();
-    }
-    catch(Exception e) {
-      LOGGER.unableAddCookieToResponse(e.getMessage(), Arrays.toString(e.getStackTrace()));
-      throw new WebApplicationException("Unable to add JWT cookie to response.");
+    } catch (Exception e) {
+      LOGGER.unableAddCookieToResponse(e.getMessage(),
+          Arrays.toString(e.getStackTrace()));
+      throw new WebApplicationException(
+          "Unable to add JWT cookie to response.");
     }
   }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?

Update the Set-Cookie header for hadoop-jwt cookie to include SameSite=none parameter.

## How was this patch tested?
This patch was tested on a local cluster.
