### PR TITLE
KNOX-2434 - Knox should fallback to JDK default keystore/truststore type instead of hardcoding JKS

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -37,6 +37,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -591,7 +592,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public String getKeystoreType() {
-    return get( KEYSTORE_TYPE, "JKS");
+    return get( KEYSTORE_TYPE, KeyStore.getDefaultType());
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.net.URL;
+import java.security.KeyStore;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -68,7 +69,7 @@ public class GatewayGlobalConfigTest {
     assertThat( config.isClientAuthNeeded(), is( true ) );
     assertThat( config.getTruststorePath(), is("./gateway-trust.jks"));
     assertThat( config.getTruststoreType(), is( "PKCS12" ) );
-    assertThat( config.getKeystoreType(), is( "JKS" ) );
+    assertThat( config.getKeystoreType(), is(KeyStore.getDefaultType()) );
   }
 
   @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -23,6 +23,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -356,7 +357,7 @@ public class GatewayConfigImplTest {
 
     // Validate default options (backwards compatibility)
     assertEquals("gateway-httpclient-truststore-password", config.getHttpClientTruststorePasswordAlias());
-    assertEquals("JKS", config.getHttpClientTruststoreType());
+    assertEquals(KeyStore.getDefaultType(), config.getHttpClientTruststoreType());
     assertNull(config.getHttpClientTruststorePath());
 
     // Validate changed options
@@ -375,7 +376,7 @@ public class GatewayConfigImplTest {
 
     // Validate default options (backwards compatibility)
     assertEquals("gateway-truststore-password", config.getTruststorePasswordAlias());
-    assertEquals("JKS", config.getTruststoreType());
+    assertEquals(KeyStore.getDefaultType(), config.getTruststoreType());
     assertNull(config.getTruststorePath());
 
     // Validate changed options

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.config;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.security.KeyStore;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,7 @@ public interface GatewayConfig {
   String IDENTITY_KEYSTORE_TYPE = "gateway.tls.keystore.type";
   String IDENTITY_KEY_ALIAS = "gateway.tls.key.alias";
   String IDENTITY_KEY_PASSPHRASE_ALIAS = "gateway.tls.key.passphrase.alias";
-  String DEFAULT_IDENTITY_KEYSTORE_TYPE = "JKS";
+  String DEFAULT_IDENTITY_KEYSTORE_TYPE = KeyStore.getDefaultType();
   String DEFAULT_IDENTITY_KEYSTORE_PASSWORD_ALIAS = "gateway-identity-keystore-password";
   String DEFAULT_IDENTITY_KEY_ALIAS = "gateway-identity";
   String DEFAULT_IDENTITY_KEY_PASSPHRASE_ALIAS = "gateway-identity-passphrase";
@@ -72,20 +73,20 @@ public interface GatewayConfig {
   String SIGNING_KEY_ALIAS = "gateway.signing.key.alias";
   String SIGNING_KEY_PASSPHRASE_ALIAS = "gateway.signing.key.passphrase.alias";
   String DEFAULT_SIGNING_KEYSTORE_PASSWORD_ALIAS = "signing.keystore.password";
-  String DEFAULT_SIGNING_KEYSTORE_TYPE = "JKS";
+  String DEFAULT_SIGNING_KEYSTORE_TYPE = KeyStore.getDefaultType();
   String DEFAULT_SIGNING_KEY_ALIAS = "gateway-identity";
   String DEFAULT_SIGNING_KEY_PASSPHRASE_ALIAS = "signing.key.passphrase";
 
   String GATEWAY_TRUSTSTORE_PASSWORD_ALIAS = "gateway.truststore.password.alias";
   String GATEWAY_TRUSTSTORE_PATH = "gateway.truststore.path";
   String GATEWAY_TRUSTSTORE_TYPE = "gateway.truststore.type";
-  String DEFAULT_GATEWAY_TRUSTSTORE_TYPE = "JKS";
+  String DEFAULT_GATEWAY_TRUSTSTORE_TYPE = KeyStore.getDefaultType();
   String DEFAULT_GATEWAY_TRUSTSTORE_PASSWORD_ALIAS = "gateway-truststore-password";
 
   String HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS = "gateway.httpclient.truststore.password.alias";
   String HTTP_CLIENT_TRUSTSTORE_PATH = "gateway.httpclient.truststore.path";
   String HTTP_CLIENT_TRUSTSTORE_TYPE = "gateway.httpclient.truststore.type";
-  String DEFAULT_HTTP_CLIENT_TRUSTSTORE_TYPE = "JKS";
+  String DEFAULT_HTTP_CLIENT_TRUSTSTORE_TYPE = KeyStore.getDefaultType();
   String DEFAULT_HTTP_CLIENT_TRUSTSTORE_PASSWORD_ALIAS = "gateway-httpclient-truststore-password";
 
   String REMOTE_CONFIG_REGISTRY_TYPE = "type";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace hardcoded `JKS` with `KeyStore.getDefaultType()`

## How was this patch tested?

* `mvn -U -T.75C clean verify -Ppackage,release -Dshellcheck`
* Check that this fixes FIPS crypto when default keystore configured at JDK level