### PR TITLE
KNOX-2547 - Token-based providers should perform signature verificati…

### DIFF
--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -60,8 +60,8 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
       }
 
       @Override
-      protected void recordTokenVerification(String tokenId) {
-        super.recordTokenVerification(tokenId);
+      protected void recordSignatureVerification(String tokenId) {
+        super.recordSignatureVerification(tokenId);
         verifiedCount++;
       }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -57,8 +57,8 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
     }
 
     @Override
-    protected void recordTokenVerification(final String tokenId) {
-      super.recordTokenVerification(tokenId);
+    protected void recordSignatureVerification(final String tokenId) {
+      super.recordSignatureVerification(tokenId);
       verificationCount++;
     }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/SSOCookieProviderTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/SSOCookieProviderTest.java
@@ -311,8 +311,8 @@ public class SSOCookieProviderTest extends AbstractJWTFilterTest {
     }
 
     @Override
-    protected void recordTokenVerification(String tokenId) {
-      super.recordTokenVerification(tokenId);
+    protected void recordSignatureVerification(String tokenId) {
+      super.recordSignatureVerification(tokenId);
       verificationCount++;
     }
 


### PR DESCRIPTION
…on last

## What changes were proposed in this pull request?

Moved token signature verification to be performed after all other token validations. I've also increased the signature verification cache maximum to 250 and added the explicit removal of signature verification records for expired tokens.

## How was this patch tested?

Added AbstractJWTFilterTest#testExpiredTokensEvictedFromSignatureVerificationCache() to validate the explicit eviction of expired tokens' signature verification. Ran all other existing tests.

