### PR TITLE
KNOX-2562 - TokenStateService getTokenMetadata method should throw Un…

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthPostFilter.java
@@ -49,6 +49,7 @@ import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilte
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
 import org.apache.knox.gateway.audit.api.Auditor;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 
 public class HadoopAuthPostFilter implements Filter {
 
@@ -87,7 +88,7 @@ public class HadoopAuthPostFilter implements Filter {
         } else if (JWTFederationFilter.TokenType.Passcode.equals(tokenType)) {
           subject = jwtFilter.createSubjectFromTokenIdentifier(token);
         }
-      } catch (ParseException e) {
+      } catch (ParseException | UnknownTokenException e) {
         // NOP: subject remains null -> SC_FORBIDDEN will be returned
       }
     } else {

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -272,11 +272,11 @@ public abstract class AbstractJWTFilter implements Filter {
     }
   }
 
-  public Subject createSubjectFromToken(final String token) throws ParseException {
+  public Subject createSubjectFromToken(final String token) throws ParseException, UnknownTokenException {
     return createSubjectFromToken(new JWTToken(token));
   }
 
-  protected Subject createSubjectFromToken(final JWT token) {
+  protected Subject createSubjectFromToken(final JWT token) throws UnknownTokenException {
     String principal = token.getSubject();
     String claimvalue = null;
     if (expectedPrincipalClaim != null) {
@@ -292,7 +292,7 @@ public abstract class AbstractJWTFilter implements Filter {
     return createSubjectFromTokenData(principal, claimvalue);
   }
 
-  public Subject createSubjectFromTokenIdentifier(final String tokenId) {
+  public Subject createSubjectFromTokenIdentifier(final String tokenId) throws UnknownTokenException {
     TokenMetadata metadata = tokenStateService.getTokenMetadata(tokenId);
     if (metadata != null) {
       return createSubjectFromTokenData(metadata.getUserName(), null);

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 import org.apache.knox.gateway.util.CertificateUtils;
@@ -175,7 +176,7 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
             // we found a valid cookie we don't need to keep checking anymore
             return;
           }
-        } catch (ParseException ignore) {
+        } catch (ParseException | UnknownTokenException ignore) {
           // Ignore the error since cookie was invalid
           // Fall through to keep checking if there are more cookies
         }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -412,7 +412,10 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
         }
 
         @Override
-        public TokenMetadata getTokenMetadata(String tokenId) {
+        public TokenMetadata getTokenMetadata(String tokenId) throws UnknownTokenException {
+            if (!tokenMetadata.containsKey(tokenId)) {
+                throw new UnknownTokenException(tokenId);
+            }
             return tokenMetadata.get(tokenId);
         }
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -385,7 +385,10 @@ public class DefaultTokenStateService implements TokenStateService {
   }
 
   @Override
-  public TokenMetadata getTokenMetadata(String tokenId) {
+  public TokenMetadata getTokenMetadata(String tokenId) throws UnknownTokenException {
+    if (!metadataMap.containsKey(tokenId)) {
+      throw new UnknownTokenException(tokenId);
+    }
     return metadataMap.get(tokenId);
   }
 }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1135,7 +1135,7 @@ public class TokenServiceResourceTest {
     }
 
     @Override
-    public TokenMetadata getTokenMetadata(String tokenId) {
+    public TokenMetadata getTokenMetadata(String tokenId) throws UnknownTokenException {
       return null;
     }
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -182,6 +182,6 @@ public interface TokenStateService extends Service {
    *          The token's unique identifier.
    * @return The associated token metadata
    */
-  TokenMetadata getTokenMetadata(String tokenId);
+  TokenMetadata getTokenMetadata(String tokenId) throws UnknownTokenException;
 
 }


### PR DESCRIPTION
…knownTokenException

## What changes were proposed in this pull request?

To align with other methods in the TokenStateService interface, the getTokenMetadata(String tokenId) method has modified to throw UnknownTokenException when there is no metadata for the specified token identifier.

## How was this patch tested?

Existing tests have been modified/executed, and I've added org.apache.knox.gateway.services.token.impl.DefaultTokenStateServiceTest#testGetMetadata_InvalidToken(), which also gets invoked for the Alias- and Journal-based TokenStateService implementations.