### PR TITLE
KNOX-2530 - Support qualifying service params for CM discovery control

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModel.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModel.java
@@ -37,6 +37,9 @@ public class ServiceModel {
   private final String roleType;
   private final String serviceUrl;
 
+  // Metadata for the model object, which is not directly from the service or role configuration
+  private final Map<String, String> qualifyingServiceParams = new ConcurrentHashMap<>();
+
   // The service configuration properties used to created the model
   private final Map<String, String> serviceConfigProperties = new ConcurrentHashMap<>();
 
@@ -62,12 +65,30 @@ public class ServiceModel {
     this.serviceUrl  = serviceUrl;
   }
 
+  public void addQualifyingServiceParam(final String name, final String value) {
+    qualifyingServiceParams.put(name, (value != null ? value : NULL_VALUE));
+  }
+
   public void addServiceProperty(final String name, final String value) {
     serviceConfigProperties.put(name, (value != null ? value : NULL_VALUE));
   }
 
   public void addRoleProperty(final String role, final String name, final String value) {
     roleConfigProperties.computeIfAbsent(role, m -> new HashMap<>()).put(name, (value != null ? value : NULL_VALUE));
+  }
+
+  /**
+   * @return The metadata properties associated with the model, which can be used to qualify service discovery.
+   */
+  public Map<String, String> getQualifyingServiceParams() {
+    return qualifyingServiceParams;
+  }
+
+  /**
+   * @return The value of the metadata property associated with the model, which can be used to qualify service discovery.
+   */
+  public String getQualifyingServiceParam(final String name) {
+    return qualifyingServiceParams.get(name);
   }
 
   /**

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGenerator.java
@@ -24,6 +24,7 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 
 import java.util.Locale;
+import java.util.Map;
 
 public class HdfsUIServiceModelGenerator extends NameNodeServiceModelGenerator {
   public static final String SERVICE = "HDFSUI";
@@ -65,7 +66,29 @@ public class HdfsUIServiceModelGenerator extends NameNodeServiceModelGenerator {
     model.addRoleProperty(role.getType(), HTTPS_PORT, getRoleConfigValue(roleConfig, HTTPS_PORT));
     model.addRoleProperty(role.getType(), HTTP_PORT, getRoleConfigValue(roleConfig, HTTP_PORT));
 
+    ServiceModel parent = super.generateService(service, serviceConfig, role, roleConfig);
+    addParentModelMetadata(model, parent);
+
     return model;
+  }
+
+  protected void addParentModelMetadata(final ServiceModel model, final ServiceModel parent) {
+    // Add parent model properties
+    for (Map.Entry<String, String> parentProp : parent.getQualifyingServiceParams().entrySet()) {
+      model.addQualifyingServiceParam(parentProp.getKey(), parentProp.getValue());
+    }
+
+    // Add parent service properties
+    for (Map.Entry<String, String> parentProp : parent.getServiceProperties().entrySet()) {
+      model.addServiceProperty(parentProp.getKey(), parentProp.getValue());
+    }
+
+    // Add parent role properties
+    for (Map.Entry<String, Map<String, String>> parentProps : parent.getRoleProperties().entrySet()) {
+      for (Map.Entry<String, String> prop : parentProps.getValue().entrySet()) {
+        model.addRoleProperty(parentProps.getKey(), prop.getKey(), prop.getValue());
+      }
+    }
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
@@ -31,6 +31,8 @@ public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator
   public static final String SERVICE_TYPE = "HDFS";
   public static final String ROLE_TYPE    = "NAMENODE";
 
+  static final String DISCOVERY_NAMESERVICE = "discovery-nameservice";
+
   static final String AUTOFAILOVER_ENABLED = "autofailover_enabled";
   static final String NN_NAMESERVICE       = "dfs_federation_namenode_nameservice";
   static final String NN_PORT              = "namenode_port";
@@ -62,7 +64,7 @@ public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator
                                       ApiConfigList    roleConfig) throws ApiException {
     boolean haEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, AUTOFAILOVER_ENABLED));
     String serviceUrl;
-    if(haEnabled) {
+    if (haEnabled) {
       String nameservice = getRoleConfigValue(roleConfig, NN_NAMESERVICE);
       serviceUrl = String.format(Locale.getDefault(), "hdfs://%s", nameservice);
     } else {
@@ -76,6 +78,9 @@ public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator
     model.addRoleProperty(getRoleType(), NN_PORT, getRoleConfigValue(roleConfig, NN_PORT));
     if (haEnabled) {
       model.addRoleProperty(getRoleType(), NN_NAMESERVICE, getRoleConfigValue(roleConfig, NN_NAMESERVICE));
+
+      // Add the nameservice metadata for qualifying the discovery process for this service
+      model.addQualifyingServiceParam(DISCOVERY_NAMESERVICE, model.getRoleProperties().get(getRoleType()).get(NN_NAMESERVICE));
     }
 
     return model;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
@@ -24,8 +24,6 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGeneratorHandleResponse;
 
-import java.util.Map;
-
 public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
   private static final String SERVICE = "WEBHDFS";
   private static final String WEBHDFS_SUFFIX = "/webhdfs";
@@ -68,20 +66,6 @@ public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
     addParentModelMetadata(model, parent);
 
     return model;
-  }
-
-  private void addParentModelMetadata(final ServiceModel model, final ServiceModel parent) {
-    // Add parent model properties
-    for (Map.Entry<String, String> parentProp : parent.getServiceProperties().entrySet()) {
-      model.addServiceProperty(parentProp.getKey(), parentProp.getValue());
-    }
-
-    // Add parent role properties
-    for (Map.Entry<String, Map<String, String>> parentProps : parent.getRoleProperties().entrySet()) {
-      for (Map.Entry<String, String> prop : parentProps.getValue().entrySet()) {
-        model.addRoleProperty(parentProps.getKey(), prop.getKey(), prop.getValue());
-      }
-    }
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGenerator.java
@@ -30,6 +30,9 @@ public class SolrServiceModelGenerator extends AbstractServiceModelGenerator {
   public static final String SERVICE_TYPE = "SOLR";
   public static final String ROLE_TYPE    = "SOLR_SERVER";
 
+  static final String DISCOVERY_SERVICE_NAME         = "discovery-service-name";
+  static final String DISCOVERY_SERVICE_DISPLAY_NAME = "discovery-service-display-name";
+
   static final String USE_SSL    = "solr_use_ssl";
   static final String HTTP_PORT  = "solr_http_port";
   static final String HTTPS_PORT = "solr_https_port";
@@ -76,6 +79,10 @@ public class SolrServiceModelGenerator extends AbstractServiceModelGenerator {
     model.addServiceProperty(USE_SSL, sslEnabled);
     model.addRoleProperty(getRoleType(), HTTP_PORT, getRoleConfigValue(roleConfig, HTTP_PORT));
     model.addRoleProperty(getRoleType(), HTTPS_PORT, getRoleConfigValue(roleConfig, HTTPS_PORT));
+
+    // Add some service details for qualifying the discovery process for this service
+    model.addQualifyingServiceParam(DISCOVERY_SERVICE_NAME, service.getName());
+    model.addQualifyingServiceParam(DISCOVERY_SERVICE_DISPLAY_NAME, service.getDisplayName());
 
     return model;
   }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
@@ -94,13 +94,16 @@ public abstract class AbstractServiceModelGeneratorTest extends AbstractCMDiscov
 
   protected void validateServiceModel(ServiceModel        candidate,
                                       Map<String, String> serviceConfig,
-                                      Map<String, String> roleConfig) {
+                                      Map<String, String> roleConfig,
+                                      boolean             validateCounts) {
 
     assertNotNull(candidate);
 
     // Validate the service configuration
     Map<String, String> modelServiceProps = candidate.getServiceProperties();
-    assertEquals(serviceConfig.size(), modelServiceProps.size());
+    if (validateCounts) {
+      assertEquals(serviceConfig.size(), modelServiceProps.size());
+    }
     for (Map.Entry<String, String> serviceProp : serviceConfig.entrySet()) {
       assertTrue(modelServiceProps.containsKey(serviceProp.getKey()));
       assertEquals(serviceConfig.get(serviceProp.getKey()), modelServiceProps.get(serviceProp.getKey()));
@@ -108,11 +111,19 @@ public abstract class AbstractServiceModelGeneratorTest extends AbstractCMDiscov
 
     // Validate the role configuration
     Map<String, String> modelRoleProperties = candidate.getRoleProperties().get(getRoleType());
-    assertEquals(roleConfig.size(), modelRoleProperties.size());
+    if (validateCounts) {
+      assertEquals(roleConfig.size(), modelRoleProperties.size());
+    }
     for (Map.Entry<String, String> roleProp : roleConfig.entrySet()) {
       assertTrue(modelRoleProperties.containsKey(roleProp.getKey()));
       assertEquals(roleConfig.get(roleProp.getKey()), modelRoleProperties.get(roleProp.getKey()));
     }
+  }
+
+  protected void validateServiceModel(ServiceModel        candidate,
+                                      Map<String, String> serviceConfig,
+                                      Map<String, String> roleConfig) {
+    validateServiceModel(candidate, serviceConfig, roleConfig, true);
   }
 
 }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGeneratorTest.java
@@ -33,7 +33,7 @@ public class HdfsUIServiceModelGeneratorTest extends AbstractServiceModelGenerat
     roleConfig.put(HdfsUIServiceModelGenerator.HTTP_PORT, "12345");
     roleConfig.put(HdfsUIServiceModelGenerator.HTTPS_PORT, "54321");
 
-    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig, false);
   }
 
   @Override

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGeneratorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.hdfs;
 
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGeneratorTest;
 import org.junit.Test;
@@ -23,6 +24,8 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class NameNodeServiceModelGeneratorTest extends AbstractServiceModelGeneratorTest {
 
@@ -34,7 +37,15 @@ public class NameNodeServiceModelGeneratorTest extends AbstractServiceModelGener
     roleConfig.put(NameNodeServiceModelGenerator.NN_NAMESERVICE, "myService");
     roleConfig.put(NameNodeServiceModelGenerator.NN_PORT, "12345");
 
-    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+    ServiceModel generated = createServiceModel(serviceConfig, roleConfig);
+    validateServiceModel(generated, serviceConfig, roleConfig);
+
+    // Validate model metadata properties
+    Map<String, String> modelProps = generated.getQualifyingServiceParams();
+    assertEquals("Expected one service model properties", 1, modelProps.size());
+    assertEquals("Expected " + NameNodeServiceModelGenerator.DISCOVERY_NAMESERVICE + " model property.",
+                 roleConfig.get(NameNodeServiceModelGenerator.NN_NAMESERVICE),
+                 modelProps.get(NameNodeServiceModelGenerator.DISCOVERY_NAMESERVICE));
   }
 
   @Test

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGeneratorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.hdfs;
 
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGeneratorTest;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -54,7 +56,29 @@ public class WebHdfsServiceModelGeneratorTest extends AbstractServiceModelGenera
     roleConfig.put(WebHdfsServiceModelGenerator.HTTP_PORT, "12345");
     roleConfig.put(WebHdfsServiceModelGenerator.HTTPS_PORT, "54321");
 
-    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig, false);
+  }
+
+  @Test
+  public void testServiceModelMetadataWithNameService() {
+    final Map<String, String> serviceConfig = new HashMap<>();
+    serviceConfig.put(WebHdfsServiceModelGenerator.WEBHDFS_ENABLED, "true");
+    serviceConfig.put(WebHdfsServiceModelGenerator.SSL_ENABLED, "false");
+
+    final Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(WebHdfsServiceModelGenerator.AUTOFAILOVER_ENABLED, "true");
+    roleConfig.put(WebHdfsServiceModelGenerator.NN_NAMESERVICE, "myService");
+    roleConfig.put(WebHdfsServiceModelGenerator.NN_PORT, "12345");
+
+    ServiceModel generated = createServiceModel(serviceConfig, roleConfig);
+    validateServiceModel(generated, serviceConfig, roleConfig, false);
+
+    // Validate model metadata properties
+    Map<String, String> modelProps = generated.getQualifyingServiceParams();
+    assertEquals("Expected one service model properties", 1, modelProps.size());
+    assertEquals("Expected " + NameNodeServiceModelGenerator.DISCOVERY_NAMESERVICE + " model property.",
+                 roleConfig.get(WebHdfsServiceModelGenerator.NN_NAMESERVICE),
+                 modelProps.get(WebHdfsServiceModelGenerator.DISCOVERY_NAMESERVICE));
   }
 
   @Override

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGeneratorTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.solr;
 
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGeneratorTest;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 public class SolrServiceModelGeneratorTest extends AbstractServiceModelGeneratorTest {
 
@@ -33,7 +36,18 @@ public class SolrServiceModelGeneratorTest extends AbstractServiceModelGenerator
     roleConfig.put(SolrServiceModelGenerator.HTTP_PORT, "2468");
     roleConfig.put(SolrServiceModelGenerator.HTTPS_PORT, "1357");
 
-    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+    ServiceModel generated = createServiceModel(serviceConfig, roleConfig);
+    validateServiceModel(generated, serviceConfig, roleConfig);
+
+    // Validate model metadata properties
+    Map<String, String> modelProps = generated.getQualifyingServiceParams();
+    assertEquals("Expected two service model properties", 2, modelProps.size());
+    assertEquals("Expected " + SolrServiceModelGenerator.DISCOVERY_SERVICE_NAME + " model property.",
+            getServiceType() + "-1",
+            modelProps.get(SolrServiceModelGenerator.DISCOVERY_SERVICE_NAME));
+    assertEquals("Expected " + SolrServiceModelGenerator.DISCOVERY_SERVICE_DISPLAY_NAME + " model property.",
+            "null",
+            modelProps.get(SolrServiceModelGenerator.DISCOVERY_SERVICE_DISPLAY_NAME));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the case of some services, or specific deployments of those services, there exists the need to direct the discovery process for topology generation. One example is HA HDFS deployments, where a particular nameservice can be desired to be proxied. Another example is multiple Solr instances within the same cluster, where one should be proxied but not the other(s).

This change introduces for Cloudera Manager discovery the concept of discovery-time-only service parameters in simple descriptors. This is already supported by Amabari service discovery for the aforementioned HDFS HA scenario, and the same pattern is being applied and extended for Cloudera Manager.

Service parameters beginning with "discovery-" can be declared for supported services in simple descriptors. The actual names of the parameters are service-specific.

This is an example for the HDFS nameservice selection:
`"services": [
  {
    "name": "WEBHDFS",
    "params": {
      "discovery-nameservice": "ns2"
    }
  },`

These discovery-time-only service params do not manifest in the resulting generated topology.

## How was this patch tested?

Manual testing, augmented/modified unit tests for the affected ServiceModelGenerator implementations.

