### PR TITLE
KNOX-2401 - Extend ClientCert Authentication Provider for CN as Prima…

### DIFF
--- a/gateway-provider-security-clientcert/pom.xml
+++ b/gateway-provider-security-clientcert/pom.xml
@@ -31,6 +31,10 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-i18n</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-spi</artifactId>
         </dependency>
         <dependency>

--- a/gateway-provider-security-clientcert/src/main/java/org/apache/knox/gateway/clientcert/filter/ClientCertMessages.java
+++ b/gateway-provider-security-clientcert/src/main/java/org/apache/knox/gateway/clientcert/filter/ClientCertMessages.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.clientcert.filter;
+
+import org.apache.knox.gateway.i18n.messages.Message;
+import org.apache.knox.gateway.i18n.messages.MessageLevel;
+import org.apache.knox.gateway.i18n.messages.Messages;
+
+@Messages(logger="org.apache.knox.gateway")
+public interface ClientCertMessages {
+  @Message( level = MessageLevel.ERROR, text = "Configured certificate attribute unknown - falling back to DN as principal: {0}" )
+  void unknownCertificateAttribute(String attrName);
+}


### PR DESCRIPTION
KNOX-2401 - Extend ClientCert Authentication Provider for CN as Pr

Change-Id: I416ae92a0f01f032e4d0ac9bb5e6bf03ce35267c

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Add the ability to configure the attribute of the principal to be used from within the X509Certificate.

## How was this patch tested?
Manual testing

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
