### PR TITLE
KNOX-2552 - Including the generated Token ID in the JSON response for the KnoxToken service

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -69,6 +69,7 @@ public class TokenResource {
   private static final String EXPIRES_IN = "expires_in";
   private static final String TOKEN_TYPE = "token_type";
   private static final String ACCESS_TOKEN = "access_token";
+  private static final String TOKEN_ID = "token_id";
   private static final String TARGET_URL = "target_url";
   private static final String ENDPOINT_PUBLIC_CERT = "endpoint_public_cert";
   private static final String BEARER = "Bearer";
@@ -408,6 +409,7 @@ public class TokenResource {
 
         HashMap<String, Object> map = new HashMap<>();
         map.put(ACCESS_TOKEN, accessToken);
+        map.put(TOKEN_ID, tokenId);
         map.put(TOKEN_TYPE, BEARER);
         map.put(EXPIRES_IN, expires);
         if (tokenTargetUrl != null) {

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -198,6 +198,8 @@ public class TokenServiceResourceTest {
     String expiry = getTagValue(retString, "expires_in");
     assertNotNull(expiry);
 
+    assertNotNull(getTagValue(retString, "token_id"));
+
     // Verify the token
     JWT parsedToken = new JWTToken(accessToken);
     assertEquals("alice", parsedToken.getSubject());


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on, the generated token ID is added into to JSON response in addition to the access token.

## How was this patch tested?

Updated/ran JUnit test.

Sample response (used `curl`):
```
{"access_token":"eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJoZGZzIiwiYXVkIjoiaWRicm9rZXIiLCJpc3MiOiJLTk9YU1NPIiwiZXhwIjoxNjE1ODM1Njc1LCJrbm94LmlkIjoiMjU1ZTdlNDctY2FiZi00MTRjLTk5N2MtOGM4NWI1ZTcwYTc4In0.NYWsM3hZ6pEu-cWU0lr5Fge06eh5_iS5bIl5OSr8nf-t_hl12rJ4eNoeCx0lIpiwEQYQFJ46vnSlMIrG5q6bJDI6JyuPVejIq4qOWqtBkGjwm0BtDTehPU0xm0l5ykwdVfiyzeZ27ED19pUEq3L2cgJeC5T3NrgYtuXFRFmz1SnEiQMv0ycnFhlcdtLWEv6dS26Sq_T0HS2YF5-MN7IaAiAu4VplqaQ-N7C86FNLA3GNcVu3vnUbZ-cj8gKZXEj0lLxLMYpedSHGVTptfOyR9Dw6FwGI6OlDH1BC2gtnAX6lLiL-fuJ9-VzLvrt-c7v9A8MQMyJkjKwlYxc3ENgOxA","endpoint_public_cert":"MIIDkDCCAnigAwIBAgIIYxwYvhmkhgkwDQYJKoZIhvcNAQEFBQAwXzELMAkGA1UEBhMCVVMxDTALBgNVBAgTBFRlc3QxDTALBgNVBAcTBFRlc3QxDzANBgNVBAoTBkhhZG9vcDENMAsGA1UECxMEVGVzdDESMBAGA1UEAxMJbG9jYWxob3N0MB4XDTIxMDMwODE4NTE0NloXDTIyMDMwODE4NTE0NlowXzELMAkGA1UEBhMCVVMxDTALBgNVBAgTBFRlc3QxDTALBgNVBAcTBFRlc3QxDzANBgNVBAoTBkhhZG9vcDENMAsGA1UECxMEVGVzdDESMBAGA1UEAxMJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkaJOHCGpjWnA9aBT9GfeZkk8n+Z/1ashOAmjW5x0HwwXhv0PzJGtomq7x/TwBpUh7z+Jwkb44ALs3RiFmvKmGGz8yf3kV7qz8F4hnWzolERoEf+TlU4K2uo3WhQnNyc7Z1vBVdQ7wJ7QAilMvD6TVxyOlFgFw6QMLyzFvw4BifO2e6JIzmqrFJG3wOO513YmA9wMG4uh+5JRwj5Bavi+bwgPzZ4aS/gGcw+7XONDzsHr+cOVnKwNdRSJinUPc+imTVMpKjHSHLuJg42Sy5ucrJYWV41xdvKftX5PFJwDdVEcGM5Rjo1uDnuOn0s8Z0/c9pZ6w1AQMI+w7wQC0DzFQwIDAQABo1AwTjBMBgNVHREERTBDghpzbW9sbmFyLTIuZ2NlLmNsb3VkZXJhLmNvbYIac21vbG5hci0yLmdjZS5jbG91ZGVyYS5jb22CCWxvY2FsaG9zdDANBgkqhkiG9w0BAQUFAAOCAQEAUNOVCDQAxyvFLjXLWRXyjCB5mAfpxYe9TwKFwVybc5PWwe5EBY3P2h3+40nEtiB6ZxoD6CmKBiuIPQn+PxcXOySiZrWPpiEJK6pR2DNKWmSVTb46U1s7FZS1Kmqp54SDUoJXDJ2MzSueIFeT3DHzbTn08MQzCng/HfPMbO670VlG5eDcbSAC/03NzaGV9xWPnngHG8TSTbZ6az/bBas0f+HH0abpua511A+25r+Hzdr+AcOpqotRxgtNexTClMWsvrOeLEYOCbFsJVImAejkHRSzlRC2FjcxN7HrCNJEaAwuUsLiezPXAFCwshGGyN1Ew7AoHRDBN6TSnRnCAUlt2w==","token_id":"255e7e47-cabf-414c-997c-8c85b5e70a78","token_type":"Bearer","expires_in":1615835675820}
```