### PR TITLE
KNOX-2527 - Added support for HMAC signature/verification in JWT token authority

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -129,9 +129,6 @@ public abstract class AbstractJWTFilter implements Filter {
     }
 
     expectedSigAlg = filterConfig.getInitParameter(JWT_EXPECTED_SIGALG);
-    if (expectedSigAlg == null) {
-      expectedSigAlg = JWT_DEFAULT_SIGALG;
-    }
   }
 
   protected List<String> parseExpectedAudiences(String expectedAudiences) {
@@ -277,10 +274,10 @@ public abstract class AbstractJWTFilter implements Filter {
       log.unableToVerifyToken(e);
     }
 
-    // Check received signature algorithm
-    if (verified) {
+    // Check received signature algorithm if expectation is configured
+    if (verified && expectedSigAlg != null) {
       try {
-        String receivedSigAlg = JWSHeader.parse(token.getHeader()).getAlgorithm().getName();
+        final String receivedSigAlg = JWSHeader.parse(token.getHeader()).getAlgorithm().getName();
         if (!receivedSigAlg.equals(expectedSigAlg)) {
           verified = false;
         }
@@ -325,12 +322,10 @@ public abstract class AbstractJWTFilter implements Filter {
           log.unableToVerifyExpiration(e);
           handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
         }
-      }
-      else {
+      } else {
         handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED, null);
       }
-    }
-    else {
+    } else {
       log.failedToVerifyTokenSignature(tokenId, displayableToken);
       handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED, null);
     }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
@@ -146,7 +146,7 @@ public class JWTAccessTokenAssertionFilter extends AbstractIdentityAssertionFilt
     };
     JWT token;
     try {
-      token = authority.issueToken(p, serviceName, "RS256", expires);
+      token = authority.issueToken(p, serviceName, signatureAlgorithm, expires);
       // Coverity CID 1327961
       if( token != null ) {
         accessToken = token.toString();

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
@@ -64,7 +64,7 @@ public class JWTAuthCodeAssertionFilter extends AbstractIdentityAssertionFilter 
     principalName = mapper.mapUserPrincipal(principalName);
     JWT authCode;
     try {
-      authCode = authority.issueToken(subject, "RS256");
+      authCode = authority.issueToken(subject, signatureAlgorithm);
       // get the url for the token service
       String url = null;
       if (sr != null) {

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -849,6 +849,7 @@ public abstract class AbstractJWTFilterTest  {
   public void testInvalidSignatureAlgorithm() throws Exception {
     try {
       Properties props = getProperties();
+      props.put(AbstractJWTFilter.JWT_EXPECTED_SIGALG, AbstractJWTFilter.JWT_DEFAULT_SIGALG);
       handler.init(new TestFilterConfig(props));
 
       SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "alice", new Date(new Date().getTime() + 5000),

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.token.impl;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -31,6 +32,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +51,7 @@ import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
+import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 
@@ -56,6 +59,9 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.KeyLengthException;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.MACVerifier;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.source.JWKSource;
@@ -72,24 +78,17 @@ import com.nimbusds.jwt.proc.JWTClaimsSetVerifier;
 public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
   private static final GatewayResources RESOURCES = ResourcesFactory.get(GatewayResources.class);
 
-  private static final Set<String> SUPPORTED_SIG_ALGS = new HashSet<>();
+  // Only standard RSA and HMAC signature algorithms are accepted
+  // https://tools.ietf.org/html/rfc7518
+  private static final Set<String> SUPPORTED_PKI_SIG_ALGS = new HashSet<>(Arrays.asList("RS256", "RS384", "RS512", "PS256", "PS384", "PS512"));
+  private static final Set<String> SUPPORTED_HMAC_SIG_ALGS = new HashSet<>(Arrays.asList("HS256", "HS384", "HS512"));
   private AliasService aliasService;
   private KeystoreService keystoreService;
   private GatewayConfig config;
 
   private char[] cachedSigningKeyPassphrase;
+  private byte[] cachedSigningHmacSecret;
   private RSAPrivateKey signingKey;
-
-  static {
-      // Only standard RSA signature algorithms are accepted
-      // https://tools.ietf.org/html/rfc7518
-      SUPPORTED_SIG_ALGS.add("RS256");
-      SUPPORTED_SIG_ALGS.add("RS384");
-      SUPPORTED_SIG_ALGS.add("RS512");
-      SUPPORTED_SIG_ALGS.add("PS256");
-      SUPPORTED_SIG_ALGS.add("PS384");
-      SUPPORTED_SIG_ALGS.add("PS512");
-  }
 
   public void setKeystoreService(KeystoreService ks) {
     this.keystoreService = ks;
@@ -138,20 +137,6 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
     return issueToken(p, audiences, algorithm, expires, null, null, null);
   }
 
-  private RSAPrivateKey getSigningKey(final String signingKeystoreName,
-                                      final String signingKeystoreAlias,
-                                      final char[] signingKeystorePassphrase)
-          throws KeystoreServiceException, TokenServiceException {
-
-    if (signingKeystorePassphrase != null) {
-      return (RSAPrivateKey) keystoreService.getSigningKey(signingKeystoreName,
-              getSigningKeyAlias(signingKeystoreAlias),
-              getSigningKeyPassphrase(signingKeystorePassphrase));
-    }
-
-    return signingKey;
-  }
-
   @Override
   public JWT issueToken(Principal p, List<String> audiences, String algorithm, long expires,
                         String signingKeystoreName, String signingKeystoreAlias, char[] signingKeystorePassphrase)
@@ -167,23 +152,59 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
       claimArray[3] = String.valueOf(expires);
     }
 
-    JWT token;
-    if (SUPPORTED_SIG_ALGS.contains(algorithm)) {
-      token = new JWTToken(algorithm, claimArray, audiences);
+    final JWT token = SUPPORTED_PKI_SIG_ALGS.contains(algorithm) || SUPPORTED_HMAC_SIG_ALGS.contains(algorithm) ? new JWTToken(algorithm, claimArray, audiences) : null;
+    if (token != null) {
+      if (SUPPORTED_HMAC_SIG_ALGS.contains(algorithm)) {
+        signTokenWithHMAC(token);
+      } else {
+        signTokenWithRSA(token, signingKeystoreName, signingKeystoreAlias, signingKeystorePassphrase);
+      }
+      return token;
+    } else {
+      throw new TokenServiceException("Cannot issue token - Unsupported algorithm: " + algorithm);
+    }
+  }
+
+  private void signTokenWithRSA(final JWT token, String signingKeystoreName, String signingKeystoreAlias, char[] signingKeystorePassphrase) throws TokenServiceException {
+    try {
+      final RSAPrivateKey key = getSigningKey(signingKeystoreName, signingKeystoreAlias, signingKeystorePassphrase);
+      // allowWeakKey to not break existing 1024 bit certificates
+      final JWSSigner signer = new RSASSASigner(key, true);
+      token.sign(signer);
+    } catch (KeystoreServiceException e) {
+      throw new TokenServiceException(e);
+    }
+  }
+
+  private RSAPrivateKey getSigningKey(final String signingKeystoreName, final String signingKeystoreAlias, final char[] signingKeystorePassphrase)
+      throws KeystoreServiceException, TokenServiceException {
+
+    if (signingKeystorePassphrase != null) {
+      return (RSAPrivateKey) keystoreService.getSigningKey(signingKeystoreName, getSigningKeyAlias(signingKeystoreAlias), getSigningKeyPassphrase(signingKeystorePassphrase));
+    }
+
+    return signingKey;
+  }
+
+  private void signTokenWithHMAC(final JWT token) throws TokenServiceException {
+    try {
+      final JWSSigner signer = new MACSigner(getHmacSecret());
+      token.sign(signer);
+    } catch (KeyLengthException e) {
+      throw new TokenServiceException(e);
+    }
+  }
+
+  private byte[] getHmacSecret() throws TokenServiceException {
+    if (cachedSigningHmacSecret == null) {
       try {
-        RSAPrivateKey key = getSigningKey(signingKeystoreName, signingKeystoreAlias, signingKeystorePassphrase);
-        // allowWeakKey to not break existing 1024 bit certificates
-        JWSSigner signer = new RSASSASigner(key, true);
-        token.sign(signer);
-      } catch (KeystoreServiceException e) {
+        final char[] hmacSecret = aliasService.getPasswordFromAliasForGateway(TokenUtils.SIGNING_HMAC_SECRET_ALIAS);
+        this.cachedSigningHmacSecret = hmacSecret == null ? null : new String(hmacSecret).getBytes(StandardCharsets.UTF_8);
+      } catch (AliasServiceException e) {
         throw new TokenServiceException(e);
       }
     }
-    else {
-      throw new TokenServiceException("Cannot issue token - Unsupported algorithm");
-    }
-
-    return token;
+    return cachedSigningHmacSecret;
   }
 
   private char[] getSigningKeyPassphrase(char[] signingKeyPassphrase) {
@@ -205,31 +226,38 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
   }
 
   @Override
-  public boolean verifyToken(JWT token)
-      throws TokenServiceException {
+  public boolean verifyToken(JWT token) throws TokenServiceException {
     return verifyToken(token, null);
   }
 
   @Override
-  public boolean verifyToken(JWT token, RSAPublicKey publicKey)
-      throws TokenServiceException {
-    boolean rc;
-    PublicKey key;
+  public boolean verifyToken(JWT token, RSAPublicKey publicKey) throws TokenServiceException {
+    final String signatureAlgorithm = token.getSignatureAlgorithm().getName();
+    return SUPPORTED_HMAC_SIG_ALGS.contains(signatureAlgorithm) ? verifyTokenUsingHMAC(token) : verifyTokenUsingRSA(token, publicKey);
+  }
+
+  private boolean verifyTokenUsingRSA(JWT token, RSAPublicKey publicKey) throws TokenServiceException {
     try {
-      if (publicKey == null) {
+      PublicKey key = publicKey;
+      if (key == null) {
         key = keystoreService.getSigningKeystore().getCertificate(getSigningKeyAlias()).getPublicKey();
       }
-      else {
-        key = publicKey;
-      }
-      JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) key);
+      final JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) key);
       // TODO: interrogate the token for issuer claim in order to determine the public key to use for verification
       // consider jwk for specifying the key too
-      rc = token.verify(verifier);
+      return token.verify(verifier);
     } catch (KeyStoreException | KeystoreServiceException e) {
       throw new TokenServiceException("Cannot verify token.", e);
     }
-    return rc;
+  }
+
+  private boolean verifyTokenUsingHMAC(JWT token) throws TokenServiceException {
+    try {
+      final JWSVerifier verifier = new MACVerifier(getHmacSecret());
+      return token.verify(verifier);
+    } catch (JOSEException e) {
+      throw new TokenServiceException("Cannot verify token.", e);
+    }
   }
 
   @Override

--- a/gateway-service-knoxtoken/pom.xml
+++ b/gateway-service-knoxtoken/pom.xml
@@ -76,6 +76,10 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.knox</groupId>

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenUtils.java
@@ -16,7 +16,10 @@
  */
 package org.apache.knox.gateway.services.security.token;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 
@@ -25,6 +28,9 @@ import javax.servlet.ServletContext;
 
 
 public class TokenUtils {
+  public static final String SIGNING_HMAC_SECRET_ALIAS = "gateway.signing.hmac.secret";
+  private static final String DEFAULT_RSA_SIG_ALG = "RS256";
+  private static final String DEFAULT_HMAC_SIG_ALG = "HS256";
 
   /**
    * Extract the unique Knox token identifier from the specified JWT's claim set.
@@ -65,6 +71,27 @@ public class TokenUtils {
     }
 
     return isServerManaged;
+  }
+
+  /**
+   * @return <code>configuredSignatureAlgorithm</code> if any OR the default HMAC algorithm if {@link #useHMAC(char[], String)} is
+   *         <code>true</code>; the default RSA algorithm otherwise
+   */
+  public static String getSignatureAlgorithm(String configuredSignatureAlgorithm, AliasService aliasService, String signingKeystoreName) throws AliasServiceException {
+    if (StringUtils.isNotBlank(configuredSignatureAlgorithm)) {
+      return configuredSignatureAlgorithm;
+    } else {
+      final char[] hmacSecret = aliasService.getPasswordFromAliasForGateway(SIGNING_HMAC_SECRET_ALIAS);
+      return useHMAC(hmacSecret == null ? null : hmacSecret, signingKeystoreName) ? DEFAULT_HMAC_SIG_ALG : DEFAULT_RSA_SIG_ALG;
+    }
+  }
+
+  /**
+   * @return true, if the HMAC secret is configured via the alias service for the gateway AND signing keystore name is not set ; false
+   *         otherwise
+   */
+  private static boolean useHMAC(char[] hmacSecret, String signingKeystoreName) {
+    return hmacSecret != null && StringUtils.isBlank(signingKeystoreName);
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWT.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWT.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.security.token.impl;
 
 import java.util.Date;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
 
@@ -58,6 +59,8 @@ public interface JWT {
   String getHeader();
 
   String getClaims();
+
+  JWSAlgorithm getSignatureAlgorithm();
 
   void sign(JWSSigner signer);
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -91,6 +91,11 @@ public class JWTToken implements JWT {
   }
 
   @Override
+  public JWSAlgorithm getSignatureAlgorithm() {
+    return jwt.getHeader().getAlgorithm();
+  }
+
+  @Override
   public String getClaims() {
     String c = null;
     JWTClaimsSet claims;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change, I'm extending the current RSA based token signing with the use of HMAC. As described in the corresponding JIRA, from now on end-users are able to configure an HMAC secret in the gateway's alias service which then will be used as a signature secret (pay attention to the key size requirements!).


## How was this patch tested?
Updated and ran a full maven build successfully and executed E2E tests:
1. configured the `gateway.signing.hmac.secret` alias:
```
$ bin/knoxcli.sh list-alias
Listing aliases for: __gateway
gateway.signing.hmac.secret
```
2. Added the `KNOXTOKEN` service in the `sandbox` topology:
```
<service>
   <role>KNOXTOKEN</role>
   <param>
      <name>knox.token.ttl</name>
      <value>36000000</value>
   </param>
   <param>
      <name>knox.token.audiences</name>
      <value>tokenbased</value>
   </param>
   <param>
      <name>knox.token.target.url</name>
      <value>https://localhost:8443/gateway/tokenbased</value>
   </param>
<!--
   <param>
      <name>knox.token.sigalg</name>
      <value>HS256</value>
   </param>
-->
</service>
```
3. Added a new topology - called tokenbased - to be able to test the generated tokens
4. Acquired a Knox token:
```
curl -iku admin:admin-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
...
HTTP/1.1 200 OK
Date: Mon, 11 Jan 2021 15:08:34 GMT
Set-Cookie: KNOXSESSIONID=node01eow5gtl4jq0z68xpcuoo9cut0.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Sun, 10-Jan-2021 15:08:34 GMT; SameSite=lax
Content-Type: application/json
Content-Length: 1862

{"access_token":"eyJhbGciOiJSUzI1NiJ9...FN7RE8Xsw","target_url":"https://localhost:8443/gateway/tokenbased","endpoint_public_cert":"MIIDe...W6Z2nJarXg==","token_type":"Bearer","expires_in":1610413714993}
```
5. Tested the acquired token by invoking the HDFS UI service in `tokenbased`:
```
curl -ik -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9...FN7RE8Xsw" https://localhost:8443/gateway/tokenbased/hdfs
```
6. Changed the value of `knox.token.sigalg` parameter to `HS384`, reset the `gateway.signing.hmac.secret` with an appropriate secret (key length matters) and repeated steps 4-5. The call finished successfully.
7. Changed the value of `knox.token.sigalg` parameter to `HS512`, reset the `gateway.signing.hmac.secret` with an appropriate secret (key length matters) and repeated steps 4-5. The call finished successfully.
8. Changed the value of  `knox.token.sigalg` parameter to `HS123` and repeated steps 4-5. Call failed as expected.
9. Removed the `gateway.signing.hmac.secret` and re-tried the get/verify steps; all were OK.

Logged into the Knox home page successfully (the `hadoop-jwt` cookie was added properly)
Also tested the case when the `gateway.signing.keystore.name` was set.