### PR TITLE
KNOX-2573 - Service discovery should support HiveServer2 transport mo…

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
@@ -40,11 +40,7 @@ public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
   @Override
   protected void checkHiveServer2HTTPMode(ApiConfigList roleConfig, ServiceModelGeneratorHandleResponse response) {
     final String hiveServer2TransportMode = getRoleConfigValue(roleConfig, HIVEONTEZ_TRANSPORT_MODE);
-    if (hiveServer2TransportMode == null) {
-      response.addConfigurationIssue("Missing configuration: " + HIVEONTEZ_TRANSPORT_MODE);
-    } else if (!TRANSPORT_MODE_HTTP.equals(hiveServer2TransportMode)) {
-      response.addConfigurationIssue("Invalid configuration: " + HIVEONTEZ_TRANSPORT_MODE + ". Expected=" + TRANSPORT_MODE_HTTP + "; Found=" + hiveServer2TransportMode);
-    }
+    validateTransportMode(HIVEONTEZ_TRANSPORT_MODE, hiveServer2TransportMode, response);
   }
 
   @Override

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -34,6 +34,7 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
   public static final String ROLE_TYPE    = "HIVESERVER2";
 
   static final String TRANSPORT_MODE_HTTP = "http";
+  static final String TRANSPORT_MODE_ALL  = "all";
 
   static final String SAFETY_VALVE   = "hive_hs2_config_safety_valve";
   static final String SSL_ENABLED    = "hive.server2.use.SSL";
@@ -114,12 +115,19 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
 
   protected void checkHiveServer2HTTPMode(ApiConfigList roleConfig, ServiceModelGeneratorHandleResponse response) {
     final String hiveServer2SafetyValve = getRoleConfigValue(roleConfig, SAFETY_VALVE);
-    final String hiveServer2TransportMode = hiveServer2SafetyValve == null ? null : getSafetyValveValue(hiveServer2SafetyValve, TRANSPORT_MODE);
-    if (hiveServer2TransportMode == null ) {
-      response.addConfigurationIssue("Missing configuration: " + TRANSPORT_MODE);
-    } else if (!TRANSPORT_MODE_HTTP.equals(hiveServer2TransportMode)) {
-      response.addConfigurationIssue("Invalid configuration: " + TRANSPORT_MODE + ". Expected=" + TRANSPORT_MODE_HTTP + "; Found=" + hiveServer2TransportMode);
-    }
+    final String hiveServer2TransportMode =
+            hiveServer2SafetyValve == null ? null : getSafetyValveValue(hiveServer2SafetyValve, TRANSPORT_MODE);
+    validateTransportMode(TRANSPORT_MODE, hiveServer2TransportMode, response);
   }
 
+  protected void validateTransportMode(final String configPropName,
+                                       final String transportMode,
+                                       final ServiceModelGeneratorHandleResponse response) {
+    if (transportMode == null ) {
+      response.addConfigurationIssue("Missing configuration: " + configPropName);
+    } else if (!TRANSPORT_MODE_HTTP.equalsIgnoreCase(transportMode) && !TRANSPORT_MODE_ALL.equalsIgnoreCase(transportMode)) {
+      response.addConfigurationIssue("Invalid configuration: " + configPropName +
+              ". Expected=" + TRANSPORT_MODE_HTTP + " or " + TRANSPORT_MODE_ALL +"; Found=" + transportMode);
+    }
+  }
 }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGeneratorTest.java
@@ -39,6 +39,14 @@ public class HiveOnTezServiceModelGeneratorTest extends AbstractServiceModelGene
   }
 
   @Test
+  public void testHandlesTransportModeAll() {
+    Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_TRANSPORT_MODE,
+                   HiveOnTezServiceModelGenerator.TRANSPORT_MODE_ALL);
+    assertTrue(doTestHandles(newGenerator(), getServiceType(), Collections.emptyMap(), getRoleType(), roleConfig));
+  }
+
+  @Test
   public void testHandlesWhenTransportModeIsBinary() {
     Map<String, String> roleConfig = new HashMap<>();
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_TRANSPORT_MODE, "binary");
@@ -53,6 +61,20 @@ public class HiveOnTezServiceModelGeneratorTest extends AbstractServiceModelGene
     roleConfig.put(HiveOnTezServiceModelGenerator.SSL_ENABLED, "false");
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_TRANSPORT_MODE,
                    HiveOnTezServiceModelGenerator.TRANSPORT_MODE_HTTP);
+    roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_HTTP_PORT, "12345");
+    roleConfig.put(HiveOnTezServiceModelGenerator.SAFETY_VALVE, "null");
+
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+  }
+
+  @Test
+  public void testServiceModelMetadataTransportModeAll() {
+    final Map<String, String> serviceConfig = Collections.emptyMap();
+
+    final Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(HiveOnTezServiceModelGenerator.SSL_ENABLED, "false");
+    roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_TRANSPORT_MODE,
+                   HiveOnTezServiceModelGenerator.TRANSPORT_MODE_ALL);
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_HTTP_PORT, "12345");
     roleConfig.put(HiveOnTezServiceModelGenerator.SAFETY_VALVE, "null");
 

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGeneratorTest.java
@@ -39,6 +39,14 @@ public class HiveServiceModelGeneratorTest extends AbstractServiceModelGenerator
   }
 
   @Test
+  public void testHandlesTransportModeAll() {
+    Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(HiveServiceModelGenerator.SAFETY_VALVE,
+                   getSafetyValveConfig(HiveServiceModelGenerator.TRANSPORT_MODE_ALL));
+    assertTrue(doTestHandles(newGenerator(), getServiceType(), Collections.emptyMap(), getRoleType(), roleConfig));
+  }
+
+  @Test
   public void testHandlesWhenTransportModeIsBinary() {
     Map<String, String> roleConfig = new HashMap<>();
     roleConfig.put(HiveServiceModelGenerator.SAFETY_VALVE, getSafetyValveConfig("binary"));
@@ -53,6 +61,18 @@ public class HiveServiceModelGeneratorTest extends AbstractServiceModelGenerator
     roleConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
     roleConfig.put(HiveServiceModelGenerator.SAFETY_VALVE,
                    getSafetyValveConfig(HiveServiceModelGenerator.TRANSPORT_MODE_HTTP));
+
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+  }
+
+  @Test
+  public void testServiceModelMetadataTransportModeAll() {
+    final Map<String, String> serviceConfig = Collections.emptyMap();
+
+    final Map<String, String> roleConfig = new HashMap<>();
+    roleConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
+    roleConfig.put(HiveServiceModelGenerator.SAFETY_VALVE,
+                   getSafetyValveConfig(HiveServiceModelGenerator.TRANSPORT_MODE_ALL));
 
     validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
   }


### PR DESCRIPTION
…de all

## What changes were proposed in this pull request?

Added support for HS2 transport mode configuration value "all", such that it is treated the same as the "http" transport mode in terms of service discovery via ClouderaManager.

## How was this patch tested?

Added tests to HiveServiceModelGeneratorTest and HiveOnTezServiceModelGeneratorTest.