### PR TITLE
KNOX-2553 - Adding the 'managed_token' flag in the issued JWT as well as the JSON response of our KnoxToken service

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
@@ -38,6 +38,8 @@ import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
@@ -146,7 +148,8 @@ public class JWTAccessTokenAssertionFilter extends AbstractIdentityAssertionFilt
     };
     JWT token;
     try {
-      token = authority.issueToken(p, serviceName, signatureAlgorithm, expires);
+      final JWTokenAttributes jwtAttributes = new JWTokenAttributesBuilder().setPrincipal(p).setAudiences(serviceName).setAlgorithm(signatureAlgorithm).setExpires(expires).build();
+      token = authority.issueToken(jwtAttributes);
       // Coverity CID 1327961
       if( token != null ) {
         accessToken = token.toString();

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
@@ -32,6 +32,7 @@ import org.apache.knox.gateway.filter.security.AbstractIdentityAssertionFilter;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.registry.ServiceRegistry;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
@@ -64,7 +65,7 @@ public class JWTAuthCodeAssertionFilter extends AbstractIdentityAssertionFilter 
     principalName = mapper.mapUserPrincipal(principalName);
     JWT authCode;
     try {
-      authCode = authority.issueToken(subject, signatureAlgorithm);
+      authCode = authority.issueToken(new JWTokenAttributesBuilder().setPrincipal(subject).setAlgorithm(signatureAlgorithm).build());
       // get the url for the token service
       String url = null;
       if (sr != null) {

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.SSOCookieFederationFilter;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
@@ -1246,46 +1247,13 @@ public abstract class AbstractJWTFilterTest  {
     }
 
     @Override
-    public JWT issueToken(Subject subject, String algorithm) {
-      return null;
-    }
-
-    @Override
-    public JWT issueToken(Principal p, String algorithm) {
-      return null;
-    }
-
-    @Override
-    public JWT issueToken(Principal p, String audience, String algorithm) {
-      return null;
-    }
-
-    @Override
     public boolean verifyToken(JWT token) {
       JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) verifyingKey);
       return token.verify(verifier);
     }
 
     @Override
-    public JWT issueToken(Principal p, String audience, String algorithm,
-        long expires) {
-      return null;
-    }
-
-    @Override
-    public JWT issueToken(Principal p, List<String> audiences, String algorithm,
-        long expires) {
-      return null;
-    }
-
-    @Override
-    public JWT issueToken(Principal p, List<String> audiences, String algorithm, long expires,
-                          String signingKeystoreName, String signingKeystoreAlias, char[] signingKeystorePassphrase) {
-      return null;
-    }
-
-    @Override
-    public JWT issueToken(Principal p, String algorithm, long expires) {
+    public JWT issueToken(JWTokenAttributes jwtAttributes) {
       return null;
     }
 

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -52,6 +52,8 @@ import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
@@ -260,7 +262,9 @@ public class WebSSOResource {
         signingKeystorePassphrase = as.getPasswordFromAliasForCluster(clusterName, signingKeystorePassphraseAlias);
       }
 
-      JWT token = tokenAuthority.issueToken(p, targetAudiences, signatureAlgorithm, getExpiry(), signingKeystoreName,  signingKeystoreAlias, signingKeystorePassphrase);
+      final JWTokenAttributes jwtAttributes = new JWTokenAttributesBuilder().setPrincipal(p).setAudiences(targetAudiences).setAlgorithm(signatureAlgorithm).setExpires(getExpiry())
+          .setSigningKeystoreName(signingKeystoreName).setSigningKeystoreAlias(signingKeystoreAlias).setSigningKeystorePassphrase(signingKeystorePassphrase).build();
+      JWT token = tokenAuthority.issueToken(jwtAttributes);
 
       // Coverity CID 1327959
       if( token != null ) {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+import java.security.Principal;
+import java.util.List;
+
+public class JWTokenAttributes {
+
+  private final Principal principal;
+  private final List<String> audiences;
+  private final String algorithm;
+  private final long expires;
+  private final String signingKeystoreName;
+  private final String signingKeystoreAlias;
+  private final char[] signingKeystorePassphrase;
+  private final boolean managed;
+
+  JWTokenAttributes(Principal principal, List<String> audiences, String algorithm, long expires, String signingKeystoreName, String signingKeystoreAlias,
+      char[] signingKeystorePassphrase, boolean managed) {
+    super();
+    this.principal = principal;
+    this.audiences = audiences;
+    this.algorithm = algorithm;
+    this.expires = expires;
+    this.signingKeystoreName = signingKeystoreName;
+    this.signingKeystoreAlias = signingKeystoreAlias;
+    this.signingKeystorePassphrase = signingKeystorePassphrase;
+    this.managed = managed;
+  }
+
+  public Principal getPrincipal() {
+    return principal;
+  }
+
+  public List<String> getAudiences() {
+    return audiences;
+  }
+
+  public String getAlgorithm() {
+    return algorithm;
+  }
+
+  public long getExpires() {
+    return expires;
+  }
+
+  public String getSigningKeystoreName() {
+    return signingKeystoreName;
+  }
+
+  public String getSigningKeystoreAlias() {
+    return signingKeystoreAlias;
+  }
+
+  public char[] getSigningKeystorePassphrase() {
+    return signingKeystorePassphrase;
+  }
+
+  public boolean isManaged() {
+    return managed;
+  }
+
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+
+import javax.security.auth.Subject;
+
+public class JWTokenAttributesBuilder {
+
+  private Principal principal;
+  private List<String> audiences;
+  private String algorithm;
+  private long expires;
+  private String signingKeystoreName;
+  private String signingKeystoreAlias;
+  private char[] signingKeystorePassphrase;
+  private boolean managed;
+
+  public JWTokenAttributesBuilder setPrincipal(Subject subject) {
+    return setPrincipal((Principal) subject.getPrincipals().toArray()[0]);
+  }
+
+  public JWTokenAttributesBuilder setPrincipal(Principal principal) {
+    this.principal = principal;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setAudiences(String audience) {
+    return setAudiences(Collections.singletonList(audience));
+  }
+
+  public JWTokenAttributesBuilder setAudiences(List<String> audiences) {
+    this.audiences = audiences;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setAlgorithm(String algorithm) {
+    this.algorithm = algorithm;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setExpires(long expires) {
+    this.expires = expires;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setSigningKeystoreName(String signingKeystoreName) {
+    this.signingKeystoreName = signingKeystoreName;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setSigningKeystoreAlias(String signingKeystoreAlias) {
+    this.signingKeystoreAlias = signingKeystoreAlias;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setSigningKeystorePassphrase(char[] signingKeystorePassphrase) {
+    this.signingKeystorePassphrase = signingKeystorePassphrase;
+    return this;
+  }
+
+  public JWTokenAttributesBuilder setManaged(boolean managed) {
+    this.managed = managed;
+    return this;
+  }
+
+  public JWTokenAttributes build() {
+    return new JWTokenAttributes(principal, (audiences == null ? Collections.emptyList() : audiences), algorithm, expires, signingKeystoreName, signingKeystoreAlias,
+        signingKeystorePassphrase, managed);
+  }
+
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAuthority.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAuthority.java
@@ -17,40 +17,17 @@
  */
 package org.apache.knox.gateway.services.security.token;
 
-import java.security.Principal;
 import java.security.interfaces.RSAPublicKey;
-import java.util.List;
-
-import javax.security.auth.Subject;
 
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 
 public interface JWTokenAuthority {
 
-  JWT issueToken(Subject subject, String algorithm)
-      throws TokenServiceException;
-
-  JWT issueToken(Principal p, String algorithm)
-      throws TokenServiceException;
-
-  JWT issueToken(Principal p, String audience,
-      String algorithm) throws TokenServiceException;
+  JWT issueToken(JWTokenAttributes jwtAttributes) throws TokenServiceException;
 
   boolean verifyToken(JWT token) throws TokenServiceException;
 
   boolean verifyToken(JWT token, RSAPublicKey publicKey) throws TokenServiceException;
 
-  boolean verifyToken(JWT token, String jwksurl ,String algorithm ) throws TokenServiceException;
-
-  JWT issueToken(Principal p, String algorithm, long expires) throws TokenServiceException;
-
-  JWT issueToken(Principal p, String audience, String algorithm,
-      long expires) throws TokenServiceException;
-
-  JWT issueToken(Principal p, List<String> audiences, String algorithm,
-      long expires) throws TokenServiceException;
-
-  JWT issueToken(Principal p, List<String> audiences, String algorithm, long expires,
-                 String signingKeystoreName, String signingKeystoreAlias, char[] signingKeystorePassphrase)
-      throws TokenServiceException;
+  boolean verifyToken(JWT token, String jwksurl, String algorithm) throws TokenServiceException;
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -38,6 +38,7 @@ public class JWTToken implements JWT {
   private static JWTProviderMessages log = MessagesFactory.get( JWTProviderMessages.class );
 
   public static final String KNOX_ID_CLAIM = "knox.id";
+  public static final String MANAGED_TOKEN_CLAIM = "managed.token";
 
   SignedJWT jwt;
 
@@ -59,6 +60,10 @@ public class JWTToken implements JWT {
   }
 
   public JWTToken(String alg, String[] claimsArray, List<String> audiences) {
+    this(alg, claimsArray, audiences, false);
+  }
+
+  public JWTToken(String alg, String[] claimsArray, List<String> audiences, boolean managed) {
     JWSHeader header = new JWSHeader(new JWSAlgorithm(alg));
 
     if (claimsArray[2] != null) {
@@ -78,6 +83,8 @@ public class JWTToken implements JWT {
 
     // Add a private UUID claim for uniqueness
     builder.claim(KNOX_ID_CLAIM, String.valueOf(UUID.randomUUID()));
+
+    builder.claim(MANAGED_TOKEN_CLAIM, String.valueOf(managed));
 
     claims = builder.build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to avoid adding new and confusing methods into `JWTokenAuthority`, I introduced a model object to store possible JWT attributes and kept only one method to issue a token.
So, from now on, the `managed` flag is available in:

- the JSON response as a new element
- the issued JWT token within a claim called `managed.token`

## How was this patch tested?

Updated/added/ran unit tests and executed manual testing:

1. added the `KNOXTOKEN` service into `sandbox`. Set the `knox.token.exp.server-managed` to `false` and then changed it to `true` (see results below)
2. added a new topology called `tokenbased`
3. I could login to the Knox Home page and to Admin UI
4. Issued the following `curl` commands

4.1 `knox.token.exp.server-managed = false`
```
$ curl -iku admin:admin-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
HTTP/1.1 200 OK
...

{"access_token":"eyJhbGciO...4kjahYA","token_id":"49fd0e9e-a5d9-4a14-86cf-c11e5bac151d","managed":"false","target_url":"https://localhost:8443/gateway/tokenbased","endpoint_public_cert":"MIIDeTCCAmGgAwI...M0XFRx+jhA=","token_type":"Bearer","expires_in":1615886851180}
```
4.2 `knox.token.exp.server-managed = true`
```
$ curl -iku admin:admin-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
HTTP/1.1 200 OK
...

{"access_token":"eyJhbGciO...F0rC4A0g","token_id":"efbed646-2210-4731-9dab-71df641943b0","managed":"true","target_url":"https://localhost:8443/gateway/tokenbased","endpoint_public_cert":"MIIDeTCCAmGgAwI...M0XFRx+jhA=","token_type":"Bearer","expires_in":1615887095677}
```
5. Verified both tokens using the `tokenbased` topology.
