### PR TITLE
KNOX-2435 Fix NiFi and NiFi Registry UI links in Knox UI

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/nifi-registry/0.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nifi-registry/0.5.0/service.xml
@@ -17,7 +17,7 @@
 <service role="NIFI-REGISTRY" name="nifi-registry" version="0.5.0">
     <metadata>
         <type>UI</type>
-        <context>/nifi-registry-app</context>
+        <context>/nifi-registry-app/nifi-registry</context>
         <shortDesc>Nifi Registry UI</shortDesc>
         <description>Registry — a subproject of Apache NiFi — is a complementary application that provides a central location for storage and management of shared resources across one or more instances of NiFi and/or MiNiFi.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/nifi/1.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nifi/1.4.0/service.xml
@@ -17,7 +17,7 @@
 <service role="NIFI" name="nifi" version="1.4.0">
     <metadata>
         <type>UI</type>
-        <context>/nifi-app</context>
+        <context>/nifi-app/nifi</context>
         <shortDesc>Nifi UI</shortDesc>
         <description>Apache NiFi supports powerful and scalable directed graphs of data routing, transformation, and system mediation logic.</description>
     </metadata>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this jira i've fixed NiFi UI and NiFi Registry UI links in Knox UI. In general urls were correct, but in the end of each url also should be added "/nifi" and "/nifi-registry".

## How was this patch tested?

I've deployed DC cluster https://vbfkis-1.vbfkis.root.hwx.site:7183/cmf/home, changed service.xml files for NiFi and NiFi Registry (via Knox Admin UI) and restarted Knox. After that i was able to get into NiFi UI and NiFi Registry UI through Knox UI links.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
