### PR TITLE
KNOX-2531 Kill Application button in YARN does not work through KNOX

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
@@ -207,7 +207,7 @@
 </filter>
 <filter name="YARNUI/yarn/outbound/filter/cluster">
     <content type="*/html">
-        <apply path="(https?://[^/':,]+:[\d]+)?/ws/v1/cluster/apps/application" rule="YARNUI/yarn/outbound/apps/cluster1"/>
+        <apply path="https?://[^/':,]+:[\d]+/ws/v1/cluster/apps/application" rule="YARNUI/yarn/outbound/apps/cluster1"/>
         <apply path="/ws/v1/.*" rule="YARNUI/yarn/outbound/ws1"/>
         <apply path="https?://[^/':,]+:[\d]+/cluster/scheduler.*" rule="YARNUI/yarn/outbound/scheduler1"/>
         <apply path="/cluster/scheduler.*" rule="YARNUI/yarn/outbound/scheduler2"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Kill Application button is broken, KNOX matches and rewrites the URL twice into an invalid URL.

This change removes the parentheses around the first pattern for `/ws/v1/`, so that relative paths are not rewritten twice.

It seems to work, though I'm not sure if it silently breaks other URLs just yet.

## How was this patch tested?

Tested in local production cluster. Spawned up a new spark job and killed it via the Kill Application button in YARN.
