### PR TITLE
KNOX-2393 - Add a configurable list of paths  that SSOCookieProvider can ignore

### DIFF
--- a/gateway-provider-security-jwt/pom.xml
+++ b/gateway-provider-security-jwt/pom.xml
@@ -72,6 +72,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>
             <scope>test</scope>

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -57,5 +57,5 @@ public interface JWTMessages {
   void jwtAudienceValidated();
 
   @Message( level = MessageLevel.INFO, text = "Path {0} is configured as unauthenticated path, letting the request {1} through" )
-  void unAuthenticatePathBypass(String path, String uri);
+  void unauthenticatedPathBypass(String path, String uri);
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -55,4 +55,7 @@ public interface JWTMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "Audience claim has been validated." )
   void jwtAudienceValidated();
+
+  @Message( level = MessageLevel.INFO, text = "Path {0} is configured as unauthenticated path, letting the request {1} through" )
+  void unAuthenticatePathBypass(String path, String uri);
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -107,7 +107,7 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
       unAuthPathString = DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM;
     }
 
-    final StringTokenizer st = new StringTokenizer(unAuthPathString, ";");
+    final StringTokenizer st = new StringTokenizer(unAuthPathString, ";,");
     while (st.hasMoreTokens()) {
       unAuthenticatedPaths.add(st.nextToken());
     }
@@ -147,19 +147,18 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
           /* This path is configured as an unauthenticated path let the request through */
           final Subject sub = new Subject();
           sub.getPrincipals().add(new PrimaryPrincipal("anonymous"));
-          LOGGER.unAuthenticatePathBypass(path, req.getRequestURI());
+          LOGGER.unauthenticatedPathBypass(path, req.getRequestURI());
           continueWithEstablishedSecurityContext(sub, req, res, chain);
         }
       }
 
-      if (req.getMethod().equals("OPTIONS")) {
+      if ("OPTIONS".equals(req.getMethod())) {
         // CORS preflight requests to determine allowed origins and related config
         // must be able to continue without being redirected
         Subject sub = new Subject();
         sub.getPrincipals().add(new PrimaryPrincipal("anonymous"));
         continueWithEstablishedSecurityContext(sub, req, res, chain);
-      }
-      else {
+      } else {
         sendRedirectToLoginURL(req, res);
       }
     } else {

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.provider.federation.jwt.filter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
@@ -39,7 +40,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
 
 public class SSOCookieFederationFilter extends AbstractJWTFilter {
   private static final JWTMessages LOGGER = MessagesFactory.get( JWTMessages.class );
@@ -59,9 +63,13 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
   private static final String ORIGINAL_URL_QUERY_PARAM = "originalUrl=";
   private static final String DEFAULT_SSO_COOKIE_NAME = "hadoop-jwt";
 
+  /* A semicolon separated list of paths that need to bypass authentication */
+  private static final String SSO_UNAUTHENTICATED_PATHS_PARAM = "gateway.knox.sso.unauthenticated.path.list";
+  private static final String DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM = "favicon.ico";
   private String cookieName;
   private String authenticationProviderUrl;
   private String gatewayPath;
+  private Set<String> unAuthenticatedPaths = new HashSet(20);
 
   @Override
   public void init( FilterConfig filterConfig ) throws ServletException {
@@ -90,6 +98,18 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
     // setup the public key of the token issuer for verification
     if (verificationPEM != null) {
       publicKey = CertificateUtils.parseRSAPublicKey(verificationPEM);
+    }
+
+    /* get unauthenticated paths list */
+    String unAuthPathString = filterConfig.getInitParameter(SSO_UNAUTHENTICATED_PATHS_PARAM);
+    /* if no list specified use default value */
+    if (StringUtils.isBlank(unAuthPathString)) {
+      unAuthPathString = DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM;
+    }
+
+    final StringTokenizer st = new StringTokenizer(unAuthPathString, ";");
+    while (st.hasMoreTokens()) {
+      unAuthenticatedPaths.add(st.nextToken());
     }
 
     // gateway path for deriving an idp url when missing
@@ -121,13 +141,25 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
 
     List<Cookie> ssoCookies = CookieUtils.getCookiesForName(req, cookieName);
     if (ssoCookies.isEmpty()) {
+      /* check for unauthenticated paths to bypass */
+      for (final String path : unAuthenticatedPaths) {
+        if (req.getRequestURI().contains(path)) {
+          /* This path is configured as an unauthenticated path let the request through */
+          final Subject sub = new Subject();
+          sub.getPrincipals().add(new PrimaryPrincipal("anonymous"));
+          LOGGER.unAuthenticatePathBypass(path, req.getRequestURI());
+          continueWithEstablishedSecurityContext(sub, req, res, chain);
+        }
+      }
+
       if (req.getMethod().equals("OPTIONS")) {
         // CORS preflight requests to determine allowed origins and related config
         // must be able to continue without being redirected
         Subject sub = new Subject();
         sub.getPrincipals().add(new PrimaryPrincipal("anonymous"));
         continueWithEstablishedSecurityContext(sub, req, res, chain);
-      } else {
+      }
+      else {
         sendRedirectToLoginURL(req, res);
       }
     } else {


### PR DESCRIPTION
This patch was tested on local cluster
## What changes were proposed in this pull request?
This change proposes adding a configurable parameter that adds a list of path elements to be ignored by SSOCookieProvider. Default set includes favicon.ico.
This is because Browsers will send unsolicited requests to get favicon.ico which can break SSO experience especially when default topology feature is used when content is served from the root.

## How was this patch tested?
This patch was tested on a local cluster.

