### PR TITLE
KNOX-2539 - Enhance JWTProvider to accept token via HTTP Basic

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -31,17 +31,22 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
+import java.util.Base64;
+import java.util.Locale;
 
 public class JWTFederationFilter extends AbstractJWTFilter {
 
-  public static final String KNOX_TOKEN_AUDIENCES = "knox.token.audiences";
-  public static final String TOKEN_VERIFICATION_PEM = "knox.token.verification.pem";
-  public static final String KNOX_TOKEN_QUERY_PARAM_NAME = "knox.token.query.param.name";
-  public static final String TOKEN_PRINCIPAL_CLAIM = "knox.token.principal.claim";
-  public static final String JWKS_URL = "knox.token.jwks.url";
-  private static final String BEARER = "Bearer ";
-  private String paramName = "knoxtoken";
+    public static final String KNOX_TOKEN_AUDIENCES = "knox.token.audiences";
+    public static final String TOKEN_VERIFICATION_PEM = "knox.token.verification.pem";
+    public static final String KNOX_TOKEN_QUERY_PARAM_NAME = "knox.token.query.param.name";
+    public static final String TOKEN_PRINCIPAL_CLAIM = "knox.token.principal.claim";
+    public static final String JWKS_URL = "knox.token.jwks.url";
+    private static final String BEARER = "Bearer ";
+    private static final String BASIC = "Basic";
+    private static final String TOKEN = "Token";
+    private String paramName;
 
   @Override
   public void init( FilterConfig filterConfig ) throws ServletException {
@@ -58,16 +63,19 @@ public class JWTFederationFilter extends AbstractJWTFilter {
     if (queryParamName != null) {
       paramName = queryParamName;
     }
+
     //  JWKSUrl
     String oidcjwksurl = filterConfig.getInitParameter(JWKS_URL);
     if (oidcjwksurl != null) {
       expectedJWKSUrl = oidcjwksurl;
     }
+
     // expected claim
     String oidcPrincipalclaim = filterConfig.getInitParameter(TOKEN_PRINCIPAL_CLAIM);
     if (oidcPrincipalclaim != null) {
       expectedPrincipalClaim = oidcPrincipalclaim;
     }
+
     // token verification pem
     String verificationPEM = filterConfig.getInitParameter(TOKEN_VERIFICATION_PEM);
     // setup the public key of the token issuer for verification
@@ -104,15 +112,36 @@ public class JWTFederationFilter extends AbstractJWTFilter {
     }
   }
 
-  public String getWireToken(ServletRequest request) {
-    final String header = ((HttpServletRequest) request).getHeader("Authorization");
-    if (header != null && header.startsWith(BEARER)) {
-      // what follows the bearer designator should be the JWT token being used to request or as an access token
-      return header.substring(BEARER.length());
-    } else {
-      // check for query param
-      return request.getParameter(paramName);
-    }
+  public String getWireToken(final ServletRequest request) {
+      String token = null;
+      final String header = ((HttpServletRequest)request).getHeader("Authorization");
+      if (header != null) {
+          if (header.startsWith("Bearer ")) {
+              // what follows the bearer designator should be the JWT token being used
+            // to request or as an access token
+              token = header.substring(BEARER.length());
+          }
+          else if (header.toLowerCase(Locale.ROOT).startsWith("Basic".toLowerCase(Locale.ROOT))) {
+              // what follows the Basic designator should be the JWT token being used
+            // to request or as an access token
+              token = this.parseFromHTTPBasicCredentials(token, header);
+          }
+      }
+      if (token == null) {
+          token = request.getParameter(this.paramName);
+      }
+      return token;
+  }
+
+  private String parseFromHTTPBasicCredentials(String token, final String header) {
+      final String base64Credentials = header.substring(BASIC.length()).trim();
+      final byte[] credDecoded = Base64.getDecoder().decode(base64Credentials);
+      final String credentials = new String(credDecoded, StandardCharsets.UTF_8);
+      final String[] values = credentials.split(":", 2);
+      if (values[0].equalsIgnoreCase(TOKEN)) {
+          token = values[1];
+      }
+      return token;
   }
 
   @Override

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -116,12 +116,12 @@ public class JWTFederationFilter extends AbstractJWTFilter {
       String token = null;
       final String header = ((HttpServletRequest)request).getHeader("Authorization");
       if (header != null) {
-          if (header.startsWith("Bearer ")) {
+          if (header.startsWith(BEARER)) {
               // what follows the bearer designator should be the JWT token being used
             // to request or as an access token
               token = header.substring(BEARER.length());
           }
-          else if (header.toLowerCase(Locale.ROOT).startsWith("Basic".toLowerCase(Locale.ROOT))) {
+          else if (header.toLowerCase(Locale.ROOT).startsWith(BASIC.toLowerCase(Locale.ROOT))) {
               // what follows the Basic designator should be the JWT token being used
             // to request or as an access token
               token = this.parseFromHTTPBasicCredentials(token, header);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.provider.federation;
+
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
+import org.junit.Test;
+import org.easymock.EasyMock;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import com.nimbusds.jwt.SignedJWT;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Before;
+import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
+
+public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTest
+{
+    @Before
+    public void setUp() {
+      handler = new TestJWTFederationFilter();
+      ((TestJWTFederationFilter) handler).setTokenService(new TestJWTokenAuthority(publicKey));
+    }
+
+    protected void setTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
+        final String token = "Basic " + Base64.getEncoder().encodeToString(("Token:" + jwt.serialize()).getBytes(StandardCharsets.UTF_8));
+        EasyMock.expect((Object)request.getHeader("Authorization")).andReturn((Object)token);
+    }
+
+    protected void setGarbledTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
+        final String token = "Basic " + Base64.getEncoder().encodeToString(("Token: ljm" + jwt.serialize()).getBytes(StandardCharsets.UTF_8));
+        EasyMock.expect((Object)request.getHeader("Authorization")).andReturn((Object)token);
+    }
+
+    protected String getAudienceProperty() {
+        return "knox.token.audiences";
+    }
+
+    private static class TestJWTFederationFilter extends JWTFederationFilter {
+      void setTokenService(JWTokenAuthority ts) {
+        authority = ts;
+      }
+    }
+
+    protected String getVerificationPemProperty() {
+        return "knox.token.verification.pem";
+    }
+
+    @Test
+    public void doTest() {
+    }
+}
+

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -35,16 +35,19 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
       ((TestJWTFederationFilter) handler).setTokenService(new TestJWTokenAuthority(publicKey));
     }
 
+    @Override
     protected void setTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
         final String token = "Basic " + Base64.getEncoder().encodeToString(("Token:" + jwt.serialize()).getBytes(StandardCharsets.UTF_8));
         EasyMock.expect((Object)request.getHeader("Authorization")).andReturn((Object)token);
     }
 
+    @Override
     protected void setGarbledTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
         final String token = "Basic " + Base64.getEncoder().encodeToString(("Token: ljm" + jwt.serialize()).getBytes(StandardCharsets.UTF_8));
         EasyMock.expect((Object)request.getHeader("Authorization")).andReturn((Object)token);
     }
 
+    @Override
     protected String getAudienceProperty() {
         return "knox.token.audiences";
     }
@@ -55,6 +58,7 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
       }
     }
 
+    @Override
     protected String getVerificationPemProperty() {
         return "knox.token.verification.pem";
     }


### PR DESCRIPTION
Change-Id: I37271ed387a990ce1c0f54aa5893cec50281765e

## What changes were proposed in this pull request?

To facilitate the use of token based authentication for 3rd party tools, like BI tools and others that expose username and password fields but nothing for Bearer token, this change will allow HTTP Basic creds to carry a JWT token as the password.

## How was this patch tested?

* New unit tests added
* Manual testing of http basic creds with JWT token

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
