### PR TITLE
KNOX-2543 - Add ability to retry failed requests

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -126,20 +126,25 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     // See KNOX-1530 for details
     builder.disableContentCompression();
 
-    if (filterConfig.getInitParameter(PARAMETER_RETRY_COUNT) != null
-        && StringUtils
-        .isNumeric(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT))) {
+    if (doesRetryParamExist(filterConfig)) {
+      int retryCount = Integer.parseInt(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT));
       /* do we want to retry non-idempotent requests? default no */
       boolean retryNonIdempotent = DEFAULT_PARAMETER_RETRY_NON_SAFE_REQUEST;
       if (filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST)
           != null) {
         retryNonIdempotent = Boolean.parseBoolean(
             filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST));
-      } builder.setRetryHandler(new DefaultHttpRequestRetryHandler(Integer
-          .parseInt(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT)),
+      }
+      builder.setRetryHandler(new DefaultHttpRequestRetryHandler(retryCount,
           retryNonIdempotent));
     }
     return builder.build();
+  }
+
+  private boolean doesRetryParamExist(final FilterConfig filterConfig) {
+    return filterConfig.getInitParameter(PARAMETER_RETRY_COUNT) != null
+        && StringUtils
+        .isNumeric(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT));
   }
 
   /**

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -27,6 +27,8 @@ import java.util.List;
 import javax.net.ssl.SSLContext;
 import javax.servlet.FilterConfig;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -69,6 +71,11 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
   private static final SpiGatewayMessages LOG = MessagesFactory.get(SpiGatewayMessages.class);
   private static final String PARAMETER_SERVICE_ROLE = "serviceRole";
   static final String PARAMETER_USE_TWO_WAY_SSL = "useTwoWaySsl";
+  /* retry in case of NoHttpResponseException */
+  static final String PARAMETER_RETRY_COUNT = "retryCount";
+  static final String PARAMETER_RETRY_NON_SAFE_REQUEST = "retryNonSafeRequest";
+  /* do not retry non-idempotent requests OOTB */
+  static final boolean DEFAULT_PARAMETER_RETRY_NON_SAFE_REQUEST = false;
 
   @Override
   public HttpClient createHttpClient(FilterConfig filterConfig) {
@@ -119,6 +126,19 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     // See KNOX-1530 for details
     builder.disableContentCompression();
 
+    if (filterConfig.getInitParameter(PARAMETER_RETRY_COUNT) != null
+        && StringUtils
+        .isNumeric(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT))) {
+      /* do we want to retry non-idempotent requests? default no */
+      boolean retryNonIdempotent = DEFAULT_PARAMETER_RETRY_NON_SAFE_REQUEST;
+      if (filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST)
+          != null) {
+        retryNonIdempotent = Boolean.parseBoolean(
+            filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST));
+      } builder.setRetryHandler(new DefaultHttpRequestRetryHandler(Integer
+          .parseInt(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT)),
+          retryNonIdempotent));
+    }
     return builder.build();
   }
 
@@ -342,5 +362,4 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     Period p = Period.parse( s, f );
     return p.toStandardDuration().getMillis();
   }
-
 }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -76,6 +76,7 @@ public class DefaultHttpClientFactoryTest {
     expect(filterConfig.getInitParameter("httpclient.connectionTimeout")).andReturn(null).once();
     expect(filterConfig.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
     expect(filterConfig.getInitParameter("serviceRole")).andReturn(null).once();
+    expect(filterConfig.getInitParameter("retryCount")).andReturn(null).once();
 
     replay(keystoreService, gatewayConfig, gatewayServices, servletContext, filterConfig);
 
@@ -233,5 +234,55 @@ public class DefaultHttpClientFactoryTest {
       keyStore.load(input, password.toCharArray());
     }
     return keyStore;
+  }
+
+  @Test
+  public void testHttpRetriesValues() throws Exception {
+    KeystoreService keystoreService = createMock(KeystoreService.class);
+    expect(keystoreService.getTruststoreForHttpClient()).andReturn(null).anyTimes();
+
+    GatewayConfig gatewayConfig = createMock(GatewayConfig.class);
+    expect(gatewayConfig.isMetricsEnabled()).andReturn(false).anyTimes();
+    expect(gatewayConfig.getHttpClientMaxConnections()).andReturn(32).anyTimes();
+    expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).anyTimes();
+    expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).anyTimes();
+
+    GatewayServices gatewayServices = createMock(GatewayServices.class);
+    expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).anyTimes();
+
+    ServletContext servletContext = createMock(ServletContext.class);
+    expect(servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gatewayConfig).atLeastOnce();
+    expect(servletContext.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(gatewayServices).atLeastOnce();
+
+    FilterConfig filterConfigSafe = createMock(FilterConfig.class);
+    expect(filterConfigSafe.getServletContext()).andReturn(servletContext).atLeastOnce();
+    expect(filterConfigSafe.getInitParameter("useTwoWaySsl")).andReturn("false").once();
+    expect(filterConfigSafe.getInitParameter("httpclient.maxConnections")).andReturn(null).once();
+    expect(filterConfigSafe.getInitParameter("httpclient.connectionTimeout")).andReturn(null).once();
+    expect(filterConfigSafe.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
+    expect(filterConfigSafe.getInitParameter("serviceRole")).andReturn(null).once();
+    expect(filterConfigSafe.getInitParameter("retryCount")).andReturn("3").anyTimes();
+    expect(filterConfigSafe.getInitParameter("retryNonSafeRequest")).andReturn(null).anyTimes();
+
+    FilterConfig filterConfigUnSafe = createMock(FilterConfig.class);
+    expect(filterConfigUnSafe.getServletContext()).andReturn(servletContext).atLeastOnce();
+    expect(filterConfigUnSafe.getInitParameter("useTwoWaySsl")).andReturn("false").once();
+    expect(filterConfigUnSafe.getInitParameter("httpclient.maxConnections")).andReturn(null).once();
+    expect(filterConfigUnSafe.getInitParameter("httpclient.connectionTimeout")).andReturn(null).once();
+    expect(filterConfigUnSafe.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
+    expect(filterConfigUnSafe.getInitParameter("serviceRole")).andReturn(null).once();
+    expect(filterConfigUnSafe.getInitParameter("retryCount")).andReturn("3").anyTimes();
+    expect(filterConfigUnSafe.getInitParameter("retryNonSafeRequest")).andReturn("true").anyTimes();
+
+    replay(keystoreService, gatewayConfig, gatewayServices, servletContext, filterConfigSafe, filterConfigUnSafe);
+
+    DefaultHttpClientFactory factory = new DefaultHttpClientFactory();
+    HttpClient clientSafe = factory.createHttpClient(filterConfigSafe);
+    assertNotNull(clientSafe);
+
+    HttpClient clientUnSafe = factory.createHttpClient(filterConfigUnSafe);
+    assertNotNull(clientUnSafe);
+
+    verify(keystoreService, gatewayConfig, gatewayServices, servletContext, filterConfigSafe, filterConfigUnSafe);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add option to replay requests when the server unexpectedly closes the connection (not in case of socket timeouts where the server is unable to reach)
Proposed changes are adding optional service params 

1. `retryCount` - how many times should a request be retried
2. `retryNonSafeRequest` - Should an unsafe request be retries, unsafe = POST, PUT, DELETE (!GET)

example
`
    <service>
        <role>WHOAMI</role>
        <url>http://localhost:50071</url>
	<param name="retryCount" value="5"/>
    </service>
`

