### PR TITLE
KNOX-2255 - Setting HTTP client connection/socket timeout to 5m for certain services as well as replayBufferSize to 65 bytes for RANGER and useTwoWaySsl to true for NIFI/NIFI-REGISTRY by default

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -21,7 +21,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.knox.gateway.config.Configure;
-import org.apache.knox.gateway.config.Optional;
 import org.apache.knox.gateway.dispatch.ConfigurableDispatch;
 import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.ha.dispatch.i18n.HaDispatchMessages;
@@ -52,10 +51,6 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
 
   private HaProvider haProvider;
 
-  @Optional
-  @Configure
-  private String serviceRole;
-
   @Override
   public void init() {
     super.init();
@@ -65,14 +60,6 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
       maxFailoverAttempts = serviceConfig.getMaxFailoverAttempts();
       failoverSleep = serviceConfig.getFailoverSleep();
     }
-  }
-
-  public String getServiceRole() {
-    return serviceRole;
-  }
-
-  public void setServiceRole(String serviceRole) {
-    this.serviceRole = serviceRole;
   }
 
   public HaProvider getHaProvider() {

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatch.java
@@ -18,7 +18,6 @@
 package org.apache.knox.gateway.ha.dispatch;
 
 import org.apache.knox.gateway.config.Configure;
-import org.apache.knox.gateway.config.Optional;
 import org.apache.knox.gateway.dispatch.DefaultDispatch;
 import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.ha.dispatch.i18n.HaDispatchMessages;
@@ -51,10 +50,6 @@ public class DefaultHaDispatch extends DefaultDispatch {
 
   private HaProvider haProvider;
 
-  @Optional
-  @Configure
-  private String serviceRole;
-
   @Override
   public void init() {
     super.init();
@@ -64,14 +59,6 @@ public class DefaultHaDispatch extends DefaultDispatch {
       maxFailoverAttempts = serviceConfig.getMaxFailoverAttempts();
       failoverSleep = serviceConfig.getFailoverSleep();
     }
-  }
-
-  public String getServiceRole() {
-    return serviceRole;
-  }
-
-  public void setServiceRole(String serviceRole) {
-    this.serviceRole = serviceRole;
   }
 
   public HaProvider getHaProvider() {

--- a/gateway-service-definitions/src/main/resources/services/cm-api/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/cm-api/1.0.0/service.xml
@@ -33,4 +33,14 @@
       <rewrite apply="CM-API/cm-api/rest" to="request.body"/>
     </route>
   </routes>
+  <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch">
+    <param>
+      <name>httpclient.connectionTimeout</name>
+      <value>5m</value>
+    </param>
+    <param>
+      <name>httpclient.socketTimeout</name>
+      <value>5m</value>
+    </param>
+  </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/hive/0.13.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hive/0.13.0/service.xml
@@ -24,5 +24,14 @@
     <routes>
         <route path="/hive"/>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.hive.HiveDispatch" ha-classname="org.apache.knox.gateway.hive.HiveHaDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.hive.HiveDispatch" ha-classname="org.apache.knox.gateway.hive.HiveHaDispatch">
+      <param>
+        <name>httpclient.connectionTimeout</name>
+        <value>5m</value>
+      </param>
+      <param>
+        <name>httpclient.socketTimeout</name>
+        <value>5m</value>
+      </param>
+    </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/hue/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hue/1.0.0/service.xml
@@ -61,5 +61,13 @@
       <name>responseExcludeHeaders</name>
       <value>WWW-AUTHENTICATE</value>
     </param>
+    <param>
+      <name>httpclient.connectionTimeout</name>
+      <value>5m</value>
+    </param>
+    <param>
+      <name>httpclient.socketTimeout</name>
+      <value>5m</value>
+    </param>
   </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/impala/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/impala/1.0.0/service.xml
@@ -26,5 +26,14 @@
     <routes>
         <route path="/impala"/>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.impala.ImpalaDispatch" ha-classname="org.apache.knox.gateway.impala.ImpalaHaDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.impala.ImpalaDispatch" ha-classname="org.apache.knox.gateway.impala.ImpalaHaDispatch">
+      <param>
+        <name>httpclient.connectionTimeout</name>
+        <value>5m</value>
+      </param>
+      <param>
+        <name>httpclient.socketTimeout</name>
+        <value>5m</value>
+      </param>
+    </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/nifi-registry/0.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nifi-registry/0.5.0/service.xml
@@ -32,5 +32,5 @@
             <rewrite apply="NIFI-REGISTRY/nifi-registry/inbound/path/query-other" to="request.url"/>
         </route>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.dispatch.NiFiRegistryDispatch" ha-classname="org.apache.knox.gateway.dispatch.NiFiRegistryHaDispatch" />
+    <dispatch classname="org.apache.knox.gateway.dispatch.NiFiRegistryDispatch" ha-classname="org.apache.knox.gateway.dispatch.NiFiRegistryHaDispatch"  use-two-way-ssl="true" />
 </service>

--- a/gateway-service-definitions/src/main/resources/services/nifi/1.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nifi/1.4.0/service.xml
@@ -32,5 +32,5 @@
             <rewrite apply="NIFI/nifi/inbound/path/query-other" to="request.url"/>
         </route>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.dispatch.NiFiDispatch" ha-classname="org.apache.knox.gateway.dispatch.NiFiHaDispatch" />
+    <dispatch classname="org.apache.knox.gateway.dispatch.NiFiDispatch" ha-classname="org.apache.knox.gateway.dispatch.NiFiHaDispatch" use-two-way-ssl="true"/>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
@@ -35,6 +35,10 @@
             <name>responseExcludeHeaders</name>
             <value>WWW-AUTHENTICATE</value>
         </param>
+        <param>
+            <name>replayBufferSize</name>
+            <value>65</value>
+        </param>
     </dispatch>
 </service>
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -91,4 +91,15 @@ public interface SpiGatewayMessages {
             text = "The dispatch to {0} was disallowed because it fails the dispatch whitelist validation. See documentation for dispatch whitelisting." )
   void dispatchDisallowed(String uri);
 
+  @Message( level = MessageLevel.DEBUG, text = "HTTP client connection timeout is set to {0} for {1}" )
+  void setHttpClientConnectionTimeout(int connectionTimeout, String serviceRole);
+
+  @Message( level = MessageLevel.DEBUG, text = "HTTP client socket timeout is set to {0} for {1}" )
+  void setHttpClientSocketTimeout(int csocketTimeout, String serviceRole);
+
+  @Message( level = MessageLevel.DEBUG, text = "replayBufferSize is set to {0} for {1}" )
+  void setReplayBufferSize(int replayBufferSize, String serviceRole);
+
+  @Message( level = MessageLevel.DEBUG, text = "Using two way SSL in {0}" )
+  void usingTwoWaySsl(String serviceRole);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -40,6 +40,7 @@ import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
 import org.apache.knox.gateway.config.Configure;
 import org.apache.knox.gateway.config.Default;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.Optional;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
 import org.apache.knox.gateway.util.MimeTypes;
@@ -72,6 +73,10 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
   private Set<String> outboundResponseExcludeHeaders = Collections.singleton(WWW_AUTHENTICATE);
   private Set<String> outboundResponseExcludedSetCookieHeaderDirectives = Collections.singleton(EXCLUDE_ALL);
 
+  @Optional
+  @Configure
+  private String serviceRole;
+
   //Buffer size in bytes
   private int replayBufferSize = -1;
 
@@ -84,6 +89,14 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
       return Math.abs(replayBufferSize/1024);
     }
     return replayBufferSize;
+  }
+
+  public String getServiceRole() {
+    return serviceRole;
+  }
+
+  public void setServiceRole(String serviceRole) {
+    this.serviceRole = serviceRole;
   }
 
   @Configure
@@ -100,6 +113,7 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
       size *= 1024;
     }
     replayBufferSize = size;
+    LOG.setReplayBufferSize(replayBufferSize, getServiceRole());
   }
 
   protected void executeRequest(

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -31,7 +31,9 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.SpiGatewayMessages;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.metrics.MetricsService;
 import org.apache.http.HttpRequest;
@@ -64,10 +66,13 @@ import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 
 public class DefaultHttpClientFactory implements HttpClientFactory {
+  private static final SpiGatewayMessages LOG = MessagesFactory.get(SpiGatewayMessages.class);
+  private static final String PARAMETER_SERVICE_ROLE = "serviceRole";
   static final String PARAMETER_USE_TWO_WAY_SSL = "useTwoWaySsl";
 
   @Override
   public HttpClient createHttpClient(FilterConfig filterConfig) {
+    final String serviceRole = filterConfig.getInitParameter(PARAMETER_SERVICE_ROLE);
     HttpClientBuilder builder;
     GatewayConfig gatewayConfig = (GatewayConfig) filterConfig.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
     GatewayServices services = (GatewayServices) filterConfig.getServletContext()
@@ -80,7 +85,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     }
 
     // Conditionally set a custom SSLContext
-    SSLContext sslContext = createSSLContext(services, filterConfig);
+    SSLContext sslContext = createSSLContext(services, filterConfig, serviceRole);
     if(sslContext != null) {
       builder.setSSLSocketFactory(new SSLConnectionSocketFactory(sslContext));
     }
@@ -109,7 +114,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     builder.setMaxConnTotal( maxConnections );
     builder.setMaxConnPerRoute( maxConnections );
 
-    builder.setDefaultRequestConfig( getRequestConfig( filterConfig ) );
+    builder.setDefaultRequestConfig(getRequestConfig(filterConfig, serviceRole));
 
     // See KNOX-1530 for details
     builder.disableContentCompression();
@@ -134,9 +139,10 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
    *
    * @param services     the {@link GatewayServices}
    * @param filterConfig a {@link FilterConfig} used to query for parameters for this operation
+   * @param serviceRole the name of the service role to whom this HTTP client is being created for
    * @return a {@link SSLContext} or <code>null</code> if a custom {@link SSLContext} is not needed.
    */
-  SSLContext createSSLContext(GatewayServices services, FilterConfig filterConfig) {
+  SSLContext createSSLContext(GatewayServices services, FilterConfig filterConfig, String serviceRole) {
     KeyStore identityKeystore;
     char[] identityKeyPassphrase;
     KeyStore trustKeystore;
@@ -144,6 +150,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     KeystoreService ks = services.getService(ServiceType.KEYSTORE_SERVICE);
     try {
       if (Boolean.parseBoolean(filterConfig.getInitParameter(PARAMETER_USE_TWO_WAY_SSL))) {
+        LOG.usingTwoWaySsl(serviceRole);
         AliasService as = services.getService(ServiceType.ALIAS_SERVICE);
 
         // Get the Gateway's configured identity keystore and key passphrase
@@ -191,16 +198,18 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     }
   }
 
-  static RequestConfig getRequestConfig( FilterConfig config ) {
+  static RequestConfig getRequestConfig(FilterConfig config, String serviceRole) {
     RequestConfig.Builder builder = RequestConfig.custom();
     int connectionTimeout = getConnectionTimeout( config );
     if ( connectionTimeout != -1 ) {
       builder.setConnectTimeout( connectionTimeout );
       builder.setConnectionRequestTimeout( connectionTimeout );
+      LOG.setHttpClientConnectionTimeout(connectionTimeout, serviceRole == null ? "N/A" : serviceRole);
     }
     int socketTimeout = getSocketTimeout( config );
     if( socketTimeout != -1 ) {
       builder.setSocketTimeout( socketTimeout );
+      LOG.setHttpClientSocketTimeout(socketTimeout, serviceRole == null ? "N/A" : serviceRole);
     }
 
     // HttpClient 4.5.7 is broken for %2F handling with url normalization.

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -75,6 +75,7 @@ public class DefaultHttpClientFactoryTest {
     expect(filterConfig.getInitParameter("httpclient.maxConnections")).andReturn(null).once();
     expect(filterConfig.getInitParameter("httpclient.connectionTimeout")).andReturn(null).once();
     expect(filterConfig.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
+    expect(filterConfig.getInitParameter("serviceRole")).andReturn(null).once();
 
     replay(keystoreService, gatewayConfig, gatewayServices, servletContext, filterConfig);
 
@@ -99,7 +100,7 @@ public class DefaultHttpClientFactoryTest {
     replay(keystoreService, gatewayServices, filterConfig);
 
     DefaultHttpClientFactory factory = new DefaultHttpClientFactory();
-    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig);
+    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig, "service");
     assertNull(context);
 
     verify(keystoreService, gatewayServices, filterConfig);
@@ -126,7 +127,7 @@ public class DefaultHttpClientFactoryTest {
     replay(keystoreService, aliasService, gatewayServices, filterConfig);
 
     DefaultHttpClientFactory factory = new DefaultHttpClientFactory();
-    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig);
+    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig, "service");
     assertNotNull(context);
 
     verify(keystoreService, aliasService, gatewayServices, filterConfig);
@@ -154,7 +155,7 @@ public class DefaultHttpClientFactoryTest {
     replay(keystoreService, aliasService, gatewayServices, filterConfig);
 
     DefaultHttpClientFactory factory = new DefaultHttpClientFactory();
-    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig);
+    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig, "service");
     assertNotNull(context);
 
     verify(keystoreService, aliasService, gatewayServices, filterConfig);
@@ -174,7 +175,7 @@ public class DefaultHttpClientFactoryTest {
     replay(keystoreService, gatewayServices, filterConfig);
 
     DefaultHttpClientFactory factory = new DefaultHttpClientFactory();
-    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig);
+    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig, "service");
     assertNull(context);
 
     verify(keystoreService, gatewayServices, filterConfig);
@@ -196,7 +197,7 @@ public class DefaultHttpClientFactoryTest {
     replay(keystoreService, gatewayServices, filterConfig);
 
     DefaultHttpClientFactory factory = new DefaultHttpClientFactory();
-    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig);
+    SSLContext context = factory.createSSLContext(gatewayServices, filterConfig, "service");
     assertNotNull(context);
 
     verify(keystoreService, gatewayServices, filterConfig);
@@ -218,7 +219,7 @@ public class DefaultHttpClientFactoryTest {
 
     replay(gatewayConfig, servletContext, filterConfig);
 
-    RequestConfig requestConfig = DefaultHttpClientFactory.getRequestConfig(filterConfig);
+    RequestConfig requestConfig = DefaultHttpClientFactory.getRequestConfig(filterConfig, "service");
 
     assertTrue(requestConfig.isNormalizeUri());
 

--- a/gateway-util-configinjector/src/main/java/org/apache/knox/gateway/config/impl/DefaultConfigurationInjector.java
+++ b/gateway-util-configinjector/src/main/java/org/apache/knox/gateway/config/impl/DefaultConfigurationInjector.java
@@ -30,6 +30,8 @@ import org.apache.knox.gateway.config.spi.ConfigurationInjector;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Locale;
 
 public class DefaultConfigurationInjector implements ConfigurationInjector {
@@ -49,6 +51,18 @@ public class DefaultConfigurationInjector implements ConfigurationInjector {
   private void injectClass( Class type, Object target, ConfigurationAdapter config, ConfigurationBinding binding )
       throws ConfigurationException {
     Field[] fields = type.getDeclaredFields();
+    Arrays.sort(fields, new Comparator<Field>() {
+      @Override
+      public int compare(Field field1, Field field2) {
+        if ("serviceRole".equals(field1.getName())) {
+          return -1;
+        } else if ("serviceRole".equals(field2.getName())) {
+          return 1;
+        } else {
+          return field1.getName().compareTo(field2.getName());
+        }
+      };
+    });
     for( Field field : fields ) {
       injectFieldValue( field, target, config, binding );
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the HTTP client connection/socket timeout to 5 minutes (default is 20 seconds) for:

- CM-API
- HIVE
- HUE
- IMPALA


Also, changed the `replayBufferSize` parameter for `RANGER` to 65 bytes and set the `useTwoWaySsl` flag to `true` for `NIFI` and `NIFI-REGISTRY` services.

## How was this patch tested?
Ran unit tests:
```
$ mvn clean -Dshellcheck=true -T1C verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 21:26 min (Wall Clock)
[INFO] Finished at: 2020-06-24T16:28:23+02:00
[INFO] Final Memory: 431M/2638M
[INFO] ------------------------------------------------------------------------
```

Manually tested and checked logs:
```
2020-06-24 11:27:18,927 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(205)) - HTTP client connection timeout is set to 300,000 for CM-API
2020-06-24 11:27:18,928 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(210)) - HTTP client socket timeout is set to 300,000 for CM-API

2020-06-24 11:27:53,387 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(205)) - HTTP client connection timeout is set to 300,000 for HUE
2020-06-24 11:27:53,387 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(210)) - HTTP client socket timeout is set to 300,000 for HUE

2020-06-24 11:30:29,051 DEBUG knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(103)) - replayBufferSize is set to -1 for IMPALA
2020-06-24 11:30:29,052 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(205)) - HTTP client connection timeout is set to 300,000 for IMPALA
2020-06-24 11:30:29,052 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(210)) - HTTP client socket timeout is set to 300,000 for IMPALA

2020-06-24 11:30:55,243 DEBUG knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(103)) - replayBufferSize is set to -1 for HIVE
2020-06-24 11:30:55,243 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(205)) - HTTP client connection timeout is set to 300,000 for HIVE
2020-06-24 11:30:55,244 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(210)) - HTTP client socket timeout is set to 300,000 for HIVE

2020-06-24 11:31:50,671 DEBUG knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(103)) - replayBufferSize is set to 66,560 for RANGER
2020-06-24 11:31:50,671 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(205)) - HTTP client connection timeout is set to 20,000 for RANGER
2020-06-24 11:31:50,672 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(210)) - HTTP client socket timeout is set to 20,000 for RANGER

2020-06-25 07:16:30,303 DEBUG knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(116)) - replayBufferSize is set to -1 for NIFI
2020-06-25 07:16:30,312 DEBUG knox.gateway (DefaultHttpClientFactory.java:createSSLContext(153)) - Using two way SSL in NIFI
2020-06-25 07:16:30,343 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(207)) - HTTP client connection timeout is set to 20,000 for NIFI
2020-06-25 07:16:30,343 DEBUG knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(212)) - HTTP client socket timeout is set to 20,000 for NIFI
```