### PR TITLE
KNOX-2548 - Removing redundant removeParamPrefix method and its references

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
 import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.hadoop.util.HttpExceptionUtils;
-import org.apache.knox.gateway.GatewayFilter;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.hadoopauth.HadoopAuthMessages;
@@ -77,7 +76,6 @@ public class HadoopAuthFilter extends
   private static final String QUERY_PARAMETER_DOAS = "doAs";
   private static final String PROXYUSER_PREFIX = "hadoop.proxyuser";
   static final String SUPPORT_JWT = "support.jwt";
-  static final String JWT_PREFIX = "jwt.";
 
   private static final HadoopAuthMessages LOG = MessagesFactory.get(HadoopAuthMessages.class);
 
@@ -128,7 +126,6 @@ public class HadoopAuthFilter extends
     final boolean jwtSupported = Boolean.parseBoolean(supportJwt == null ? "false" : supportJwt);
     if (jwtSupported) {
       jwtFilter = new JWTFederationFilter();
-      ((GatewayFilter.Holder)filterConfig).removeParamPrefix(JWT_PREFIX);
       jwtFilter.init(filterConfig);
       LOG.initializedJwtFilter();
     }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.knox.gateway.hadoopauth.filter;
 
-import static org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter.JWT_PREFIX;
 import static org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter.SUPPORT_JWT;
 import static org.apache.knox.gateway.hadoopauth.filter.HadoopAuthFilter.shouldUseJwtFilter;
 
@@ -46,7 +45,6 @@ import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.hadoopauth.HadoopAuthMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
-import org.apache.knox.gateway.GatewayFilter;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
 import org.apache.knox.gateway.audit.api.Auditor;
@@ -67,7 +65,6 @@ public class HadoopAuthPostFilter implements Filter {
     final boolean jwtSupported = Boolean.parseBoolean(supportJwt == null ? "false" : supportJwt);
     if (jwtSupported) {
       jwtFilter = new JWTFederationFilter();
-      ((GatewayFilter.Holder)filterConfig).removeParamPrefix(JWT_PREFIX);
       jwtFilter.init(filterConfig);
     }
   }

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -22,7 +22,6 @@ import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.createMockBuilder;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.getCurrentArguments;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
@@ -165,8 +164,6 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn(supportJwt).anyTimes();
     final boolean isJwtSupported = Boolean.parseBoolean(supportJwt);
     if (isJwtSupported) {
-      filterConfig.removeParamPrefix("jwt.");
-      expectLastCall();
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_AUDIENCES)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_QUERY_PARAM_NAME)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.JWKS_URL)).andReturn(null).anyTimes();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -328,21 +328,6 @@ public class GatewayFilter implements Filter {
       return value;
     }
 
-    public void removeParamPrefix(String prefix) {
-      if (params != null) {
-        final Set<String> relevantParams = new HashSet<>();
-        params.entrySet().forEach(paramEntry -> {
-          if (paramEntry.getKey().startsWith(prefix)) {
-            relevantParams.add(paramEntry.getKey());
-          }
-        });
-        relevantParams.forEach(param -> {
-          String value = params.remove(param);
-          params.put(param.replace(prefix, ""), value);
-        });
-      }
-    }
-
     @Override
     public Enumeration<String> getInitParameterNames() {
       Enumeration<String> names = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed the redundant modification of the filter parameters as it's not needed but might cause issues.

## How was this patch tested?

Ran unit tests and manual E2E testing.