### PR TITLE
KNOX-2459 - KNOX-METADATA, KNOXSSOUT and KNOX-SESSION services do not need any URL or param to be added in the generated topology

### DIFF
--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -51,6 +51,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Processes simple topology descriptors, producing full topology files, which can subsequently be deployed to the
@@ -88,7 +90,7 @@ public class SimpleDescriptorHandler {
 
     private static Map<String, ServiceDiscovery> discoveryInstances = new HashMap<>();
 
-    private static final Set<String> ALLOWED_SERVICES_WITHOUT_URLS_AND_PARAMS = Collections.singleton("KNOX");
+    private static final Set<String> ALLOWED_SERVICES_WITHOUT_URLS_AND_PARAMS = Collections.unmodifiableSet(Stream.of("KNOX", "KNOX-METADATA", "KNOXSSOUT", "KNOX-SESSION").collect(Collectors.toSet()));
 
     public static Map<String, File> handle(GatewayConfig config, File desc, File destDirectory, Service...gatewayServices) throws IOException {
         return handle(config, SimpleDescriptorFactory.parse(desc.getAbsolutePath()), desc.getParentFile(), destDirectory, gatewayServices);


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are some services internal to the Knox Gateway that do not need any URL or param defined in a descriptor to be added in the generated topology. Until now, only the `KNOX` service was like that. However, there are 3 more services which should behave the same way: `KNOX-METADATA`, `KNOXSSOUT` and `KNOX-SESSION`.

## How was this patch tested?
Tested manually: added a new descriptor called `test` with these services and confirmed that the generated topology contained all of them.

<img width="1675" alt="Screen Shot 2020-09-23 at 9 08 19 AM" src="https://user-images.githubusercontent.com/34065904/93978513-64f87d00-fd7c-11ea-98eb-71e66a1cc4bb.png">
<img width="1671" alt="Screen Shot 2020-09-23 at 9 08 29 AM" src="https://user-images.githubusercontent.com/34065904/93978521-67f36d80-fd7c-11ea-9edf-55c1b62d041e.png">
