### PR TITLE
KNOX-2397 knox failed to start with error "java.lang.NoSuchMethodError: org.eclipse.persistence.internal.oxm.mappings.Field.setNestedArray(Z)V"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,8 +212,9 @@
         <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jaxws-ri.version>2.3.2</jaxws-ri.version>
-        <jakarta.xml.bind.version>2.3.2</jakarta.xml.bind.version>
+        <jaxws-ri.version>2.3.3</jaxws-ri.version>
+        <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
+        <jakarta.activation.version>1.2.2</jakarta.activation.version>
         <java-support.version>7.5.1</java-support.version>
         <jericho-html.version>3.4</jericho-html.version>
         <jersey.version>2.6</jersey.version>
@@ -1324,6 +1325,12 @@
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jakarta.xml.bind.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>jakarta.activation</artifactId>
+                <version>${jakarta.activation.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
knox failed to start with error "java.lang.NoSuchMethodError:org.eclipse.persistence.internal.oxm.mappings.Field.setNestedArray(Z)V"

 There are mixed version of 2.7.6 and 2.7.4 eclipse persistence jars in knox/dep folder:
eclipselink-2.7.6.jar
sdo-eclipselink-plugin-2.3.2.jar
jaxws-eclipselink-plugin-2.3.2.jar
org.eclipse.persistence.core-2.7.4.jar           
org.eclipse.persistence.sdo-2.7.4.jar
org.eclipse.persistence.asm-2.7.4.jar            
org.eclipse.persistence.moxy-2.7.4.jar

We should upgrade jaxws-ri from 2.3.2 to 2.3.3 so that eclipse persistence class will have the same 2.7.6 version.