### PR TITLE
KNOX-2572 - Unique token identifiers still being logged in entirety

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateService.java
@@ -25,6 +25,7 @@ import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.token.impl.state.TokenStateJournalFactory;
 import org.apache.knox.gateway.services.token.state.JournalEntry;
 import org.apache.knox.gateway.services.token.state.TokenStateJournal;
+import org.apache.knox.gateway.util.Tokens;
 
 import java.io.IOException;
 import java.util.List;
@@ -56,7 +57,7 @@ public class JournalBasedTokenStateService extends DefaultTokenStateService {
                     super.addToken(id, issueTime, expiration, maxLifetime);
 
                 } catch (Exception e) {
-                    log.failedToLoadJournalEntry(id, e);
+                    log.failedToLoadJournalEntry(Tokens.getTokenIDDisplayText(id), e);
                 }
             }
         } catch (IOException e) {
@@ -71,7 +72,7 @@ public class JournalBasedTokenStateService extends DefaultTokenStateService {
         try {
             journal.add(tokenId, issueTime, expiration, maxLifetimeDuration, null);
         } catch (IOException e) {
-            log.failedToAddJournalEntry(tokenId, e);
+            log.failedToAddJournalEntry(Tokens.getTokenIDDisplayText(tokenId), e);
         }
     }
 
@@ -146,7 +147,7 @@ public class JournalBasedTokenStateService extends DefaultTokenStateService {
         try {
             JournalEntry entry = journal.get(tokenId);
             if (entry == null) {
-                log.journalEntryNotFound(tokenId);
+                log.journalEntryNotFound(Tokens.getTokenIDDisplayText(tokenId));
             } else {
                 // Adding will overwrite the existing journal entry, thus updating it with the new expiration
                 journal.add(entry.getTokenId(),
@@ -178,7 +179,7 @@ public class JournalBasedTokenStateService extends DefaultTokenStateService {
     try {
       JournalEntry entry = journal.get(tokenId);
       if (entry == null) {
-        log.journalEntryNotFound(tokenId);
+        log.journalEntryNotFound(Tokens.getTokenIDDisplayText(tokenId));
       } else {
         journal.add(entry.getTokenId(), Long.parseLong(entry.getIssueTime()), Long.parseLong(entry.getExpiration()), Long.parseLong(entry.getMaxLifetime()), metadata);
       }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournalTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/MultiFileTokenStateJournalTest.java
@@ -20,14 +20,53 @@ package org.apache.knox.gateway.services.token.impl.state;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.token.state.TokenStateJournal;
+import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class MultiFileTokenStateJournalTest extends AbstractFileTokenStateJournalTest {
 
     @Override
     TokenStateJournal createTokenStateJournal(GatewayConfig config) throws IOException {
         return new MultiFileTokenStateJournal(config);
+    }
+
+    @Test
+    public void testGetDisplayableJournalFilepathWithoutID() throws Exception {
+        final String dirPath = "/tmp/test/tokens/journal/";
+        final String tokenId = UUID.randomUUID().toString();
+        final String entryFilePath = dirPath + tokenId + MultiFileTokenStateJournal.ENTRY_FILE_EXT;
+        MultiFileTokenStateJournal journal = (MultiFileTokenStateJournal) createTokenStateJournal(getGatewayConfig());
+        Method m = MultiFileTokenStateJournal.class.getDeclaredMethod("getDisplayableJournalFilepath", String.class);
+        assertNotNull(m);
+        m.setAccessible(true);
+        String displayablePath = (String) m.invoke(journal, entryFilePath);
+        assertNotNull(displayablePath);
+        assertTrue(displayablePath.length() < entryFilePath.length());
+        assertFalse(displayablePath.contains(tokenId));
+    }
+
+    @Test
+    public void testGetDisplayableJournalFilepathWithID() throws Exception {
+        final String dirPath = "/tmp/test/tokens/journal/";
+        final String tokenId = UUID.randomUUID().toString();
+        final String entryFilePath = dirPath + tokenId + MultiFileTokenStateJournal.ENTRY_FILE_EXT;
+        MultiFileTokenStateJournal journal = (MultiFileTokenStateJournal) createTokenStateJournal(getGatewayConfig());
+        Method m = MultiFileTokenStateJournal.class.getDeclaredMethod("getDisplayableJournalFilepath",
+                                                                      String.class,
+                                                                      String.class);
+        assertNotNull(m);
+        m.setAccessible(true);
+        String displayablePath = (String) m.invoke(journal, tokenId, entryFilePath);
+        assertNotNull(displayablePath);
+        assertTrue(displayablePath.length() < entryFilePath.length());
+        assertFalse(displayablePath.contains(tokenId));
     }
 
 }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/Tokens.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/Tokens.java
@@ -16,7 +16,9 @@
  */
 package org.apache.knox.gateway.util;
 
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 public class Tokens {
 
@@ -56,6 +58,14 @@ public class Tokens {
                                         uuid.substring(uuid.lastIndexOf('-') + 1));
         }
         return displayText;
+    }
+
+    public static Set<String> getDisplayableTokenIDsText(final Set<String> tokenIds) {
+        Set<String> displayableTokenIds = new HashSet<>();
+        for (String tokenId : tokenIds) {
+            displayableTokenIds.add(Tokens.getTokenIDDisplayText(tokenId));
+        }
+        return displayableTokenIds;
     }
 
 }

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/TokensTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/TokensTest.java
@@ -20,6 +20,8 @@ package org.apache.knox.gateway.util;
 
 import org.junit.Test;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -66,6 +68,21 @@ public class TokensTest {
         doTestTokenDisplay(new String(invalid), true);
     }
 
+    @Test
+    public void testDisplayableTokenIDSet() throws Exception {
+        final Set<String> tokenIDs = new HashSet<>();
+        for (int i=0 ; i < 5; i++) {
+            tokenIDs.add(UUID.randomUUID().toString());
+        }
+
+        Set<String> displayableTokenIDs = Tokens.getDisplayableTokenIDsText(tokenIDs);
+
+        for (String displayable : displayableTokenIDs) {
+            assertTrue(displayable.length() < 36);
+            assertTrue(displayable.contains("..."));
+        }
+    }
+
     private void doTestTokenDisplay(final String tokenId) {
         doTestTokenDisplay(tokenId, false);
     }
@@ -82,4 +99,5 @@ public class TokensTest {
                          displayableTokenId);
         }
     }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Apparently, there are a number of places where the UUIDs associated with Knox JWTs are still being logged in their entirety.
This change is to mask all of those remaining messages.

## How was this patch tested?

Added ZookeeperTokenStateServiceTest#testTokenIDDisplayText() to test the masking of token ID in aliases.
Added MultiFileTokenStateJournalTest#testGetDisplayableJournalFilepathWithID() and MultiFileTokenStateJournalTest#testGetDisplayableJournalFilepathWithoutID() to test the masking of journal entry file paths that contain UUIDs.
The rest of the changes involving plain tokens uses the previously tested Tokens.getTokenIDDisplayText(String id) facility.
