### PR TITLE
KNOX-2557 - Persisting token related metadata using Knox's alias service

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -38,6 +38,7 @@ import javax.management.ObjectName;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
@@ -61,6 +62,8 @@ public class DefaultTokenStateService implements TokenStateService {
   private final Map<String, Long> tokenExpirations = new ConcurrentHashMap<>();
 
   private final Map<String, Long> maxTokenLifetimes = new ConcurrentHashMap<>();
+
+  private final Map<String, TokenMetadata> metadataMap = new ConcurrentHashMap<>();
 
   // Token eviction interval (in seconds)
   private long tokenEvictionInterval;
@@ -282,6 +285,7 @@ public class DefaultTokenStateService implements TokenStateService {
   private void removeTokenState(final Set<String> tokenIds) {
     tokenExpirations.keySet().removeAll(tokenIds);
     maxTokenLifetimes.keySet().removeAll(tokenIds);
+    metadataMap.keySet().removeAll(tokenIds);
     log.removedTokenState(String.join(", ", tokenIds));
   }
 
@@ -375,4 +379,13 @@ public class DefaultTokenStateService implements TokenStateService {
     return tokenExpirations.keySet().stream().collect(Collectors.toList());
   }
 
+  @Override
+  public void addMetadata(String tokenId, TokenMetadata metadata) {
+    metadataMap.put(tokenId, metadata);
+  }
+
+  @Override
+  public TokenMetadata getTokenMetadata(String tokenId) {
+    return metadataMap.get(tokenId);
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
@@ -30,6 +30,7 @@ import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.factory.AliasServiceFactory;
 import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.token.RemoteTokenStateChangeListener;
 
 /**
@@ -133,6 +134,8 @@ public class ZookeeperTokenStateService extends AliasBasedTokenStateService impl
         if (alias.endsWith(TOKEN_MAX_LIFETIME_POSTFIX)) {
           final long maxLifeTime = Long.parseLong(value);
           setMaxLifetime(tokenId, maxLifeTime);
+        } else if (alias.endsWith(TOKEN_META_POSTFIX)) {
+          addMetadataInMemory(tokenId, TokenMetadata.fromJSON(value));
         } else {
           final long expiration = Long.parseLong(value);
           updateExpirationInMemory(tokenId, expiration);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournal.java
@@ -19,6 +19,7 @@
 package org.apache.knox.gateway.services.token.impl.state;
 
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.token.state.JournalEntry;
 
 import java.io.BufferedWriter;
@@ -53,8 +54,8 @@ class MultiFileTokenStateJournal extends FileTokenStateJournal {
     }
 
     @Override
-    public void add(final String tokenId, long issueTime, long expiration, long maxLifetime) throws IOException {
-        add(Collections.singletonList(new FileJournalEntry(tokenId, issueTime, expiration, maxLifetime)));
+    public void add(final String tokenId, long issueTime, long expiration, long maxLifetime, TokenMetadata tokenMetadata) throws IOException {
+        add(Collections.singletonList(new FileJournalEntry(tokenId, issueTime, expiration, maxLifetime, tokenMetadata)));
     }
 
     @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/JournalEntry.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/JournalEntry.java
@@ -18,6 +18,8 @@
  */
 package org.apache.knox.gateway.services.token.state;
 
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+
 /**
  * An entry in the TokenStateJournal
  */
@@ -48,4 +50,10 @@ public interface JournalEntry {
      * @return The token's maximum allowed lifetime
      */
     String getMaxLifetime();
+
+    /**
+     * @return The metadata belongs to this token
+     */
+    TokenMetadata getTokenMetadata();
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/TokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/state/TokenStateJournal.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+
 /**
  *
  */
@@ -34,10 +36,11 @@ public interface TokenStateJournal {
      * @param issueTime   The issue timestamp
      * @param expiration  The expiration time
      * @param maxLifetime The maximum allowed lifetime
+     * @param tokenMetafata The associated token metadata
      *
      * @throws IOException exception on error
      */
-    void add(String tokenId, long issueTime, long expiration, long maxLifetime)
+    void add(String tokenId, long issueTime, long expiration, long maxLifetime, TokenMetadata tokenMetadata)
         throws IOException;
 
     /**

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateServiceTest.java
@@ -157,7 +157,8 @@ public class JournalBasedTokenStateServiceTest extends DefaultTokenStateServiceT
         testJournal.add(uncachedTokenId,
                         System.currentTimeMillis(),
                         uncachedToken.getExpiresDate().getTime(),
-                        maxTokenLifetime);
+                        maxTokenLifetime,
+                        null);
         assertEquals("Expected the uncached journal entry", 1, testJournal.get().size());
 
         // Create and initialize the TokenStateService

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateServiceTest.java
@@ -48,6 +48,7 @@ import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.easymock.EasyMock;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -115,6 +116,13 @@ public class ZookeeperTokenStateServiceTest {
     final long expiration = zktokenStateServiceNode2.getTokenExpiration("node1Token");
     Thread.sleep(LONG_TOKEN_STATE_ALIAS_PERSISTENCE_INTERVAL * 1000);
     assertEquals(2000L, expiration);
+
+    final String userName = "testUser";
+    final String comment = "This is my test comment";
+    zktokenStateServiceNode1.addMetadata("node1Token", new TokenMetadata(userName, comment));
+    Thread.sleep(LONG_TOKEN_STATE_ALIAS_PERSISTENCE_INTERVAL * 1000);
+    assertEquals(userName, zktokenStateServiceNode2.getTokenMetadata("node1Token").getUserName());
+    assertEquals(comment, zktokenStateServiceNode2.getTokenMetadata("node1Token").getComment());
   }
 
   @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/AbstractFileTokenStateJournalTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/AbstractFileTokenStateJournalTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractFileTokenStateJournalTest {
         long issueTime = System.currentTimeMillis();
         long expiration = issueTime + TimeUnit.MINUTES.toMillis(5);
         long maxLifetime = issueTime + (5 * TimeUnit.MINUTES.toMillis(5));
-        journal.add(tokenId, issueTime, expiration, maxLifetime);
+        journal.add(tokenId, issueTime, expiration, maxLifetime, null);
 
         // Get the token state from the journal, and validate its contents
         JournalEntry entry = journal.get(tokenId);
@@ -109,7 +109,7 @@ public abstract class AbstractFileTokenStateJournalTest {
         long issueTime = System.currentTimeMillis();
         long expiration = issueTime + TimeUnit.MINUTES.toMillis(5);
         long maxLifetime = issueTime + (5 * TimeUnit.MINUTES.toMillis(5));
-        journal.add(tokenId, issueTime, expiration, maxLifetime);
+        journal.add(tokenId, issueTime, expiration, maxLifetime, null);
 
         // Get the token state from the journal, and validate its contents
         JournalEntry entry = journal.get(tokenId);
@@ -120,7 +120,7 @@ public abstract class AbstractFileTokenStateJournalTest {
         assertEquals(maxLifetime, Long.parseLong(entry.getMaxLifetime()));
 
         long updatedExpiration = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
-        journal.add(tokenId, issueTime, updatedExpiration, maxLifetime);
+        journal.add(tokenId, issueTime, updatedExpiration, maxLifetime, null);
 
         // Get and validate the updated token state
         entry = journal.get(tokenId);

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -53,6 +53,7 @@ import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
 import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
@@ -441,6 +442,7 @@ public class TokenResource {
                                      System.currentTimeMillis(),
                                      expires,
                                      maxTokenLifetime.orElse(tokenStateService.getDefaultMaxLifetimeDuration()));
+          tokenStateService.addMetadata(tokenId, new TokenMetadata(p.getName()));
           log.storedToken(getTopologyName(), Tokens.getTokenDisplayText(accessToken), tokenId);
         }
 

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -33,6 +33,7 @@ import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
@@ -1127,6 +1128,15 @@ public class TokenServiceResourceTest {
     @Override
     public long getTokenExpiration(String tokenId, boolean validate) throws UnknownTokenException {
       return 0;
+    }
+
+    @Override
+    public void addMetadata(String tokenId, TokenMetadata metadata) {
+    }
+
+    @Override
+    public TokenMetadata getTokenMetadata(String tokenId) {
+      return null;
     }
 
     @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.knox.gateway.util.JsonUtils;
+
+public class TokenMetadata {
+  private static final String JSON_ELEMENT_USER_NAME = "userName";
+  private static final String JSON_ELEMENT_COMMENT = "comment";
+  private static final String EMPTY_COMMENT = "";
+
+  private final String userName;
+  private final String comment;
+
+  public TokenMetadata(String userName) {
+    this(userName, EMPTY_COMMENT);
+  }
+
+  public TokenMetadata(String userName, String comment) {
+    this.userName = userName;
+    this.comment = comment;
+  }
+
+  public String getUserName() {
+    return userName;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public String toJSON() {
+    final Map<String, String> metadataMap = new HashMap<>();
+    metadataMap.put(JSON_ELEMENT_USER_NAME, getUserName());
+    metadataMap.put(JSON_ELEMENT_COMMENT, getComment() == null ? EMPTY_COMMENT : getComment());
+    return JsonUtils.renderAsJsonString(metadataMap);
+  }
+
+  public static TokenMetadata fromJSON(String json) {
+    final Map<String, String> metadataMap = JsonUtils.getMapFromJsonString(json);
+    if (metadataMap != null) {
+      return new TokenMetadata(metadataMap.get(JSON_ELEMENT_USER_NAME), metadataMap.get(JSON_ELEMENT_COMMENT));
+    }
+    throw new IllegalArgumentException("Invalid metadata JSON: " + json);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return EqualsBuilder.reflectionEquals(this, obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return HashCodeBuilder.reflectionHashCode(this);
+  }
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -166,4 +166,22 @@ public interface TokenStateService extends Service {
    */
   long getTokenExpiration(String tokenId, boolean validate) throws UnknownTokenException;
 
+  /**
+   * Adds metadata to the token identified by the given ID
+   *
+   * @param tokenId
+   *          The token's unique identifier.
+   * @param metadata
+   *          The metadata to be added
+   */
+  void addMetadata(String tokenId, TokenMetadata metadata);
+
+  /**
+   *
+   * @param tokenId
+   *          The token's unique identifier.
+   * @return The associated token metadata
+   */
+  TokenMetadata getTokenMetadata(String tokenId);
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enriched the token state persistence layer (in-memory, alias, and file journal) to store additional metadata:

- username
- comment

## How was this patch tested?

Updated and ran JUnit tests:
```
$ mvn clean -Dshellcheck=true verify -Prelease,package -am -pl gateway-service-knoxtoken
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] build-tools ........................................ SUCCESS [  3.144 s]
[INFO] gateway ............................................ SUCCESS [ 26.414 s]
[INFO] gateway-test-utils ................................. SUCCESS [ 11.378 s]
[INFO] gateway-i18n ....................................... SUCCESS [ 13.076 s]
[INFO] gateway-util-common ................................ SUCCESS [ 15.629 s]
[INFO] gateway-util-configinjector ........................ SUCCESS [  7.179 s]
[INFO] gateway-util-launcher .............................. SUCCESS [  6.417 s]
[INFO] gateway-util-urltemplate ........................... SUCCESS [ 10.257 s]
[INFO] gateway-demo-ldap .................................. SUCCESS [ 13.721 s]
[INFO] gateway-i18n-logging-log4j ......................... SUCCESS [  5.675 s]
[INFO] gateway-service-definitions ........................ SUCCESS [  7.501 s]
[INFO] gateway-provider-rewrite-common .................... SUCCESS [  5.822 s]
[INFO] gateway-spi ........................................ SUCCESS [ 16.077 s]
[INFO] gateway-topology-simple ............................ SUCCESS [  9.828 s]
[INFO] gateway-topology-hadoop-xml ........................ SUCCESS [ 10.690 s]
[INFO] gateway-service-hashicorp-vault .................... SUCCESS [  8.593 s]
[INFO] gateway-provider-rewrite ........................... SUCCESS [ 19.183 s]
[INFO] gateway-server-xforwarded-filter ................... SUCCESS [  6.845 s]
[INFO] gateway-service-remoteconfig ....................... SUCCESS [ 28.776 s]
[INFO] gateway-server ..................................... SUCCESS [02:23 min]
[INFO] gateway-provider-jersey ............................ SUCCESS [  9.313 s]
[INFO] gateway-service-knoxtoken .......................... SUCCESS [  8.751 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 06:30 min
[INFO] Finished at: 2021-03-22T18:59:41+01:00
[INFO] Final Memory: 256M/1762M
[INFO] ------------------------------------------------------------------------
```