### PR TITLE
KNOX-2476 - Fix issue with X-Forwarded-Context header when there is a failover

### DIFF
--- a/gateway-service-nifi/src/main/java/org/apache/knox/gateway/dispatch/NiFiRequestUtil.java
+++ b/gateway-service-nifi/src/main/java/org/apache/knox/gateway/dispatch/NiFiRequestUtil.java
@@ -43,7 +43,7 @@ class NiFiRequestUtil {
     final Header originalXForwardedContextHeader = outboundRequest.getFirstHeader(NiFiHeaders.X_FORWARDED_CONTEXT);
     if (originalXForwardedContextHeader != null) {
       String xForwardedContextHeaderValue = originalXForwardedContextHeader.getValue();
-      if (xForwardedContextHeaderValue != null && !xForwardedContextHeaderValue.isEmpty()) {
+      if (xForwardedContextHeaderValue != null && !xForwardedContextHeaderValue.isEmpty() && !xForwardedContextHeaderValue.contains("nifi-app")) {
         // Inspect the inbound request and outbound request to determine the additional context path from the rewrite
         // rules that needs to be added to the X-Forwarded-Context header to allow proper proxying to NiFi.
         //


### PR DESCRIPTION

## What changes were proposed in this pull request?

Fix an issue where extra nifi-app context is appended when there is a HA failover.

## How was this patch tested?
Patch was tested locally 