### PR TITLE
KNOX-2399 - Implemented ZookeeperTokenStateService

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AbstractServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AbstractServiceFactory.java
@@ -53,10 +53,10 @@ public abstract class AbstractServiceFactory implements ServiceFactory {
       if (service == null && StringUtils.isNotBlank(implementation)) {
         // no known service implementation created, try to create the custom one
         try {
-          service = Service.class.cast(Class.forName(implementation).newInstance());
+          service = (Service) Class.forName(implementation).newInstance();
           logServiceUsage(implementation, serviceType);
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-          throw new ServiceLifecycleException("Errror while instantiating " + serviceType.getShortName() + " service implementation " + implementation, e);
+          throw new ServiceLifecycleException("Error while instantiating " + serviceType.getShortName() + " service implementation " + implementation, e);
         }
       }
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AliasServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/AliasServiceFactory.java
@@ -54,7 +54,7 @@ public class AliasServiceFactory extends AbstractServiceFactory {
       } else if (matchesImplementation(implementation, RemoteAliasService.class)) {
         service = new RemoteAliasService(defaultAliasService, getMasterService(gatewayServices));
       } else if (matchesImplementation(implementation, ZookeeperRemoteAliasService.class)) {
-        service = new ZookeeperRemoteAliasServiceProvider().newInstance(defaultAliasService, getMasterService(gatewayServices));
+        service = new ZookeeperRemoteAliasServiceProvider().newInstance(gatewayServices, defaultAliasService, getMasterService(gatewayServices));
       }
 
       logServiceUsage(implementation, serviceType);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
@@ -31,6 +31,7 @@ import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService;
 import org.apache.knox.gateway.services.token.impl.DefaultTokenStateService;
 import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService;
+import org.apache.knox.gateway.services.token.impl.ZookeeperTokenStateService;
 
 public class TokenStateServiceFactory extends AbstractServiceFactory {
 
@@ -46,6 +47,8 @@ public class TokenStateServiceFactory extends AbstractServiceFactory {
         ((AliasBasedTokenStateService) service).setAliasService(getAliasService(gatewayServices));
       } else if (matchesImplementation(implementation, JournalBasedTokenStateService.class)) {
         service = new JournalBasedTokenStateService();
+      } else if (matchesImplementation(implementation, ZookeeperTokenStateService.class)) {
+        service = new ZookeeperTokenStateService(gatewayServices);
       }
 
       logServiceUsage(implementation, serviceType);
@@ -61,6 +64,7 @@ public class TokenStateServiceFactory extends AbstractServiceFactory {
 
   @Override
   protected Collection<String> getKnownImplementations() {
-    return unmodifiableList(asList(DefaultTokenStateService.class.getName(), AliasBasedTokenStateService.class.getName(), JournalBasedTokenStateService.class.getName()));
+    return unmodifiableList(asList(DefaultTokenStateService.class.getName(), AliasBasedTokenStateService.class.getName(), JournalBasedTokenStateService.class.getName(),
+        ZookeeperTokenStateService.class.getName()));
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
@@ -34,11 +34,16 @@ import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasServic
  */
 public class ZookeeperTokenStateService extends AliasBasedTokenStateService {
 
-  private final AliasServiceFactory aliasServiceFactory = new AliasServiceFactory();
   private final GatewayServices gatewayServices;
+  private final AliasServiceFactory aliasServiceFactory;
 
   public ZookeeperTokenStateService(GatewayServices gatewayServices) {
+    this(gatewayServices, new AliasServiceFactory());
+  }
+
+  public ZookeeperTokenStateService(GatewayServices gatewayServices, AliasServiceFactory aliasServiceFactory) {
     this.gatewayServices = gatewayServices;
+    this.aliasServiceFactory = aliasServiceFactory;
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import static org.apache.knox.gateway.services.ServiceType.ALIAS_SERVICE;
+
+import java.util.Map;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.factory.AliasServiceFactory;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
+
+/**
+ * A Zookeeper Token State Service is actually an Alias based TSS where the 'alias service' happens to be the 'zookeeper' implementation.
+ * This means the only important thing that should be overridden here is the init method where the underlying alias service is configured
+ * properly.
+ */
+public class ZookeeperTokenStateService extends AliasBasedTokenStateService {
+
+  private final AliasServiceFactory aliasServiceFactory = new AliasServiceFactory();
+  private final GatewayServices gatewayServices;
+
+  public ZookeeperTokenStateService(GatewayServices gatewayServices) {
+    this.gatewayServices = gatewayServices;
+  }
+
+  @Override
+  public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+    final ZookeeperRemoteAliasService zookeeperAliasService = (ZookeeperRemoteAliasService) aliasServiceFactory.create(gatewayServices, ALIAS_SERVICE, config, options,
+        ZookeeperRemoteAliasService.class.getName());
+    zookeeperAliasService.init(config, options);
+    super.setAliasService(zookeeperAliasService);
+    super.init(config, options);
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -52,7 +52,7 @@ class ServiceFactoryTest {
 
   protected final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
   protected final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
-  protected final Map<String, String> options = Collections.emptyMap();
+  protected final Map<String, String> options = new HashMap<>();
 
   protected void initConfig() {
     final MasterService masterService = EasyMock.createNiceMock(MasterService.class);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
@@ -37,6 +37,7 @@ import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.TestService;
+import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.MasterService;
@@ -61,6 +62,8 @@ class ServiceFactoryTest {
     expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreservice).anyTimes();
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
+    final RemoteConfigurationRegistryClientService registryClientService = EasyMock.createNiceMock(RemoteConfigurationRegistryClientService.class);
+    expect(gatewayServices.getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE)).andReturn(registryClientService).anyTimes();
     replay(gatewayServices);
     expect(gatewayConfig.getServiceParameter(anyString(), anyString())).andReturn("").anyTimes();
     replay(gatewayConfig);
@@ -85,7 +88,7 @@ class ServiceFactoryTest {
       throws Exception {
     expectedException.expect(ServiceLifecycleException.class);
     final String implementation = "this.is.my.non.existing.Service";
-    expectedException.expectMessage(String.format(Locale.ROOT, "Errror while instantiating %s service implementation %s", serviceType.getShortName(), implementation));
+    expectedException.expectMessage(String.format(Locale.ROOT, "Error while instantiating %s service implementation %s", serviceType.getShortName(), implementation));
     expectedException.expectCause(isA(ClassNotFoundException.class));
     serviceFactory.create(gatewayServices, serviceType, null, null, implementation);
   }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
@@ -43,7 +43,7 @@ public class TokenStateServiceFactoryTest extends ServiceFactoryTest {
   }
 
   @Test
-  public void shouldReturnDefaultAliasService() throws Exception {
+  public void shouldReturnDefaultTopkenStateService() throws Exception {
     TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, gatewayConfig, options,
         DefaultTokenStateService.class.getName());
     assertTrue(tokenStateService instanceof DefaultTokenStateService);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService;
 import org.apache.knox.gateway.services.token.impl.DefaultTokenStateService;
 import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService;
+import org.apache.knox.gateway.services.token.impl.ZookeeperTokenStateService;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,22 +44,31 @@ public class TokenStateServiceFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void shouldReturnDefaultAliasService() throws Exception {
-    TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, DefaultTokenStateService.class.getName());
+    TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, gatewayConfig, options,
+        DefaultTokenStateService.class.getName());
     assertTrue(tokenStateService instanceof DefaultTokenStateService);
 
-    tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, "");
+    tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, gatewayConfig, options, "");
     assertTrue(tokenStateService instanceof DefaultTokenStateService);
   }
 
   @Test
   public void shouldReturnAliasBasedTokenStateService() throws Exception {
-    final TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, AliasBasedTokenStateService.class.getName());
+    final TokenStateService tokenStateService = (TokenStateService) serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, gatewayConfig, options,
+        AliasBasedTokenStateService.class.getName());
     assertTrue(tokenStateService instanceof AliasBasedTokenStateService);
     assertTrue(isAliasServiceSet(tokenStateService));
   }
 
   @Test
-  public void shouldReturnHJournalTokenStateService() throws Exception {
-    assertTrue(serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, null, null, JournalBasedTokenStateService.class.getName()) instanceof JournalBasedTokenStateService);
+  public void shouldReturnJournalTokenStateService() throws Exception {
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, gatewayConfig, options,
+        JournalBasedTokenStateService.class.getName()) instanceof JournalBasedTokenStateService);
+  }
+
+  @Test
+  public void shouldReturnZookeeperTokenStateService() throws Exception {
+    assertTrue(serviceFactory.create(gatewayServices, ServiceType.TOKEN_STATE_SERVICE, gatewayConfig, options,
+        ZookeeperTokenStateService.class.getName()) instanceof ZookeeperTokenStateService);
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/RemoteAliasServiceTestProvider.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/RemoteAliasServiceTestProvider.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.security.impl;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.security.RemoteAliasServiceProvider;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.MasterService;
@@ -40,6 +41,11 @@ public class RemoteAliasServiceTestProvider implements RemoteAliasServiceProvide
 
   @Override
   public AliasService newInstance(AliasService localAliasService, MasterService masterService) {
+    return new TestAliasService();
+  }
+
+  @Override
+  public AliasService newInstance(GatewayServices gatewayService, AliasService localAliasService, MasterService masterService) {
     return new TestAliasService();
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateServiceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import static org.apache.knox.gateway.config.GatewayConfig.REMOTE_CONFIG_REGISTRY_ADDRESS;
+import static org.apache.knox.gateway.config.GatewayConfig.REMOTE_CONFIG_REGISTRY_TYPE;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingCluster;
+import org.apache.curator.test.TestingZooKeeperServer;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.service.config.remote.zk.ZooKeeperClientService;
+import org.apache.knox.gateway.service.config.remote.zk.ZooKeeperClientServiceProvider;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.easymock.EasyMock;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ZookeeperTokenStateServiceTest {
+
+  @ClassRule
+  public static final TemporaryFolder testFolder = new TemporaryFolder();
+
+  private static final String CONFIG_MONITOR_NAME = "remoteConfigMonitorClient";
+  private static final long TOKEN_STATE_ALIAS_PERSISTENCE_INTERVAL = 2L;
+  private static TestingCluster zkNodes;
+
+  @BeforeClass
+  public static void configureAndStartZKCluster() throws Exception {
+    // Configure security for the ZK cluster instances
+    final Map<String, Object> customInstanceSpecProps = new HashMap<>();
+    customInstanceSpecProps.put("authProvider.1", "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
+    customInstanceSpecProps.put("requireClientAuthScheme", "sasl");
+    customInstanceSpecProps.put("admin.enableServer", false);
+
+    // Define the test cluster (with 2 nodes)
+    List<InstanceSpec> instanceSpecs = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      InstanceSpec is = new InstanceSpec(null, -1, -1, -1, false, (i + 1), -1, -1, customInstanceSpecProps);
+      instanceSpecs.add(is);
+    }
+    zkNodes = new TestingCluster(instanceSpecs);
+
+    // Start the cluster
+    zkNodes.start();
+  }
+
+  @AfterClass
+  public static void tearDownSuite() throws Exception {
+    // Shutdown the ZK cluster
+    zkNodes.close();
+  }
+
+  @Test
+  public void testStoringTokenAliasesInZookeeper() throws Exception {
+    // mocking GatewayConfig
+    final GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+    expect(gc.getRemoteRegistryConfigurationNames()).andReturn(Collections.singletonList(CONFIG_MONITOR_NAME)).anyTimes();
+    final String registryConfig = REMOTE_CONFIG_REGISTRY_TYPE + "=" + ZooKeeperClientService.TYPE + ";" + REMOTE_CONFIG_REGISTRY_ADDRESS + "=" + zkNodes.getConnectString();
+    expect(gc.getRemoteRegistryConfiguration(CONFIG_MONITOR_NAME)).andReturn(registryConfig).anyTimes();
+    expect(gc.getRemoteConfigurationMonitorClientName()).andReturn(CONFIG_MONITOR_NAME).anyTimes();
+    expect(gc.getAlgorithm()).andReturn("AES").anyTimes();
+    expect(gc.isRemoteAliasServiceEnabled()).andReturn(true).anyTimes();
+    expect(gc.getKnoxTokenStateAliasPersistenceInterval()).andReturn(TOKEN_STATE_ALIAS_PERSISTENCE_INTERVAL).anyTimes();
+    final Path baseFolder = Paths.get(testFolder.newFolder().getAbsolutePath());
+    expect(gc.getGatewayDataDir()).andReturn(Paths.get(baseFolder.toString(), "data").toString()).anyTimes();
+    expect(gc.getGatewayKeystoreDir()).andReturn(Paths.get(baseFolder.toString(), "data", "keystores").toString()).anyTimes();
+    replay(gc);
+
+    // mocking GatewayServices
+    final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
+    final char[] masterSecret = "ThisIsMySup3rS3cr3tM4sterPassW0rd!".toCharArray();
+    final MasterService masterService = EasyMock.createNiceMock(MasterService.class);
+    expect(masterService.getMasterSecret()).andReturn(masterSecret).anyTimes();
+    expect(gatewayServices.getService(ServiceType.MASTER_SERVICE)).andReturn(masterService).anyTimes();
+    final KeystoreService keystoreservice = EasyMock.createNiceMock(KeystoreService.class);
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreservice).anyTimes();
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
+    final RemoteConfigurationRegistryClientService clientService = (new ZooKeeperClientServiceProvider()).newInstance();
+    clientService.setAliasService(aliasService);
+    clientService.init(gc, Collections.emptyMap());
+    expect(gatewayServices.getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE)).andReturn(clientService).anyTimes();
+    replay(gatewayServices, masterService);
+
+    final ZookeeperTokenStateService zktokenStateService = new ZookeeperTokenStateService(gatewayServices);
+    zktokenStateService.init(gc, new HashMap<>());
+    zktokenStateService.start();
+
+    assertFalse(zkNodeExists("/knox/security/topology/__gateway/token1"));
+    assertFalse(zkNodeExists("/knox/security/topology/__gateway/token1--max"));
+
+    zktokenStateService.addToken("token1", 1L, 2L);
+
+    // give some time for the token state service to persist the token aliases in ZK (doubled the persistence interval)
+    Thread.sleep(2 * TOKEN_STATE_ALIAS_PERSISTENCE_INTERVAL * 1000);
+
+    assertTrue(zkNodeExists("/knox/security/topology/__gateway/token1"));
+    assertTrue(zkNodeExists("/knox/security/topology/__gateway/token1--max"));
+  }
+
+  private boolean zkNodeExists(String nodeName) {
+    for (TestingZooKeeperServer server : zkNodes.getServers()) {
+      if (server.getQuorumPeer().getActiveServer().getZKDatabase().getNode(nodeName) != null) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/gateway-service-hashicorp-vault/src/main/java/org/apache/knox/gateway/backend/hashicorp/vault/HashicorpVaultRemoteAliasServiceProvider.java
+++ b/gateway-service-hashicorp-vault/src/main/java/org/apache/knox/gateway/backend/hashicorp/vault/HashicorpVaultRemoteAliasServiceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.backend.hashicorp.vault;
 
 import org.apache.knox.gateway.security.RemoteAliasServiceProvider;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.MasterService;
 
@@ -29,6 +30,11 @@ public class HashicorpVaultRemoteAliasServiceProvider implements RemoteAliasServ
 
   @Override
   public AliasService newInstance(AliasService localAliasService, MasterService ms) {
+    return newInstance(null, localAliasService, ms);
+  }
+
+  @Override
+  public AliasService newInstance(GatewayServices gatewayServices, AliasService localAliasService, MasterService masterService) {
     return new HashicorpVaultAliasService(localAliasService);
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/RemoteAliasServiceProvider.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/RemoteAliasServiceProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.security;
 
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.MasterService;
 
@@ -23,4 +24,6 @@ public interface RemoteAliasServiceProvider {
   String getType();
 
   AliasService newInstance(AliasService localAliasService, MasterService masterService);
+
+  AliasService newInstance(GatewayServices gatewayServices, AliasService localAliasService, MasterService masterService);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new token state service implementation that uses Zookeeper as token storage.

## How was this patch tested?

Updated/ran JUnit tests and executed the following manual test steps:

1. Enabled token state service in sandbox:
```
      <param>
          <name>knox.token.exp.server-managed</name>
          <value>true</value>
      </param>
```
2. Configured Knox to use the new ZK Token State Service in `gateway-site.xml`:
```
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.ZookeeperTokenStateService</value>
    </property>
    <property>
        <name>gateway.remote.config.registry.zookeeper-client</name>
        <value>type=ZooKeeper;address=$ZK_HOST:2181</value>
        <description>ZooKeeper configuration registry client details.</description>
    </property>
    <property>
        <name>gateway.remote.config.monitor.client</name>
        <value>zookeeper-client</value>
        <description>Remote configuration monitor client name.</description>
    </property>
```
3. Started Knox
4. Acquired a Knox delegation token:
```
$ curl -ivku guest:guest-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
...
* Connection #0 to host localhost left intact
{"access_token":"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJndWVzdCIsImF1...,"target_url":"https://localhost:8443/gateway/tokenbased",...,"token_type":"Bearer","expires_in":1594764588683}

gateway.log:
2020-07-14 14:09:48,681 INFO  service.knoxtoken (TokenResource.java:init(169)) - Server management of token state is enabled for the "sandbox" topology.
2020-07-14 14:09:48,682 WARN  service.knoxtoken (TokenResource.java:init(199)) - There are no token renewers white-listed in the "sandbox" topology.
2020-07-14 14:09:48,690 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(400)) - Knox Token service (sandbox) issued token eyJhbG...WYtr9Q (483b5976-f5ca-4761-b2d3-65041aa40d09)
```
5. Confirmed that the token became persisted in Zookeeper:
```
$ zookeeper-client -server $ZK_HOST:2181
Connecting to $ZK_HOST:2181
Welcome to ZooKeeper!
JLine support is enabled

WATCHER::

WatchedEvent state:SyncConnected type:None path:null

[zk: $ZK_HOST:2181(CONNECTED) 0] ls /knox/security/topology/__gateway
[483b5976-f5ca-4761-b2d3-65041aa40d09, 483b5976-f5ca-4761-b2d3-65041aa40d09--max]
```