### PR TITLE
KNOX-2535 Add a job to build and test on ARM64 Graviton2 node at TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,22 @@ matrix:
   include:
     - env: IMAGE=maven:3-jdk-8
     - env: IMAGE=maven:3-jdk-11
+    - name: Linux ARM64
+      env: IMAGE=maven:3-jdk-11
+      arch: arm64-graviton2
+      virt: lxd
+      group: edge
+      os: linux
+      dist: focal
     
 env:
   global:
-  - DOCKERRUN="docker run -it --rm -v $PWD:/src -v $HOME/.m2:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -w /src"
+  - DOCKERRUN="docker run --rm -v $PWD:/src -v $HOME/.m2:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -w /src"
 services:
   - docker
 before_install:
+  - lscpu
+  - sudo apt-get -y install shellcheck
   - docker pull $IMAGE
 script:
   - $DOCKERRUN $IMAGE mvn -T.75C clean verify -U -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -B -V


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds an extra job to TravisCI config to run the build and tests on ARM64 Graviton2 node.

## How was this patch tested?

With this change the current build and tests will be executed on ARM64 CPU architecture and make sure that Knox works properly on this architecture.