### PR TITLE
KNOX-2541: Fixed Typo in gateway-site.xml

### DIFF
--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -132,7 +132,7 @@ limitations under the License.
         <value>(objectclass=groupOfNames)</value>
     </property>
     <property>
-        <name>hgateway.group.config.adoop.security.group.mapping.ldap.search.attr.member</name>
+        <name>gateway.group.config.hadoop.security.group.mapping.ldap.search.attr.member</name>
         <value>member</value>
     </property>
     <property>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

This PR fixes a typo in current gateway-site.xml. Config gateway.group.config.hadoop.security.group.mapping.ldap.search.attr.member is written incorrectly as hgateway.group.config.adoop.security.group.mapping.ldap.search.attr.member

## How was this patch tested?

It looks a very small typo, so relying on Travis CI tests only, please suggest if any more tests are required

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
