### PR TITLE
KNOX-2469 - Fixing Knox keystore path directory creation for symlinks

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -516,7 +516,7 @@ public class DefaultKeystoreService implements KeystoreService {
     // Ensure the parent directory exists...
     // This is symlink safe.
     Path parentPath = keystoreFilePath.getParent();
-    if (parentPath == null || !Files.isDirectory(parentPath)) {
+    if (parentPath != null && !Files.isDirectory(parentPath)) {
       try{
         // This will attempt to create all missing directories.  No failures will occur if the
         // directories already exist.

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -513,11 +513,11 @@ public class DefaultKeystoreService implements KeystoreService {
   // Package private for unit test access
   // We need this to be synchronized to prevent multiple threads from using at once
   synchronized KeyStore createKeyStore(Path keystoreFilePath, String keystoreType, char[] password) throws KeystoreServiceException {
-    if (Files.notExists(keystoreFilePath)) {
     // Ensure the parent directory exists...
     // This is symlink safe.
     Path parentPath = keystoreFilePath.getParent();
     if (!Files.isDirectory(parentPath)) {
+      try{
         // This will attempt to create all missing directories.  No failures will occur if the
         // directories already exist.
         Files.createDirectories(parentPath);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -516,7 +516,7 @@ public class DefaultKeystoreService implements KeystoreService {
     // Ensure the parent directory exists...
     // This is symlink safe.
     Path parentPath = keystoreFilePath.getParent();
-    if (!Files.isDirectory(parentPath)) {
+    if (parentPath == null || !Files.isDirectory(parentPath)) {
       try{
         // This will attempt to create all missing directories.  No failures will occur if the
         // directories already exist.

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -514,11 +514,13 @@ public class DefaultKeystoreService implements KeystoreService {
   // We need this to be synchronized to prevent multiple threads from using at once
   synchronized KeyStore createKeyStore(Path keystoreFilePath, String keystoreType, char[] password) throws KeystoreServiceException {
     if (Files.notExists(keystoreFilePath)) {
-      // Ensure the parent directory exists...
-      try {
+    // Ensure the parent directory exists...
+    // This is symlink safe.
+    Path parentPath = keystoreFilePath.getParent();
+    if (!Files.isDirectory(parentPath)) {
         // This will attempt to create all missing directories.  No failures will occur if the
         // directories already exist.
-        Files.createDirectories(keystoreFilePath.getParent());
+        Files.createDirectories(parentPath);
       } catch (IOException e) {
         LOG.failedToCreateKeystore(keystoreFilePath.toString(), keystoreType, e);
         throw new KeystoreServiceException(e);


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

This patch fixes a potential issue regarding the creation of Knox's keystores. The current logic checks to see if the keystore path exists--if it doesn't, it tries to create the parent folder of the keystore path. However, there is an edge case, as described in JDK-8130464, where the directory creation fails if the final, parent directory of the keystore path is a symlink. This causes a failure during startup. This PR remedies this by checking if the keystore parent directory exists instead of checking the keystore itself, as checking directories is symlink-safe. There is also no extra logic after the keystore creation, so if the keystore does exist, this turns into a no-op.
(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

This PR was tested against an environment in which the keystore path's parent directory is a symlink on Knox 1.4.0. The tests that pass before this change pass after this change, locally.

One issue that may be worth noting is that this does not fix the case where some ancestor directory within the keystore path directory chain is an invalid symlink. If C:\a is a symlink to C:\b but C:\b does not exist, then the attempt to create C:\a\z will fail. However, depending on how we would like to do this, this might be a task best assigned to the users.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
