### PR TITLE
KNOX-2566 - JWT Token Signature Verification Caching NPE

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -69,4 +69,8 @@ public interface JWTMessages {
             text = "The configuration value ({0}) for maximum token verification cache is invalid; Using the default value." )
   void invalidVerificationCacheMaxConfiguration(String value);
 
+  @Message( level = MessageLevel.ERROR,
+            text = "Missing token passcode." )
+  void missingTokenPasscode();
+
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -167,8 +167,9 @@ public class JWTFederationFilter extends AbstractJWTFilter {
       final String credentials = new String(credDecoded, StandardCharsets.UTF_8);
       final String[] values = credentials.split(":", 2);
       String username = values[0];
+      String passcode = values[1].isEmpty() ? null : values[1];
       if (TOKEN.equalsIgnoreCase(username) || PASSCODE.equalsIgnoreCase(username)) {
-          parsed = Pair.of(TOKEN.equalsIgnoreCase(username) ? TokenType.JWT : TokenType.Passcode, values[1]);
+          parsed = Pair.of(TOKEN.equalsIgnoreCase(username) ? TokenType.JWT : TokenType.Passcode, passcode);
       }
 
       return parsed;

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -77,7 +77,8 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
     protected void setTokenOnRequest(final HttpServletRequest request,
                                      final String             authUsername,
                                      final String             authPassword) {
-        final byte[] basicAuth = (authUsername + ":" + authPassword).getBytes(StandardCharsets.UTF_8);
+        final byte[] basicAuth =
+                (authUsername + ":" + (authPassword != null ? authPassword : "")).getBytes(StandardCharsets.UTF_8);
         final String authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(basicAuth);
         EasyMock.expect((Object)request.getHeader("Authorization")).andReturn(authHeaderValue);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added some checks for missing Knox token UUID claim around the signature verification caching (which was added as part of KNOX-2544) to avoid NullPointerException when JWTs which were not issued by Knox (but which Knox can verify) are received.

## How was this patch tested?

Added org.apache.knox.gateway.provider.federation.AbstractJWTFilterTest#testJWTWithoutKnoxUUIDClaim() and org.apache.knox.gateway.provider.federation.AbstractJWTFilterTest#testExpiredJWTWithoutKnoxUUIDClaim()to reproduce the NPE condition and then to verify the fix. Ran all other existing tests as part of the build.
