### PR TITLE
KNOX-2577 - In Livy UI, make application and container log links point to YARN UI v2

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.3/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.3/rewrite.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+  <!-- These should be removed at some point since Livy
+       doesn't have /v1 in the REST API specification -->
+  <rule dir="IN" name="LIVYSERVER/livy/root/v1/inbound/" pattern="*://*:*/**/livy/v1">
+    <rewrite template="{$serviceUrl[LIVYSERVER]}"/>
+  </rule>
+  <rule dir="IN" name="LIVYSERVER/livy/path/v1/inbound" pattern="*://*:*/**/livy/v1/{path=**}?{**}">
+    <rewrite template="{$serviceUrl[LIVYSERVER]}/{path=**}?{**}"/>
+  </rule>
+
+  <!-- Prefer these rules without v1 in the url -->
+  <rule dir="IN" name="LIVYSERVER/livy/root/inbound" pattern="*://*:*/**/livy">
+    <rewrite template="{$serviceUrl[LIVYSERVER]}"/>
+  </rule>
+  <rule dir="IN" name="LIVYSERVER/livy/path/inbound" pattern="*://*:*/**/livy/{path=**}?{**}">
+    <rewrite template="{$serviceUrl[LIVYSERVER]}/{path=**}?{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/sparkurl" pattern="*://*:*/proxy/{**}">
+    <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}"/>
+  </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/logs" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
+    <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{**}?{scheme}?host={$hostmap(host)}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/logs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}">
+    <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{scheme}?host={$hostmap(host)}?{port}"/>
+  </rule>
+
+  <rule dir="OUT" name="LIVYSERVER/livy/outbound/headers/ui" pattern="{scheme}://{host}:{port}/ui/">
+    <rewrite template="{$frontend[url]}/livy/ui/"/>
+  </rule>
+
+  <filter name="LIVYSERVER/livy/outbound/headers">
+    <content type="application/x-http-headers">
+      <apply path="Location" rule="LIVYSERVER/livy/outbound/headers/ui"/>
+    </content>
+  </filter>
+
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.3/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.3/service.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="LIVYSERVER" name="livy" version="0.4.3">
+  <metadata>
+    <type>API_AND_UI</type>
+    <context>/livy</context>
+    <shortDesc>Livy Server</shortDesc>
+    <description>Apache Livy is a service that enables easy interaction with a Spark cluster over a REST interface.</description>
+  </metadata>
+  <routes>
+    <route path="/livy/**?**"/>
+    <route path="/livy">
+      <rewrite apply="LIVYSERVER/livy/outbound/headers" to="response.headers"/>
+    </route>
+    <route path="/livy/">
+      <rewrite apply="LIVYSERVER/livy/outbound/headers" to="response.headers"/>
+    </route>
+  </routes>
+  <dispatch classname="org.apache.knox.gateway.livy.LivyDispatch"/>
+</service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the Livy UI, there are links to the Spark application and the driver log. They point to the old YARN UI.
Make the links point to the YARN UI v2.

## How was this patch tested?

Manually modified the rewrite.xml in a Knox gateway and tested the links.