### PR TITLE
KNOX-2578 - TokenResource logging token UUIDs

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -261,7 +261,9 @@ public class TokenResource {
       // If the token state service is disabled, then return the expiration from the specified token
       try {
         JWTToken jwt = new JWTToken(token);
-        log.renewalDisabled(getTopologyName(), Tokens.getTokenDisplayText(token), TokenUtils.getTokenId(jwt));
+        log.renewalDisabled(getTopologyName(),
+                            Tokens.getTokenDisplayText(token),
+                            Tokens.getTokenIDDisplayText(TokenUtils.getTokenId(jwt)));
         expiration = Long.parseLong(jwt.getExpires());
       } catch (ParseException e) {
         log.invalidToken(getTopologyName(), Tokens.getTokenDisplayText(token), e);
@@ -279,7 +281,7 @@ public class TokenResource {
                                                     renewInterval.orElse(tokenStateService.getDefaultRenewInterval()));
           log.renewedToken(getTopologyName(),
                            Tokens.getTokenDisplayText(token),
-                           TokenUtils.getTokenId(jwt),
+                           Tokens.getTokenIDDisplayText(TokenUtils.getTokenId(jwt)),
                            renewer);
         } catch (ParseException e) {
           log.invalidToken(getTopologyName(), Tokens.getTokenDisplayText(token), e);
@@ -326,7 +328,7 @@ public class TokenResource {
           tokenStateService.revokeToken(jwt);
           log.revokedToken(getTopologyName(),
                            Tokens.getTokenDisplayText(token),
-                           TokenUtils.getTokenId(jwt),
+                           Tokens.getTokenIDDisplayText(TokenUtils.getTokenId(jwt)),
                            renewer);
         } catch (ParseException e) {
           log.invalidToken(getTopologyName(), Tokens.getTokenDisplayText(token), e);
@@ -416,7 +418,7 @@ public class TokenResource {
       if (token != null) {
         String accessToken = token.toString();
         String tokenId = TokenUtils.getTokenId(token);
-        log.issuedToken(getTopologyName(), Tokens.getTokenDisplayText(accessToken), tokenId);
+        log.issuedToken(getTopologyName(), Tokens.getTokenDisplayText(accessToken), Tokens.getTokenIDDisplayText(tokenId));
 
         HashMap<String, Object> map = new HashMap<>();
         map.put(ACCESS_TOKEN, accessToken);
@@ -443,7 +445,7 @@ public class TokenResource {
                                      expires,
                                      maxTokenLifetime.orElse(tokenStateService.getDefaultMaxLifetimeDuration()));
           tokenStateService.addMetadata(tokenId, new TokenMetadata(p.getName()));
-          log.storedToken(getTopologyName(), Tokens.getTokenDisplayText(accessToken), tokenId);
+          log.storedToken(getTopologyName(), Tokens.getTokenDisplayText(accessToken), Tokens.getTokenIDDisplayText(tokenId));
         }
 
         return Response.ok().entity(jsonResponse).build();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace the logging of Knox token UUIDs in TokenResource with masked representations which are safe to present in logs.

## How was this patch tested?

mvn -Ppackage,release clean install

1. Installed the gateway and enabled DEBUG logging.
2. Deployed the KNOXTOKEN service with server-managed state enabled.
3. Deployed a topology with the JWTProvider (server-managed state enabled) and WEBHDFS.
4. Requested a token.
5. curl -ivku Token:$TOKEN "https://localhost:8443/gateway/pz-demo/webhdfs/v1/?op=LISTSTATUS"
6. curl -ivku Passcode:$PASSCODE "https://localhost:8443/gateway/pz-demo/webhdfs/v1/tmp?op=LISTSTATUS"
7. Performed the same with invalid token/passcode (to verify UnknownTokenException contents).
8. Grepped the logs for (\S){8}-(\S){4}-(\S){4}-(\S){4}-(\S){12} - confirmed no matches
9. Grepped the logs for (\S){8}\.{3}(\S){12} - confirmed matches
