### PR TITLE
KNOX-2437 The request url does not have to be coded

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandler.java
@@ -113,7 +113,7 @@ public class GatewayWebsocketHandler extends WebSocketHandler
 
     try {
       final URI requestURI = req.getRequestURI();
-      final String path = requestURI.getPath();
+      final String path = requestURI.getRawPath();
 
       /* URL used to connect to websocket backend */
       final String backendURL = getMatchedBackendURL(path, requestURI);


### PR DESCRIPTION
## What changes were proposed in this pull request?

URI.getPath() returns is an encoded URL
The request does not have to be coded, they should be rewritten but left as they are.
Backend applications expect that they are not.



## How was this patch tested?

all unit tests are working after the fix


