### PR TITLE
KNOX-2412 - Add Logout Link to Home Page for Select Authentication Pr…

### DIFF
--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -89,6 +89,13 @@ limitations under the License.
         <description>The interval (in seconds) for polling Ambari for cluster configuration changes.</description>
     </property>
 
+    <!-- @since 1.5.0 homepage logout -->
+    <property>
+        <name>knox.homepage.logout.enabled</name>
+        <value>true</value>
+        <description>Enable/disable logout from the Knox Homepage.</description>
+    </property>
+
     <!-- Knox Admin related config -->
     <property>
         <name>gateway.knox.admin.groups</name>

--- a/gateway-release/home/conf/topologies/homepage.xml
+++ b/gateway-release/home/conf/topologies/homepage.xml
@@ -54,6 +54,12 @@
       </provider>
    </gateway>
    <service>
+      <role>KNOXSSOUT</role>
+   </service>
+   <service>
+      <role>KNOX-SESSION</role>
+   </service>
+   <service>
       <role>KNOX-METADATA</role>
    </service>
    <application>

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -451,7 +451,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
-            <artifactId>gateway-service-metadata</artifactId>
+            <artifactId>gateway-service-session</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -261,6 +261,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String KNOX_HOMEPAGE_PINNED_TOPOLOGIES =  "knox.homepage.pinned.topologies";
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata", "homepage"));
+  private static final String KNOX_HOMEPAGE_LOGOUT_ENABLED =  "knox.homepage.logout.enabled";
 
   public GatewayConfigImpl() {
     init();
@@ -1172,6 +1173,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getServiceParameter(String service, String parameter) {
     return get(GATEWAY_SERVICE_PREFIX + service + "." + parameter, "");
+  }
+
+  @Override
+  public boolean homePageLogoutEnabled() {
+    return getBoolean(KNOX_HOMEPAGE_LOGOUT_ENABLED, false);
   }
 
 }

--- a/gateway-service-knoxssout/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOutResource.java
+++ b/gateway-service-knoxssout/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOutResource.java
@@ -44,7 +44,7 @@ public class WebSSOutResource {
   private static final String SSO_COOKIE_NAME = "knoxsso.cookie.name";
   private static final String DEFAULT_SSO_COOKIE_NAME = "hadoop-jwt";
 
-  static final String RESOURCE_PATH = "/api/v1/webssout";
+  static final String RESOURCE_PATH = "knoxssout/api/v1/webssout";
 
   private String cookieName;
 

--- a/gateway-service-session/pom.xml
+++ b/gateway-service-session/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.knox</groupId>
+        <artifactId>gateway</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gateway-service-session</artifactId>
+    <name>gateway-service-session</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-i18n</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-provider-jersey</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>eclipselink</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformation.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformation.java
@@ -15,30 +15,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.knox.gateway.service.knoxsso.deploy;
+package org.apache.knox.gateway.service.session;
 
-import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 
-public class KnoxSSOutServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
+@XmlRootElement(name = "sessioninfo")
+public class SessionInformation {
+  @XmlElement
+  private String user;
 
-  @Override
-  public String getRole() {
-    return "KNOXSSOUT";
+  @XmlElement
+  private String logoutUrl;
+
+  public String getUser() {
+    return user;
   }
 
-  @Override
-  public String getName() {
-    return "KnoxSSOutService";
+  public void setUser(String user) {
+    this.user = user;
   }
 
-  @Override
-  protected String[] getPackages() {
-    return new String[]{ "org.apache.knox.gateway.service.knoxsso" };
+  public String getLogoutUrl() {
+    return logoutUrl;
   }
 
-  @Override
-  protected String[] getPatterns() {
-    return new String[]{ "knoxssout/api/**?**" };
+  public void setLogoutUrl(String logoutUrl) {
+    this.logoutUrl = logoutUrl;
   }
-
 }

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformationMarshaller.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformationMarshaller.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.session;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+
+import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.eclipse.persistence.jaxb.JAXBContextProperties;
+
+@Provider
+@Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+public class SessionInformationMarshaller implements MessageBodyWriter<SessionInformation>{
+  private static Marshaller xmlMarshaller;
+  private static Marshaller jsonMarshaller;
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return SessionInformation.class == type;
+  }
+
+  @Override
+  public long getSize(SessionInformation t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return -1;
+  }
+
+  @Override
+  public void writeTo(SessionInformation instance, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+      MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+    try {
+      getMarshaller(mediaType).marshal(instance, entityStream);
+    } catch (JAXBException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private Marshaller getMarshaller(MediaType mediaType) throws JAXBException {
+    return MediaType.APPLICATION_JSON_TYPE.getSubtype().equals(mediaType.getSubtype()) ? getJsonMarshaller() : getXmlMarshaller();
+  }
+
+  private synchronized Marshaller getXmlMarshaller() throws JAXBException {
+    if (xmlMarshaller == null) {
+      final Map<String, Object> properties = new HashMap<>(1);
+      properties.put(JAXBContextProperties.MEDIA_TYPE, MediaType.APPLICATION_XML);
+      xmlMarshaller = JAXBContextFactory.createContext(new Class[] { SessionInformation.class }, properties).createMarshaller();
+      xmlMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+    }
+    return xmlMarshaller;
+  }
+
+  private synchronized Marshaller getJsonMarshaller() throws JAXBException {
+    if (jsonMarshaller == null) {
+      final Map<String, Object> properties = new HashMap<>(1);
+      properties.put(JAXBContextProperties.MEDIA_TYPE, MediaType.APPLICATION_JSON);
+      jsonMarshaller = JAXBContextFactory.createContext(new Class[] { SessionInformation.class }, properties).createMarshaller();
+      jsonMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+    }
+    return jsonMarshaller;
+  }
+
+}

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.service.session;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+
+import javax.inject.Singleton;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.security.SubjectUtils;
+
+@Singleton
+@Path("session/api/v1/")
+public class SessionResource {
+  private static final SessionServiceMessages LOG = MessagesFactory.get(SessionServiceMessages.class);
+
+  @Context
+  HttpServletRequest request;
+
+  @Context
+  ServletContext context;
+
+  @GET
+  @Produces({ APPLICATION_JSON, APPLICATION_XML })
+  @Path("sessioninfo")
+  public SessionInformation getSessionInformation() {
+    final SessionInformation sessionInfo = new SessionInformation();
+    sessionInfo.setUser(SubjectUtils.getCurrentEffectivePrincipalName());
+    final GatewayConfig config = (GatewayConfig) context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    if (config != null && config.homePageLogoutEnabled()) {
+      String logoutUrl = getBaseGatewayUrl(config) + "/homepage/knoxssout/api/v1/webssout";
+      LOG.homePageLogoutEnabled(logoutUrl);
+      sessionInfo.setLogoutUrl(logoutUrl);
+    }
+
+    return sessionInfo;
+  }
+
+  private String getBaseGatewayUrl(GatewayConfig config) {
+    return request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/" + config.getGatewayPath();
+  }
+}

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionServiceDeploymentContributor.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionServiceDeploymentContributor.java
@@ -15,30 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.knox.gateway.service.knoxsso.deploy;
+package org.apache.knox.gateway.service.session;
 
 import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
 
-public class KnoxSSOutServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
+public class SessionServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
 
   @Override
   public String getRole() {
-    return "KNOXSSOUT";
+    return "KNOX-SESSION";
   }
 
   @Override
   public String getName() {
-    return "KnoxSSOutService";
+    return "knox-session";
   }
 
   @Override
   protected String[] getPackages() {
-    return new String[]{ "org.apache.knox.gateway.service.knoxsso" };
+    return new String[] { "org.apache.knox.gateway.service.session" };
   }
 
   @Override
   protected String[] getPatterns() {
-    return new String[]{ "knoxssout/api/**?**" };
+    return new String[] { "session/api/**?**" };
   }
 
 }

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionServiceMessages.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionServiceMessages.java
@@ -15,30 +15,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.knox.gateway.service.knoxsso.deploy;
+package org.apache.knox.gateway.service.session;
 
-import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
+import org.apache.knox.gateway.i18n.messages.Message;
+import org.apache.knox.gateway.i18n.messages.MessageLevel;
+import org.apache.knox.gateway.i18n.messages.Messages;
 
-public class KnoxSSOutServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
+@Messages(logger = "org.apache.knox.gateway.service.session")
+public interface SessionServiceMessages {
 
-  @Override
-  public String getRole() {
-    return "KNOXSSOUT";
-  }
-
-  @Override
-  public String getName() {
-    return "KnoxSSOutService";
-  }
-
-  @Override
-  protected String[] getPackages() {
-    return new String[]{ "org.apache.knox.gateway.service.knoxsso" };
-  }
-
-  @Override
-  protected String[] getPatterns() {
-    return new String[]{ "knoxssout/api/**?**" };
-  }
-
+  @Message(level = MessageLevel.INFO, text = "Homepage Logout is enabled and will use the URL: {0}")
+  void homePageLogoutEnabled(String logUrl);
 }

--- a/gateway-service-session/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ServiceDeploymentContributor
+++ b/gateway-service-session/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ServiceDeploymentContributor
@@ -1,0 +1,18 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+org.apache.knox.gateway.service.session.SessionServiceDeploymentContributor

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -699,4 +699,9 @@ public interface GatewayConfig {
    * @return the value of the given parameter for the given service if declared; an empty String otherwise
    */
   String getServiceParameter(String service, String parameter);
+
+  /**
+   * @return the whether logout from the knox home page is enabled or not
+   */
+  boolean homePageLogoutEnabled();
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -817,4 +817,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public String getServiceParameter(String service, String parameter) {
     return "";
   }
+
+  @Override
+  public boolean homePageLogoutEnabled() {
+    return false;
+  }
 }

--- a/knox-homepage-ui/home/app/app.module.ts
+++ b/knox-homepage-ui/home/app/app.module.ts
@@ -22,6 +22,7 @@ import {BsModalModule} from 'ng2-bs3-modal/ng2-bs3-modal';
 
 import {GeneralProxyInformationComponent} from './generalProxyInformation/general.proxy.information.component';
 import {TopologyInformationsComponent} from './topologies/topology.information.component';
+import {SessionInformationComponent} from './sessionInformation/session.information.component';
 import {HomepageService} from './homepage.service';
 
 @NgModule({
@@ -32,11 +33,13 @@ import {HomepageService} from './homepage.service';
         BsModalModule
     ],
     declarations: [GeneralProxyInformationComponent,
-                   TopologyInformationsComponent
+                   TopologyInformationsComponent,
+                   SessionInformationComponent
     ],
     providers: [HomepageService
     ],
-    bootstrap: [GeneralProxyInformationComponent,
+    bootstrap: [SessionInformationComponent,
+                GeneralProxyInformationComponent,
                 TopologyInformationsComponent
     ]
 })

--- a/knox-homepage-ui/home/app/homepage.service.ts
+++ b/knox-homepage-ui/home/app/homepage.service.ts
@@ -22,10 +22,12 @@ import 'rxjs/add/operator/toPromise';
 
 import {GeneralProxyInformation} from './generalProxyInformation/general.proxy.information';
 import {TopologyInformation} from './topologies/topology.information';
+import {SessionInformation} from './sessionInformation/session.information';
 
 @Injectable()
 export class HomepageService {
     apiUrl = window.location.pathname.replace(new RegExp('home/.*'), 'api/v1/metadata/');
+    sessionUrl = window.location.pathname.replace(new RegExp('home/.*'), 'session/api/v1/sessioninfo');
     generalProxyInformationUrl = this.apiUrl + 'info';
     publicCertUrl = this.apiUrl + 'publicCert?type=';
     topologiesUrl = this.apiUrl + 'topologies';
@@ -57,6 +59,38 @@ export class HomepageService {
             .then(response => response['topologyInformations'].topologyInformation as TopologyInformation[])
             .catch((err: HttpErrorResponse) => {
                 console.debug('HomepageService --> getTopologies() --> ' + this.topologiesUrl + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    getSessionInformation(): Promise<SessionInformation> {
+        let headers = new HttpHeaders();
+        headers = this.addJsonHeaders(headers);
+        return this.http.get(this.sessionUrl, { headers: headers})
+            .toPromise()
+            .then(response => response['sessioninfo'] as SessionInformation)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('HomepageService --> getSessionInformation() --> ' + this.sessionUrl + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    logout(logoutUrl): Promise<JSON> {
+        let headers = new HttpHeaders();
+        headers = this.addJsonHeaders(headers);
+        return this.http.get(logoutUrl, { headers: headers})
+            .toPromise()
+            .then(response => response['loggedOut'])
+            .catch((err: HttpErrorResponse) => {
+                console.debug('HomepageService --> logout() --> ' + logoutUrl + '\n  error: ' + err.message);
                 if (err.status === 401) {
                     window.location.assign(document.location.pathname);
                 } else {

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.component.html
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.component.html
@@ -1,0 +1,35 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<div class="table-responsive">
+    <table class="table table-striped table-hover">
+       <colgroup>
+            <col width="90%">
+            <col width="5%">
+            <col width="5%">
+        </colgroup>
+        <tbody>
+            <tr>
+                <td></td>
+                <td>Welcome</td>
+                <td>{{ getUser() }}</td>
+	        </tr>
+	        <tr *ngIf="logoutSupported">
+                <td></td>
+                <td></td>
+                <td><a class="btn btn-primary" (click)="logout()">logout</a></td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.component.ts
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.component.ts
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {HomepageService} from '../homepage.service';
+import {SessionInformation} from './session.information';
+
+@Component({
+    selector: 'app-session-information',
+    templateUrl: './session.information.component.html',
+    providers: [HomepageService]
+})
+
+export class SessionInformationComponent implements OnInit {
+
+    sessionInformation: SessionInformation;
+    logoutSupported = true;
+
+    constructor(private homepageService: HomepageService) {
+        this['showSessionInformation'] = true;
+    }
+
+    getUser() {
+        if (this.sessionInformation) {
+            console.debug('SessionInformationComponent --> getUser() --> ' + this.sessionInformation.user);
+            return this.sessionInformation.user;
+        }
+        console.debug('SessionInformationComponent --> getUser() --> dr.who');
+        return 'dr.who';
+    }
+
+    getLogoutUrl() {
+        if (this.sessionInformation) {
+            console.debug('SessionInformationComponent --> getLogoutUrl() --> ' + this.sessionInformation.logoutUrl);
+            return this.sessionInformation.logoutUrl;
+        }
+        return null;
+    }
+
+    logout() {
+        // window.alert('Are you sure???');
+        console.debug('SessionInformationComponent --> attempting logout() --> ');
+        if (this.sessionInformation) {
+            if (this.getLogoutUrl() == null) {
+                window.alert('Logout for the configured is IDP not supported.\nPlease close all browser windows to logout.');
+            }
+            else {
+                this.homepageService.logout(this.getLogoutUrl())
+                                        .then(() => location.reload());
+            }
+        }
+    }
+
+    ngOnInit(): void {
+        console.debug('SessionInformationComponent --> ngOnInit() --> ');
+        this.homepageService.getSessionInformation()
+                            .then(sessionInformation => this.setSessonInformation(sessionInformation));
+        console.debug('SessionInformationComponent --> ngOnInit() --> ' + this.sessionInformation);
+    }
+
+    setSessonInformation(sessionInformation: SessionInformation) {
+        this.sessionInformation = sessionInformation;
+        if (this.getLogoutUrl() == null) {
+            this.logoutSupported = false;
+        }
+    }
+}

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.component.ts
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.component.ts
@@ -54,7 +54,7 @@ export class SessionInformationComponent implements OnInit {
         // window.alert('Are you sure???');
         console.debug('SessionInformationComponent --> attempting logout() --> ');
         if (this.sessionInformation) {
-            if (this.getLogoutUrl() == null) {
+            if (!this.logoutSupported) {
                 window.alert('Logout for the configured is IDP not supported.\nPlease close all browser windows to logout.');
             }
             else {

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.ts
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.ts
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class SessionInformation {
+    user: string;
+    logoutUrl: string;
+}

--- a/knox-homepage-ui/home/index.html
+++ b/knox-homepage-ui/home/index.html
@@ -43,6 +43,7 @@
     </div>
 
     <div class="container-fluid">
+        <app-session-information></app-session-information>
         <app-general-proxy-information></app-general-proxy-information>
         <app-topologies-information></app-topologies-information>
     </div>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
         <module>gateway-topology-simple</module>
         <module>gateway-topology-hadoop-xml</module>
         <module>gateway-service-metadata</module>
+        <module>gateway-service-session</module>
         <module>knox-homepage-ui</module>
     </modules>
 
@@ -1190,6 +1191,11 @@
             <dependency>
                 <groupId>org.apache.knox</groupId>
                 <artifactId>gateway-service-metadata</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.knox</groupId>
+                <artifactId>gateway-service-session</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Logout Button on Homepage
* Homepage Logout Configurable from gateway-site.xml
* KNOXSSOUT service changed to be able to be hosted in arbitrary topologies - may break existing use of this service in a dedicated knoxssout.xml topology which was the original intent but it was never really documented as supported.
* KNOX-SESSION API added to return authenticated user and optionally logoutUrl
* A SessionInformation section added to the Homepage with a Welcome {username} and logout button
* KNOXSSOUT and KNOX-SESSION added to homepage.xml topology by default
* homePageLogoutEnabled defaults to true since the default KnoxSSO with form based IDP is supported.

### Planned for Future

* Move session-information module into the header
* Integrate KNOXSSO with TokenStateServer feature for token revocation for cookie tokens
* Extend KNOXSSOUT to revoke tokens on logout
* Pluggable logout providers rather than a single logoutUrl mechanism so other IDP logout mechanisms can be integrated

## How was this patch tested?
* Existing unit tests run
* SessionResourceTest unit test added

![image](https://user-images.githubusercontent.com/2303672/92186654-79082900-ee25-11ea-932c-ffa6b93fc659.png)

The following has homePageLogoutEnabled=false

![image](https://user-images.githubusercontent.com/2303672/92187841-dd78b780-ee28-11ea-9019-37b6468bbf09.png)

