### PR TITLE
KNOX-2410 - Handling the new 'RestartWaitingForStalenessSuccess' CM audit event

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -76,12 +76,14 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
   static final String ROLLING_RESTART_COMMAND = "RollingRestart";
 
+  static final String RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND = "RestartWaitingForStalenessSuccess";
+
   static final String CM_SERVICE_TYPE = "ManagerServer";
   static final String CM_SERVICE      = "ClouderaManager";
 
   // Collection of those commands which represent the potential activation of service configuration changes
-  private static final Collection<String> ACTIVATION_COMMANDS =
-                          Arrays.asList(START_COMMAND, RESTART_COMMAND, ROLLING_RESTART_COMMAND);
+  private static final Collection<String> ACTIVATION_COMMANDS = Arrays.asList(START_COMMAND, RESTART_COMMAND, ROLLING_RESTART_COMMAND,
+      RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND);
 
   // The format of the filter employed when start events are queried from ClouderaManager
   private static final String EVENTS_QUERY_FORMAT =
@@ -231,7 +233,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
       if (CM_SERVICE_TYPE.equals(serviceType)) {
         if (CM_SERVICE.equals(re.getService())) {
-          // This is a rolling cluster restart event, so assume configuration has changed
+          // This is a 'rolling cluster restart' or 'restart waiting for staleness' event, so assume configuration has changed
           configHasChanged = true;
         }
       }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -230,6 +230,21 @@ public class PollingConfigurationAnalyzerTest {
     assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
   }
 
+  /**
+   * Test the restart waiting for staleness, for which it should be assumed that configuration has changed.
+   */
+  @Test
+  public void testRestartWaitingForStalenessSuccessEvent() {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster 8";
+
+    // Simulate a successful restart waiting for staleness event
+    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, PollingConfigurationAnalyzer.CM_SERVICE_TYPE, PollingConfigurationAnalyzer.CM_SERVICE,
+        PollingConfigurationAnalyzer.RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS, "EV_CLUSTER_RESTARTED");
+
+    final ChangeListener listener = doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
+    assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
+  }
 
   @Test
   public void testClusterConfigMonitorTerminationForNoLongerReferencedClusters() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

CM service discovery handles the recently introduced `RestartWaitingForStalenessSuccess` audit event.

## How was this patch tested?

Updated and ran JUnit tests. As well as manually tested:
1. redeployed Knox with my changes (topology cdp-proxy was already configured to monitor my remote CM cluster where ATLAS was installed)
2. changed `atlas.server.https.port` from 31443 to 31445 and restarted the stale services
3. waited for the restart to finish and confirmed that `cdp-proxy` got redeployed due to the CM config change and ATLAS had the new port number:
<img width="1664" alt="Screen Shot 2020-07-23 at 7 48 35 AM" src="https://user-images.githubusercontent.com/34065904/88255998-431a4580-ccba-11ea-86cb-add308d48c2b.png">
