### PR TITLE
KNOX-2453 Fix Host header handling in websockets

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketBackendUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketBackendUrlTest.java
@@ -70,9 +70,8 @@ public class WebsocketBackendUrlTest extends WebsocketEchoTestBase {
   @Test
   public void testWebsocketBackendUrl() throws Exception {
     URI requestURI = new URI(serverUri.toString() + "gateway/websocket/123foo456bar/channels");
-    final String path = requestURI.getPath();
     GatewayWebsocketHandler gwh = new GatewayWebsocketHandler(gatewayConfig, services);
-    String backendUrl = gwh.getMatchedBackendURL(path, requestURI);
+    String backendUrl = gwh.getMatchedBackendURL(requestURI);
     String expectedBackendUrl = backendServerUri.toString() + "channels";
     assertThat(backendUrl, is(expectedBackendUrl));
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix proper handling of [Host header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) when websocket requests are proxied through Knox. Currently the host header contains knox hostname instead of the websocket backend host name (this is during the http upgrade part of WS request). This PR fixes this issue.

## How was this patch tested?
This patch was tested on a local cluster
