### PR TITLE
KNOX-2456 SHS links sometimes broken on FINISHED jobs page

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
@@ -246,9 +246,13 @@
 </rule>
 
 
-<rule dir="OUT" name="YARNUI/yarn/outbound/apps/history">
-    <match pattern="*://*:*/proxy/{**}"/>
-    <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+<rule flow="OR" dir="OUT" name="YARNUI/yarn/outbound/apps/history">
+    <match pattern="*://*:*/proxy/{**}">
+        <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+    </match>
+    <match pattern="/proxy/{**}">
+        <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+    </match>
 </rule>
 <rule dir="OUT" name="YARNUI/yarn/outbound/apps/history1">
     <match pattern="/proxy/{**}?{**}"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

For unexplained reasons, most of the time SHS links are in the format `http://host:port/proxy/application_123_456`, but sometimes they can be `/proxy/application_123_456`.

This causes broken URLs on the page, along with the following logged error.

```
Failed to rewrite URL: /proxy/application_1597654526563_0024/, direction: OUT via rule: YARNUI/yarn/outbound/apps/history, status: FAILURE
```

This patch fixes the issue.

## How was this patch tested?

Tested in local production cluster.  Spawned up hundreds of spark jobs and checked links, without this patch every 1 in 20 or so is broken.  With the patch, all previously broken links now work.
