### PR TITLE
KNOX-2413 - Added JWT support in HadoopAuth provider

### DIFF
--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-provider-security-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-server</artifactId>
         </dependency>
         <dependency>

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -35,4 +35,10 @@ public interface HadoopAuthMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "Proxy user Authentication failed: {0}" )
   void hadoopAuthProxyUserFailed(@StackTrace Throwable t);
+
+  @Message( level = MessageLevel.DEBUG, text = "Initialized the JWT federation filter" )
+  void initializedJwtFilter();
+
+  @Message( level = MessageLevel.DEBUG, text = "Using JWT filter to serve the request" )
+  void useJwtFilter();
 }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -22,17 +22,21 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.hadoop.util.HttpExceptionUtils;
+import org.apache.knox.gateway.GatewayFilter;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.hadoopauth.HadoopAuthMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -44,6 +48,8 @@ import java.util.Set;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
@@ -72,10 +78,13 @@ public class HadoopAuthFilter extends
 
   private static final String QUERY_PARAMETER_DOAS = "doAs";
   private static final String PROXYUSER_PREFIX = "hadoop.proxyuser";
+  static final String SUPPORT_JWT = "support.jwt";
+  static final String JWT_PREFIX = "jwt.";
 
   private static final HadoopAuthMessages LOG = MessagesFactory.get(HadoopAuthMessages.class);
 
   private final Set<String> ignoreDoAs = new HashSet<>();
+  private JWTFederationFilter jwtFilter;
 
   @Override
   protected Properties getConfiguration(String configPrefix, FilterConfig filterConfig) throws ServletException {
@@ -116,11 +125,34 @@ public class HadoopAuthFilter extends
     }
 
     super.init(filterConfig);
+
+    final String supportJwt = filterConfig.getInitParameter(SUPPORT_JWT);
+    final boolean jwtSupported = Boolean.parseBoolean(supportJwt == null ? "false" : supportJwt);
+    if (jwtSupported) {
+      jwtFilter = new JWTFederationFilter();
+      ((GatewayFilter.Holder)filterConfig).removeParamPrefix(JWT_PREFIX);
+      jwtFilter.init(filterConfig);
+      LOG.initializedJwtFilter();
+    }
   }
 
   @Override
-  protected void doFilter(FilterChain filterChain, HttpServletRequest request,
-                          HttpServletResponse response) throws IOException, ServletException {
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+    if (shouldUseJwtFilter(jwtFilter, filterChain, (HttpServletRequest) request, (HttpServletResponse) response)) {
+      LOG.useJwtFilter();
+      jwtFilter.doFilter(request, response, filterChain);
+    } else {
+      super.doFilter(request, response, filterChain);
+    }
+  }
+
+  @Override
+  protected void doFilter(FilterChain filterChain, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+    if (shouldUseJwtFilter(jwtFilter, filterChain, request, response)) {
+      LOG.useJwtFilter();
+      jwtFilter.doFilter(request, response, filterChain);
+      return;
+    }
 
     /*
      * If impersonation is not ignored for the authenticated user, attempt to set a proxied user if
@@ -172,6 +204,22 @@ public class HadoopAuthFilter extends
     }
 
     super.doFilter(filterChain, request, response);
+  }
+
+  static boolean shouldUseJwtFilter(JWTFederationFilter jwtFilter, FilterChain filterChain, HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    if (jwtFilter != null) {
+      final String wireToken = jwtFilter.getWireToken(request);
+      if (wireToken != null) {
+        try {
+          final JWTToken jwtToken = new JWTToken(wireToken);
+          return jwtFilter.validateToken(request, response, filterChain, jwtToken);
+        } catch (ParseException e) {
+          // NOP: in this case we should continue with HadoopAuth
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -243,5 +291,9 @@ public class HadoopAuthFilter extends
       }
     }
     return props;
+  }
+
+  boolean isJwtSupported() {
+    return jwtFilter != null;
   }
 }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
@@ -17,9 +17,15 @@
  */
 package org.apache.knox.gateway.hadoopauth.filter;
 
+import static org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter.JWT_PREFIX;
+import static org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter.SUPPORT_JWT;
+import static org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter.shouldUseJwtFilter;
+
 import java.io.IOException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.text.ParseException;
+import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
 import javax.servlet.Filter;
@@ -39,6 +45,8 @@ import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
 import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.hadoopauth.HadoopAuthMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
+import org.apache.knox.gateway.GatewayFilter;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
 import org.apache.knox.gateway.audit.api.Auditor;
@@ -51,8 +59,17 @@ public class HadoopAuthPostFilter implements Filter {
       AuditConstants.DEFAULT_AUDITOR_NAME, AuditConstants.KNOX_SERVICE_NAME,
       AuditConstants.KNOX_COMPONENT_NAME );
 
+  private JWTFederationFilter jwtFilter;
+
   @Override
   public void init( FilterConfig filterConfig ) throws ServletException {
+    final String supportJwt = filterConfig.getInitParameter(SUPPORT_JWT);
+    final boolean jwtSupported = Boolean.parseBoolean(supportJwt == null ? "false" : supportJwt);
+    if (jwtSupported) {
+      jwtFilter = new JWTFederationFilter();
+      ((GatewayFilter.Holder)filterConfig).removeParamPrefix(JWT_PREFIX);
+      jwtFilter.init(filterConfig);
+    }
   }
 
   @Override
@@ -60,21 +77,35 @@ public class HadoopAuthPostFilter implements Filter {
   }
 
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-      throws IOException, ServletException {
-    HttpServletRequest httpRequest = (HttpServletRequest)request;
-    String principal = httpRequest.getRemoteUser();
-    if (principal != null) {
-        Subject subject = new Subject();
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    Subject subject = null;
+    if (shouldUseJwtFilter(jwtFilter, chain, (HttpServletRequest) request, (HttpServletResponse) response)) {
+      try {
+        subject = jwtFilter.createSubjectFromToken(jwtFilter.getWireToken(request));
+      } catch (ParseException e) {
+        // NOP: subject remains null -> SC_FORBIDDEN will be returned
+      }
+    } else {
+      final String principal = ((HttpServletRequest) request).getRemoteUser();
+      if (principal != null) {
+        subject = new Subject();
         subject.getPrincipals().add(new PrimaryPrincipal(principal));
-        log.hadoopAuthAssertedPrincipal(principal);
-        auditService.getContext().setUsername( principal ); //KM: Audit Fix
+      }
+    }
+
+    if (subject != null) {
+        log.hadoopAuthAssertedPrincipal(getPrincipalsAsString(subject));
+        auditService.getContext().setUsername(getPrincipalsAsString(subject)); //KM: Audit Fix
         String sourceUri = (String)request.getAttribute( AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME );
         auditor.audit( Action.AUTHENTICATION , sourceUri, ResourceType.URI, ActionOutcome.SUCCESS );
-        doAs(httpRequest, response, chain, subject);
+        doAs(request, response, chain, subject);
     } else {
       ((HttpServletResponse)response).sendError(HttpServletResponse.SC_FORBIDDEN, "User not authenticated");
     }
+  }
+
+  private String getPrincipalsAsString(Subject subject) {
+    return String.join(",", subject.getPrincipals().stream().map(principal -> principal.getName()).collect(Collectors.toSet()));
   }
 
   private void doAs(final ServletRequest request, final ServletResponse response, final FilterChain chain, Subject subject)

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
@@ -79,7 +79,7 @@ public class HadoopAuthPostFilter implements Filter {
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
     Subject subject = null;
-    if (shouldUseJwtFilter(jwtFilter, chain, (HttpServletRequest) request, (HttpServletResponse) response)) {
+    if (shouldUseJwtFilter(jwtFilter, (HttpServletRequest) request)) {
       try {
         subject = jwtFilter.createSubjectFromToken(jwtFilter.getWireToken(request));
       } catch (ParseException e) {

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -22,6 +22,7 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createMockBuilder;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.getCurrentArguments;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
@@ -29,7 +30,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.knox.gateway.GatewayFilter;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.topology.Topology;
 import org.junit.Test;
@@ -98,6 +103,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter(GatewayConfig.PROXYUSER_SERVICES_IGNORE_DOAS))
         .andReturn("Knox, hdfs,TesT") // Spacing and case set on purpose
         .atLeastOnce();
+    expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     expect(filterConfig.getServletContext()).andReturn(servletContext).atLeastOnce();
 
     Properties configProperties = createMock(Properties.class);
@@ -134,5 +140,61 @@ public class HadoopAuthFilterTest {
     assertFalse(hadoopAuthFilter.ignoreDoAs("HivE"));
 
     verify(filterConfig, configProperties, hadoopAuthFilter, servletContext);
+  }
+
+  @Test
+  public void shouldNotUseJwtFilterIfProviderParamIsNotSet() throws Exception {
+    testIfJwtSupported(null);
+  }
+
+  @Test
+  public void shouldNotUseJwtFilterIfProviderParamIsFalse() throws Exception {
+    testIfJwtSupported("false");
+  }
+
+  @Test
+  public void shouldUseJwtFilterIfProviderParamIsTrue() throws Exception {
+    testIfJwtSupported("true");
+  }
+
+  private HadoopAuthFilter testIfJwtSupported(String supportJwt) throws Exception {
+    final GatewayFilter.Holder filterConfig = createMock(GatewayFilter.Holder.class);
+    expect(filterConfig.getInitParameterNames()).andReturn(Collections.enumeration(Collections.emptyList()));
+    expect(filterConfig.getInitParameter(GatewayConfig.PROXYUSER_SERVICES_IGNORE_DOAS)).andReturn("service").atLeastOnce();
+    expect(filterConfig.getInitParameter("config.prefix")).andReturn("some.prefix").atLeastOnce();
+    expect(filterConfig.getInitParameter("support.jwt")).andReturn(supportJwt).anyTimes();
+    final boolean isJwtSupported = Boolean.parseBoolean(supportJwt);
+    if (isJwtSupported) {
+      filterConfig.removeParamPrefix("jwt.");
+      expectLastCall();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_AUDIENCES)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_QUERY_PARAM_NAME)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.JWKS_URL)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.TOKEN_PRINCIPAL_CLAIM)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.TOKEN_VERIFICATION_PEM)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_ISSUER)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_SIGALG)).andReturn(null).anyTimes();
+    }
+
+    final ServletContext servletContext = createMock(ServletContext.class);
+    expect(servletContext.getAttribute("signer.secret.provider.object")).andReturn(null).atLeastOnce();
+    if (isJwtSupported) {
+      expect(servletContext.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(null).anyTimes();
+    }
+    expect(filterConfig.getServletContext()).andReturn(servletContext).atLeastOnce();
+
+    final HadoopAuthFilter hadoopAuthFilter = createMockBuilder(HadoopAuthFilter.class).addMockedMethod("getConfiguration", String.class, FilterConfig.class).withConstructor()
+        .createMock();
+    final Properties config = new Properties();
+    config.put("type", "simple");
+    expect(hadoopAuthFilter.getConfiguration(eq("some.prefix."), eq(filterConfig))).andReturn(config).atLeastOnce();
+
+    replay(servletContext, filterConfig, hadoopAuthFilter);
+
+    hadoopAuthFilter.init(filterConfig);
+
+    assertEquals(isJwtSupported, hadoopAuthFilter.isJwtSupported());
+
+    return hadoopAuthFilter;
   }
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -61,6 +61,7 @@ import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 
 import com.nimbusds.jose.JWSHeader;
 
@@ -229,6 +230,10 @@ public abstract class AbstractJWTFilter implements Filter {
     }
   }
 
+  public Subject createSubjectFromToken(String token) throws ParseException {
+    return createSubjectFromToken(new JWTToken(token));
+  }
+
   protected Subject createSubjectFromToken(JWT token) {
     String principal = token.getSubject();
     String claimvalue = null;
@@ -255,7 +260,7 @@ public abstract class AbstractJWTFilter implements Filter {
     return new Subject(true, principals, emptySet, emptySet);
   }
 
-  protected boolean validateToken(HttpServletRequest request, HttpServletResponse response,
+  public boolean validateToken(HttpServletRequest request, HttpServletResponse response,
       FilterChain chain, JWT token)
       throws IOException, ServletException {
     boolean verified = false;

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -260,7 +260,7 @@ public abstract class AbstractJWTFilter implements Filter {
     return new Subject(true, principals, emptySet, emptySet);
   }
 
-  public boolean validateToken(HttpServletRequest request, HttpServletResponse response,
+  protected boolean validateToken(HttpServletRequest request, HttpServletResponse response,
       FilterChain chain, JWT token)
       throws IOException, ServletException {
     boolean verified = false;

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -37,7 +37,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
 
   public static final String KNOX_TOKEN_AUDIENCES = "knox.token.audiences";
   public static final String TOKEN_VERIFICATION_PEM = "knox.token.verification.pem";
-  private static final String KNOX_TOKEN_QUERY_PARAM_NAME = "knox.token.query.param.name";
+  public static final String KNOX_TOKEN_QUERY_PARAM_NAME = "knox.token.query.param.name";
   public static final String TOKEN_PRINCIPAL_CLAIM = "knox.token.principal.claim";
   public static final String JWKS_URL = "knox.token.jwks.url";
   private static final String BEARER = "Bearer ";
@@ -85,16 +85,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
-    String header = ((HttpServletRequest) request).getHeader("Authorization");
-    String wireToken;
-    if (header != null && header.startsWith(BEARER)) {
-      // what follows the bearer designator should be the JWT token being used to request or as an access token
-      wireToken = header.substring(BEARER.length());
-    }
-    else {
-      // check for query param
-      wireToken = request.getParameter(paramName);
-    }
+    final String wireToken = getWireToken(request);
 
     if (wireToken != null) {
       try {
@@ -110,6 +101,17 @@ public class JWTFederationFilter extends AbstractJWTFilter {
     else {
       // no token provided in header
       ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+  }
+
+  public String getWireToken(ServletRequest request) {
+    final String header = ((HttpServletRequest) request).getHeader("Authorization");
+    if (header != null && header.startsWith(BEARER)) {
+      // what follows the bearer designator should be the JWT token being used to request or as an access token
+      return header.substring(BEARER.length());
+    } else {
+      // check for query param
+      return request.getParameter(paramName);
     }
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -280,7 +280,7 @@ public class GatewayFilter implements Filter {
     }
   }
 
-  private class Holder implements Filter, FilterConfig {
+  public class Holder implements Filter, FilterConfig {
     private Template template;
     private String name;
     private Map<String,String> params;
@@ -326,6 +326,21 @@ public class GatewayFilter implements Filter {
         value = params.get( name );
       }
       return value;
+    }
+
+    public void removeParamPrefix(String prefix) {
+      if (params != null) {
+        final Set<String> relevantParams = new HashSet<>();
+        params.entrySet().forEach(paramEntry -> {
+          if (paramEntry.getKey().startsWith(prefix)) {
+            relevantParams.add(paramEntry.getKey());
+          }
+        });
+        relevantParams.forEach(param -> {
+          String value = params.remove(param);
+          params.put(param.replace(prefix, ""), value);
+        });
+      }
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new provider configuration parameter in the `HadoopAuth` security provider to enable end-users to use JWT tokens instead of the usual Hadoop Authentication mechanism if there is a Bearer token defined in the request's `Authorization` header. The new parameter name is `support.jwt`. If that is set to `true` (defaults to `false`) and there is a _valid_  (parsable, non-expired) JWT token in the authorization header Knox will use that token in the HadoopAuth security provider.

## How was this patch tested?

Updated and ran JUnit tests:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 20:01 min (Wall Clock)
[INFO] Finished at: 2020-07-30T22:42:31+02:00
[INFO] Final Memory: 448M/2323M
[INFO] ------------------------------------------------------------------------
```

Additionally, the following E2E test steps were executed:
1. Deployed the Knox Gateway with my changes
2. Added the KNOXTOKEN service into `sandbox` (to be able to get a Knox delegation token)
3. Had the following the `authentication` provider in the `metadata` topology:
```
    {
      "role": "authentication",
      "name": "HadoopAuth",
      "enabled": "true",
      "params": {
        "config.prefix": "hadoop.auth.config",
        "hadoop.auth.config.type": "kerberos",
        "hadoop.auth.config.signature.secret": "password",
        "hadoop.auth.config.simple.anonymous.allowed": "false",
        "hadoop.auth.config.token.validity": "1800",
        "hadoop.auth.config.cookie.path": "/",
        "hadoop.auth.config.kerberos.principal": "HTTP/$GATEWAY_HOST@$REALM",
        "hadoop.auth.config.kerberos.keytab": "/$KEYTAB_PATH/knox.keytab",
        "hadoop.auth.config.kerberos.name.rules": "DEFAULT",
        "support.jwt": "true"
      }
```
4. Logged into Kerberos as `knox` and tried to get metadata about the `sandbox` topology using Kerberos:
```
$ curl -s --negotiate -u: -k "http://$GATEWAY_HOST:8444/gateway/metadata/api/v1/metadata/topologies/sandbox"
<?xml version="1.0" encoding="UTF-8"?>
<topologyInformations>
   <topologyInformation>
      <topology>sandbox</topology>
      <pinned>false</pinned>
      ...
   </topologyInformation>
</topologyInformations>
```
5. Obtained a Knox delegation token (using the `KNOXTOKEN` service in sandbox)
6. Tried to get  metadata about the `sandbox` topology using the acquired JWT token:
```
$ curl -v -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJrbm94IiwiYXVkIjoiaWRicm9rZXIiLCJpc3MiOiJLTk9YU1NPIiwiZXhwIjoxNTk2MTQzNzg4LCJrbm94LmlkIjoiMGM2NTUwZGItNzM4ZS00NjYwLWI1YWMtNGJlN2ZjNTllNzc2In0.KwRWOaye-7lgUN5pG-AV11HvRGwQKT6BSZWSWKOapn8DHaKce5hTaO4eTkHlyIx8kg7zaI65Cq950pC6lQf3Ocznh8DQaqbm_OxgBZQCI6wFl3UTHe1m1BbK7G3HxrOUHLnGUk4g5_z-gv_CN4vQDpgvPCNjC34knOUIeoc7uUHl_IABsQGDa4i57K5Gb9-iBJlhEWwFYEiIA24vE0fL1MnOvmUzypAth6l8x8m3FUpLYLMJOFOT9dXBTXKTklfy7S4pPRW5TFI9kwArhBr5-_KtT-ZZhiPu_LJPjVZHu1LwBgtYE_uJjVzE8RR1T20iYSPub15sPiX4ntUerto1Rg" "http://$GATEWAY_HOST:8444/gateway/metadata/api/v1/metadata/topologies/sandbox"

* About to connect() to $GATEWAY_HOST port 8444 (#0)
*   Trying xxx...
* Connected to $GATEWAY_HOST (xxx...) port 8444 (#0)
> GET /gateway/metadata/api/v1/metadata/topologies/sandbox HTTP/1.1
> User-Agent: curl/7.29.0
> Host: $GATEWAY_HOST:8444
> Accept: */*
> Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJrbm94IiwiYXVkIjoiaWRicm9rZXIiLCJpc3MiOiJLTk9YU1NPIiwiZXhwIjoxNTk2MTQzNzg4LCJrbm94LmlkIjoiMGM2NTUwZGItNzM4ZS00NjYwLWI1YWMtNGJlN2ZjNTllNzc2In0.KwRWOaye-7lgUN5pG-AV11HvRGwQKT6BSZWSWKOapn8DHaKce5hTaO4eTkHlyIx8kg7zaI65Cq950pC6lQf3Ocznh8DQaqbm_OxgBZQCI6wFl3UTHe1m1BbK7G3HxrOUHLnGUk4g5_z-gv_CN4vQDpgvPCNjC34knOUIeoc7uUHl_IABsQGDa4i57K5Gb9-iBJlhEWwFYEiIA24vE0fL1MnOvmUzypAth6l8x8m3FUpLYLMJOFOT9dXBTXKTklfy7S4pPRW5TFI9kwArhBr5-_KtT-ZZhiPu_LJPjVZHu1LwBgtYE_uJjVzE8RR1T20iYSPub15sPiX4ntUerto1Rg
> 
< HTTP/1.1 200 OK
< Date: Thu, 30 Jul 2020 20:18:31 GMT
< Content-Type: application/xml
< Transfer-Encoding: chunked
< 
<?xml version="1.0" encoding="UTF-8"?>
<topologyInformations>
   <topologyInformation>
      <topology>sandbox</topology>
      <pinned>false</pinned>
      ...
   </topologyInformation>
</topologyInformations>
* Connection #0 to host $GATEWAY_HOST left intact
```
7. Checked the `gateway.log` (set the logging level to `DEBUG` before I started the gateway) and found that everything worked  as expected