### PR TITLE
KNOX-2395 - Make Gateway Services Pluggable

### DIFF
--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -19,6 +19,11 @@ limitations under the License.
 <configuration>
 
     <property>
+        <name>gateway.services</name>
+        <value>alias:remote</value>
+        <description>Overriding some of the gateway services so that Knox will use the selected implementation</description>
+    </property>
+    <property>
         <name>gateway.port</name>
         <value>8443</value>
         <description>The HTTP port for the Gateway.</description>

--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -19,9 +19,8 @@ limitations under the License.
 <configuration>
 
     <property>
-        <name>gateway.services</name>
-        <value>alias:remote</value>
-        <description>Overriding some of the gateway services so that Knox will use the selected implementation</description>
+        <name>gateway.service.alias.impl</name>
+        <value>org.apache.knox.gateway.services.security.impl.RemoteAliasService</value>
     </property>
     <property>
         <name>gateway.port</name>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -71,6 +71,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-service-hashicorp-vault</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-i18n</artifactId>
         </dependency>
         <dependency>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -698,4 +698,10 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Error creating provider descriptor {0} from topology {1}, cause: {2}")
   void errorSavingDescriptorConfiguration(String providerPath, String topologyName, String message);
+
+  @Message(level = MessageLevel.ERROR, text = "No service found by type {0}")
+  void noServiceFound(String serviceType);
+
+  @Message(level = MessageLevel.INFO, text = "Using {0} implementation for {1}")
+  void usingServiceImplementation(String implementation, String serviceType);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -45,7 +45,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -98,7 +97,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String[] GATEWAY_CONFIG_FILENAMES = {GATEWAY_CONFIG_FILE_PREFIX + "-default.xml", GATEWAY_CONFIG_FILE_PREFIX + "-site.xml"};
 
-  private static final String GATEWAY_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".services";
+  private static final String GATEWAY_SERVICE_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".service.";
   public static final String HTTP_HOST = GATEWAY_CONFIG_FILE_PREFIX + ".host";
   public static final String HTTP_PORT = GATEWAY_CONFIG_FILE_PREFIX + ".port";
   public static final String HTTP_PATH = GATEWAY_CONFIG_FILE_PREFIX + ".path";
@@ -1169,14 +1168,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public String getServiceImplementation(String service) {
-    final Collection<String> gatewayServices = getTrimmedStringCollection(GATEWAY_SERVICES);
-    final Optional<String> gatewayServiceImplPair = gatewayServices.stream().filter(gatewayService -> gatewayService.startsWith(service)).findFirst();
-    if (gatewayServiceImplPair.isPresent()) {
-      final String[] gatewayServiceAndImplParts = gatewayServiceImplPair.get().split(":");
-      return gatewayServiceAndImplParts.length == 1 ? "" : gatewayServiceAndImplParts[1];
-    }
-    return "";
+  public String getServiceParameter(String service, String parameter) {
+    return get(GATEWAY_SERVICE_PREFIX + service + "." + parameter, "");
   }
 
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -97,6 +98,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String[] GATEWAY_CONFIG_FILENAMES = {GATEWAY_CONFIG_FILE_PREFIX + "-default.xml", GATEWAY_CONFIG_FILE_PREFIX + "-site.xml"};
 
+  private static final String GATEWAY_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".services";
   public static final String HTTP_HOST = GATEWAY_CONFIG_FILE_PREFIX + ".host";
   public static final String HTTP_PORT = GATEWAY_CONFIG_FILE_PREFIX + ".port";
   public static final String HTTP_PATH = GATEWAY_CONFIG_FILE_PREFIX + ".path";
@@ -1165,4 +1167,16 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     return getBoolean(KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED,
         KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT);
   }
+
+  @Override
+  public String getServiceImplementation(String service) {
+    final Collection<String> gatewayServices = getTrimmedStringCollection(GATEWAY_SERVICES);
+    final Optional<String> gatewayServiceImplPair = gatewayServices.stream().filter(gatewayService -> gatewayService.startsWith(service)).findFirst();
+    if (gatewayServiceImplPair.isPresent()) {
+      final String[] gatewayServiceAndImplParts = gatewayServiceImplPair.get().split(":");
+      return gatewayServiceAndImplParts.length == 1 ? "" : gatewayServiceAndImplParts[1];
+    }
+    return "";
+  }
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
@@ -17,24 +17,18 @@
  */
 package org.apache.knox.gateway.services;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
-import org.apache.knox.gateway.service.config.remote.RemoteConfigurationRegistryClientServiceFactory;
-import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
-import org.apache.knox.gateway.services.security.impl.RemoteAliasService;
-import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
-import org.apache.knox.gateway.services.security.impl.DefaultAliasService;
-import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
-import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
-import org.apache.knox.gateway.services.security.impl.CLIMasterService;
 import org.apache.knox.gateway.topology.Provider;
 
-import java.util.List;
-import java.util.Map;
-
 public class CLIGatewayServices extends AbstractGatewayServices {
+
+  private final GatewayServiceFactory gatewayServiceFactory = new GatewayServiceFactory();
 
   public CLIGatewayServices() {
     super("Services", "GatewayServices");
@@ -42,19 +36,9 @@ public class CLIGatewayServices extends AbstractGatewayServices {
 
   @Override
   public void init(GatewayConfig config, Map<String,String> options) throws ServiceLifecycleException {
-    CLIMasterService ms = new CLIMasterService();
-    ms.init(config, options);
-    addService(ServiceType.MASTER_SERVICE, ms);
-
-    DefaultKeystoreService ks = new DefaultKeystoreService();
-    ks.setMasterService(ms);
-    ks.init(config, options);
-    addService(ServiceType.KEYSTORE_SERVICE, ks);
-
-    DefaultAliasService defaultAlias = new DefaultAliasService();
-    defaultAlias.setKeystoreService(ks);
-    defaultAlias.setMasterService(ms);
-    defaultAlias.init(config, options);
+    addService(ServiceType.MASTER_SERVICE, gatewayServiceFactory.create(this, ServiceType.MASTER_SERVICE, config, options, "cli"));
+    addService(ServiceType.KEYSTORE_SERVICE, gatewayServiceFactory.create(this, ServiceType.KEYSTORE_SERVICE, config, options));
+    addService(ServiceType.ALIAS_SERVICE, gatewayServiceFactory.create(this, ServiceType.ALIAS_SERVICE, config, options));
 
     /*
     Doesn't make sense for this to be set to the remote alias service since the impl could
@@ -62,32 +46,11 @@ public class CLIGatewayServices extends AbstractGatewayServices {
     IE: If ZK digest auth and using ZK remote alias service, then wouldn't be able to connect
     to ZK anyway due to the circular dependency.
      */
-    final RemoteConfigurationRegistryClientService registryClientService =
-        RemoteConfigurationRegistryClientServiceFactory.newInstance(config);
-    registryClientService.setAliasService(defaultAlias);
-    registryClientService.init(config, options);
-    addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, registryClientService);
+    addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, gatewayServiceFactory.create(this, ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, config, options));
 
+    addService(ServiceType.CRYPTO_SERVICE, gatewayServiceFactory.create(this, ServiceType.CRYPTO_SERVICE, config, options));
 
-    /* create an instance so that it can be passed to other services */
-    final RemoteAliasService alias = new RemoteAliasService(defaultAlias, ms);
-    /*
-     * Setup and initialize remote Alias Service.
-     * NOTE: registryClientService.init() needs to
-     * be called before alias.start();
-     */
-    alias.init(config, options);
-    addService(ServiceType.ALIAS_SERVICE, alias);
-
-    DefaultCryptoService crypto = new DefaultCryptoService();
-    crypto.setKeystoreService(ks);
-    crypto.setAliasService(alias);
-    crypto.init(config, options);
-    addService(ServiceType.CRYPTO_SERVICE, crypto);
-
-    DefaultTopologyService tops = new DefaultTopologyService();
-    tops.init(  config, options  );
-    addService(ServiceType.TOPOLOGY_SERVICE, tops);
+    addService(ServiceType.TOPOLOGY_SERVICE, gatewayServiceFactory.create(this, ServiceType.TOPOLOGY_SERVICE, config, options));
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
+import org.apache.knox.gateway.services.security.impl.CLIMasterService;
 import org.apache.knox.gateway.topology.Provider;
 
 public class CLIGatewayServices extends AbstractGatewayServices {
@@ -36,9 +37,8 @@ public class CLIGatewayServices extends AbstractGatewayServices {
 
   @Override
   public void init(GatewayConfig config, Map<String,String> options) throws ServiceLifecycleException {
-    addService(ServiceType.MASTER_SERVICE, gatewayServiceFactory.create(this, ServiceType.MASTER_SERVICE, config, options, "cli"));
+    addService(ServiceType.MASTER_SERVICE, gatewayServiceFactory.create(this, ServiceType.MASTER_SERVICE, config, options, CLIMasterService.class.getName()));
     addService(ServiceType.KEYSTORE_SERVICE, gatewayServiceFactory.create(this, ServiceType.KEYSTORE_SERVICE, config, options));
-    addService(ServiceType.ALIAS_SERVICE, gatewayServiceFactory.create(this, ServiceType.ALIAS_SERVICE, config, options));
 
     /*
     Doesn't make sense for this to be set to the remote alias service since the impl could
@@ -47,6 +47,8 @@ public class CLIGatewayServices extends AbstractGatewayServices {
     to ZK anyway due to the circular dependency.
      */
     addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, gatewayServiceFactory.create(this, ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, config, options));
+
+    addService(ServiceType.ALIAS_SERVICE, gatewayServiceFactory.create(this, ServiceType.ALIAS_SERVICE, config, options));
 
     addService(ServiceType.CRYPTO_SERVICE, gatewayServiceFactory.create(this, ServiceType.CRYPTO_SERVICE, config, options));
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -17,37 +17,22 @@
  */
 package org.apache.knox.gateway.services;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.service.config.remote.RemoteConfigurationRegistryClientServiceFactory;
-import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
-import org.apache.knox.gateway.services.registry.impl.DefaultServiceDefinitionRegistry;
-import org.apache.knox.gateway.services.metrics.impl.DefaultMetricsService;
 import org.apache.knox.gateway.services.security.KeystoreService;
-import org.apache.knox.gateway.services.security.impl.RemoteAliasService;
-import org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService;
-import org.apache.knox.gateway.services.topology.impl.DefaultClusterConfigurationMonitorService;
-import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
-import org.apache.knox.gateway.services.hostmap.impl.DefaultHostMapperService;
-import org.apache.knox.gateway.services.registry.impl.DefaultServiceRegistryService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
-import org.apache.knox.gateway.services.security.impl.DefaultAliasService;
-import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
-import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
-import org.apache.knox.gateway.services.security.impl.DefaultMasterService;
-import org.apache.knox.gateway.services.security.impl.JettySSLService;
-import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
 import org.apache.knox.gateway.topology.Provider;
-
-import java.util.List;
-import java.util.Map;
 
 public class DefaultGatewayServices extends AbstractGatewayServices {
   private static GatewayMessages log = MessagesFactory.get( GatewayMessages.class );
+  private final GatewayServiceFactory gatewayServiceFactory = new GatewayServiceFactory();
 
   public DefaultGatewayServices() {
     super("Services", "GatewayServices");
@@ -55,19 +40,10 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
 
   @Override
   public void init(GatewayConfig config, Map<String,String> options) throws ServiceLifecycleException {
-    DefaultMasterService ms = new DefaultMasterService();
-    ms.init(config, options);
-    addService(ServiceType.MASTER_SERVICE, ms);
-
-    DefaultKeystoreService ks = new DefaultKeystoreService();
-    ks.setMasterService(ms);
-    ks.init(config, options);
-    addService(ServiceType.KEYSTORE_SERVICE, ks);
-
-    final DefaultAliasService defaultAlias = new DefaultAliasService();
-    defaultAlias.setKeystoreService(ks);
-    defaultAlias.setMasterService(ms);
-    defaultAlias.init(config, options);
+    //order is important: different service factory implementations may use already added services
+    addService(ServiceType.MASTER_SERVICE, gatewayServiceFactory.create(this, ServiceType.MASTER_SERVICE, config, options));
+    addService(ServiceType.KEYSTORE_SERVICE, gatewayServiceFactory.create(this, ServiceType.KEYSTORE_SERVICE, config, options));
+    addService(ServiceType.ALIAS_SERVICE, gatewayServiceFactory.create(this, ServiceType.ALIAS_SERVICE, config, options));
 
     /*
     Doesn't make sense for this to be set to the remote alias service since the impl could
@@ -75,80 +51,32 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
     IE: If ZK digest auth and using ZK remote alias service, then wouldn't be able to connect
     to ZK anyway due to the circular dependency.
      */
-    final RemoteConfigurationRegistryClientService registryClientService =
-        RemoteConfigurationRegistryClientServiceFactory.newInstance(config);
-    registryClientService.setAliasService(defaultAlias);
-    registryClientService.init(config, options);
-    addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, registryClientService);
+    addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, gatewayServiceFactory.create(this, ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, config, options));
 
+    addService(ServiceType.CRYPTO_SERVICE, gatewayServiceFactory.create(this, ServiceType.CRYPTO_SERVICE, config, options));
 
-    /* create an instance so that it can be passed to other services */
-    final RemoteAliasService alias = new RemoteAliasService(defaultAlias, ms);
-    /*
-     * Setup and initialize remote Alias Service.
-     * NOTE: registryClientService.init() needs to
-     * be called before alias.start();
-     */
-    alias.init(config, options);
-    addService(ServiceType.ALIAS_SERVICE, alias);
-
-    DefaultCryptoService crypto = new DefaultCryptoService();
-    crypto.setKeystoreService(ks);
-    crypto.setAliasService(alias);
-    crypto.init(config, options);
-    addService(ServiceType.CRYPTO_SERVICE, crypto);
-
-    JettySSLService ssl = new JettySSLService();
-    ssl.setAliasService(alias);
-    ssl.setKeystoreService(ks);
-    ssl.init(config, options);
-    addService(ServiceType.SSL_SERVICE, ssl);
+    addService(ServiceType.SSL_SERVICE, gatewayServiceFactory.create(this, ServiceType.SSL_SERVICE, config, options));
 
     // The DefaultTokenAuthorityService needs to be initialized after the JettySSLService to ensure
     // that the signing keystore is available for it.
-    DefaultTokenAuthorityService ts = new DefaultTokenAuthorityService();
-    ts.setAliasService(alias);
-    ts.setKeystoreService(ks);
-    ts.init(config, options);
-    // prolly should not allow the token service to be looked up?
-    addService(ServiceType.TOKEN_SERVICE, ts);
+    // probably should not allow the token service to be looked up?
+    addService(ServiceType.TOKEN_SERVICE, gatewayServiceFactory.create(this, ServiceType.TOKEN_SERVICE, config, options));
 
-    AliasBasedTokenStateService tss = new AliasBasedTokenStateService();
-    tss.setAliasService(alias);
-    tss.init(config, options);
-    addService(ServiceType.TOKEN_STATE_SERVICE, tss);
+    addService(ServiceType.TOKEN_STATE_SERVICE, gatewayServiceFactory.create(this, ServiceType.TOKEN_STATE_SERVICE, config, options));
 
-    DefaultServiceRegistryService sr = new DefaultServiceRegistryService();
-    sr.setCryptoService( crypto );
-    sr.init( config, options );
-    addService(ServiceType.SERVICE_REGISTRY_SERVICE, sr);
+    addService(ServiceType.SERVICE_REGISTRY_SERVICE, gatewayServiceFactory.create(this, ServiceType.SERVICE_REGISTRY_SERVICE, config, options));
 
-    DefaultHostMapperService hm = new DefaultHostMapperService();
-    hm.init( config, options );
-    addService(ServiceType.HOST_MAPPING_SERVICE, hm );
+    addService(ServiceType.HOST_MAPPING_SERVICE, gatewayServiceFactory.create(this, ServiceType.HOST_MAPPING_SERVICE, config, options));
 
-    DefaultServerInfoService sis = new DefaultServerInfoService();
-    sis.init( config, options );
-    addService(ServiceType.SERVER_INFO_SERVICE, sis );
+    addService(ServiceType.SERVER_INFO_SERVICE, gatewayServiceFactory.create(this, ServiceType.SERVER_INFO_SERVICE, config, options));
 
-    DefaultClusterConfigurationMonitorService ccs = new DefaultClusterConfigurationMonitorService();
-    ccs.setAliasService(alias);
-    ccs.setKeystoreService(ks);
-    ccs.init(config, options);
-    addService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, ccs);
+    addService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, gatewayServiceFactory.create(this, ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, config, options));
 
-    DefaultTopologyService tops = new DefaultTopologyService();
-    tops.setAliasService(alias);
-    tops.init(  config, options  );
-    addService(ServiceType.TOPOLOGY_SERVICE, tops  );
+    addService(ServiceType.TOPOLOGY_SERVICE, gatewayServiceFactory.create(this, ServiceType.TOPOLOGY_SERVICE, config, options));
 
-    DefaultServiceDefinitionRegistry sdr = new DefaultServiceDefinitionRegistry();
-    sdr.init( config, options );
-    addService(ServiceType.SERVICE_DEFINITION_REGISTRY, sdr );
+    addService(ServiceType.SERVICE_DEFINITION_REGISTRY, gatewayServiceFactory.create(this, ServiceType.SERVICE_DEFINITION_REGISTRY, config, options));
 
-    DefaultMetricsService metricsService = new DefaultMetricsService();
-    metricsService.init( config, options );
-    addService(ServiceType.METRICS_SERVICE, metricsService );
+    addService(ServiceType.METRICS_SERVICE, gatewayServiceFactory.create(this, ServiceType.METRICS_SERVICE, config, options));
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -43,7 +43,6 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
     //order is important: different service factory implementations may use already added services
     addService(ServiceType.MASTER_SERVICE, gatewayServiceFactory.create(this, ServiceType.MASTER_SERVICE, config, options));
     addService(ServiceType.KEYSTORE_SERVICE, gatewayServiceFactory.create(this, ServiceType.KEYSTORE_SERVICE, config, options));
-    addService(ServiceType.ALIAS_SERVICE, gatewayServiceFactory.create(this, ServiceType.ALIAS_SERVICE, config, options));
 
     /*
     Doesn't make sense for this to be set to the remote alias service since the impl could
@@ -52,6 +51,8 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
     to ZK anyway due to the circular dependency.
      */
     addService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, gatewayServiceFactory.create(this, ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE, config, options));
+
+    addService(ServiceType.ALIAS_SERVICE, gatewayServiceFactory.create(this, ServiceType.ALIAS_SERVICE, config, options));
 
     addService(ServiceType.CRYPTO_SERVICE, gatewayServiceFactory.create(this, ServiceType.CRYPTO_SERVICE, config, options));
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/GatewayServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/GatewayServiceFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services;
+
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+
+public class GatewayServiceFactory implements ServiceFactory {
+  private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+  private ServiceLoader<ServiceFactory> serviceFactories;
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options) throws ServiceLifecycleException {
+    return create(gatewayServices, serviceType, gatewayConfig, options, null);
+  }
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    for (ServiceFactory serviceFactory : getServiceFactories()) {
+      service = implementation == null ? serviceFactory.create(gatewayServices, serviceType, gatewayConfig, options)
+          : serviceFactory.create(gatewayServices, serviceType, gatewayConfig, options, implementation);
+      if (service != null) {
+        break;
+      }
+    }
+    if (service != null) {
+      service.init(gatewayConfig, options);
+    } else {
+      LOG.noServiceFound(serviceType.getServiceTypeName());
+    }
+    return service;
+  }
+
+  private ServiceLoader<ServiceFactory> getServiceFactories() {
+    if (serviceFactories == null) {
+      serviceFactories = ServiceLoader.load(ServiceFactory.class);
+    }
+    return serviceFactories;
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AbstractServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AbstractServiceFactory.java
@@ -34,6 +34,8 @@ import org.apache.knox.gateway.services.security.MasterService;
 public abstract class AbstractServiceFactory implements ServiceFactory {
 
   private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+  private static final String IMPLEMENTATION_PARAM_NAME = "impl";
+  private static final String EMPTY_DEFAULT_IMPLEMENTATION = "";
 
   @Override
   public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options) throws ServiceLifecycleException {
@@ -41,7 +43,19 @@ public abstract class AbstractServiceFactory implements ServiceFactory {
   }
 
   protected String getImplementation(GatewayConfig gatewayConfig) {
-    return gatewayConfig.getServiceImplementation(getServiceType().getShortName());
+    return gatewayConfig.getServiceParameter(getServiceType().getShortName(), IMPLEMENTATION_PARAM_NAME);
+  }
+
+  protected boolean matchesImplementation(String implementation, Class<? extends Object> clazz) {
+    return matchesImplementation(implementation, clazz, false);
+  }
+
+  protected boolean matchesImplementation(String implementation, Class<? extends Object> clazz, boolean acceptEmptyImplementation) {
+    boolean match = clazz.getName().equals(implementation);
+    if (!match && acceptEmptyImplementation) {
+      match = EMPTY_DEFAULT_IMPLEMENTATION.equals(implementation);
+    }
+    return match;
   }
 
   protected abstract ServiceType getServiceType();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AbstractServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AbstractServiceFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceFactory;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.MasterService;
+
+public abstract class AbstractServiceFactory implements ServiceFactory {
+
+  private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options) throws ServiceLifecycleException {
+    return create(gatewayServices, serviceType, gatewayConfig, options, getImplementation(gatewayConfig));
+  }
+
+  protected String getImplementation(GatewayConfig gatewayConfig) {
+    return gatewayConfig.getServiceImplementation(getServiceType().getShortName());
+  }
+
+  protected abstract ServiceType getServiceType();
+
+  protected MasterService getMasterService(GatewayServices gatewayServices) {
+    return gatewayServices.getService(ServiceType.MASTER_SERVICE);
+  }
+
+  protected KeystoreService getKeystoreService(GatewayServices gatewayServices) {
+    return gatewayServices.getService(ServiceType.KEYSTORE_SERVICE);
+  }
+
+  protected AliasService getAliasService(GatewayServices gatewayServices) {
+    return gatewayServices.getService(ServiceType.ALIAS_SERVICE);
+  }
+
+  protected void logServiceUsage(String implementation, ServiceType serviceType) {
+    LOG.usingServiceImplementation("".equals(implementation) ? "default" : implementation, serviceType.getServiceTypeName());
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AliasServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AliasServiceFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.backend.hashicorp.vault.HashicorpVaultAliasService;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.impl.DefaultAliasService;
+import org.apache.knox.gateway.services.security.impl.RemoteAliasService;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasServiceProvider;
+
+public class AliasServiceFactory extends AbstractServiceFactory {
+  private static final String DEFAULT_IMPLEMENTATION_NAME = "default";
+  private static final String HASHICORP_IMPLEMENTATION_NAME = "hashicorp";
+  private static final String REMOTE_IMPLEMENTATION_NAME = "remote";
+  private static final String ZK_IMPLEMENTATION_NAME = "zookeeper";
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      final AliasService defaultAliasService = new DefaultAliasService();
+      ((DefaultAliasService) defaultAliasService).setMasterService(getMasterService(gatewayServices));
+      ((DefaultAliasService) defaultAliasService).setKeystoreService(getKeystoreService(gatewayServices));
+      defaultAliasService.init(gatewayConfig, options); //invoking init on DefaultAliasService twice is ok (in case implementation is set to 'default')
+      switch (implementation) {
+      case DEFAULT_IMPLEMENTATION_NAME:
+      case "":
+        service = defaultAliasService;
+        break;
+      case HASHICORP_IMPLEMENTATION_NAME:
+        service = new HashicorpVaultAliasService(defaultAliasService);
+        break;
+      case REMOTE_IMPLEMENTATION_NAME:
+        service = new RemoteAliasService(defaultAliasService, getMasterService(gatewayServices));
+        break;
+      case ZK_IMPLEMENTATION_NAME:
+        service = new ZookeeperRemoteAliasServiceProvider().newInstance(defaultAliasService, getMasterService(gatewayServices));
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid Alias Service implementation provided: " + implementation);
+      }
+
+      logServiceUsage(implementation, serviceType);
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.ALIAS_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.topology.impl.DefaultClusterConfigurationMonitorService;
+
+public class ClusterConfigurationMonitorServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new DefaultClusterConfigurationMonitorService();
+      ((DefaultClusterConfigurationMonitorService) service).setAliasService(getAliasService(gatewayServices));
+      ((DefaultClusterConfigurationMonitorService) service).setKeystoreService(getKeystoreService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.topology.impl.DefaultClusterConfiguratio
 public class ClusterConfigurationMonitorServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new DefaultClusterConfigurationMonitorService();
       ((DefaultClusterConfigurationMonitorService) service).setAliasService(getAliasService(gatewayServices));
       ((DefaultClusterConfigurationMonitorService) service).setKeystoreService(getKeystoreService(gatewayServices));
@@ -45,4 +47,8 @@ public class ClusterConfigurationMonitorServiceFactory extends AbstractServiceFa
     return ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultClusterConfigurationMonitorService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/CryptoServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/CryptoServiceFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
+
+public class CryptoServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new DefaultCryptoService();
+      ((DefaultCryptoService) service).setKeystoreService(getKeystoreService(gatewayServices));
+      ((DefaultCryptoService) service).setAliasService(getAliasService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.CRYPTO_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/CryptoServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/CryptoServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
 public class CryptoServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new DefaultCryptoService();
       ((DefaultCryptoService) service).setKeystoreService(getKeystoreService(gatewayServices));
       ((DefaultCryptoService) service).setAliasService(getAliasService(gatewayServices));
@@ -45,4 +47,8 @@ public class CryptoServiceFactory extends AbstractServiceFactory {
     return ServiceType.CRYPTO_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultCryptoService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.hostmap.impl.DefaultHostMapperService;
+
+public class HostMappingServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    return getServiceType() == serviceType ? new DefaultHostMapperService() : null;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.HOST_MAPPING_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,9 +31,9 @@ import org.apache.knox.gateway.services.hostmap.impl.DefaultHostMapperService;
 public class HostMappingServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
-    return getServiceType() == serviceType ? new DefaultHostMapperService() : null;
+    return shouldCreateService(implementation) ? new DefaultHostMapperService() : null;
   }
 
   @Override
@@ -39,4 +41,8 @@ public class HostMappingServiceFactory extends AbstractServiceFactory {
     return ServiceType.HOST_MAPPING_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultHostMapperService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
 public class KeystoreServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new DefaultKeystoreService();
       ((DefaultKeystoreService) service).setMasterService(getMasterService(gatewayServices));
     }
@@ -44,4 +46,8 @@ public class KeystoreServiceFactory extends AbstractServiceFactory {
     return ServiceType.KEYSTORE_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultKeystoreService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
+
+public class KeystoreServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new DefaultKeystoreService();
+      ((DefaultKeystoreService) service).setMasterService(getMasterService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.KEYSTORE_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MasterServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MasterServiceFactory.java
@@ -28,28 +28,23 @@ import org.apache.knox.gateway.services.security.impl.CLIMasterService;
 import org.apache.knox.gateway.services.security.impl.DefaultMasterService;
 
 public class MasterServiceFactory extends AbstractServiceFactory {
-  private static final String DEFAULT_IMPLEMENTATION_NAME = "default";
-  private static final String CLI_IMPLEMENTATION_NAME = "cli";
 
   @Override
   public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
     if (getServiceType() == serviceType) {
-      switch (implementation) {
-      case DEFAULT_IMPLEMENTATION_NAME:
-      case "":
+      if (matchesImplementation(implementation, DefaultMasterService.class, true)) {
         service = new DefaultMasterService();
-        break;
-      case CLI_IMPLEMENTATION_NAME:
+      } else if (matchesImplementation(implementation, CLIMasterService.class)) {
         service = new CLIMasterService();
-        break;
-      default:
+      } else {
         throw new IllegalArgumentException("Invalid Master Service implementation provided: " + implementation);
       }
+
+      logServiceUsage(implementation, serviceType);
     }
 
-    logServiceUsage(implementation, serviceType);
     return service;
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MasterServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MasterServiceFactory.java
@@ -17,6 +17,10 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.Collection;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -30,16 +34,14 @@ import org.apache.knox.gateway.services.security.impl.DefaultMasterService;
 public class MasterServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       if (matchesImplementation(implementation, DefaultMasterService.class, true)) {
         service = new DefaultMasterService();
       } else if (matchesImplementation(implementation, CLIMasterService.class)) {
         service = new CLIMasterService();
-      } else {
-        throw new IllegalArgumentException("Invalid Master Service implementation provided: " + implementation);
       }
 
       logServiceUsage(implementation, serviceType);
@@ -53,4 +55,8 @@ public class MasterServiceFactory extends AbstractServiceFactory {
     return ServiceType.MASTER_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return unmodifiableList(asList(DefaultMasterService.class.getName(), CLIMasterService.class.getName()));
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MasterServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MasterServiceFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.impl.CLIMasterService;
+import org.apache.knox.gateway.services.security.impl.DefaultMasterService;
+
+public class MasterServiceFactory extends AbstractServiceFactory {
+  private static final String DEFAULT_IMPLEMENTATION_NAME = "default";
+  private static final String CLI_IMPLEMENTATION_NAME = "cli";
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      switch (implementation) {
+      case DEFAULT_IMPLEMENTATION_NAME:
+      case "":
+        service = new DefaultMasterService();
+        break;
+      case CLI_IMPLEMENTATION_NAME:
+        service = new CLIMasterService();
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid Master Service implementation provided: " + implementation);
+      }
+    }
+
+    logServiceUsage(implementation, serviceType);
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.MASTER_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MetricsServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MetricsServiceFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.metrics.impl.DefaultMetricsService;
+
+public class MetricsServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    return getServiceType() == serviceType ? new DefaultMetricsService() : null;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.METRICS_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MetricsServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/MetricsServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,9 +31,9 @@ import org.apache.knox.gateway.services.metrics.impl.DefaultMetricsService;
 public class MetricsServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
-    return getServiceType() == serviceType ? new DefaultMetricsService() : null;
+    return shouldCreateService(implementation) ? new DefaultMetricsService() : null;
   }
 
   @Override
@@ -39,4 +41,8 @@ public class MetricsServiceFactory extends AbstractServiceFactory {
     return ServiceType.METRICS_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultMetricsService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/RemoteRegistryClientServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/RemoteRegistryClientServiceFactory.java
@@ -17,10 +17,14 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.service.config.remote.RemoteConfigurationRegistryClientServiceFactory;
+import org.apache.knox.gateway.service.config.remote.zk.ZooKeeperClientService;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -37,12 +41,12 @@ public class RemoteRegistryClientServiceFactory extends AbstractServiceFactory {
   private final AliasServiceFactory aliasServiceFactory = new AliasServiceFactory();
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = RemoteConfigurationRegistryClientServiceFactory.newInstance(gatewayConfig);
-      //it should be the 'default' alias service
+      // it should be the 'default' alias service
       final AliasService localAliasService = (AliasService) aliasServiceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, gatewayConfig, options, "");
       localAliasService.init(gatewayConfig, options);
       ((RemoteConfigurationRegistryClientService) service).setAliasService(localAliasService);
@@ -53,6 +57,11 @@ public class RemoteRegistryClientServiceFactory extends AbstractServiceFactory {
   @Override
   protected ServiceType getServiceType() {
     return ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE;
+  }
+
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(ZooKeeperClientService.class.getName());
   }
 
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/RemoteRegistryClientServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/RemoteRegistryClientServiceFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.service.config.remote.RemoteConfigurationRegistryClientServiceFactory;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
+
+// There are two implementations of 'RemoteConfigurationRegistryClientService':
+// - LocalFileSystemRemoteConfigurationRegistryClientService
+// - CuratorClientService
+// However, the first one - local - is for test-only purposes
+public class RemoteRegistryClientServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = RemoteConfigurationRegistryClientServiceFactory.newInstance(gatewayConfig);
+      ((RemoteConfigurationRegistryClientService) service).setAliasService(getAliasService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/RemoteRegistryClientServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/RemoteRegistryClientServiceFactory.java
@@ -26,6 +26,7 @@ import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
+import org.apache.knox.gateway.services.security.AliasService;
 
 // There are two implementations of 'RemoteConfigurationRegistryClientService':
 // - LocalFileSystemRemoteConfigurationRegistryClientService
@@ -33,13 +34,18 @@ import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistr
 // However, the first one - local - is for test-only purposes
 public class RemoteRegistryClientServiceFactory extends AbstractServiceFactory {
 
+  private final AliasServiceFactory aliasServiceFactory = new AliasServiceFactory();
+
   @Override
   public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
     if (getServiceType() == serviceType) {
       service = RemoteConfigurationRegistryClientServiceFactory.newInstance(gatewayConfig);
-      ((RemoteConfigurationRegistryClientService) service).setAliasService(getAliasService(gatewayServices));
+      //it should be the 'default' alias service
+      final AliasService localAliasService = (AliasService) aliasServiceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, gatewayConfig, options, "");
+      localAliasService.init(gatewayConfig, options);
+      ((RemoteConfigurationRegistryClientService) service).setAliasService(localAliasService);
     }
     return service;
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.DefaultServerInfoService;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+
+public class ServerInfoServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    return getServiceType() == serviceType ? new DefaultServerInfoService() : null;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.SERVER_INFO_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,9 +31,9 @@ import org.apache.knox.gateway.services.ServiceType;
 public class ServerInfoServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
-    return getServiceType() == serviceType ? new DefaultServerInfoService() : null;
+    return shouldCreateService(implementation) ? new DefaultServerInfoService() : null;
   }
 
   @Override
@@ -39,4 +41,8 @@ public class ServerInfoServiceFactory extends AbstractServiceFactory {
     return ServiceType.SERVER_INFO_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultServerInfoService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,9 +31,9 @@ import org.apache.knox.gateway.services.registry.impl.DefaultServiceDefinitionRe
 public class ServiceDefinitionRegistryFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
-    return getServiceType() == serviceType ? new DefaultServiceDefinitionRegistry() : null;
+    return shouldCreateService(implementation) ? new DefaultServiceDefinitionRegistry() : null;
   }
 
   @Override
@@ -39,4 +41,8 @@ public class ServiceDefinitionRegistryFactory extends AbstractServiceFactory {
     return ServiceType.SERVICE_DEFINITION_REGISTRY;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultServiceDefinitionRegistry.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.registry.impl.DefaultServiceDefinitionRegistry;
+
+public class ServiceDefinitionRegistryFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    return getServiceType() == serviceType ? new DefaultServiceDefinitionRegistry() : null;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.SERVICE_DEFINITION_REGISTRY;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceRegistryServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceRegistryServiceFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.registry.impl.DefaultServiceRegistryService;
+
+public class ServiceRegistryServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new DefaultServiceRegistryService();
+      ((DefaultServiceRegistryService) service).setCryptoService(gatewayServices.getService(ServiceType.CRYPTO_SERVICE));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.SERVICE_REGISTRY_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceRegistryServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ServiceRegistryServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.registry.impl.DefaultServiceRegistryServ
 public class ServiceRegistryServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new DefaultServiceRegistryService();
       ((DefaultServiceRegistryService) service).setCryptoService(gatewayServices.getService(ServiceType.CRYPTO_SERVICE));
     }
@@ -44,4 +46,8 @@ public class ServiceRegistryServiceFactory extends AbstractServiceFactory {
     return ServiceType.SERVICE_REGISTRY_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultServiceRegistryService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/SslServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/SslServiceFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.impl.JettySSLService;
+
+public class SslServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new JettySSLService();
+      ((JettySSLService) service).setKeystoreService(getKeystoreService(gatewayServices));
+      ((JettySSLService) service).setAliasService(getAliasService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.SSL_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/SslServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/SslServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.security.impl.JettySSLService;
 public class SslServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new JettySSLService();
       ((JettySSLService) service).setKeystoreService(getKeystoreService(gatewayServices));
       ((JettySSLService) service).setAliasService(getAliasService(gatewayServices));
@@ -45,4 +47,8 @@ public class SslServiceFactory extends AbstractServiceFactory {
     return ServiceType.SSL_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(JettySSLService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
 public class TokenServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new DefaultTokenAuthorityService();
       ((DefaultTokenAuthorityService) service).setKeystoreService(getKeystoreService(gatewayServices));
       ((DefaultTokenAuthorityService) service).setAliasService(getAliasService(gatewayServices));
@@ -45,4 +47,8 @@ public class TokenServiceFactory extends AbstractServiceFactory {
     return ServiceType.TOKEN_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultTokenAuthorityService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenServiceFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
+
+public class TokenServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new DefaultTokenAuthorityService();
+      ((DefaultTokenAuthorityService) service).setKeystoreService(getKeystoreService(gatewayServices));
+      ((DefaultTokenAuthorityService) service).setAliasService(getAliasService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.TOKEN_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService;
+import org.apache.knox.gateway.services.token.impl.DefaultTokenStateService;
+import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService;
+
+public class TokenStateServiceFactory extends AbstractServiceFactory {
+  private static final String DEFAULT_IMPLEMENTATION_NAME = "default";
+  private static final String ALIAS_IMPLEMENTATION_NAME = "alias";
+  private static final String JOURNAL_IMPLEMENTATION_NAME = "journal";
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      switch (implementation) {
+      case DEFAULT_IMPLEMENTATION_NAME:
+      case "":
+        service = new DefaultTokenStateService();
+        break;
+      case ALIAS_IMPLEMENTATION_NAME:
+        service = new AliasBasedTokenStateService();
+        ((AliasBasedTokenStateService) service).setAliasService(getAliasService(gatewayServices));
+        break;
+      case JOURNAL_IMPLEMENTATION_NAME:
+        service = new JournalBasedTokenStateService();
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid Token State Service implementation provided: " + implementation);
+      }
+
+      logServiceUsage(implementation, serviceType);
+    }
+
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.TOKEN_STATE_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
@@ -17,6 +17,10 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.Collection;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -31,10 +35,10 @@ import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService
 public class TokenStateServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       if (matchesImplementation(implementation, DefaultTokenStateService.class, true)) {
         service = new DefaultTokenStateService();
       } else if (matchesImplementation(implementation, AliasBasedTokenStateService.class)) {
@@ -42,8 +46,6 @@ public class TokenStateServiceFactory extends AbstractServiceFactory {
         ((AliasBasedTokenStateService) service).setAliasService(getAliasService(gatewayServices));
       } else if (matchesImplementation(implementation, JournalBasedTokenStateService.class)) {
         service = new JournalBasedTokenStateService();
-      } else {
-        throw new IllegalArgumentException("Invalid Token State Service implementation provided: " + implementation);
       }
 
       logServiceUsage(implementation, serviceType);
@@ -57,4 +59,8 @@ public class TokenStateServiceFactory extends AbstractServiceFactory {
     return ServiceType.TOKEN_STATE_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return unmodifiableList(asList(DefaultTokenStateService.class.getName(), AliasBasedTokenStateService.class.getName(), JournalBasedTokenStateService.class.getName()));
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
@@ -29,28 +29,20 @@ import org.apache.knox.gateway.services.token.impl.DefaultTokenStateService;
 import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService;
 
 public class TokenStateServiceFactory extends AbstractServiceFactory {
-  private static final String DEFAULT_IMPLEMENTATION_NAME = "default";
-  private static final String ALIAS_IMPLEMENTATION_NAME = "alias";
-  private static final String JOURNAL_IMPLEMENTATION_NAME = "journal";
 
   @Override
   public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
     if (getServiceType() == serviceType) {
-      switch (implementation) {
-      case DEFAULT_IMPLEMENTATION_NAME:
-      case "":
+      if (matchesImplementation(implementation, DefaultTokenStateService.class, true)) {
         service = new DefaultTokenStateService();
-        break;
-      case ALIAS_IMPLEMENTATION_NAME:
+      } else if (matchesImplementation(implementation, AliasBasedTokenStateService.class)) {
         service = new AliasBasedTokenStateService();
         ((AliasBasedTokenStateService) service).setAliasService(getAliasService(gatewayServices));
-        break;
-      case JOURNAL_IMPLEMENTATION_NAME:
+      } else if (matchesImplementation(implementation, JournalBasedTokenStateService.class)) {
         service = new JournalBasedTokenStateService();
-        break;
-      default:
+      } else {
         throw new IllegalArgumentException("Invalid Token State Service implementation provided: " + implementation);
       }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TopologyServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TopologyServiceFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
+
+public class TopologyServiceFactory extends AbstractServiceFactory {
+
+  @Override
+  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException {
+    Service service = null;
+    if (getServiceType() == serviceType) {
+      service = new DefaultTopologyService();
+      ((DefaultTopologyService) service).setAliasService(getAliasService(gatewayServices));
+    }
+    return service;
+  }
+
+  @Override
+  protected ServiceType getServiceType() {
+    return ServiceType.TOPOLOGY_SERVICE;
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TopologyServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TopologyServiceFactory.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -29,10 +31,10 @@ import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
 public class TopologyServiceFactory extends AbstractServiceFactory {
 
   @Override
-  public Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+  protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
       throws ServiceLifecycleException {
     Service service = null;
-    if (getServiceType() == serviceType) {
+    if (shouldCreateService(implementation)) {
       service = new DefaultTopologyService();
       ((DefaultTopologyService) service).setAliasService(getAliasService(gatewayServices));
     }
@@ -44,4 +46,8 @@ public class TopologyServiceFactory extends AbstractServiceFactory {
     return ServiceType.TOPOLOGY_SERVICE;
   }
 
+  @Override
+  protected Collection<String> getKnownImplementations() {
+    return Collections.singleton(DefaultTopologyService.class.getName());
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultCryptoService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultCryptoService.java
@@ -43,23 +43,23 @@ public class DefaultCryptoService implements CryptoService {
 
   private static final Map<String,ConfigurableEncryptor> ENCRYPTOR_CACHE = new HashMap<>();
 
-  private AliasService as;
-  private KeystoreService ks;
+  private AliasService aliasService;
+  private KeystoreService keystoreService;
   private GatewayConfig config;
 
   public void setKeystoreService(KeystoreService ks) {
-    this.ks = ks;
+    this.keystoreService = ks;
   }
 
   public void setAliasService(AliasService as) {
-    this.as = as;
+    this.aliasService = as;
   }
 
   @Override
   public void init(GatewayConfig config, Map<String, String> options)
       throws ServiceLifecycleException {
     this.config = config;
-  if (as == null) {
+  if (aliasService == null) {
       throw new ServiceLifecycleException("Alias service is not set");
     }
   }
@@ -77,7 +77,7 @@ public class DefaultCryptoService implements CryptoService {
   @Override
   public void createAndStoreEncryptionKeyForCluster(String clusterName, String alias) {
     try {
-      as.generateAliasForCluster(clusterName, alias);
+      aliasService.generateAliasForCluster(clusterName, alias);
     } catch (AliasServiceException e) {
       e.printStackTrace();
     }
@@ -87,7 +87,7 @@ public class DefaultCryptoService implements CryptoService {
   public EncryptionResult encryptForCluster(String clusterName, String alias, byte[] clear) {
     char[] password = null;
     try {
-      password = as.getPasswordFromAliasForCluster(clusterName, alias);
+      password = aliasService.getPasswordFromAliasForCluster(clusterName, alias);
     } catch (AliasServiceException e2) {
       e2.printStackTrace();
     }
@@ -111,7 +111,7 @@ public class DefaultCryptoService implements CryptoService {
     try {
       char[] password;
       ConfigurableEncryptor encryptor;
-        password = as.getPasswordFromAliasForCluster(clusterName, alias);
+        password = aliasService.getPasswordFromAliasForCluster(clusterName, alias);
         if (password != null) {
           encryptor = getEncryptor(clusterName,password );
           try {
@@ -134,7 +134,7 @@ public class DefaultCryptoService implements CryptoService {
     boolean verified = false;
     try {
       Signature sig=Signature.getInstance(algorithm);
-      sig.initVerify(ks.getCertificateForGateway().getPublicKey());
+      sig.initVerify(keystoreService.getCertificateForGateway().getPublicKey());
       sig.update(signed.getBytes(StandardCharsets.UTF_8));
       verified = sig.verify(signature);
     } catch (SignatureException | KeystoreServiceException | InvalidKeyException | NoSuchAlgorithmException | KeyStoreException e) {
@@ -148,8 +148,8 @@ public class DefaultCryptoService implements CryptoService {
   public byte[] sign(String algorithm, String payloadToSign) {
     try {
       char[] passphrase;
-      passphrase = as.getGatewayIdentityPassphrase();
-      PrivateKey privateKey = (PrivateKey) ks.getKeyForGateway(passphrase);
+      passphrase = aliasService.getGatewayIdentityPassphrase();
+      PrivateKey privateKey = (PrivateKey) keystoreService.getKeyForGateway(passphrase);
       Signature signature = Signature.getInstance(algorithm);
       signature.initSign(privateKey);
       signature.update(payloadToSign.getBytes(StandardCharsets.UTF_8));

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -26,7 +26,6 @@ import org.apache.knox.gateway.GatewayResources;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
-import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
@@ -68,7 +67,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.crypto.spec.SecretKeySpec;
 
-public class DefaultKeystoreService implements KeystoreService, Service {
+public class DefaultKeystoreService implements KeystoreService {
   private static final String DN_TEMPLATE = "CN={0},OU=Test,O=Hadoop,L=Test,ST=Test,C=US";
   private static final String CREDENTIALS_SUFFIX = "-credentials.jceks";
   private static final String CREDENTIALS_STORE_TYPE = "JCEKS";

--- a/gateway-server/src/main/resources/META-INF/services/org.apache.knox.gateway.services.ServiceFactory
+++ b/gateway-server/src/main/resources/META-INF/services/org.apache.knox.gateway.services.ServiceFactory
@@ -1,0 +1,33 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+
+org.apache.knox.gateway.services.factory.AliasServiceFactory
+org.apache.knox.gateway.services.factory.ClusterConfigurationMonitorServiceFactory
+org.apache.knox.gateway.services.factory.CryptoServiceFactory
+org.apache.knox.gateway.services.factory.HostMappingServiceFactory
+org.apache.knox.gateway.services.factory.KeystoreServiceFactory
+org.apache.knox.gateway.services.factory.MasterServiceFactory
+org.apache.knox.gateway.services.factory.MetricsServiceFactory
+org.apache.knox.gateway.services.factory.RemoteRegistryClientServiceFactory
+org.apache.knox.gateway.services.factory.ServerInfoServiceFactory
+org.apache.knox.gateway.services.factory.ServiceDefinitionRegistryFactory
+org.apache.knox.gateway.services.factory.ServiceRegistryServiceFactory
+org.apache.knox.gateway.services.factory.SslServiceFactory
+org.apache.knox.gateway.services.factory.TokenServiceFactory
+org.apache.knox.gateway.services.factory.TokenStateServiceFactory
+org.apache.knox.gateway.services.factory.TopologyServiceFactory

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -406,24 +406,21 @@ public class GatewayConfigImplTest {
   }
 
   @Test
-  public void testGetServiceImplementation() throws Exception {
+  public void testGetServiceParameter() throws Exception {
     final GatewayConfigImpl gatewayConfig = new GatewayConfigImpl();
 
-    // should return an empty string if 'gateway.services' is not set
-    assertEquals("", gatewayConfig.getServiceImplementation("alias"));
+    // should return an empty string if 'gateway.service.alias.impl' is not set
+    assertEquals("", gatewayConfig.getServiceParameter("alias", "impl"));
 
-    // spaces are left in the value on purpose
-    gatewayConfig.set("gateway.services", "alias:remote , master:cli,  keystore  ");
+    gatewayConfig.set("gateway.service.alias.impl", "myAliasService");
+    gatewayConfig.set("gateway.service.tokenstate.impl", "myTokenStateService");
 
     // should return an empty string if the given service is not defined
-    assertEquals("", gatewayConfig.getServiceImplementation("notListedService"));
+    assertEquals("", gatewayConfig.getServiceParameter("notListedService", "impl"));
 
-    // should return an empty string if the given service has no declared implementation
-    assertEquals("", gatewayConfig.getServiceImplementation("keystore"));
-
-    // should return the declared implementations
-    assertEquals("remote", gatewayConfig.getServiceImplementation("alias"));
-    assertEquals("cli", gatewayConfig.getServiceImplementation("master"));
+    //should return the declared implementations
+    assertEquals("myAliasService", gatewayConfig.getServiceParameter("alias", "impl"));
+    assertEquals("myTokenStateService", gatewayConfig.getServiceParameter("tokenstate", "impl"));
   }
 
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+  import static org.junit.Assert.assertTrue;
 
 public class GatewayConfigImplTest {
 
@@ -403,6 +403,27 @@ public class GatewayConfigImplTest {
     final Map<String, String> remoteAliasServiceConfiguration = new GatewayConfigImpl().getRemoteAliasServiceConfiguration();
     assertTrue(remoteAliasServiceConfiguration.containsKey(REMOTE_ALIAS_SERVICE_TYPE));
     assertEquals(ZookeeperRemoteAliasService.TYPE, remoteAliasServiceConfiguration.get(REMOTE_ALIAS_SERVICE_TYPE));
+  }
+
+  @Test
+  public void testGetServiceImplementation() throws Exception {
+    final GatewayConfigImpl gatewayConfig = new GatewayConfigImpl();
+
+    // should return an empty string if 'gateway.services' is not set
+    assertEquals("", gatewayConfig.getServiceImplementation("alias"));
+
+    // spaces are left in the value on purpose
+    gatewayConfig.set("gateway.services", "alias:remote , master:cli,  keystore  ");
+
+    // should return an empty string if the given service is not defined
+    assertEquals("", gatewayConfig.getServiceImplementation("notListedService"));
+
+    // should return an empty string if the given service has no declared implementation
+    assertEquals("", gatewayConfig.getServiceImplementation("keystore"));
+
+    // should return the declared implementations
+    assertEquals("remote", gatewayConfig.getServiceImplementation("alias"));
+    assertEquals("cli", gatewayConfig.getServiceImplementation("master"));
   }
 
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/TestService.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/TestService.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+
+public class TestService implements Service {
+
+  @Override
+  public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+  }
+
+  @Override
+  public void start() throws ServiceLifecycleException {
+  }
+
+  @Override
+  public void stop() throws ServiceLifecycleException {
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/AliasServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/AliasServiceFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.backend.hashicorp.vault.HashicorpVaultAliasService;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.impl.DefaultAliasService;
+import org.apache.knox.gateway.services.security.impl.RemoteAliasService;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AliasServiceFactoryTest extends ServiceFactoryTest {
+
+  private final AliasServiceFactory serviceFactory = new AliasServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.ALIAS_SERVICE, true);
+  }
+
+  @Test
+  public void shouldReturnDefaultAliasService() throws Exception {
+    AliasService aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "default");
+    assertTrue(aliasService instanceof DefaultAliasService);
+    assertTrue(isMasterServiceSet(aliasService));
+    assertTrue(isKeystoreServiceSet(aliasService));
+
+    aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "");
+    assertTrue(aliasService instanceof DefaultAliasService);
+    assertTrue(isMasterServiceSet(aliasService));
+    assertTrue(isKeystoreServiceSet(aliasService));
+  }
+
+  @Test
+  public void shouldReturnHashicorpVaultAliasService() throws Exception {
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "hashicorp") instanceof HashicorpVaultAliasService);
+  }
+
+  @Test
+  public void shouldReturnRemoteAliasService() throws Exception {
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "remote") instanceof RemoteAliasService);
+  }
+
+  @Test
+  public void shouldReturnZookeeperAliasService() throws Exception {
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "zookeeper") instanceof ZookeeperRemoteAliasService);
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/AliasServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/AliasServiceFactoryTest.java
@@ -44,7 +44,7 @@ public class AliasServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultAliasService() throws Exception {
-    AliasService aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "default");
+    AliasService aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, DefaultAliasService.class.getName());
     assertTrue(aliasService instanceof DefaultAliasService);
     assertTrue(isMasterServiceSet(aliasService));
     assertTrue(isKeystoreServiceSet(aliasService));
@@ -57,17 +57,17 @@ public class AliasServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnHashicorpVaultAliasService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "hashicorp") instanceof HashicorpVaultAliasService);
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, HashicorpVaultAliasService.class.getName()) instanceof HashicorpVaultAliasService);
   }
 
   @Test
   public void shouldReturnRemoteAliasService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "remote") instanceof RemoteAliasService);
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, RemoteAliasService.class.getName()) instanceof RemoteAliasService);
   }
 
   @Test
   public void shouldReturnZookeeperAliasService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "zookeeper") instanceof ZookeeperRemoteAliasService);
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, ZookeeperRemoteAliasService.class.getName()) instanceof ZookeeperRemoteAliasService);
   }
 
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/AliasServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/AliasServiceFactoryTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static org.apache.knox.gateway.services.ServiceType.ALIAS_SERVICE;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.knox.gateway.backend.hashicorp.vault.HashicorpVaultAliasService;
@@ -39,17 +40,17 @@ public class AliasServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void testBasics() throws Exception {
-    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.ALIAS_SERVICE, true);
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.ALIAS_SERVICE);
   }
 
   @Test
   public void shouldReturnDefaultAliasService() throws Exception {
-    AliasService aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, DefaultAliasService.class.getName());
+    AliasService aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, gatewayConfig, options, DefaultAliasService.class.getName());
     assertTrue(aliasService instanceof DefaultAliasService);
     assertTrue(isMasterServiceSet(aliasService));
     assertTrue(isKeystoreServiceSet(aliasService));
 
-    aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, "");
+    aliasService = (AliasService) serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, gatewayConfig, options, "");
     assertTrue(aliasService instanceof DefaultAliasService);
     assertTrue(isMasterServiceSet(aliasService));
     assertTrue(isKeystoreServiceSet(aliasService));
@@ -57,17 +58,17 @@ public class AliasServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnHashicorpVaultAliasService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, HashicorpVaultAliasService.class.getName()) instanceof HashicorpVaultAliasService);
+    assertTrue(serviceFactory.create(gatewayServices, ALIAS_SERVICE, gatewayConfig, options, HashicorpVaultAliasService.class.getName()) instanceof HashicorpVaultAliasService);
   }
 
   @Test
   public void shouldReturnRemoteAliasService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, RemoteAliasService.class.getName()) instanceof RemoteAliasService);
+    assertTrue(serviceFactory.create(gatewayServices, ALIAS_SERVICE, gatewayConfig, options, RemoteAliasService.class.getName()) instanceof RemoteAliasService);
   }
 
   @Test
   public void shouldReturnZookeeperAliasService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.ALIAS_SERVICE, null, null, ZookeeperRemoteAliasService.class.getName()) instanceof ZookeeperRemoteAliasService);
+    assertTrue(serviceFactory.create(gatewayServices, ALIAS_SERVICE, gatewayConfig, options, ZookeeperRemoteAliasService.class.getName()) instanceof ZookeeperRemoteAliasService);
   }
 
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactoryTest.java
@@ -42,7 +42,7 @@ public class ClusterConfigurationMonitorServiceFactoryTest extends ServiceFactor
   @Test
   public void shouldReturnDefaultClusterConfigurationMonitorService() throws Exception {
     final ClusterConfigurationMonitorService clusterConfigurationMonitorService = (ClusterConfigurationMonitorService) serviceFactory.create(gatewayServices,
-        ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, null, null, null);
+        ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, gatewayConfig, options);
     assertTrue(clusterConfigurationMonitorService instanceof DefaultClusterConfigurationMonitorService);
     assertTrue(isAliasServiceSet(clusterConfigurationMonitorService));
     assertTrue(isKeystoreServiceSet(clusterConfigurationMonitorService));

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ClusterConfigurationMonitorServiceFactoryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.topology.impl.DefaultClusterConfigurationMonitorService;
+import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClusterConfigurationMonitorServiceFactoryTest extends ServiceFactoryTest {
+
+  private final ClusterConfigurationMonitorServiceFactory serviceFactory = new ClusterConfigurationMonitorServiceFactory();
+
+  @Before
+  public void setUp() {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultClusterConfigurationMonitorService() throws Exception {
+    final ClusterConfigurationMonitorService clusterConfigurationMonitorService = (ClusterConfigurationMonitorService) serviceFactory.create(gatewayServices,
+        ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, null, null, null);
+    assertTrue(clusterConfigurationMonitorService instanceof DefaultClusterConfigurationMonitorService);
+    assertTrue(isAliasServiceSet(clusterConfigurationMonitorService));
+    assertTrue(isKeystoreServiceSet(clusterConfigurationMonitorService));
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/CryptoServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/CryptoServiceFactoryTest.java
@@ -40,7 +40,7 @@ public class CryptoServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultCryptoService() throws Exception {
-    final CryptoService cryptoService = (CryptoService) serviceFactory.create(gatewayServices, ServiceType.CRYPTO_SERVICE, null, null, null);
+    final CryptoService cryptoService = (CryptoService) serviceFactory.create(gatewayServices, ServiceType.CRYPTO_SERVICE, gatewayConfig, options);
     assertTrue(cryptoService instanceof DefaultCryptoService);
     assertTrue(isKeystoreServiceSet(cryptoService));
     assertTrue(isAliasServiceSet(cryptoService));

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/CryptoServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/CryptoServiceFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.CryptoService;
+import org.apache.knox.gateway.services.security.impl.DefaultCryptoService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CryptoServiceFactoryTest extends ServiceFactoryTest {
+  private final CryptoServiceFactory serviceFactory = new CryptoServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.CRYPTO_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultCryptoService() throws Exception {
+    final CryptoService cryptoService = (CryptoService) serviceFactory.create(gatewayServices, ServiceType.CRYPTO_SERVICE, null, null, null);
+    assertTrue(cryptoService instanceof DefaultCryptoService);
+    assertTrue(isKeystoreServiceSet(cryptoService));
+    assertTrue(isAliasServiceSet(cryptoService));
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactoryTest.java
@@ -41,7 +41,7 @@ public class HostMappingServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultHostMapperService() throws Exception {
-    final HostMapperService hostMapperService = (HostMapperService) serviceFactory.create(gatewayServices, ServiceType.HOST_MAPPING_SERVICE, null, null, null);
+    final HostMapperService hostMapperService = (HostMapperService) serviceFactory.create(gatewayServices, ServiceType.HOST_MAPPING_SERVICE, gatewayConfig, options);
     assertTrue(hostMapperService instanceof DefaultHostMapperService);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/HostMappingServiceFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.hostmap.HostMapperService;
+import org.apache.knox.gateway.services.hostmap.impl.DefaultHostMapperService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HostMappingServiceFactoryTest extends ServiceFactoryTest {
+
+  private final HostMappingServiceFactory serviceFactory = new HostMappingServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.HOST_MAPPING_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultHostMapperService() throws Exception {
+    final HostMapperService hostMapperService = (HostMapperService) serviceFactory.create(gatewayServices, ServiceType.HOST_MAPPING_SERVICE, null, null, null);
+    assertTrue(hostMapperService instanceof DefaultHostMapperService);
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KeystoreServiceFactoryTest extends ServiceFactoryTest {
+
+  private final KeystoreServiceFactory serviceFactory = new KeystoreServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.KEYSTORE_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultKeystoreService() throws Exception {
+    final KeystoreService keystoreService = (KeystoreService) serviceFactory.create(gatewayServices, ServiceType.KEYSTORE_SERVICE, null, null, null);
+    assertTrue(keystoreService instanceof DefaultKeystoreService);
+    assertTrue(isMasterServiceSet(keystoreService));
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/KeystoreServiceFactoryTest.java
@@ -41,7 +41,7 @@ public class KeystoreServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultKeystoreService() throws Exception {
-    final KeystoreService keystoreService = (KeystoreService) serviceFactory.create(gatewayServices, ServiceType.KEYSTORE_SERVICE, null, null, null);
+    final KeystoreService keystoreService = (KeystoreService) serviceFactory.create(gatewayServices, ServiceType.KEYSTORE_SERVICE, gatewayConfig, options);
     assertTrue(keystoreService instanceof DefaultKeystoreService);
     assertTrue(isMasterServiceSet(keystoreService));
   }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MasterServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MasterServiceFactoryTest.java
@@ -42,7 +42,7 @@ public class MasterServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultMasterService() throws Exception {
-    MasterService masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, "default");
+    MasterService masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, DefaultMasterService.class.getName());
     assertTrue(masterService instanceof DefaultMasterService);
 
     masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, "");
@@ -51,7 +51,7 @@ public class MasterServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnCliMasterService() throws Exception {
-    MasterService masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, "cli");
+    MasterService masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, CLIMasterService.class.getName());
     assertTrue(masterService instanceof CLIMasterService);
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MasterServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MasterServiceFactoryTest.java
@@ -37,7 +37,7 @@ public class MasterServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void testBasics() throws Exception {
-    super.testBasics(serviceFactory, ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, ServiceType.MASTER_SERVICE, true);
+    super.testBasics(serviceFactory, ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, ServiceType.MASTER_SERVICE);
   }
 
   @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MasterServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MasterServiceFactoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.services.security.impl.CLIMasterService;
+import org.apache.knox.gateway.services.security.impl.DefaultMasterService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MasterServiceFactoryTest extends ServiceFactoryTest {
+
+  private final MasterServiceFactory serviceFactory = new MasterServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE, ServiceType.MASTER_SERVICE, true);
+  }
+
+  @Test
+  public void shouldReturnDefaultMasterService() throws Exception {
+    MasterService masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, "default");
+    assertTrue(masterService instanceof DefaultMasterService);
+
+    masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, "");
+    assertTrue(masterService instanceof DefaultMasterService);
+  }
+
+  @Test
+  public void shouldReturnCliMasterService() throws Exception {
+    MasterService masterService = (MasterService) serviceFactory.create(gatewayServices, ServiceType.MASTER_SERVICE, null, null, "cli");
+    assertTrue(masterService instanceof CLIMasterService);
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MetricsServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MetricsServiceFactoryTest.java
@@ -41,7 +41,7 @@ public class MetricsServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultMetricsService() throws Exception {
-    final MetricsService metricsService = (MetricsService) serviceFactory.create(gatewayServices, ServiceType.METRICS_SERVICE, null, null, null);
+    final MetricsService metricsService = (MetricsService) serviceFactory.create(gatewayServices, ServiceType.METRICS_SERVICE, gatewayConfig, options);
     assertTrue(metricsService instanceof DefaultMetricsService);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MetricsServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/MetricsServiceFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.metrics.MetricsService;
+import org.apache.knox.gateway.services.metrics.impl.DefaultMetricsService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MetricsServiceFactoryTest extends ServiceFactoryTest {
+
+  private final MetricsServiceFactory serviceFactory = new MetricsServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.METRICS_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultMetricsService() throws Exception {
+    final MetricsService metricsService = (MetricsService) serviceFactory.create(gatewayServices, ServiceType.METRICS_SERVICE, null, null, null);
+    assertTrue(metricsService instanceof DefaultMetricsService);
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactoryTest.java
@@ -41,7 +41,7 @@ public class ServerInfoServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultServerInfoService() throws Exception {
-    final ServerInfoService serverInfoService = (ServerInfoService) serviceFactory.create(gatewayServices, ServiceType.SERVER_INFO_SERVICE, null, null, null);
+    final ServerInfoService serverInfoService = (ServerInfoService) serviceFactory.create(gatewayServices, ServiceType.SERVER_INFO_SERVICE, gatewayConfig, options);
     assertTrue(serverInfoService instanceof DefaultServerInfoService);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServerInfoServiceFactoryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.DefaultServerInfoService;
+import org.apache.knox.gateway.services.ServerInfoService;
+import org.apache.knox.gateway.services.ServiceType;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServerInfoServiceFactoryTest extends ServiceFactoryTest {
+
+  private final ServerInfoServiceFactory serviceFactory = new ServerInfoServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.SERVER_INFO_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultServerInfoService() throws Exception {
+    final ServerInfoService serverInfoService = (ServerInfoService) serviceFactory.create(gatewayServices, ServiceType.SERVER_INFO_SERVICE, null, null, null);
+    assertTrue(serverInfoService instanceof DefaultServerInfoService);
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.registry.ServiceDefinitionRegistry;
+import org.apache.knox.gateway.services.registry.impl.DefaultServiceDefinitionRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServiceDefinitionRegistryFactoryTest extends ServiceFactoryTest {
+
+  private final ServiceDefinitionRegistryFactory serviceFactory = new ServiceDefinitionRegistryFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.SERVICE_DEFINITION_REGISTRY);
+  }
+
+  @Test
+  public void shouldReturnDefaultServiceDefinitionRegistry() throws Exception {
+    final ServiceDefinitionRegistry serviceDefinitionRegistry = (ServiceDefinitionRegistry) serviceFactory.create(gatewayServices, ServiceType.SERVICE_DEFINITION_REGISTRY, null,
+        null, null);
+    assertTrue(serviceDefinitionRegistry instanceof DefaultServiceDefinitionRegistry);
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceDefinitionRegistryFactoryTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static org.apache.knox.gateway.services.ServiceType.SERVICE_DEFINITION_REGISTRY;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.knox.gateway.services.ServiceType;
@@ -36,13 +37,13 @@ public class ServiceDefinitionRegistryFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void testBasics() throws Exception {
-    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.SERVICE_DEFINITION_REGISTRY);
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, SERVICE_DEFINITION_REGISTRY);
   }
 
   @Test
   public void shouldReturnDefaultServiceDefinitionRegistry() throws Exception {
-    final ServiceDefinitionRegistry serviceDefinitionRegistry = (ServiceDefinitionRegistry) serviceFactory.create(gatewayServices, ServiceType.SERVICE_DEFINITION_REGISTRY, null,
-        null, null);
+    final ServiceDefinitionRegistry serviceDefinitionRegistry = (ServiceDefinitionRegistry) serviceFactory.create(gatewayServices, SERVICE_DEFINITION_REGISTRY, gatewayConfig,
+        options);
     assertTrue(serviceDefinitionRegistry instanceof DefaultServiceDefinitionRegistry);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Field;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.easymock.EasyMock;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+class ServiceFactoryTest {
+
+  @SuppressWarnings("deprecation")
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  protected final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
+
+  protected void initConfig() {
+    final MasterService masterService = EasyMock.createNiceMock(MasterService.class);
+    expect(gatewayServices.getService(ServiceType.MASTER_SERVICE)).andReturn(masterService).anyTimes();
+    final KeystoreService keystoreservice = EasyMock.createNiceMock(KeystoreService.class);
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreservice).anyTimes();
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
+    replay(gatewayServices);
+  }
+
+  protected void testBasics(AbstractServiceFactory serviceFactory, ServiceType nonMatchingServiceType, ServiceType matchingServiceType) throws Exception {
+    testBasics(serviceFactory, nonMatchingServiceType, matchingServiceType, false);
+  }
+
+  protected void testBasics(AbstractServiceFactory serviceFactory, ServiceType nonMatchingServiceType, ServiceType matchingServiceType, boolean checkUnknownImplementation)
+      throws Exception {
+    shouldReturnCorrectServiceType(serviceFactory, matchingServiceType);
+    shouldReturnNullForNonMatchingServiceType(serviceFactory, nonMatchingServiceType);
+    if (checkUnknownImplementation) {
+      shouldThrowIllegalArgumentExceptionIfNoMatchingImplementationFound(serviceFactory, matchingServiceType);
+    }
+  }
+
+  private void shouldReturnCorrectServiceType(AbstractServiceFactory serviceFactory, ServiceType serviceType) {
+    assertEquals(serviceType, serviceFactory.getServiceType());
+  }
+
+  private void shouldReturnNullForNonMatchingServiceType(AbstractServiceFactory serviceFactory, ServiceType serviceType) throws Exception {
+    assertNull(serviceFactory.create(gatewayServices, serviceType, null, null, null));
+  }
+
+  private void shouldThrowIllegalArgumentExceptionIfNoMatchingImplementationFound(AbstractServiceFactory serviceFactory, ServiceType serviceType) throws Exception {
+    expectedException.expect(IllegalArgumentException.class);
+    final String serviceName = ServiceType.TOKEN_STATE_SERVICE == serviceType ? "Token State" : StringUtils.capitalize(serviceType.getShortName());
+    expectedException.expectMessage(String.format(Locale.ROOT, "Invalid %s Service implementation provided: unknown", serviceName));
+    serviceFactory.create(gatewayServices, serviceType, null, null, "unknown");
+  }
+
+  protected boolean isMasterServiceSet(Service serviceToCheck) throws Exception {
+    return isServiceSet(serviceToCheck, "masterService");
+  }
+
+  protected boolean isKeystoreServiceSet(Service serviceToCheck) throws Exception {
+    return isServiceSet(serviceToCheck, "keystoreService");
+  }
+
+  protected boolean isAliasServiceSet(Service serviceToCheck) throws Exception {
+    return isServiceSet(serviceToCheck, "aliasService");
+  }
+
+  private boolean isServiceSet(Service serviceToCheck, String expectedServiceName) throws Exception {
+    final Field aliasServiceField = FieldUtils.getDeclaredField(serviceToCheck.getClass(), expectedServiceName, true);
+    final Object aliasServiceValue = aliasServiceField.get(serviceToCheck);
+    return aliasServiceValue != null;
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/SslServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/SslServiceFactoryTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.SSLService;
+import org.apache.knox.gateway.services.security.impl.JettySSLService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SslServiceFactoryTest extends ServiceFactoryTest {
+
+  private final SslServiceFactory serviceFactory = new SslServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.SSL_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnJettySslService() throws Exception {
+    final SSLService keystoreService = (SSLService) serviceFactory.create(gatewayServices, ServiceType.SSL_SERVICE, null, null, null);
+    assertTrue(keystoreService instanceof JettySSLService);
+    assertTrue(isKeystoreServiceSet(keystoreService));
+    assertTrue(isAliasServiceSet(keystoreService));
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/SslServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/SslServiceFactoryTest.java
@@ -41,7 +41,7 @@ public class SslServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnJettySslService() throws Exception {
-    final SSLService keystoreService = (SSLService) serviceFactory.create(gatewayServices, ServiceType.SSL_SERVICE, null, null, null);
+    final SSLService keystoreService = (SSLService) serviceFactory.create(gatewayServices, ServiceType.SSL_SERVICE, gatewayConfig, options);
     assertTrue(keystoreService instanceof JettySSLService);
     assertTrue(isKeystoreServiceSet(keystoreService));
     assertTrue(isAliasServiceSet(keystoreService));

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenServiceFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TokenServiceFactoryTest extends ServiceFactoryTest {
+
+  private final TokenServiceFactory serviceFactory = new TokenServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.TOKEN_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultTokenService() throws Exception {
+    final DefaultTokenAuthorityService keystoreService = (DefaultTokenAuthorityService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_SERVICE, null, null, null);
+    assertTrue(keystoreService instanceof DefaultTokenAuthorityService);
+    assertTrue(isKeystoreServiceSet(keystoreService));
+    assertTrue(isAliasServiceSet(keystoreService));
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenServiceFactoryTest.java
@@ -40,7 +40,7 @@ public class TokenServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultTokenService() throws Exception {
-    final DefaultTokenAuthorityService keystoreService = (DefaultTokenAuthorityService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_SERVICE, null, null, null);
+    final DefaultTokenAuthorityService keystoreService = (DefaultTokenAuthorityService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_SERVICE, gatewayConfig, options);
     assertTrue(keystoreService instanceof DefaultTokenAuthorityService);
     assertTrue(isKeystoreServiceSet(keystoreService));
     assertTrue(isAliasServiceSet(keystoreService));

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
@@ -43,7 +43,7 @@ public class TokenStateServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultAliasService() throws Exception {
-    TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "default");
+    TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, DefaultTokenStateService.class.getName());
     assertTrue(tokenStateService instanceof DefaultTokenStateService);
 
     tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "");
@@ -52,13 +52,13 @@ public class TokenStateServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnAliasBasedTokenStateService() throws Exception {
-    final TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "alias");
+    final TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, AliasBasedTokenStateService.class.getName());
     assertTrue(tokenStateService instanceof AliasBasedTokenStateService);
     assertTrue(isAliasServiceSet(tokenStateService));
   }
 
   @Test
   public void shouldReturnHJournalTokenStateService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "journal") instanceof JournalBasedTokenStateService);
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, JournalBasedTokenStateService.class.getName()) instanceof JournalBasedTokenStateService);
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService;
+import org.apache.knox.gateway.services.token.impl.DefaultTokenStateService;
+import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TokenStateServiceFactoryTest extends ServiceFactoryTest {
+
+  private final TokenStateServiceFactory serviceFactory = new TokenStateServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.TOKEN_STATE_SERVICE, true);
+  }
+
+  @Test
+  public void shouldReturnDefaultAliasService() throws Exception {
+    TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "default");
+    assertTrue(tokenStateService instanceof DefaultTokenStateService);
+
+    tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "");
+    assertTrue(tokenStateService instanceof DefaultTokenStateService);
+  }
+
+  @Test
+  public void shouldReturnAliasBasedTokenStateService() throws Exception {
+    final TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "alias");
+    assertTrue(tokenStateService instanceof AliasBasedTokenStateService);
+    assertTrue(isAliasServiceSet(tokenStateService));
+  }
+
+  @Test
+  public void shouldReturnHJournalTokenStateService() throws Exception {
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "journal") instanceof JournalBasedTokenStateService);
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
@@ -38,7 +38,7 @@ public class TokenStateServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void testBasics() throws Exception {
-    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.TOKEN_STATE_SERVICE, true);
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.TOKEN_STATE_SERVICE);
   }
 
   @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TopologyServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TopologyServiceFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.topology.TopologyService;
+import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TopologyServiceFactoryTest extends ServiceFactoryTest {
+
+  private final TopologyServiceFactory serviceFactory = new TopologyServiceFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.TOPOLOGY_SERVICE);
+  }
+
+  @Test
+  public void shouldReturnDefaultAliasService() throws Exception {
+    TopologyService topologyService = (TopologyService) serviceFactory.create(gatewayServices, ServiceType.TOPOLOGY_SERVICE, null, null, null);
+    assertTrue(topologyService instanceof DefaultTopologyService);
+    assertTrue(isAliasServiceSet(topologyService));
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TopologyServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TopologyServiceFactoryTest.java
@@ -40,8 +40,8 @@ public class TopologyServiceFactoryTest extends ServiceFactoryTest {
   }
 
   @Test
-  public void shouldReturnDefaultAliasService() throws Exception {
-    TopologyService topologyService = (TopologyService) serviceFactory.create(gatewayServices, ServiceType.TOPOLOGY_SERVICE, null, null, null);
+  public void shouldReturnDefaultTopologyService() throws Exception {
+    TopologyService topologyService = (TopologyService) serviceFactory.create(gatewayServices, ServiceType.TOPOLOGY_SERVICE, gatewayConfig, null);
     assertTrue(topologyService instanceof DefaultTopologyService);
     assertTrue(isAliasServiceSet(topologyService));
   }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -310,7 +310,7 @@ public class BadUrlTest {
         .andReturn(TEST_KEY_ALIAS)
         .anyTimes();
 
-    EasyMock.expect(gatewayConfig.getServiceImplementation(EasyMock.anyString())).andReturn("").anyTimes();
+    EasyMock.expect(gatewayConfig.getServiceParameter(EasyMock.anyString(), EasyMock.anyString())).andReturn("").anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -310,6 +310,8 @@ public class BadUrlTest {
         .andReturn(TEST_KEY_ALIAS)
         .anyTimes();
 
+    EasyMock.expect(gatewayConfig.getServiceImplementation(EasyMock.anyString())).andReturn("").anyTimes();
+
     EasyMock.replay(gatewayConfig);
 
     try {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
@@ -336,6 +336,7 @@ public class WebsocketEchoTestBase {
         .andReturn(TEST_KEY_ALIAS)
         .anyTimes();
 
+    EasyMock.expect(gatewayConfig.getServiceImplementation(EasyMock.anyString())).andReturn("").anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
@@ -336,7 +336,7 @@ public class WebsocketEchoTestBase {
         .andReturn(TEST_KEY_ALIAS)
         .anyTimes();
 
-    EasyMock.expect(gatewayConfig.getServiceImplementation(EasyMock.anyString())).andReturn("").anyTimes();
+    EasyMock.expect(gatewayConfig.getServiceParameter(EasyMock.anyString(), EasyMock.anyString())).andReturn("").anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
@@ -373,7 +373,7 @@ public class WebsocketMultipleConnectionTest {
         .andReturn(TEST_KEY_ALIAS)
         .anyTimes();
 
-    EasyMock.expect(gatewayConfig.getServiceImplementation(EasyMock.anyString())).andReturn("").anyTimes();
+    EasyMock.expect(gatewayConfig.getServiceParameter(EasyMock.anyString(), EasyMock.anyString())).andReturn("").anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
@@ -373,6 +373,8 @@ public class WebsocketMultipleConnectionTest {
         .andReturn(TEST_KEY_ALIAS)
         .anyTimes();
 
+    EasyMock.expect(gatewayConfig.getServiceImplementation(EasyMock.anyString())).andReturn("").anyTimes();
+
     EasyMock.replay(gatewayConfig);
 
     try {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -693,4 +693,9 @@ public interface GatewayConfig {
    * @return returns whether know token permissive validation is enabled
    */
   boolean isKnoxTokenPermissiveValidationEnabled();
+
+  /**
+   * @return the implementation for the given service if declared; an empty String otherwise
+   */
+  String getServiceImplementation(String service);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -695,7 +695,7 @@ public interface GatewayConfig {
   boolean isKnoxTokenPermissiveValidationEnabled();
 
   /**
-   * @return the implementation for the given service if declared; an empty String otherwise
+   * @return the value of the given parameter for the given service if declared; an empty String otherwise
    */
-  String getServiceImplementation(String service);
+  String getServiceParameter(String service, String parameter);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+
+public interface ServiceFactory {
+
+  Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options) throws ServiceLifecycleException;
+
+  Service create(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation)
+      throws ServiceLifecycleException;
+
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
@@ -18,6 +18,8 @@
 
 package org.apache.knox.gateway.services;
 
+import java.util.Locale;
+
 public enum ServiceType {
   ALIAS_SERVICE("AliasService"),
   CLUSTER_CONFIGURATION_MONITOR_SERVICE("ClusterConfigurationMonitorService"),
@@ -36,12 +38,18 @@ public enum ServiceType {
   TOPOLOGY_SERVICE("TopologyService");
 
   private final String serviceTypeName;
+  private final String shortName;
 
   ServiceType(String serviceTypeName) {
     this.serviceTypeName = serviceTypeName;
+    this.shortName = serviceTypeName.toLowerCase(Locale.ROOT).replace("service", "");
   }
 
   public String getServiceTypeName() {
     return serviceTypeName;
+  }
+
+  public String getShortName() {
+    return shortName;
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/KeystoreService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/KeystoreService.java
@@ -24,7 +24,9 @@ import java.security.cert.Certificate;
 import java.util.Map;
 import java.util.Set;
 
-public interface KeystoreService {
+import org.apache.knox.gateway.services.Service;
+
+public interface KeystoreService extends Service {
 
   void createKeystoreForGateway() throws KeystoreServiceException;
 

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -812,4 +812,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public boolean isKnoxTokenPermissiveValidationEnabled() {
     return false;
   }
+
+  @Override
+  public String getServiceImplementation(String service) {
+    return "";
+  }
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -814,7 +814,7 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public String getServiceImplementation(String service) {
+  public String getServiceParameter(String service, String parameter) {
     return "";
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on end-users can select different implementation for certain Knox services (where there are more than one implementations) through a newly introduced `gateway-site.xml` configuration called `gateway.service.$SERVICE.impl`.
Where `$SERVICE` is the short name of the service you want to configure and the value is the fully qualified class name of the desired implementation.  This works as an `override` option for the default implementation (which is hard-coded now in the Java code).
Currently, the following service/implementation pairs are configurable:
- alias
   - `org.apache.knox.gateway.services.security.impl.DefaultAliasService`
   - `org.apache.knox.gateway.backend.hashicorp.vault.HashicorpVaultAliasService`
   - `org.apache.knox.gateway.services.security.impl.RemoteAliasService`
   - `org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService`
- master
   - `org.apache.knox.gateway.services.security.impl.DefaultMasterService`
   - `org.apache.knox.gateway.services.security.impl.CLIMasterService`
- tokenstate
   - `org.apache.knox.gateway.services.token.impl.DefaultTokenStateService`
   - `org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService`
   - `org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService`

`DefaultGatewayServices` and `CLIGatewayServices` have been modified to use the new service factories. Different service factories are loaded into the memory once using Java's `ServiceLoader` feature.

## How was this patch tested?

Edited existing JUnit tests, added a bunch of new tests to cover new classes, and executed them locally. As well as running some manual tests:

Ran the `knoxcli` tool:
- created the master secret
- added/listed some aliases

Started the Knox Gateway:
- checked the home page
- logged into the Admin UI
   - modified the 'sandbox' topology
   - modified a service definition (one that was listed in `sandbox`, confirmed that it got redeployed)
- set different values for `gateway.service.[alias|tokenstate].impl` in `gateway-site.xml` and confirmed the factories created the proper instances based on configuration
   