### PR TITLE
KNOX-2479 - Fix an issue where Knox munges set-cookie header

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -382,7 +382,14 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
           return ""; // we should exclude all -> there should not be any value added with this header
         } else {
           final String separator = SET_COOKIE.equalsIgnoreCase(headerNameToCheck) ? "; " : " ";
-          Set<String> headerValuesToCheck = new HashSet<>(Arrays.asList(headerToCheck.getValue().trim().split("\\s+")));
+          Set<String> headerValuesToCheck;
+          if(headerToCheck.getName().equalsIgnoreCase(SET_COOKIE)) {
+              headerValuesToCheck = new HashSet<>(Arrays.asList(headerToCheck.getValue().trim().split(";")));
+              /* trim */
+              headerValuesToCheck = headerValuesToCheck.stream().map(String::trim).collect(Collectors.toSet());
+          } else {
+              headerValuesToCheck = new HashSet<>(Arrays.asList(headerToCheck.getValue().trim().split("\\s+")));
+          }
           headerValuesToCheck = headerValuesToCheck.stream().map(h -> h.replaceAll(separator.trim(), "")).collect(Collectors.toSet());
           headerValuesToCheck.removeIf(h -> excludedHeaderValues.stream().anyMatch(e -> h.contains(e)));
           return headerValuesToCheck.isEmpty() ? "" : String.join(separator, headerValuesToCheck);

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/ConfigurableDispatchTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/ConfigurableDispatchTest.java
@@ -325,8 +325,32 @@ public class ConfigurableDispatchTest {
     dispatch.copyResponseHeaderFields(outboundResponse, inboundResponse);
 
     assertThat(outboundResponse.getHeaderNames().size(), is(1));
-    assertThat(outboundResponse.getHeader(SET_COOKIE), is("Secure; Path=/; RANGERADMINSESSIONID=5C0C1805BD3B43BA8E9FC04A63586505; HttpOnly"));
+    assertThat(outboundResponse.getHeader(SET_COOKIE), is("Secure; Path=/; HttpOnly; RANGERADMINSESSIONID=5C0C1805BD3B43BA8E9FC04A63586505"));
   }
+
+    /**
+     * Test a case where SET-COOKIE header does not use spaces
+     * @throws Exception
+     */
+    @Test
+    public void testAllowSetCookieHeaderNoSpaces() throws Exception {
+        final Header[] headers = new Header[] {
+                new BasicHeader(SET_COOKIE, "SESSION=e69d3d08-7452-45cb-90bb-9cdde3fa1342;Path=/;HttpOnly")};
+        final HttpResponse inboundResponse = EasyMock.createNiceMock(HttpResponse.class);
+        EasyMock.expect(inboundResponse.getAllHeaders()).andReturn(headers).anyTimes();
+        EasyMock.replay(inboundResponse);
+
+        final ConfigurableDispatch dispatch = new ConfigurableDispatch();
+
+        final String setCookieExludeHeaders = "WWW-AUTHENTICATE";
+        dispatch.setResponseExcludeHeaders(setCookieExludeHeaders);
+
+        final HttpServletResponse outboundResponse = new MockHttpServletResponse();
+        dispatch.copyResponseHeaderFields(outboundResponse, inboundResponse);
+
+        assertThat(outboundResponse.getHeaderNames().size(), is(1));
+        assertThat(outboundResponse.getHeader(SET_COOKIE), is("SESSION=e69d3d08-7452-45cb-90bb-9cdde3fa1342; Path=/; HttpOnly"));
+    }
 
   /**
    * Case where auth cookie can be configured to pass through


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix an issue where set-cookie responses from are broken when backend services send set-cookies with no spaces.

## How was this patch tested?
Locally tested