### PR TITLE
KNOX-2556 - Enhance JWTProvider to accept knox.id as Passcode Token

### DIFF
--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>
             <scope>test</scope>

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -32,6 +32,9 @@ public interface JWTMessages {
   @Message( level = MessageLevel.INFO, text = "Access token {0} ({1}) has expired; a new one must be acquired." )
   void tokenHasExpired(String tokenDisplayText, String tokenId);
 
+  @Message( level = MessageLevel.INFO, text = "Access token {0} has expired; a new one must be acquired." )
+  void tokenHasExpired(String tokenId);
+
   @Message( level = MessageLevel.INFO, text = "The NotBefore check failed." )
   void notBeforeCheckFailed();
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -64,10 +64,8 @@ import java.security.cert.Certificate;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
@@ -129,33 +127,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -175,33 +158,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -223,31 +191,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be true.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -267,33 +220,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -313,31 +251,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be true.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -356,33 +279,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -402,33 +310,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -451,33 +344,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -496,31 +374,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be false.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be false.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -538,33 +401,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL).anyTimes();
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -583,31 +431,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setGarbledTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL).anyTimes();
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be true.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -635,31 +468,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL).anyTimes();
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be true.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -691,25 +509,11 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
@@ -732,31 +536,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-         new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be true.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -775,33 +564,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled);
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -825,33 +599,18 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
       Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
       Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-      Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
       Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -876,31 +635,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be false.", !chain.doFilterCalled );
+      Assert.assertFalse("doFilterCalled should not be false.", chain.doFilterCalled );
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -921,31 +665,16 @@ public abstract class AbstractJWTFilterTest  {
       HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
       setTokenOnRequest(request, jwt);
 
-      EasyMock.expect(request.getRequestURL()).andReturn(
-          new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(
-          SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
       handler.doFilter(request, response, chain);
-      Assert.assertTrue("doFilterCalled should not be false.", !chain.doFilterCalled);
+      Assert.assertFalse("doFilterCalled should not be false.", chain.doFilterCalled);
       Assert.assertNull("No Subject should be returned.", chain.subject);
     } catch (ServletException se) {
       fail("Should NOT have thrown a ServletException.");
@@ -987,20 +716,7 @@ public abstract class AbstractJWTFilterTest  {
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
-      EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-        @Override
-        public void write(int b) {
-        }
-
-        @Override
-        public void setWriteListener(WriteListener arg0) {
-        }
-
-        @Override
-        public boolean isReady() {
-          return false;
-        }
-      }).anyTimes();
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
       EasyMock.replay(request, response);
 
       doTestVerificationOptimization(request, response, principalAlice);
@@ -1100,20 +816,7 @@ public abstract class AbstractJWTFilterTest  {
   private HttpServletResponse createMockResponse() throws Exception {
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
-    EasyMock.expect(response.getOutputStream()).andAnswer(() -> new ServletOutputStream() {
-      @Override
-      public void write(int b) {
-      }
-
-      @Override
-      public void setWriteListener(WriteListener arg0) {
-      }
-
-      @Override
-      public boolean isReady() {
-        return false;
-      }
-    }).anyTimes();
+    EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
     return response;
   }
 
@@ -1136,7 +839,7 @@ public abstract class AbstractJWTFilterTest  {
     handler.doFilter(request, response, chain);
     Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
     Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
-    Assert.assertTrue("No PrimaryPrincipal", !principals.isEmpty());
+    Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
     Assert.assertEquals("Not the expected principal", expectedPrincipal, ((Principal)principals.toArray()[0]).getName());
   }
 
@@ -1179,20 +882,15 @@ public abstract class AbstractJWTFilterTest  {
   protected SignedJWT getJWT(String issuer, String sub, String aud, Date expires, Date nbf, RSAPrivateKey privateKey,
                              String signatureAlgorithm)
       throws Exception {
-    List<String> audiences = new ArrayList<>();
-    if (aud != null) {
-      audiences.add(aud);
-    }
-
     JWTClaimsSet claims = new JWTClaimsSet.Builder()
-    .issuer(issuer)
-    .subject(sub)
-    .audience(aud)
-    .expirationTime(expires)
-    .notBeforeTime(nbf)
-    .claim("scope", "openid")
-    .claim(JWTToken.KNOX_ID_CLAIM, String.valueOf(UUID.randomUUID()))
-    .build();
+                                          .issuer(issuer)
+                                          .subject(sub)
+                                          .audience(aud)
+                                          .expirationTime(expires)
+                                          .notBeforeTime(nbf)
+                                          .claim("scope", "openid")
+                                          .claim(JWTToken.KNOX_ID_CLAIM, String.valueOf(UUID.randomUUID()))
+                                          .build();
 
     JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.parse(signatureAlgorithm)).build();
 
@@ -1283,6 +981,21 @@ public abstract class AbstractJWTFilterTest  {
 
   protected interface TokenVerificationCounter {
     int getVerificationCount();
+  }
+
+  static class DummyServletOutputStream extends ServletOutputStream {
+      @Override
+      public void write(int b) {
+      }
+
+      @Override
+      public void setWriteListener(WriteListener arg0) {
+      }
+
+      @Override
+      public boolean isReady() {
+        return false;
+      }
   }
 
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/CommonJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/CommonJWTFilterTest.java
@@ -131,6 +131,9 @@ public class CommonJWTFilterTest {
     EasyMock.expect(tss.getTokenExpiration(anyObject(JWT.class)))
             .andThrow(new UnknownTokenException("eyjhbgcioi1234567890neg"))
             .anyTimes();
+    EasyMock.expect(tss.getTokenExpiration(anyObject(String.class)))
+            .andThrow(new UnknownTokenException("eyjhbgcioi1234567890neg"))
+            .anyTimes();
     EasyMock.replay(tss);
 
     doTestIsStillValid(tss);
@@ -139,6 +142,9 @@ public class CommonJWTFilterTest {
   private boolean doTestIsStillValid(final Long expiration) throws Exception {
     TokenStateService tss = EasyMock.createNiceMock(TokenStateService.class);
     EasyMock.expect(tss.getTokenExpiration(anyObject(JWT.class)))
+            .andReturn(expiration)
+            .anyTimes();
+    EasyMock.expect(tss.getTokenExpiration(anyObject(String.class)))
             .andReturn(expiration)
             .anyTimes();
     EasyMock.replay(tss);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -17,18 +17,29 @@
  */
 package org.apache.knox.gateway.provider.federation;
 
+import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
-import org.junit.Test;
 import org.easymock.EasyMock;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import com.nimbusds.jwt.SignedJWT;
-import javax.servlet.http.HttpServletRequest;
-import org.junit.Before;
-import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Properties;
 
-public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTest
-{
+import com.nimbusds.jwt.SignedJWT;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTest {
+
     @Before
     public void setUp() {
       handler = new TestJWTFederationFilter();
@@ -36,48 +47,67 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
     }
 
     @Override
-    protected void setTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
-        final String token = "Basic " + Base64.getEncoder().encodeToString(("Token:" + jwt.serialize()).getBytes(StandardCharsets.UTF_8));
-        EasyMock.expect((Object)request.getHeader("Authorization")).andReturn((Object)token);
-    }
-
-    @Override
-    protected void setGarbledTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
-        final String token = "Basic " + Base64.getEncoder().encodeToString(("Token: ljm" + jwt.serialize()).getBytes(StandardCharsets.UTF_8));
-        EasyMock.expect((Object)request.getHeader("Authorization")).andReturn((Object)token);
-    }
-
-    @Override
     protected String getAudienceProperty() {
-        return "knox.token.audiences";
-    }
-
-    private static class TestJWTFederationFilter extends JWTFederationFilter implements TokenVerificationCounter {
-      private int verifiedCount;
-
-      void setTokenService(JWTokenAuthority ts) {
-        authority = ts;
-      }
-
-      @Override
-      protected void recordSignatureVerification(String tokenId) {
-        super.recordSignatureVerification(tokenId);
-        verifiedCount++;
-      }
-
-      @Override
-      public int getVerificationCount() {
-        return verifiedCount;
-      }
+        return TestJWTFederationFilter.KNOX_TOKEN_AUDIENCES;
     }
 
     @Override
     protected String getVerificationPemProperty() {
-        return "knox.token.verification.pem";
+        return TestJWTFederationFilter.TOKEN_VERIFICATION_PEM;
+    }
+
+    @Override
+    protected void setTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
+        setTokenOnRequest(request, TestJWTFederationFilter.TOKEN, jwt.serialize());
+    }
+
+    @Override
+    protected void setGarbledTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
+        setTokenOnRequest(request, TestJWTFederationFilter.TOKEN, "ljm" + jwt.serialize());
+    }
+
+    /**
+     * Bind the specified JWT to the specified request, and apply the specified authUsername as the HTTP Basic
+     * username in the Authorization header value.
+     *
+     * @param request      The request to which the JWT should be bound.
+     * @param authUsername The HTTP Basic auth username to apply in the Authorization header value.
+     * @param authPassword The HTTP Basic auth password to apply in the Authorization header value.
+     */
+    protected void setTokenOnRequest(final HttpServletRequest request,
+                                     final String             authUsername,
+                                     final String             authPassword) {
+        final byte[] basicAuth = (authUsername + ":" + authPassword).getBytes(StandardCharsets.UTF_8);
+        final String authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(basicAuth);
+        EasyMock.expect((Object)request.getHeader("Authorization")).andReturn(authHeaderValue);
     }
 
     @Test
-    public void doTest() {
+    public void testAlternativeCaseUsername() throws Exception {
+        try {
+            Properties props = getProperties();
+            handler.init(new TestFilterConfig(props));
+
+            SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob",
+                                   new Date(new Date().getTime() + 5000), privateKey);
+
+            HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+            setTokenOnRequest(request, JWTFederationFilter.TOKEN.toLowerCase(Locale.ROOT), jwt.serialize());
+
+            EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getQueryString()).andReturn(null);
+            HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+            EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+            EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+            EasyMock.replay(request, response);
+
+            TestFilterChain chain = new TestFilterChain();
+            handler.doFilter(request, response, chain);
+            Assert.assertTrue("doFilterCalled should be true.", chain.doFilterCalled );
+        } catch (ServletException se) {
+            fail("Should NOT have thrown a ServletException.");
+        }
     }
+
 }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -18,13 +18,12 @@
 package org.apache.knox.gateway.provider.federation;
 
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
-import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.easymock.EasyMock;
 import org.junit.Before;
 
 import javax.servlet.http.HttpServletRequest;
 
+@SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class JWTFederationFilterTest extends AbstractJWTFilterTest {
   @Before
   public void setUp() {
@@ -33,39 +32,8 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
   }
 
   @Override
-  protected void setTokenOnRequest(HttpServletRequest request, SignedJWT jwt) {
-    String token = "Bearer " + jwt.serialize();
-    EasyMock.expect(request.getHeader("Authorization")).andReturn(token);
-  }
-
-  @Override
-  protected void setGarbledTokenOnRequest(HttpServletRequest request, SignedJWT jwt) {
-    String token = "Bearer " + "ljm" + jwt.serialize();
-    EasyMock.expect(request.getHeader("Authorization")).andReturn(token);
-  }
-
-  @Override
   protected String getAudienceProperty() {
     return TestJWTFederationFilter.KNOX_TOKEN_AUDIENCES;
-  }
-
-  private static class TestJWTFederationFilter extends JWTFederationFilter implements TokenVerificationCounter {
-    private int verificationCount;
-
-    void setTokenService(final JWTokenAuthority ts) {
-      authority = ts;
-    }
-
-    @Override
-    protected void recordSignatureVerification(final String tokenId) {
-      super.recordSignatureVerification(tokenId);
-      verificationCount++;
-    }
-
-    @Override
-    public int getVerificationCount() {
-      return verificationCount;
-    }
   }
 
   @Override
@@ -73,4 +41,15 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
     return TestJWTFederationFilter.TOKEN_VERIFICATION_PEM;
   }
 
+  @Override
+  protected void setTokenOnRequest(HttpServletRequest request, SignedJWT jwt) {
+    String token = TestJWTFederationFilter.BEARER + " " + jwt.serialize();
+    EasyMock.expect(request.getHeader("Authorization")).andReturn(token);
+  }
+
+  @Override
+  protected void setGarbledTokenOnRequest(HttpServletRequest request, SignedJWT jwt) {
+    String token = TestJWTFederationFilter.BEARER + " ljm" + jwt.serialize();
+    EasyMock.expect(request.getHeader("Authorization")).andReturn(token);
+  }
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TestJWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TestJWTFederationFilter.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements. See the NOTICE file distributed with this
+ *  * work for additional information regarding copyright ownership. The ASF
+ *  * licenses this file to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+package org.apache.knox.gateway.provider.federation;
+
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
+import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
+
+import java.lang.reflect.Field;
+
+public class TestJWTFederationFilter extends JWTFederationFilter
+                                     implements AbstractJWTFilterTest.TokenVerificationCounter {
+    private int verifiedCount;
+
+    void setTokenService(JWTokenAuthority ts) {
+        authority = ts;
+    }
+
+    void setTokenStateService(final TokenStateService tss) {
+        try {
+            Field tssField = getClass().getSuperclass().getSuperclass().getDeclaredField("tokenStateService");
+            tssField.setAccessible(true);
+            tssField.set(this, tss);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void recordSignatureVerification(String tokenId) {
+        super.recordSignatureVerification(tokenId);
+        verifiedCount++;
+    }
+
+    @Override
+    public int getVerificationCount() {
+        return verifiedCount;
+    }
+
+}

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -1,0 +1,419 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements. See the NOTICE file distributed with this
+ *  * work for additional information regarding copyright ownership. The ASF
+ *  * licenses this file to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+package org.apache.knox.gateway.provider.federation;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.security.token.TokenUtils;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+@SuppressWarnings({"PMD.JUnit4TestShouldUseBeforeAnnotation", "PMD.JUnit4TestShouldUseTestAnnotation"})
+public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicCredsFederationFilterTest {
+
+    TestTokenStateService tss;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        tss = new TestTokenStateService();
+        ((TestJWTFederationFilter) handler).setTokenStateService(tss);
+    }
+
+    @Override
+    protected void setTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
+        addTokenState(jwt);
+        setTokenOnRequest(request, TestJWTFederationFilter.PASSCODE, getTokenId(jwt));
+    }
+
+    /**
+     * Bind the specified JWT to the specified request, and apply the specified authUsername as the HTTP Basic
+     * username in the Authorization header value.
+     *
+     * @param request      The request to which the JWT should be bound.
+     * @param jwt          The JWT
+     * @param authUsername The HTTP Basic auth username to apply in the Authorization header value.
+     */
+    protected void setTokenOnRequest(final HttpServletRequest request,
+                                     final SignedJWT          jwt,
+                                     final String             authUsername) {
+        addTokenState(jwt);
+        setTokenOnRequest(request, authUsername, getTokenId(jwt));
+    }
+
+    @Override
+    protected void setGarbledTokenOnRequest(final HttpServletRequest request, final SignedJWT jwt) {
+        setTokenOnRequest(request, TestJWTFederationFilter.PASSCODE, "junk" + getTokenId(jwt));
+    }
+
+    private String getTokenId(final SignedJWT jwt) {
+        String tokenId = null;
+        try {
+             tokenId = (String) jwt.getJWTClaimsSet().getClaim(JWTToken.KNOX_ID_CLAIM);
+        } catch (ParseException e) {
+            //
+        }
+        return tokenId;
+    }
+
+    private void addTokenState(final SignedJWT jwt) {
+        try {
+            JWTToken token = new JWTToken(jwt.serialize());
+            tss.addToken(token, System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5));
+
+            String subject = (String) jwt.getJWTClaimsSet().getClaim(JWTToken.SUBJECT);
+            tss.addMetadata(TokenUtils.getTokenId(token), new TokenMetadata(subject));
+        } catch (ParseException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Override
+    public void testAlternativeCaseUsername() throws Exception {
+        try {
+            Properties props = getProperties();
+            handler.init(new TestFilterConfig(props));
+
+            SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob",
+                    new Date(new Date().getTime() + 5000), privateKey);
+
+            HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+            setTokenOnRequest(request, jwt, JWTFederationFilter.PASSCODE.toLowerCase(Locale.ROOT));
+
+            EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getQueryString()).andReturn(null);
+            HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+            EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+            EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+            EasyMock.replay(request, response);
+
+            TestFilterChain chain = new TestFilterChain();
+            handler.doFilter(request, response, chain);
+            Assert.assertTrue("doFilterCalled should be true.", chain.doFilterCalled );
+        } catch (ServletException se) {
+            fail("Should NOT have thrown a ServletException.");
+        }
+    }
+
+    @Test
+    public void testInvalidUsername() throws Exception {
+        try {
+            Properties props = getProperties();
+            handler.init(new TestFilterConfig(props));
+
+            SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob",
+                                   new Date(new Date().getTime() + 5000), privateKey);
+
+            HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+            setTokenOnRequest(request, jwt, "InvalidBasicAuthUsername");
+
+            EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getQueryString()).andReturn(null);
+            HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+            EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+            EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+            EasyMock.replay(request, response);
+
+            TestFilterChain chain = new TestFilterChain();
+            handler.doFilter(request, response, chain);
+            Assert.assertFalse("doFilterCalled should be false.", chain.doFilterCalled );
+        } catch (ServletException se) {
+            fail("Should NOT have thrown a ServletException.");
+        }
+    }
+
+    /**
+     * Negative test, specifying the Basic auth username as the one used for JWTs while specifying
+     * the passcode as the password.
+     */
+    @Test
+    public void testInvalidJWTForPasscode() throws Exception {
+        try {
+            Properties props = getProperties();
+            handler.init(new TestFilterConfig(props));
+
+            SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob",
+                            new Date(new Date().getTime() + 5000), privateKey);
+
+            HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+            setTokenOnRequest(request, jwt, JWTFederationFilter.TOKEN);
+
+            EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getQueryString()).andReturn(null);
+            HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+            EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+            EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+            EasyMock.replay(request, response);
+
+            TestFilterChain chain = new TestFilterChain();
+            handler.doFilter(request, response, chain);
+            Assert.assertFalse("doFilterCalled should be false.", chain.doFilterCalled );
+        } catch (ServletException se) {
+            fail("Should NOT have thrown a ServletException.");
+        }
+    }
+
+    /**
+     * Negative test, specifying the Basic auth username as the one used for passcodes while specifying the JWT
+     * as the password.
+     */
+    @Test
+    public void testInvalidPasscodeForJWT() throws Exception {
+        try {
+            Properties props = getProperties();
+            handler.init(new TestFilterConfig(props));
+
+            SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob",
+                                   new Date(new Date().getTime() + 5000), privateKey);
+
+            HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+            setTokenOnRequest(request, JWTFederationFilter.PASSCODE, jwt.serialize());
+
+            EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getQueryString()).andReturn(null);
+            HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+            EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+            EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+            EasyMock.replay(request, response);
+
+            TestFilterChain chain = new TestFilterChain();
+            handler.doFilter(request, response, chain);
+            Assert.assertFalse("doFilterCalled should be false.", chain.doFilterCalled );
+            Assert.assertNull("Subject should be null since authentication should have failed.", chain.subject);
+        } catch (ServletException se) {
+            fail("Should NOT have thrown a ServletException.");
+        }
+    }
+
+    @Override
+    public void testInvalidAudienceJWT() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testNoTokenAudience() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testNoAudienceConfigured() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testEmptyAudienceConfigured() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testValidAudienceJWT() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testValidAudienceJWTWhitespace() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testValidIssuerViaConfig() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testInvalidIssuer() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testFailedSignatureValidationJWT() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testInvalidVerificationPEM() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testRS512SignatureAlgorithm() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testInvalidSignatureAlgorithm() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testValidVerificationPEM() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testNotBeforeJWT() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testVerificationOptimization() throws Exception {
+        // Override to disable N/A test
+    }
+
+    @Override
+    public void testExpiredTokensEvictedFromSignatureVerificationCache() throws Exception {
+        // Override to disable N/A test
+    }
+
+    /**
+     * Very basic TokenStateService implementation for these tests only
+     */
+    private static class TestTokenStateService implements TokenStateService {
+
+        private final Map<String, Long> tokenExpirations = new ConcurrentHashMap<>();
+        private final Map<String, TokenMetadata> tokenMetadata = new ConcurrentHashMap<>();
+
+        @Override
+        public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+        }
+
+        @Override
+        public void start() throws ServiceLifecycleException {
+        }
+
+        @Override
+        public void stop() throws ServiceLifecycleException {
+        }
+
+        @Override
+        public long getDefaultRenewInterval() {
+            return TimeUnit.DAYS.toMillis(1);
+        }
+
+        @Override
+        public long getDefaultMaxLifetimeDuration() {
+            return TimeUnit.DAYS.toMillis(7);
+        }
+
+        @Override
+        public void addToken(JWTToken token, long issueTime) {
+            String expiration = token.getExpires();
+            if (expiration == null || expiration.isEmpty()) {
+                expiration = "0";
+            }
+            tokenExpirations.put(TokenUtils.getTokenId(token), Long.parseLong(expiration));
+        }
+
+        @Override
+        public void addToken(String tokenId, long issueTime, long expiration) {
+            tokenExpirations.put(tokenId, expiration);
+        }
+
+        @Override
+        public void addToken(String tokenId, long issueTime, long expiration, long maxLifetimeDuration) {
+            tokenExpirations.put(tokenId, expiration);
+        }
+
+        @Override
+        public boolean isExpired(JWTToken token) throws UnknownTokenException {
+            Long expiration = tokenExpirations.get(TokenUtils.getTokenId(token));
+            return (new Date(expiration).before(new Date()));
+        }
+
+        @Override
+        public void revokeToken(JWTToken token) throws UnknownTokenException {
+
+        }
+
+        @Override
+        public void revokeToken(String tokenId) throws UnknownTokenException {
+
+        }
+
+        @Override
+        public long renewToken(JWTToken token) throws UnknownTokenException {
+            return 0;
+        }
+
+        @Override
+        public long renewToken(JWTToken token, long renewInterval) throws UnknownTokenException {
+            return 0;
+        }
+
+        @Override
+        public long renewToken(String tokenId) throws UnknownTokenException {
+            return 0;
+        }
+
+        @Override
+        public long renewToken(String tokenId, long renewInterval) throws UnknownTokenException {
+            return 0;
+        }
+
+        @Override
+        public long getTokenExpiration(JWT token) throws UnknownTokenException {
+            return getTokenExpiration(TokenUtils.getTokenId(token));
+        }
+
+        @Override
+        public long getTokenExpiration(String tokenId) throws UnknownTokenException {
+            if (!tokenExpirations.containsKey(tokenId)) {
+                throw new UnknownTokenException(tokenId);
+            }
+            return tokenExpirations.get(tokenId);
+        }
+
+        @Override
+        public long getTokenExpiration(String tokenId, boolean validate) throws UnknownTokenException {
+            return getTokenExpiration(tokenId);
+        }
+
+        @Override
+        public void addMetadata(String tokenId, TokenMetadata metadata) {
+            tokenMetadata.put(tokenId, metadata);
+        }
+
+        @Override
+        public TokenMetadata getTokenMetadata(String tokenId) {
+            return tokenMetadata.get(tokenId);
+        }
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added JWTProvider support for specifying the unique identifier associated with Knox JWTs as a HTTP Basic password (username=TokenPasscode, password=&lt;UUID&gt;) when server-managed token state is enabled.

Example:
curl -ivku TokenPasscode:$PASSCODE "https://localhost:8443/gateway/proxy-token/webhdfs/v1/?op=LISTSTATUS"

## How was this patch tested?

I've added org.apache.knox.gateway.provider.federation.TokenIDAsHTTPBasicCredsFederationFilterTest and executed all the existing Knox tests (mvn -Ppackage,release clean package).

I've manually tested by:
- Enabling server-managed token state in the homepage deployment of KNOXTOKEN
- Defining a provider configuration with the JWTProvider (with server-managed token state enabled)
- Defining a descriptor that references that provider config
- Generated a token using the homepage facility
- curl -ivku TokenPasscode:$PASSCODE "https://localhost:8443/gateway/proxy-token/webhdfs/v1/?op=LISTSTATUS"

I've also done some manual testing with server-managed token state DISABLED to verify the behavior.

I could not find any existing tests for org.apache.knox.gateway.hadoopauth.filter.HadoopAuthPostFilter, so I haven't yet added any tests to verify the associated changes.

I may add more negative test cases to org.apache.knox.gateway.provider.federation.TokenIDAsHTTPBasicCredsFederationFilterTest