### PR TITLE
KNOX-2554 - Implemented JDBC Token State Service

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -423,6 +423,24 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-shell</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbynet</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
             <scope>test</scope>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -397,6 +397,14 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbyclient</artifactId>
+        </dependency>
 
         <!-- ********** ********** ********** ********** ********** ********** -->
         <!-- ********** Test Dependencies                           ********** -->

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -17,19 +17,6 @@
  */
 package org.apache.knox.gateway.config.impl;
 
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.knox.gateway.GatewayMessages;
-import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.dto.HomePageProfile;
-import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
-import org.joda.time.Period;
-import org.joda.time.format.PeriodFormatter;
-import org.joda.time.format.PeriodFormatterBuilder;
-
 import static org.apache.knox.gateway.services.security.impl.RemoteAliasService.REMOTE_ALIAS_SERVICE_TYPE;
 
 import java.io.File;
@@ -51,6 +38,20 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.dto.HomePageProfile;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
+import org.joda.time.Period;
+import org.joda.time.format.PeriodFormatter;
+import org.joda.time.format.PeriodFormatterBuilder;
+
 
 /**
  * The configuration for the Gateway.
@@ -270,6 +271,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata", "homepage"));
   private static final String KNOX_HOMEPAGE_LOGOUT_ENABLED =  "knox.homepage.logout.enabled";
   private static final String KNOX_INCOMING_XFORWARDED_ENABLED = "gateway.incoming.xforwarded.enabled";
+
+  //Gateway Database related properties
+  private static final String GATEWAY_DATABASE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".database.type";
+  private static final String GATEWAY_DATABASE_HOST =  GATEWAY_CONFIG_FILE_PREFIX + ".database.host";
+  private static final String GATEWAY_DATABASE_PORT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.port";
+  private static final String GATEWAY_DATABASE_NAME =  GATEWAY_CONFIG_FILE_PREFIX + ".database.name";
 
   public GatewayConfigImpl() {
     init();
@@ -1230,5 +1237,25 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     profiles.put("thin", HomePageProfile.getThinProfileElemens());
     profiles.put("token", HomePageProfile.getTokenProfileElements());
     return profiles;
+  }
+
+  @Override
+  public String getDatabaseType() {
+    return get(GATEWAY_DATABASE_TYPE, "none");
+  }
+
+  @Override
+  public String getDatabaseHost() {
+    return get(GATEWAY_DATABASE_HOST);
+  }
+
+  @Override
+  public int getDatabasePort() {
+    return getInt(GATEWAY_DATABASE_PORT, 0);
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return get(GATEWAY_DATABASE_NAME, "GATEWAY_DATABASE");
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/TokenStateServiceFactory.java
@@ -30,6 +30,7 @@ import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService;
 import org.apache.knox.gateway.services.token.impl.DefaultTokenStateService;
+import org.apache.knox.gateway.services.token.impl.JDBCTokenStateService;
 import org.apache.knox.gateway.services.token.impl.JournalBasedTokenStateService;
 import org.apache.knox.gateway.services.token.impl.ZookeeperTokenStateService;
 
@@ -49,6 +50,9 @@ public class TokenStateServiceFactory extends AbstractServiceFactory {
         service = new JournalBasedTokenStateService();
       } else if (matchesImplementation(implementation, ZookeeperTokenStateService.class)) {
         service = new ZookeeperTokenStateService(gatewayServices);
+      } else if (matchesImplementation(implementation, JDBCTokenStateService.class)) {
+        service = new JDBCTokenStateService();
+       ((JDBCTokenStateService) service).setAliasService(getAliasService(gatewayServices));
       }
 
       logServiceUsage(isEmptyDefaultImplementation(implementation) ? AliasBasedTokenStateService.class.getName() : implementation, serviceType);
@@ -65,6 +69,6 @@ public class TokenStateServiceFactory extends AbstractServiceFactory {
   @Override
   protected Collection<String> getKnownImplementations() {
     return unmodifiableList(asList(DefaultTokenStateService.class.getName(), AliasBasedTokenStateService.class.getName(), JournalBasedTokenStateService.class.getName(),
-        ZookeeperTokenStateService.class.getName()));
+        ZookeeperTokenStateService.class.getName(), JDBCTokenStateService.class.getName()));
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -153,7 +153,7 @@ public class JDBCTokenStateService extends DefaultTokenStateService {
   @Override
   protected void removeToken(String tokenId) throws UnknownTokenException {
     try {
-      final boolean removed = tokenDatabase.removeToken(Tokens.getTokenIDDisplayText(tokenId));
+      final boolean removed = tokenDatabase.removeToken(tokenId);
       if (removed) {
         super.removeToken(tokenId);
         log.removedTokenFromDatabase(Tokens.getTokenIDDisplayText(tokenId));

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
+import org.apache.knox.gateway.util.JDBCUtils;
+import org.apache.knox.gateway.util.Tokens;
+
+public class JDBCTokenStateService extends DefaultTokenStateService {
+  private AliasService aliasService; // connection username/pw is stored here
+  private TokenStateDatabase tokenDatabase;
+
+  public void setAliasService(AliasService aliasService) {
+    this.aliasService = aliasService;
+  }
+
+  @Override
+  public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+    super.init(config, options);
+    if (aliasService == null) {
+      throw new ServiceLifecycleException("The required AliasService reference has not been set.");
+    }
+    try {
+      this.tokenDatabase = new TokenStateDatabase(JDBCUtils.getDataSource(config, aliasService));
+    } catch (Exception e) {
+      throw new ServiceLifecycleException("Error while initiating JDBCTokenStateService: " + e, e);
+    }
+  }
+
+  @Override
+  public void addToken(String tokenId, long issueTime, long expiration, long maxLifetimeDuration) {
+    super.addToken(tokenId, issueTime, expiration, maxLifetimeDuration);
+    try {
+      final boolean added = tokenDatabase.addToken(tokenId, issueTime, expiration, maxLifetimeDuration);
+      if (added) {
+        log.savedTokenInDatabase(Tokens.getTokenIDDisplayText(tokenId));
+      } else {
+        log.failedToSaveTokenInDatabase(Tokens.getTokenIDDisplayText(tokenId));
+      }
+    } catch (SQLException e) {
+      log.errorSavingTokenInDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+    }
+  }
+
+  @Override
+  protected void removeTokens(Set<String> tokenIds) {
+    try {
+      boolean removed = tokenDatabase.removeTokens(tokenIds);
+      if (removed) {
+        log.removedTokensFromDatabase(tokenIds.size());
+      } else {
+        log.failedToRemoveTokensFromDatabase(tokenIds.size());
+      }
+    } catch (SQLException e) {
+      log.errorRemovingTokensFromDatabase(tokenIds.size(), e.getMessage(), e);
+    }
+    super.removeTokens(tokenIds);
+  }
+
+  @Override
+  public long getTokenExpiration(String tokenId, boolean validate) throws UnknownTokenException {
+    try {
+      // check the in-memory cache, then
+      return super.getTokenExpiration(tokenId, validate);
+    } catch (UnknownTokenException e) {
+      // It's not in memory
+    }
+
+    long expiration = 0;
+    try {
+      expiration = tokenDatabase.getTokenExpiration(tokenId);
+      log.fetchedExpirationFromDatabase(Tokens.getTokenIDDisplayText(tokenId), expiration);
+    } catch (SQLException e) {
+      log.errorFetchingExpirationFromDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+    }
+    return expiration;
+  }
+
+  @Override
+  protected void updateExpiration(String tokenId, long expiration) {
+    // Update in-memory
+    super.updateExpiration(tokenId, expiration);
+
+    try {
+      final boolean updated = tokenDatabase.updateExpiration(tokenId, expiration);
+      if (updated) {
+        log.updatedExpirationInDatabase(Tokens.getTokenIDDisplayText(tokenId), expiration);
+      } else {
+        log.failedToUpdateExpirationInDatabase(Tokens.getTokenIDDisplayText(tokenId), expiration);
+      }
+    } catch (SQLException e) {
+      log.errorUpdatingExpirationInDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+    }
+  }
+
+  @Override
+  protected long getMaxLifetime(String tokenId) {
+    long maxLifetime = super.getMaxLifetime(tokenId);
+
+    // If there is no result from the in-memory collection, proceed to check the Database
+    if (maxLifetime < 1L) {
+      try {
+        maxLifetime = tokenDatabase.getMaxLifetime(tokenId);
+        log.fetchedMaxLifetimeFromDatabase(Tokens.getTokenIDDisplayText(tokenId), maxLifetime);
+      } catch (SQLException e) {
+        log.errorFetchingMaxLifetimeFromDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+      }
+    }
+    return maxLifetime;
+  }
+
+  @Override
+  protected boolean isUnknown(String tokenId) {
+    boolean isUnknown = super.isUnknown(tokenId);
+
+    // If it's not in the cache, then check in the Database
+    if (isUnknown) {
+      try {
+        isUnknown = tokenDatabase.getMaxLifetime(tokenId) < 0;
+      } catch (SQLException e) {
+        log.errorFetchingMaxLifetimeFromDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+      }
+    }
+    return isUnknown;
+  }
+
+  @Override
+  protected List<String> getTokenIds() {
+    List<String> tokenIds = new LinkedList<>();
+    try {
+      tokenIds = tokenDatabase.getTokenIds();
+      log.fetchedAllTokenIdsFromDatabase(tokenIds.size());
+    } catch (SQLException e) {
+      log.errorFetchingAllTokenIdsFromDatabase(e.getMessage(), e);
+    }
+    return tokenIds;
+  }
+
+  @Override
+  public void addMetadata(String tokenId, TokenMetadata metadata) {
+    // Update in-memory
+    super.addMetadata(tokenId, metadata);
+
+    try {
+      final boolean added = tokenDatabase.addMetadata(tokenId, metadata);
+      if (added) {
+        log.updatedMetadataInDatabase(Tokens.getTokenIDDisplayText(tokenId));
+      } else {
+        log.failedToUpdateMetadataInDatabase(Tokens.getTokenIDDisplayText(tokenId));
+      }
+    } catch (SQLException e) {
+      log.errorUpdatingMetadataInDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+    }
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -25,6 +25,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.TokenStateServiceException;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.util.JDBCUtils;
 import org.apache.knox.gateway.util.Tokens;
@@ -57,13 +58,15 @@ public class JDBCTokenStateService extends DefaultTokenStateService {
       if (added) {
         log.savedTokenInDatabase(Tokens.getTokenIDDisplayText(tokenId));
 
-        //add in-memory
+        // add in-memory
         super.addToken(tokenId, issueTime, expiration, maxLifetimeDuration);
       } else {
         log.failedToSaveTokenInDatabase(Tokens.getTokenIDDisplayText(tokenId));
+        throw new TokenStateServiceException("Failed to save token " + Tokens.getTokenIDDisplayText(tokenId) + " in the database");
       }
     } catch (SQLException e) {
       log.errorSavingTokenInDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+      throw new TokenStateServiceException("An error occurred while saving token " + Tokens.getTokenIDDisplayText(tokenId) + " in the database", e);
     }
   }
 
@@ -97,9 +100,11 @@ public class JDBCTokenStateService extends DefaultTokenStateService {
         super.updateExpiration(tokenId, expiration);
       } else {
         log.failedToUpdateExpirationInDatabase(Tokens.getTokenIDDisplayText(tokenId), expiration);
+        throw new TokenStateServiceException("Failed to updated expiration for " + Tokens.getTokenIDDisplayText(tokenId) + " in the database");
       }
     } catch (SQLException e) {
       log.errorUpdatingExpirationInDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+      throw new TokenStateServiceException("An error occurred while updating expiration for " + Tokens.getTokenIDDisplayText(tokenId) + " in the database", e);
     }
   }
 
@@ -158,9 +163,11 @@ public class JDBCTokenStateService extends DefaultTokenStateService {
         super.addMetadata(tokenId, metadata);
       } else {
         log.failedToUpdateMetadataInDatabase(Tokens.getTokenIDDisplayText(tokenId));
+        throw new TokenStateServiceException("Failed to update metadata for " + Tokens.getTokenIDDisplayText(tokenId) + " in the database");
       }
     } catch (SQLException e) {
       log.errorUpdatingMetadataInDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+      throw new TokenStateServiceException("An error occurred while updating metadata for " + Tokens.getTokenIDDisplayText(tokenId) + " in the database", e);
     }
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
@@ -21,10 +21,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -33,13 +29,11 @@ import org.apache.knox.gateway.services.security.token.TokenMetadata;
 public class TokenStateDatabase {
   private static final String TOKENS_TABLE_NAME = "KNOX_TOKENS";
   private static final String ADD_TOKEN_SQL = "INSERT INTO " + TOKENS_TABLE_NAME + "(token_id, issue_time, expiration, max_lifetime) VALUES(?, ?, ?, ?)";
-  private static final String REMOVE_TOKENS_SQL_PREFIX = "DELETE FROM " + TOKENS_TABLE_NAME + " WHERE token_id IN (";
+  private static final String REMOVE_EXPIRED_TOKENS_SQL = "DELETE FROM " + TOKENS_TABLE_NAME + " WHERE expiration < ?";
   private static final String GET_TOKEN_EXPIRATION_SQL = "SELECT expiration FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
   private static final String UPDATE_TOKEN_EXPIRATION_SQL = "UPDATE " + TOKENS_TABLE_NAME + " SET expiration = ? WHERE token_id = ?";
   private static final String GET_MAX_LIFETIME_SQL = "SELECT max_lifetime FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
-  private static final String GET_ALL_TOKEN_IDS_SQL = "SELECT token_id FROM " + TOKENS_TABLE_NAME;
   private static final String ADD_METADATA_SQL = "UPDATE " + TOKENS_TABLE_NAME + " SET username = ?, comment = ? WHERE token_id = ?";
-  private static final int DELETE_BATCH_SIZE = 500;
 
   private final DataSource dataSource;
 
@@ -54,44 +48,6 @@ public class TokenStateDatabase {
       addTokenStatement.setLong(3, expiration);
       addTokenStatement.setLong(4, issueTime + maxLifetimeDuration);
       return addTokenStatement.executeUpdate() == 1;
-    }
-  }
-
-  // This needs to be done in batches as many DB vendors have limitations on the number of items within the 'IN' clause
-  boolean removeTokens(Set<String> tokenIds) throws SQLException {
-    int removed = 0;
-    if (tokenIds.size() <= DELETE_BATCH_SIZE) {
-      removed += doRemoveTokens(tokenIds);
-    } else {
-      Set<String> tokenIdBatch = new HashSet<>();
-      for (String tokenId : tokenIds) {
-        tokenIdBatch.add(tokenId);
-        if (tokenIdBatch.size() == DELETE_BATCH_SIZE) {
-          removed += doRemoveTokens(tokenIdBatch);
-          tokenIdBatch.clear();
-        }
-      }
-      // one more round of removal if the last batch has less items than the configured batch size
-      removed += doRemoveTokens(tokenIdBatch);
-    }
-    return removed == tokenIds.size();
-  }
-
-  private int doRemoveTokens(Set<String> tokenIds) throws SQLException {
-    final StringBuilder statementPostFixBuilder = new StringBuilder(REMOVE_TOKENS_SQL_PREFIX);
-    for (int i = 0; i < tokenIds.size(); i++) {
-      if (statementPostFixBuilder.length() > REMOVE_TOKENS_SQL_PREFIX.length()) {
-        statementPostFixBuilder.append(", ");
-      }
-      statementPostFixBuilder.append('?');
-    }
-    statementPostFixBuilder.append(')');
-    try (Connection connection = dataSource.getConnection(); PreparedStatement removeTokensStatement = connection.prepareStatement(statementPostFixBuilder.toString())) {
-      int i = 0;
-      for (String tokenId : tokenIds) {
-        removeTokensStatement.setString(++i, tokenId);
-      }
-      return removeTokensStatement.executeUpdate();
     }
   }
 
@@ -121,16 +77,11 @@ public class TokenStateDatabase {
     }
   }
 
-  List<String> getTokenIds() throws SQLException {
-    final List<String> tokenIds = new LinkedList<>();
-    try (Connection connection = dataSource.getConnection();
-        PreparedStatement getAlltokenIdsStatement = connection.prepareStatement(GET_ALL_TOKEN_IDS_SQL);
-        ResultSet rs = getAlltokenIdsStatement.executeQuery()) {
-      while (rs.next()) {
-        tokenIds.add(rs.getString(1));
-      }
+  int deleteExpiredTokens(long tokenEvictionGracePeriod) throws SQLException {
+    try (Connection connection = dataSource.getConnection(); PreparedStatement deleteExpiredTokensStatement = connection.prepareStatement(REMOVE_EXPIRED_TOKENS_SQL)) {
+      deleteExpiredTokensStatement.setLong(1, System.currentTimeMillis() - tokenEvictionGracePeriod);
+      return deleteExpiredTokensStatement.executeUpdate();
     }
-    return tokenIds;
   }
 
   boolean addMetadata(String tokenId, TokenMetadata metadata) throws SQLException {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+
+public class TokenStateDatabase {
+  private static final String TOKENS_TABLE_NAME = "KNOX_TOKENS";
+  private static final String ADD_TOKEN_SQL = "INSERT INTO " + TOKENS_TABLE_NAME + "(token_id, issue_time, expiration, max_lifetime) VALUES(?, ?, ?, ?)";
+  private static final String REMOVE_TOKENS_SQL_PREFIX = "DELETE FROM " + TOKENS_TABLE_NAME + " WHERE token_id IN (";
+  private static final String GET_TOKEN_EXPIRATION_SQL = "SELECT expiration FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
+  private static final String UPDATE_TOKEN_EXPIRATION_SQL = "UPDATE " + TOKENS_TABLE_NAME + " SET expiration = ? WHERE token_id = ?";
+  private static final String GET_MAX_LIFETIME_SQL = "SELECT max_lifetime FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
+  private static final String GET_ALL_TOKEN_IDS_SQL = "SELECT token_id FROM " + TOKENS_TABLE_NAME;
+  private static final String ADD_METADATA_SQL = "UPDATE " + TOKENS_TABLE_NAME + " SET username = ?, comment = ? WHERE token_id = ?";
+  private static final int DELETE_BATCH_SIZE = 500;
+
+  private final DataSource dataSource;
+
+  TokenStateDatabase(DataSource dataSource) throws Exception {
+    this.dataSource = dataSource;
+  }
+
+  boolean addToken(String tokenId, long issueTime, long expiration, long maxLifetimeDuration) throws SQLException {
+    try (Connection connection = dataSource.getConnection(); PreparedStatement addTokenStatement = connection.prepareStatement(ADD_TOKEN_SQL)) {
+      addTokenStatement.setString(1, tokenId);
+      addTokenStatement.setLong(2, issueTime);
+      addTokenStatement.setLong(3, expiration);
+      addTokenStatement.setLong(4, issueTime + maxLifetimeDuration);
+      return addTokenStatement.executeUpdate() == 1;
+    }
+  }
+
+  // This needs to be done in batches as many DB vendors have limitations on the number of items within the 'IN' clause
+  boolean removeTokens(Set<String> tokenIds) throws SQLException {
+    int removed = 0;
+    if (tokenIds.size() <= DELETE_BATCH_SIZE) {
+      removed += doRemoveTokens(tokenIds);
+    } else {
+      Set<String> tokenIdBatch = new HashSet<>();
+      for (String tokenId : tokenIds) {
+        tokenIdBatch.add(tokenId);
+        if (tokenIdBatch.size() == DELETE_BATCH_SIZE) {
+          removed += doRemoveTokens(tokenIdBatch);
+          tokenIdBatch.clear();
+        }
+      }
+      // one more round of removal if the last batch has less items than the configured batch size
+      removed += doRemoveTokens(tokenIdBatch);
+    }
+    return removed == tokenIds.size();
+  }
+
+  private int doRemoveTokens(Set<String> tokenIds) throws SQLException {
+    final StringBuilder statementPostFixBuilder = new StringBuilder(REMOVE_TOKENS_SQL_PREFIX);
+    for (int i = 0; i < tokenIds.size(); i++) {
+      if (statementPostFixBuilder.length() > REMOVE_TOKENS_SQL_PREFIX.length()) {
+        statementPostFixBuilder.append(", ");
+      }
+      statementPostFixBuilder.append('?');
+    }
+    statementPostFixBuilder.append(')');
+    try (Connection connection = dataSource.getConnection(); PreparedStatement removeTokensStatement = connection.prepareStatement(statementPostFixBuilder.toString())) {
+      int i = 0;
+      for (String tokenId : tokenIds) {
+        removeTokensStatement.setString(++i, tokenId);
+      }
+      return removeTokensStatement.executeUpdate();
+    }
+  }
+
+  long getTokenExpiration(String tokenId) throws SQLException {
+    try (Connection connection = dataSource.getConnection(); PreparedStatement getTokenExpirationStatement = connection.prepareStatement(GET_TOKEN_EXPIRATION_SQL)) {
+      getTokenExpirationStatement.setString(1, tokenId);
+      try (ResultSet rs = getTokenExpirationStatement.executeQuery()) {
+        return rs.next() ? rs.getLong(1) : 0;
+      }
+    }
+  }
+
+  boolean updateExpiration(final String tokenId, long expiration) throws SQLException {
+    try (Connection connection = dataSource.getConnection(); PreparedStatement updateTokenExpirationStatement = connection.prepareStatement(UPDATE_TOKEN_EXPIRATION_SQL)) {
+      updateTokenExpirationStatement.setLong(1, expiration);
+      updateTokenExpirationStatement.setString(2, tokenId);
+      return updateTokenExpirationStatement.executeUpdate() == 1;
+    }
+  }
+
+  long getMaxLifetime(String tokenId) throws SQLException {
+    try (Connection connection = dataSource.getConnection(); PreparedStatement getMaxLifetimeStatement = connection.prepareStatement(GET_MAX_LIFETIME_SQL)) {
+      getMaxLifetimeStatement.setString(1, tokenId);
+      try (ResultSet rs = getMaxLifetimeStatement.executeQuery()) {
+        return rs.next() ? rs.getLong(1) : -1;
+      }
+    }
+  }
+
+  List<String> getTokenIds() throws SQLException {
+    final List<String> tokenIds = new LinkedList<>();
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement getAlltokenIdsStatement = connection.prepareStatement(GET_ALL_TOKEN_IDS_SQL);
+        ResultSet rs = getAlltokenIdsStatement.executeQuery()) {
+      while (rs.next()) {
+        tokenIds.add(rs.getString(1));
+      }
+    }
+    return tokenIds;
+  }
+
+  boolean addMetadata(String tokenId, TokenMetadata metadata) throws SQLException {
+    try (Connection connection = dataSource.getConnection(); PreparedStatement addMetadataStatement = connection.prepareStatement(ADD_METADATA_SQL)) {
+      addMetadataStatement.setString(1, metadata.getUserName());
+      addMetadataStatement.setString(2, metadata.getComment());
+      addMetadataStatement.setString(3, tokenId);
+      return addMetadataStatement.executeUpdate() == 1;
+    }
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -217,7 +217,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.DEBUG, text = "Updated metadata for {0} in the database")
   void updatedMetadataInDatabase(String tokenId);
 
-  @Message(level = MessageLevel.DEBUG, text = "Failed to updated metadata for {0} in the database")
+  @Message(level = MessageLevel.DEBUG, text = "Failed to update metadata for {0} in the database")
   void failedToUpdateMetadataInDatabase(String tokenId);
 
   @Message(level = MessageLevel.ERROR, text = "An error occurred while updating metadata for {0} in the database : {1}")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -187,14 +187,11 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "An error occurred while saving token {0} in the database : {1}")
   void errorSavingTokenInDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
-  @Message(level = MessageLevel.DEBUG, text = "{0} tokens have been removed from the database")
+  @Message(level = MessageLevel.DEBUG, text = "{0} expired tokens have been removed from the database")
   void removedTokensFromDatabase(int size);
 
-  @Message(level = MessageLevel.ERROR, text = "Failed to remove {0} tokens from the database")
-  void failedToRemoveTokensFromDatabase(int size);
-
-  @Message(level = MessageLevel.ERROR, text = "An error occurred while removing {0} tokens from the database : {1}")
-  void errorRemovingTokensFromDatabase(int size, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while removing expired tokens from the database : {1}")
+  void errorRemovingTokensFromDatabase(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.DEBUG, text = "Fetched expiration for {0} from the database : {1}")
   void fetchedExpirationFromDatabase(String tokenId, long expiration);
@@ -216,12 +213,6 @@ public interface TokenStateServiceMessages {
 
   @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching max lifetime for {0} from the database : {1}")
   void errorFetchingMaxLifetimeFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
-
-  @Message(level = MessageLevel.DEBUG, text = "Fetched all {0} token IDs from the database")
-  void fetchedAllTokenIdsFromDatabase(int size);
-
-  @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching all token IDs from the database : {0}")
-  void errorFetchingAllTokenIdsFromDatabase(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.DEBUG, text = "Updated metadata for {0} in the database")
   void updatedMetadataInDatabase(String tokenId);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -177,4 +177,58 @@ public interface TokenStateServiceMessages {
 
   @Message(level = MessageLevel.INFO, text = "Removed related token alias {0} on receiving signal from Zookeeper ")
   void onRemoteTokenStateRemoval(String alias);
+
+  @Message(level = MessageLevel.DEBUG, text = "Token {0} has been saved in the database")
+  void savedTokenInDatabase(String tokenId);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to save token {0} in the database")
+  void failedToSaveTokenInDatabase(String tokenId);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while saving token {0} in the database : {1}")
+  void errorSavingTokenInDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "{0} tokens have been removed from the database")
+  void removedTokensFromDatabase(int size);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to remove {0} tokens from the database")
+  void failedToRemoveTokensFromDatabase(int size);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while removing {0} tokens from the database : {1}")
+  void errorRemovingTokensFromDatabase(int size, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Fetched expiration for {0} from the database : {1}")
+  void fetchedExpirationFromDatabase(String tokenId, long expiration);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching expiration for {0} from the database : {1}")
+  void errorFetchingExpirationFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Updated expiration for {0} in the database to {1}")
+  void updatedExpirationInDatabase(String tokenId, long expiration);
+
+  @Message(level = MessageLevel.DEBUG, text = "Failed to updated expiration for {0} in the database to {1}")
+  void failedToUpdateExpirationInDatabase(String tokenId, long expiration);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while updating expiration for {0} in the database : {1}")
+  void errorUpdatingExpirationInDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Fetched max lifetime for {0} from the database : {1}")
+  void fetchedMaxLifetimeFromDatabase(String tokenId, long maxLifetime);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching max lifetime for {0} from the database : {1}")
+  void errorFetchingMaxLifetimeFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Fetched all {0} token IDs from the database")
+  void fetchedAllTokenIdsFromDatabase(int size);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching all token IDs from the database : {0}")
+  void errorFetchingAllTokenIdsFromDatabase(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Updated metadata for {0} in the database")
+  void updatedMetadataInDatabase(String tokenId);
+
+  @Message(level = MessageLevel.DEBUG, text = "Failed to updated metadata for {0} in the database")
+  void failedToUpdateMetadataInDatabase(String tokenId);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while updating metadata for {0} in the database : {1}")
+  void errorUpdatingMetadataInDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -187,6 +187,12 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "An error occurred while saving token {0} in the database : {1}")
   void errorSavingTokenInDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.DEBUG, text = "Token {0} has been removed from the database")
+  void removedTokenFromDatabase(String tokenId);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while removing token {0} from the database : {1}")
+  void errorRemovingTokenFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
   @Message(level = MessageLevel.DEBUG, text = "{0} expired tokens have been removed from the database")
   void removedTokensFromDatabase(int size);
 
@@ -222,4 +228,10 @@ public interface TokenStateServiceMessages {
 
   @Message(level = MessageLevel.ERROR, text = "An error occurred while updating metadata for {0} in the database : {1}")
   void errorUpdatingMetadataInDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Fetched metadata for {0} from the database")
+  void fetchedMetadataFromDatabase(String tokenId);
+
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching metadata for {0} from the database : {1}")
+  void errorFetchingMetadataFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import javax.sql.DataSource;
+
+import org.apache.derby.jdbc.ClientDataSource;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.postgresql.ds.PGSimpleDataSource;
+
+public class JDBCUtils {
+  private static final String POSTGRES_DB_TYPE = "postgres";
+  private static final String DERBY_DB_TYPE = "derbydb";
+  private static final String DATABASE_USER_ALIAS_NAME = "gateway_database_user";
+  private static final String DATABASE_PASSWORD_ALIAS_NAME = "gateway_database_password";
+
+  public static DataSource getDataSource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
+    if (POSTGRES_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
+      return createPostgresDataSource(gatewayConfig, aliasService);
+    } else if (DERBY_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
+      return createDerbyDatasource(gatewayConfig, aliasService);
+    }
+    throw new IllegalArgumentException("Invalid database type: " + gatewayConfig.getDatabaseType());
+  }
+
+  private static DataSource createPostgresDataSource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
+    final PGSimpleDataSource postgresDataSource = new PGSimpleDataSource();
+    postgresDataSource.setDatabaseName(gatewayConfig.getDatabaseName());
+    postgresDataSource.setServerNames(new String[] { gatewayConfig.getDatabaseHost() });
+    postgresDataSource.setPortNumbers(new int[] { gatewayConfig.getDatabasePort() });
+    postgresDataSource.setUser(getDatabaseUser(aliasService));
+    postgresDataSource.setPassword(getDatabasePassword(aliasService));
+    return postgresDataSource;
+  }
+
+  private static DataSource createDerbyDatasource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
+    final ClientDataSource derbyDatasource = new ClientDataSource();
+    derbyDatasource.setDatabaseName(gatewayConfig.getDatabaseName());
+    derbyDatasource.setServerName(gatewayConfig.getDatabaseHost());
+    derbyDatasource.setPortNumber(gatewayConfig.getDatabasePort());
+    derbyDatasource.setUser(getDatabaseUser(aliasService));
+    derbyDatasource.setPassword(getDatabasePassword(aliasService));
+    return derbyDatasource;
+  }
+
+  private static String getDatabaseUser(AliasService aliasService) throws AliasServiceException {
+    return getDatabaseAlias(aliasService, DATABASE_USER_ALIAS_NAME);
+  }
+
+  private static String getDatabasePassword(AliasService aliasService) throws AliasServiceException {
+    return getDatabaseAlias(aliasService, DATABASE_PASSWORD_ALIAS_NAME);
+  }
+
+  private static String getDatabaseAlias(AliasService aliasService, String aliasName) throws AliasServiceException {
+    final char[] value = aliasService.getPasswordFromAliasForGateway(aliasName);
+    return value == null ? null : new String(value);
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
@@ -26,10 +26,10 @@ import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.postgresql.ds.PGSimpleDataSource;
 
 public class JDBCUtils {
-  private static final String POSTGRES_DB_TYPE = "postgres";
-  private static final String DERBY_DB_TYPE = "derbydb";
-  private static final String DATABASE_USER_ALIAS_NAME = "gateway_database_user";
-  private static final String DATABASE_PASSWORD_ALIAS_NAME = "gateway_database_password";
+  public static final String POSTGRES_DB_TYPE = "postgres";
+  public static final String DERBY_DB_TYPE = "derbydb";
+  public static final String DATABASE_USER_ALIAS_NAME = "gateway_database_user";
+  public static final String DATABASE_PASSWORD_ALIAS_NAME = "gateway_database_password";
 
   public static DataSource getDataSource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
     if (POSTGRES_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {

--- a/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
@@ -1,0 +1,24 @@
+--  Licensed to the Apache Software Foundation (ASF) under one or more
+--  contributor license agreements. See the NOTICE file distributed with this
+--  work for additional information regarding copyright ownership. The ASF
+--  licenses this file to you under the Apache License, Version 2.0 (the
+--  "License"); you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+-- 
+--  http://www.apache.org/licenses/LICENSE-2.0
+-- 
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+--  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+--  License for the specific language governing permissions and limitations under
+--  the License.
+
+CREATE TABLE KNOX_TOKENS (
+   token_id varchar(128) NOT NULL,
+   issue_time bigint NOT NULL,
+   expiration bigint NOT NULL,
+   max_lifetime bigint NOT NULL,
+   username varchar(128),
+   comment varchar(256),
+   PRIMARY KEY (token_id)
+);

--- a/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
@@ -21,4 +21,4 @@ CREATE TABLE KNOX_TOKENS (
    username varchar(128),
    comment varchar(256),
    PRIMARY KEY (token_id)
-);
+)

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.derby.drda.NetworkServerControl;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
+import org.apache.knox.gateway.shell.jdbc.Database;
+import org.apache.knox.gateway.shell.jdbc.derby.DerbyDatabase;
+import org.apache.knox.gateway.util.JDBCUtils;
+import org.easymock.EasyMock;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class JDBCTokenStateServiceTest {
+
+  private static final String GET_TOKENS_COUNT_SQL = "SELECT count(*) FROM " + TokenStateDatabase.TOKENS_TABLE_NAME;
+  private static final String GET_USERNAME_SQL = "SELECT username FROM " + TokenStateDatabase.TOKENS_TABLE_NAME + " WHERE token_id = ?";
+  private static final String GET_COMMENT_SQL = "SELECT comment FROM " + TokenStateDatabase.TOKENS_TABLE_NAME + " WHERE token_id = ?";
+  private static final String TRUNCATE_KNOX_TOKENS_SQL = "TRUNCATE TABLE " + TokenStateDatabase.TOKENS_TABLE_NAME;
+
+  @ClassRule
+  public static final TemporaryFolder testFolder = new TemporaryFolder();
+
+  private static final String SYSTEM_PROPERTY_DERBY_STREAM_ERROR_FILE = "derby.stream.error.file";
+  private static final String SAMPLE_DERBY_DATABASE_NAME = "sampleDerbyDatabase";
+  private static NetworkServerControl derbyNetworkServerControl;
+  private static Database derbyDatabase;
+  private static JDBCTokenStateService jdbcTokenStateService;
+
+  @SuppressWarnings("PMD.JUnit4TestShouldUseBeforeAnnotation")
+  @BeforeClass
+  public static void setUp() throws Exception {
+    final String username = "app";
+    final String password = "P4ssW0rd!";
+    System.setProperty(SYSTEM_PROPERTY_DERBY_STREAM_ERROR_FILE, "/dev/null");
+    derbyNetworkServerControl = new NetworkServerControl(username, password);
+    derbyNetworkServerControl.start(null);
+    TimeUnit.SECONDS.sleep(1); // give a bit of time for the server to start
+    final Path derbyDatabaseFolder = Paths.get(testFolder.newFolder().toPath().toString(), SAMPLE_DERBY_DATABASE_NAME);
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(NetworkServerControl.DEFAULT_PORTNUMBER).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn(derbyDatabaseFolder.toString()).anyTimes();
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn(username.toCharArray()).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn(password.toCharArray()).anyTimes();
+    EasyMock.replay(gatewayConfig, aliasService);
+
+    derbyDatabase = prepareDerbyDatabase(derbyDatabaseFolder);
+    assertTrue(derbyDatabase.hasTable(TokenStateDatabase.TOKENS_TABLE_NAME));
+
+    jdbcTokenStateService = new JDBCTokenStateService();
+    jdbcTokenStateService.setAliasService(aliasService);
+    jdbcTokenStateService.init(gatewayConfig, null);
+  }
+
+  private static Database prepareDerbyDatabase(Path derbyDatabaseFolder) throws SQLException, IOException {
+    final Database derbyDatabase = new DerbyDatabase(derbyDatabaseFolder.toString(), true);
+    derbyDatabase.create();
+    final String createTableSql = readFileToString(new File(JDBCTokenStateServiceTest.class.getClassLoader().getResource("createKnoxTokenDatabaseTable.sql").getFile()), UTF_8);
+    try (Connection connection = derbyDatabase.getConnection(); Statement createTableStatment = connection.createStatement();) {
+      createTableStatment.execute(createTableSql);
+    }
+    return derbyDatabase;
+  }
+
+  @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
+  @AfterClass
+  public static void tearDown() throws Exception {
+    if (derbyDatabase != null) {
+      derbyDatabase.shutdown();
+    }
+    derbyNetworkServerControl.shutdown();
+    System.clearProperty(SYSTEM_PROPERTY_DERBY_STREAM_ERROR_FILE);
+  }
+
+  @Test
+  public void testAddToken() throws Exception {
+    final String tokenId = UUID.randomUUID().toString();
+    long issueTime = System.currentTimeMillis();
+    long maxLifetimeDuration = 1000;
+    long expiration = issueTime + maxLifetimeDuration;
+    jdbcTokenStateService.addToken(tokenId, issueTime, expiration, maxLifetimeDuration);
+
+    assertEquals(expiration, jdbcTokenStateService.getTokenExpiration(tokenId));
+    assertEquals(issueTime + maxLifetimeDuration, jdbcTokenStateService.getMaxLifetime(tokenId));
+
+    assertEquals(expiration, getLongTokenAttributeFromDatabase(tokenId, TokenStateDatabase.GET_TOKEN_EXPIRATION_SQL));
+    assertEquals(issueTime + maxLifetimeDuration, getLongTokenAttributeFromDatabase(tokenId, TokenStateDatabase.GET_MAX_LIFETIME_SQL));
+  }
+
+  @Test(expected = UnknownTokenException.class)
+  public void testRemoveToken() throws Exception {
+    truncateDatabase();
+    final String tokenId = UUID.randomUUID().toString();
+    jdbcTokenStateService.addToken(tokenId, 1, 1, 1);
+    assertEquals(1, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
+    jdbcTokenStateService.removeToken(tokenId);
+    assertEquals(0, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
+    jdbcTokenStateService.getTokenExpiration(tokenId);
+  }
+
+  @Test
+  public void testUpdateExpiration() throws Exception {
+    final String tokenId = UUID.randomUUID().toString();
+    jdbcTokenStateService.addToken(tokenId, 1, 1, 1);
+    jdbcTokenStateService.updateExpiration(tokenId, 2);
+
+    assertEquals(2, jdbcTokenStateService.getTokenExpiration(tokenId));
+    assertEquals(2, getLongTokenAttributeFromDatabase(tokenId, TokenStateDatabase.GET_TOKEN_EXPIRATION_SQL));
+  }
+
+  @Test(expected = UnknownTokenException.class)
+  public void testAddMetadata() throws Exception {
+    final String tokenId = UUID.randomUUID().toString();
+    jdbcTokenStateService.addToken(tokenId, 1, 1, 1);
+    jdbcTokenStateService.addMetadata(tokenId, new TokenMetadata("sampleUser", "my test comment"));
+
+    assertEquals("sampleUser", jdbcTokenStateService.getTokenMetadata(tokenId).getUserName());
+    assertEquals("my test comment", jdbcTokenStateService.getTokenMetadata(tokenId).getComment());
+
+    assertEquals("sampleUser", getStringTokenAttributeFromDatabase(tokenId, GET_USERNAME_SQL));
+    assertEquals("my test comment", getStringTokenAttributeFromDatabase(tokenId, GET_COMMENT_SQL));
+
+    jdbcTokenStateService.removeToken(tokenId);
+    jdbcTokenStateService.getTokenMetadata(tokenId);
+  }
+
+  @Test
+  public void testEvictExpiredTokens() throws Exception {
+    truncateDatabase();
+    final int tokenCount = 1000;
+    for (int i = 0; i < tokenCount; i++) {
+      final String tokenId = UUID.randomUUID().toString();
+      jdbcTokenStateService.addToken(tokenId, 1, 1, 1);
+    }
+    assertEquals(tokenCount, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
+    jdbcTokenStateService.evictExpiredTokens();
+    assertEquals(0, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
+  }
+
+  private long getLongTokenAttributeFromDatabase(String tokenId, String sql) throws SQLException {
+    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+      if (tokenId != null) {
+        stmt.setString(1, tokenId);
+      }
+      try (ResultSet rs = stmt.executeQuery()) {
+        return rs.next() ? rs.getLong(1) : 0;
+      }
+    }
+  }
+
+  private String getStringTokenAttributeFromDatabase(String tokenId, String sql) throws SQLException {
+    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+      stmt.setString(1, tokenId);
+      try (ResultSet rs = stmt.executeQuery()) {
+        return rs.next() ? rs.getString(1) : null;
+      }
+    }
+  }
+
+  private void truncateDatabase() throws SQLException {
+    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(TRUNCATE_KNOX_TOKENS_SQL)) {
+      stmt.executeUpdate();
+    }
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.derby.jdbc.ClientDataSource;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+public class JDBCUtilsTest {
+
+  @Test
+  public void shouldReturnPostgresDataSource() throws Exception {
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRES_DB_TYPE).anyTimes();
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(EasyMock.anyString())).andReturn(null).anyTimes();
+    EasyMock.replay(gatewayConfig, aliasService);
+    assertTrue(JDBCUtils.getDataSource(gatewayConfig, aliasService) instanceof PGSimpleDataSource);
+  }
+
+  @Test
+  public void postgresDataSourceShouldHaveProperConnectionProperties() throws AliasServiceException {
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRES_DB_TYPE).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(5432).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("sampleDatabase");
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn("user".toCharArray()).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn("password".toCharArray()).anyTimes();
+    EasyMock.replay(gatewayConfig, aliasService);
+    final PGSimpleDataSource dataSource = (PGSimpleDataSource) JDBCUtils.getDataSource(gatewayConfig, aliasService);
+    assertEquals("localhost", dataSource.getServerNames()[0]);
+    assertEquals(5432, dataSource.getPortNumbers()[0]);
+    assertEquals("sampleDatabase", dataSource.getDatabaseName());
+    assertEquals("user", dataSource.getUser());
+    assertEquals("password", dataSource.getPassword());
+  }
+
+  @Test
+  public void shouldReturnDerbyDataSource() throws Exception {
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(EasyMock.anyString())).andReturn(null).anyTimes();
+    EasyMock.replay(gatewayConfig, aliasService);
+    assertTrue(JDBCUtils.getDataSource(gatewayConfig, aliasService) instanceof ClientDataSource);
+  }
+
+  @Test
+  public void derbyDataSourceShouldHaveProperConnectionProperties() throws AliasServiceException {
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(1527).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("sampleDatabase");
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn("user".toCharArray()).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn("password".toCharArray()).anyTimes();
+    EasyMock.replay(gatewayConfig, aliasService);
+    final ClientDataSource dataSource = (ClientDataSource) JDBCUtils.getDataSource(gatewayConfig, aliasService);
+    assertEquals("localhost", dataSource.getServerName());
+    assertEquals(1527, dataSource.getPortNumber());
+    assertEquals("sampleDatabase", dataSource.getDatabaseName());
+    assertEquals("user", dataSource.getUser());
+    assertEquals("password", dataSource.getPassword());
+  }
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/derby/DerbyDatabase.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/derby/DerbyDatabase.java
@@ -27,7 +27,8 @@ import org.apache.knox.gateway.shell.jdbc.Database;
 
 public class DerbyDatabase implements Database {
 
-  public static final String DRIVER = "org.apache.derby.jdbc.EmbeddedDriver";
+  public static final String EMBEDDED_DRIVER = "org.apache.derby.jdbc.EmbeddedDriver";
+  public static final String NETWORK_SERVER_DRIVER = "org.apache.derby.jdbc.ClientDriver";
   public static final String PROTOCOL = "jdbc:derby:";
   private static final String CREATE_ATTRIBUTE = ";create=true";
   private static final String SHUTDOWN_ATTRIBUTE = ";shutdown=true";
@@ -44,8 +45,12 @@ public class DerbyDatabase implements Database {
    *           if the database engine can not be load for some reasons
    */
   public DerbyDatabase(String directory) throws DerbyDatabaseException {
-    this.dbUri = PROTOCOL + directory;
-    loadDriver();
+    this(directory, false);
+  }
+
+  public DerbyDatabase(String directory, boolean networkServer) throws DerbyDatabaseException {
+    this.dbUri = PROTOCOL + (networkServer ? "//localhost:1527/" : "") + directory;
+    loadDriver(networkServer);
   }
 
   @Override
@@ -104,15 +109,16 @@ public class DerbyDatabase implements Database {
     return result;
   }
 
-  private void loadDriver() throws DerbyDatabaseException {
+  private void loadDriver(boolean networkServer) throws DerbyDatabaseException {
+    final String driverToLoad = networkServer ? NETWORK_SERVER_DRIVER : EMBEDDED_DRIVER;
     try {
-      Class.forName(DRIVER).newInstance();
+      Class.forName(driverToLoad).newInstance();
     } catch (ClassNotFoundException e) {
-      throw new DerbyDatabaseException("Unable to load the JDBC driver " + DRIVER + ". Check your CLASSPATH.", e);
+      throw new DerbyDatabaseException("Unable to load the JDBC driver " + driverToLoad + ". Check your CLASSPATH.", e);
     } catch (InstantiationException e) {
-      throw new DerbyDatabaseException("Unable to instantiate the JDBC driver " + DRIVER, e);
+      throw new DerbyDatabaseException("Unable to instantiate the JDBC driver " + driverToLoad, e);
     } catch (IllegalAccessException e) {
-      throw new DerbyDatabaseException("Not allowed to access the JDBC driver " + DRIVER, e);
+      throw new DerbyDatabaseException("Not allowed to access the JDBC driver " + driverToLoad, e);
     }
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/derby/DerbyDatabase.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/jdbc/derby/DerbyDatabase.java
@@ -31,6 +31,7 @@ public class DerbyDatabase implements Database {
   public static final String PROTOCOL = "jdbc:derby:";
   private static final String CREATE_ATTRIBUTE = ";create=true";
   private static final String SHUTDOWN_ATTRIBUTE = ";shutdown=true";
+  private static final String DEFAULT_SCHEMA_NAME = "APP";
 
   private final String dbUri;
 
@@ -87,7 +88,7 @@ public class DerbyDatabase implements Database {
 
   @Override
   public boolean hasTable(String tableName) throws SQLException {
-    return hasTable(null, tableName);
+    return hasTable(DEFAULT_SCHEMA_NAME, tableName);
   }
 
   @Override

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -479,7 +479,7 @@ public class KnoxShellTableTest {
     try {
       derbyDatabase = prepareDerbyDatabase(derbyDatabaseFolder);
       assertTrue(derbyDatabase.hasTable("BOOKS"));
-      final KnoxShellTable table = KnoxShellTable.builder().jdbc().driver(DerbyDatabase.DRIVER).connectTo(DerbyDatabase.PROTOCOL + derbyDatabaseFolder.toString())
+      final KnoxShellTable table = KnoxShellTable.builder().jdbc().driver(DerbyDatabase.EMBEDDED_DRIVER).connectTo(DerbyDatabase.PROTOCOL + derbyDatabaseFolder.toString())
           .sql("select * from books");
       assertEquals(2, table.getRows().size());
       assertTrue(table.values("TITLE").containsAll(Arrays.asList("Apache Knox: The Definitive Guide", "Apache Knox: The Definitive Guide 2nd Edition")));

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -747,4 +747,13 @@ public interface GatewayConfig {
    * It's important that keys in the returned map are converted to lowercase strings.
    */
   Map<String, Collection<String>> getHomePageProfiles();
+
+  String getDatabaseType();
+
+  String getDatabaseHost();
+
+  int getDatabasePort();
+
+  String getDatabaseName();
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateServiceException.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateServiceException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+@SuppressWarnings("serial")
+public class TokenStateServiceException extends RuntimeException {
+
+  public TokenStateServiceException(String message) {
+    super(message);
+  }
+
+  public TokenStateServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+}

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -853,4 +853,25 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public Map<String, Collection<String>> getHomePageProfiles() {
     return null;
   }
+
+  @Override
+  public String getDatabaseType() {
+    return null;
+  }
+
+  @Override
+  public String getDatabaseHost() {
+    return null;
+  }
+
+  @Override
+  public int getDatabasePort() {
+    return 0;
+  }
+
+  @Override
+  public String getDatabaseName() {
+    return null;
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,7 @@
         <okhttp.version>2.7.5</okhttp.version>
         <opensaml.version>3.4.5</opensaml.version>
         <pac4j.version>4.3.0</pac4j.version>
+        <postgresql.version>42.2.19</postgresql.version>
         <protobuf.version>3.14.0</protobuf.version>
         <rest-assured.version>4.3.3</rest-assured.version>
         <shiro.version>1.7.0</shiro.version>
@@ -2041,6 +2042,17 @@
                 <artifactId>swagger-annotations</artifactId>
                 <version>${swagger-annotations.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <!-- pac4j Dependencies -->
             <dependency>
@@ -2328,7 +2340,12 @@
                 <groupId>org.apache.derby</groupId>
                 <artifactId>derby</artifactId>
                 <version>${derby.db.version}</version>
-                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbyclient</artifactId>
+                <version>${derby.db.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2349,6 +2349,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.derby</groupId>
+                <artifactId>derbynet</artifactId>
+                <version>${derby.db.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity</artifactId>
                 <version>${velocity.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change introduces a new `TokenStateService` implementation that operates using pure JDBC connections to relational databases. In the first version, only `Postgres` and `Derby` database types are supported.

## How was this patch tested?

Added new JUnit test classes and updated existing test cases as needed.

I also executed manual testing:

1. Used our new `tokengen` application to fetch a token
```
2021-04-19 23:24:38,972 DEBUG knox.gateway (GatewayFilter.java:doFilter(116)) - Received request: GET /knoxtoken/api/v1/token
2021-04-19 23:24:38,982 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(419)) - Knox Token service (homepage) issued token eyJhbG...WdNDTw (8c419cf4...675b1dc14cce)
2021-04-19 23:24:39,001 DEBUG token.state (JDBCTokenStateService.java:addToken(59)) - Token 8c419cf4...675b1dc14cce has been saved in the database
2021-04-19 23:24:39,002 DEBUG token.state (DefaultTokenStateService.java:addToken(144)) - Added token 8c419cf4...675b1dc14cce, expiration 2021-05-19T21:24:38.978Z
2021-04-19 23:24:39,011 DEBUG token.state (JDBCTokenStateService.java:addMetadata(186)) - Updated metadata for 8c419cf4...675b1dc14cce in the database
2021-04-19 23:24:39,012 DEBUG service.knoxtoken (TokenResource.java:getAuthenticationToken(446)) - Knox Token service (homepage) stored state for token eyJhbG...WdNDTw (8c419cf4...675b1dc14cce)

postgres=# select * FROM KNOX_TOKENS where token_id LIKE '8c419cf4%';
               token_id               |  issue_time   |  expiration   | max_lifetime  | username | comment 
--------------------------------------+---------------+---------------+---------------+----------+---------
 8c419cf4-ff57-4412-93dd-675b1dc14cce | 1618867478983 | 1621459478978 | 1619472278983 | admin    | 
(1 row)
```

2. Renewed the previously acquired token:
```
$ curl -ku admin:admin-password -d "@token.txt" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/renew
{
  "renewed": "true",
  "expires": "1618954035727"
}

2021-04-19 23:27:15,711 DEBUG knox.gateway (GatewayFilter.java:doFilter(116)) - Received request: POST /knoxtoken/api/v1/token/renew
2021-04-19 23:27:15,713 INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=admin,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: admin
2021-04-19 23:27:15,740 DEBUG token.state (JDBCTokenStateService.java:updateExpiration(108)) - Updated expiration for 8c419cf4...675b1dc14cce in the database to 1,618,954,035,727
2021-04-19 23:27:15,740 DEBUG token.state (DefaultTokenStateService.java:renewToken(219)) - Renewed token 8c419cf4...675b1dc14cce, expiration 2021-04-20T21:27:15.727Z
2021-04-19 23:27:15,741 INFO  service.knoxtoken (TokenResource.java:renew(280)) - Knox Token service (sandbox) renewed the expiration for token eyJhbG...WdNDTw (8c419cf4...675b1dc14cce) (renewer=admin)

postgres=# select * FROM KNOX_TOKENS where token_id LIKE '8c419cf4%';
               token_id               |  issue_time   |  expiration   | max_lifetime  | username | comment 
--------------------------------------+---------------+---------------+---------------+----------+---------
 8c419cf4-ff57-4412-93dd-675b1dc14cce | 1618867478983 | 1618954035727 | 1619472278983 | admin    | 
(1 row)
```
3. Used that token to list `WEBHDFS` status. This time the configured `WEBHDFS` backend pointed to a non-existing cluster, but the point is that the supplied `Passcode` token could be validated. I also covered this case by restarting Knox and repeated the same step, so that a DB lookup was necessary as the token was not available in the in-memory collections:
```
$ curl -ku Passcode:8c419cf4-ff57-4412-93dd-675b1dc14cce https://localhost:8443/gateway/tokenbased/webhdfs/v1?op=LISTSTATUS
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 500 java.io.IOException: Service connectivity error.</title>
</head>
...
</html>


2021-04-19 23:32:49,216 DEBUG knox.gateway (GatewayFilter.java:doFilter(116)) - Received request: GET /webhdfs/v1
2021-04-19 23:32:49,336 DEBUG token.state (JDBCTokenStateService.java:getTokenExpiration(90)) - Fetched expiration for 8c419cf4...675b1dc14cce from the database : 1,618,954,035,727
2021-04-19 23:32:49,343 DEBUG token.state (JDBCTokenStateService.java:getTokenMetadata(215)) - Fetched metadata for 8c419cf4...675b1dc14cce from the database

postgres=# select * FROM KNOX_TOKENS where token_id LIKE '8c419cf4%';
               token_id               |  issue_time   |  expiration   | max_lifetime  | username | comment 
--------------------------------------+---------------+---------------+---------------+----------+---------
 8c419cf4-ff57-4412-93dd-675b1dc14cce | 1618867478983 | 1618954035727 | 1619472278983 | admin    | 
(1 row)
```
4. Revoked that token:
```
$ curl -ku admin:admin-password -d "@token.txt" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/revoke
{
  "revoked": "true"
}


2021-04-19 23:34:36,081 DEBUG knox.gateway (GatewayFilter.java:doFilter(116)) - Received request: POST /knoxtoken/api/v1/token/revoke
2021-04-19 23:34:36,124 INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=admin,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: admin
2021-04-19 23:34:36,808 DEBUG token.state (DefaultTokenStateService.java:removeTokenState(290)) - Removed state for tokens 8c419cf4...675b1dc14cce
2021-04-19 23:34:36,808 DEBUG token.state (JDBCTokenStateService.java:removeToken(159)) - Token 8c419cf4...675b1dc14cce has been removed from the database
2021-04-19 23:34:36,809 DEBUG token.state (DefaultTokenStateService.java:revokeToken(244)) - Revoked token 8c419cf4...675b1dc14cce
2021-04-19 23:34:36,809 INFO  service.knoxtoken (TokenResource.java:revoke(327)) - Knox Token service (sandbox) revoked token eyJhbG...WdNDTw (8c419cf4...675b1dc14cce) (renewer=admin)

postgres=# select * FROM KNOX_TOKENS where token_id LIKE '8c419cf4%';
 token_id | issue_time | expiration | max_lifetime | username | comment 
----------+------------+------------+--------------+----------+---------
(0 rows)
```

I also let the Knox Gateway running for the long weekend and confirmed that expired tokens got removed by the reaper thread.