### PR TITLE
KNOX-2571 - Introducing Knox Home page profiles

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.dto.HomePageProfile;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
 import org.joda.time.Period;
@@ -42,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -262,6 +264,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final long KNOX_TOKEN_ALIAS_PERSISTENCE_INTERVAL_DEFAULT = TimeUnit.SECONDS.toSeconds(15);
   private static final boolean KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT = false;
 
+  private static final String KNOX_HOMEPAGE_PROFILE_PREFIX =  "knox.homepage.profile.";
   private static final String KNOX_HOMEPAGE_PINNED_TOPOLOGIES =  "knox.homepage.pinned.topologies";
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata", "homepage"));
@@ -1208,5 +1211,24 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public boolean isGatewayServerIncomingXForwardedSupportEnabled() {
     return getBoolean(KNOX_INCOMING_XFORWARDED_ENABLED, true);
+  }
+
+  @Override
+  public Map<String, Collection<String>> getHomePageProfiles() {
+    final Map<String, Collection<String>> profiles = getPreConfiguredProfiles(); // pre-configured profiles might be overwritten
+    this.forEach(config -> {
+      if (config.getKey().startsWith(KNOX_HOMEPAGE_PROFILE_PREFIX)) {
+        profiles.put(config.getKey().substring(KNOX_HOMEPAGE_PROFILE_PREFIX.length()).toLowerCase(Locale.getDefault()), getTrimmedStringCollection(config.getKey()));
+      }
+    });
+    return profiles;
+  }
+
+  private Map<String, Collection<String>> getPreConfiguredProfiles() {
+    final Map<String, Collection<String>> profiles = new HashMap<>();
+    profiles.put("full", HomePageProfile.getFullProfileElements());
+    profiles.put("thin", HomePageProfile.getThinProfileElemens());
+    profiles.put("token", HomePageProfile.getTokenProfileElements());
+    return profiles;
   }
 }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -29,9 +29,11 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -50,6 +52,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.dto.HomePageProfile;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.service.definition.Metadata;
 import org.apache.knox.gateway.service.definition.ServiceDefinitionPair;
@@ -62,6 +65,7 @@ import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.topology.Service;
 import org.apache.knox.gateway.topology.Topology;
+import org.apache.knox.gateway.util.JsonUtils;
 import org.apache.knox.gateway.util.X509CertificateUtil;
 
 import io.swagger.annotations.Api;
@@ -248,6 +252,20 @@ public class KnoxMetadataResource {
     serviceModel.setServiceMetadata(serviceMetadata);
     serviceModel.setServiceUrl(serviceUrl);
     return serviceModel;
+  }
+
+  @GET
+  @Produces({ APPLICATION_JSON })
+  @Path("profiles/{profile}")
+  public String getProfile(@PathParam("profile") String profileName) {
+    final GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    final Map<String, Collection<String>> configuredProfiles = config.getHomePageProfiles();
+    if (configuredProfiles.containsKey(profileName.toLowerCase(Locale.getDefault()))) {
+      final HomePageProfile profile = new HomePageProfile(configuredProfiles.get(profileName));
+      return JsonUtils.renderAsJsonString(profile.getProfileElements());
+    } else {
+      return JsonUtils.renderAsJsonString(Collections.emptyMap());
+    }
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.config;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.security.KeyStore;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -740,4 +741,10 @@ public interface GatewayConfig {
    * @return true if incoming X-Forwarded headers are enabled
    */
   boolean isGatewayServerIncomingXForwardedSupportEnabled();
+
+  /**
+   * Gets the home page profiles (pre-configured and user-defined profiles too).
+   * It's important that keys in the returned map are converted to lowercase strings.
+   */
+  Map<String, Collection<String>> getHomePageProfiles();
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dto/HomePageProfile.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dto/HomePageProfile.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.dto;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class HomePageProfile {
+  static final String GPI_PREFIX = "gpi_";
+  static final String GPI_VERSION = GPI_PREFIX + "version";
+  static final String GPI_CERT = GPI_PREFIX + "cert";
+  static final String GPI_ADMIN_UI = GPI_PREFIX + "admin_ui";
+  static final String GPI_ADMIN_API = GPI_PREFIX + "admin_api";
+  static final String GPI_METADATA_API = GPI_PREFIX + "md_api";
+  static final String GPI_TOKENS = GPI_PREFIX + "tokens";
+  static final String TOPOLOGIES = "topologies";
+  static final String TOPOLOGY_PREFIX = "top_";
+  static final String ALL_TOPOLOGIES = TOPOLOGY_PREFIX + "all";
+
+  private final Map<String, String> profileElements = new HashMap<>();
+
+  public HomePageProfile(Collection<String> profileConfiguration) {
+    addElement(GPI_VERSION, profileConfiguration);
+    addElement(GPI_CERT, profileConfiguration);
+    addElement(GPI_ADMIN_UI, profileConfiguration);
+    addElement(GPI_ADMIN_API, profileConfiguration);
+    addElement(GPI_METADATA_API, profileConfiguration);
+    addElement(GPI_TOKENS, profileConfiguration);
+    addTopologies(profileConfiguration);
+  }
+
+  private void addTopologies(Collection<String> profileConfiguration) {
+    final Set<String> topologies = new HashSet<>();
+    profileConfiguration.forEach(config -> {
+      if (config.startsWith(TOPOLOGY_PREFIX)) {
+        topologies.add(config.substring(TOPOLOGY_PREFIX.length()));
+      }
+    });
+    profileElements.put(TOPOLOGIES, String.join(",", topologies));
+  }
+
+  private void addElement(String element, Collection<String> profileConfiguration) {
+    if (profileConfiguration.contains(element)) {
+      profileElements.put(element, Boolean.TRUE.toString());
+    } else {
+      profileElements.put(element, Boolean.FALSE.toString());
+    }
+  }
+
+  public Map<String, String> getProfileElements() {
+    return profileElements;
+  }
+
+  public static Collection<String> getFullProfileElements() {
+    return Arrays.asList(GPI_VERSION, GPI_CERT, GPI_ADMIN_UI, GPI_ADMIN_API, GPI_METADATA_API, GPI_TOKENS);
+  }
+
+  public static Collection<String> getThinProfileElemens() {
+    return Arrays.asList(GPI_VERSION, GPI_CERT);
+  }
+
+  public static Collection<String> getTokenProfileElements() {
+    return Arrays.asList(GPI_VERSION, GPI_TOKENS);
+  }
+}

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dto/HomePageProfileTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dto/HomePageProfileTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class HomePageProfileTest {
+
+  @Test
+  public void testEmptyConfiguration() throws Exception {
+    final HomePageProfile profile = new HomePageProfile(Collections.emptySet());
+    assertEquals(7, profile.getProfileElements().size());
+    profile.getProfileElements().forEach((key, value) -> {
+      if (key.startsWith(HomePageProfile.GPI_PREFIX)) {
+        assertFalse(Boolean.parseBoolean(value));
+      } else {
+        assertTrue(value.isEmpty());
+      }
+    });
+  }
+
+  @Test
+  public void testGeneralProxyInformationVersion() throws Exception {
+    doTestGeneralProxyInformationElement(HomePageProfile.GPI_VERSION);
+  }
+
+  @Test
+  public void testGeneralProxyInformationCert() throws Exception {
+    doTestGeneralProxyInformationElement(HomePageProfile.GPI_CERT);
+  }
+
+  @Test
+  public void testGeneralProxyInformationAdminUI() throws Exception {
+    doTestGeneralProxyInformationElement(HomePageProfile.GPI_ADMIN_UI);
+  }
+
+  @Test
+  public void testGeneralProxyInformationAdminAPI() throws Exception {
+    doTestGeneralProxyInformationElement(HomePageProfile.GPI_ADMIN_API);
+  }
+
+  @Test
+  public void testGeneralProxyInformatioMetadataAPI() throws Exception {
+    doTestGeneralProxyInformationElement(HomePageProfile.GPI_METADATA_API);
+  }
+
+  @Test
+  public void testGeneralProxyInformationTokens() throws Exception {
+    doTestGeneralProxyInformationElement(HomePageProfile.GPI_TOKENS);
+  }
+
+  private void doTestGeneralProxyInformationElement(String gpiElement) {
+    final HomePageProfile profile = new HomePageProfile(Arrays.asList(gpiElement));
+    assertTrue(Boolean.parseBoolean(profile.getProfileElements().get(gpiElement)));
+  }
+}

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -846,5 +847,10 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   @Override
   public boolean isGatewayServerIncomingXForwardedSupportEnabled() {
     return true;
+  }
+
+  @Override
+  public Map<String, Collection<String>> getHomePageProfiles() {
+    return null;
   }
 }

--- a/knox-homepage-ui/home/app/app.module.ts
+++ b/knox-homepage-ui/home/app/app.module.ts
@@ -19,6 +19,8 @@ import {BrowserModule} from '@angular/platform-browser';
 import {HttpClientModule, HttpClientXsrfModule} from '@angular/common/http';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {BsModalModule} from 'ng2-bs3-modal/ng2-bs3-modal';
+import {Routes, RouterModule}  from '@angular/router';
+import {APP_BASE_HREF} from '@angular/common';
 
 import {GeneralProxyInformationComponent} from './generalProxyInformation/general.proxy.information.component';
 import {TopologyInformationsComponent} from './topologies/topology.information.component';
@@ -30,13 +32,18 @@ import {HomepageService} from './homepage.service';
         HttpClientModule,
         HttpClientXsrfModule,
         MatGridListModule,
-        BsModalModule
+        BsModalModule,
+        RouterModule.forRoot([])
     ],
     declarations: [GeneralProxyInformationComponent,
                    TopologyInformationsComponent,
                    SessionInformationComponent
     ],
-    providers: [HomepageService
+    providers: [HomepageService,
+      {
+        provide: APP_BASE_HREF,
+        useValue: window['base-href']
+      }
     ],
     bootstrap: [SessionInformationComponent,
                 GeneralProxyInformationComponent,

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
@@ -22,11 +22,11 @@
             <col width="70%">
         </colgroup>
         <tbody>
-            <tr>
+            <tr *ngIf="this['showKnoxVersion']">
                 <td>Knox Version</td>
                 <td>{{ getVersion() }}</td>
             </tr>
-            <tr>
+            <tr *ngIf="this['showPublicCerts']">
                 <td>TLS Public Certificate</td>
                 <td>
                     <a href="{{ getMetadataAPIUrl('publicCert?type=pem') }}">PEM</a>
@@ -34,11 +34,11 @@
                     <a href="{{ getMetadataAPIUrl('publicCert?type=jks') }}">JKS</a>
                 </td>
             </tr>
-            <tr>
+            <tr *ngIf="this['showAdminUI']">
                 <td>Admin UI URL</td>
                 <td><a href="{{ getAdminUiUrl() }}" target="_blank">{{ getAdminUiUrl() }}</a></td>
             </tr>
-            <tr>
+            <tr *ngIf="this['showAdminAPI']">
                 <td>
                     Admin API Details
                     <span class="inline-glyph glyphicon glyphicon-info-sign btn btn-xs"
@@ -48,7 +48,7 @@
                     <a href="{{ getAdminApiBookUrl() }}" target="_blank">{{ getAdminApiBookUrl() }}</a>
                 </td>
             </tr>
-            <tr>
+            <tr *ngIf="this['showMetadataAPI']">
                 <td>
                     Metadata API
                 </td>
@@ -58,7 +58,7 @@
                     <a href="{{ getMetadataAPIUrl('topologies') }}" target="_blank">Topologies</a>
                 </td>
             </tr>
-            <tr>
+            <tr *ngIf="this['showTokens']">
                 <td>
                     Integration Tokens
                 </td>

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
 import {HomepageService} from '../homepage.service';
 import {GeneralProxyInformation} from './general.proxy.information';
 
@@ -27,9 +28,16 @@ import {GeneralProxyInformation} from './general.proxy.information';
 export class GeneralProxyInformationComponent implements OnInit {
 
     generalProxyInformation: GeneralProxyInformation;
+    profile: JSON;
 
-    constructor(private homepageService: HomepageService) {
+    constructor(private homepageService: HomepageService, private route: ActivatedRoute) {
         this['showGeneralProxyInformation'] = false;
+        this['showKnoxVersion'] = true;
+        this['showPublicCerts'] = true;
+        this['showAdminUI'] = true;
+        this['showAdminAPI'] = true;
+        this['showMetadataAPI'] = true;
+        this['showTokens'] = true;
     }
 
     getVersion() {
@@ -70,6 +78,25 @@ export class GeneralProxyInformationComponent implements OnInit {
         console.debug('GeneralProxyInformationComponent --> ngOnInit() --> ');
         this.homepageService.getGeneralProxyInformation()
                             .then(generalProxyInformation => this.generalProxyInformation = generalProxyInformation);
+        let profileName;
+        this.route.queryParams.subscribe(params => {
+        	    profileName = params['profile'];
+            console.debug('Profile name = ' + profileName)
+            if (profileName) {
+            	    console.debug('Fetching profile information...');
+            	    this.homepageService.getProfile(profileName).then(profile => this.setProfileFlags(profile));
+            }
+        });
+    }
+
+    setProfileFlags(profile: JSON) {
+    	    console.debug('Setting GPI profile flags...');
+        this['showKnoxVersion'] = (profile['gpi_version'] === 'true');
+        this['showPublicCerts'] = (profile['gpi_cert'] === 'true');
+        this['showAdminUI'] = (profile['gpi_admin_ui'] === 'true');
+        this['showAdminAPI'] = (profile['gpi_admin_api'] === 'true');
+        this['showMetadataAPI'] = (profile['gpi_md_api'] === 'true');
+        this['showTokens'] = (profile['gpi_tokens'] === 'true');
     }
 
     toggleBoolean(propertyName: string) {

--- a/knox-homepage-ui/home/app/homepage.service.ts
+++ b/knox-homepage-ui/home/app/homepage.service.ts
@@ -99,6 +99,22 @@ export class HomepageService {
             });
     }
 
+    getProfile(profileName): Promise<JSON> {
+        let headers = new HttpHeaders();
+        headers = this.addJsonHeaders(headers);
+        return this.http.get(this.apiUrl + '/profiles/' + profileName, { headers: headers})
+            .toPromise()
+            .then(response => response)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('HomepageService --> getProfile() --> ' + this.apiUrl + '/profiles/' + profileName + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
     addJsonHeaders(headers: HttpHeaders): HttpHeaders {
         return this.addCsrfHeaders(headers.append('Accept', 'application/json').append('Content-Type', 'application/json'));
     }

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.component.html
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.component.html
@@ -12,24 +12,5 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<div class="table-responsive">
-    <table class="table table-striped table-hover">
-       <colgroup>
-            <col width="90%">
-            <col width="5%">
-            <col width="5%">
-        </colgroup>
-        <tbody>
-            <tr>
-                <td></td>
-                <td>Welcome</td>
-                <td>{{ getUser() }}</td>
-	        </tr>
-	        <tr *ngIf="logoutSupported">
-                <td></td>
-                <td></td>
-                <td><a class="btn btn-primary" (click)="logout()">logout</a></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+<div style="text-align: right; color: rgb(130, 180, 93);">Welcome {{ getUser() }}</div>
+<div *ngIf="logoutSupported" style="text-align: right;"><a class="btn btn-primary" (click)="logout()">logout</a></div>

--- a/knox-homepage-ui/home/index.html
+++ b/knox-homepage-ui/home/index.html
@@ -22,6 +22,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Custom styles for this template -->
     <link href="assets/sticky-footer.css" rel="stylesheet">
+	<script>
+	  window['base-href'] = window.location.pathname;
+	  console.log(window['base-href']);
+	</script>
 </head>
 <body>
 <div class="navbar-wrapper">
@@ -38,12 +42,12 @@
                     </button>
                     <a class="navbar-brand" href="#"> <img style="max-width:200px; margin-top: -9px;" src="assets/knox-logo-transparent.gif" alt="Apache Knox Home"></a>
                 </div>
+                <app-session-information></app-session-information>
             </div>
         </nav>
     </div>
 
     <div class="container-fluid">
-        <app-session-information></app-session-information>
         <app-general-proxy-information></app-general-proxy-information>
         <app-topologies-information></app-topologies-information>
     </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the ability to declare an arbitrary number of homepage profiles in `gateway-site.xml`. The relevant configuration prefix is `knox.homepage.profile.` which should be finished with the profile name (e.g. `knox.homepage.profile.smolnar` declares the profile called `smolnar`).
The purpose of these profiles is to
- control what's going to be displayed in General Proxy Information
- optionally, filter topologies too

The following language elements should be used when declaring a profile in `gateway-site.xml`
- gpi_version - allows `Knox Version`
- gpi_cert - allows `TLS Public Certificate`
- gpi_admin_ui - allows `Admin UI URL`
- gpi_admin_api - allows `Admin API Details`
- gpi_md_api - allows `Metadata API`
- gpi_tokens - allows `Integration Tokens`
- top_$TOPOLOGY_LIST - allows to define a comma-separated list of topology names that should be included in the `Topologies` section

Let's see a sample:
```
    <property>
        <name>knox.homepage.profile.smolnar</name>
        <value>gpi_version,gpi_tokens,top_other</value>
    </property>
```
The `smolnar` profile will allow displaying the `Knox Version` and `Integration Tokens` elements in `General Proxy Information` and will filter topologies such as only the topology called `other` will be displayed in `Topologies`.

Other than adding homepage profile support I also moved the session information block (username and optional logout button) into the top-left corner.

## How was this patch tested?

Manually tested (I used the above described `smolnar` profile during my tests):
<img width="1668" alt="Screen Shot 2021-04-07 at 2 41 43 PM" src="https://user-images.githubusercontent.com/34065904/113870239-ead89480-97b1-11eb-95f3-e0f3037a63c4.png">
<img width="1673" alt="Screen Shot 2021-04-07 at 2 41 57 PM" src="https://user-images.githubusercontent.com/34065904/113870253-edd38500-97b1-11eb-8ed2-451c36ad2791.png">
<img width="1668" alt="Screen Shot 2021-04-07 at 2 42 12 PM" src="https://user-images.githubusercontent.com/34065904/113870257-ee6c1b80-97b1-11eb-9c49-ec3106648aa4.png">
<img width="1668" alt="Screen Shot 2021-04-07 at 2 42 35 PM" src="https://user-images.githubusercontent.com/34065904/113870260-ef04b200-97b1-11eb-8302-6c1faac091e4.png">
<img width="1672" alt="Screen Shot 2021-04-07 at 2 43 23 PM" src="https://user-images.githubusercontent.com/34065904/113870262-ef9d4880-97b1-11eb-97dd-77d0a5fc7b08.png">


```
curl -ku admin:admin-password https://localhost:8443/gateway/metadata/api/v1/metadata/profiles/full
{
  "gpi_tokens" : "true",
  "gpi_version" : "true",
  "gpi_md_api" : "true",
  "gpi_cert" : "true",
  "gpi_admin_ui" : "true",
  "gpi_admin_api" : "true",
  "topologies" : ""
}


curl -ku admin:admin-password https://localhost:8443/gateway/metadata/api/v1/metadata/profiles/smolnar
{
  "gpi_tokens" : "true",
  "gpi_version" : "true",
  "gpi_md_api" : "false",
  "gpi_cert" : "false",
  "gpi_admin_ui" : "false",
  "gpi_admin_api" : "false",
  "topologies" : "other"
}
```