### PR TITLE
KNOX-2532 Supporting 'none' user/group principal case setting in SwitchCase identity assertion provider

### DIFF
--- a/gateway-admin-ui/admin-ui/app/provider-config-wizard/switchcase-idassertion-provider-config.ts
+++ b/gateway-admin-ui/admin-ui/app/provider-config-wizard/switchcase-idassertion-provider-config.ts
@@ -19,7 +19,7 @@ import {IdentityAssertionProviderConfig} from './identity-assertion-provider-con
 
 export class SwitchCaseAssertionProviderConfig extends IdentityAssertionProviderConfig {
 
-    private static CASE_VALUES: string[] = ['upper', 'lower'];
+    private static CASE_VALUES: string[] = ['upper', 'lower', 'none'];
 
     private static PRINCIPAL_CASE = 'Principal Case';
     private static GROUP_PRINCIPAL_CASE = 'Group Principal Case';


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified the Admin UI to allow entering `none` in the SwichCase shared provider configuration for the `Principal Case` and `Group Principal Case` input fields.

## How was this patch tested?

Manually confirmed it's working:
<img width="1675" alt="Screen Shot 2021-01-26 at 8 41 14 AM" src="https://user-images.githubusercontent.com/34065904/105815132-c773bb00-5fb2-11eb-975a-1d123a3d7278.png">
<img width="1676" alt="Screen Shot 2021-01-26 at 8 41 31 AM" src="https://user-images.githubusercontent.com/34065904/105815140-ca6eab80-5fb2-11eb-9be5-5d3f008540e7.png">
```
$ cat conf/shared-providers/test.json 
{
  "providers": [
    {
      "role": "identity-assertion",
      "name": "SwitchCase",
      "enabled": "true",
      "params": {
        "principal.case": "none",
        "group.principal.case": "none"
      }
    }
  ]
}
```