### PR TITLE
KNOX-2549 - Fetching audit events from CM beyond previous query timestamp

### DIFF
--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -101,6 +101,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
     </dependencies>
 </project>
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -172,6 +172,15 @@ public interface ClouderaManagerServiceDiscoveryMessages {
                                                  String discoveryAddress,
                                                  String sinceTimestamp);
 
+  @Message(level = MessageLevel.DEBUG, text = "There is no any activation event found within the given time period")
+  void noActivationEventFound();
+
+  @Message(level = MessageLevel.DEBUG, text = "Activation event relevance: {0} = {1}")
+  void activationEventRelevance(String eventId, String relevance);
+
+  @Message(level = MessageLevel.DEBUG, text = "Activation event - {0} - has already been processed, skipping ...")
+  void activationEventAlreadyProcessed(String eventId);
+
   @Message(level = MessageLevel.DEBUG, text = "Analyzing current {0} configuration for changes...")
   void analyzingCurrentServiceConfiguration(String serviceName);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To mitigate the chance of losing relevant audit events from CM, Knox needs to look back a little bit more than the last query timestamp. To be able to do this without processing relevant events again and again a cache was introduced to have them in memory for a short time.
Additionally, I removed made the maximum audit event resultset size so that every audit event are fetched from CM within the given time interval.

## How was this patch tested?

(Manual testing with Knox HA and a live CM.