### PR TITLE
KNOX-2596 - Changed gateway-site config value to support PostgeSQL as token state backend

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
@@ -26,13 +26,13 @@ import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.postgresql.ds.PGSimpleDataSource;
 
 public class JDBCUtils {
-  public static final String POSTGRES_DB_TYPE = "postgres";
+  public static final String POSTGRESQL_DB_TYPE = "postgresql";
   public static final String DERBY_DB_TYPE = "derbydb";
   public static final String DATABASE_USER_ALIAS_NAME = "gateway_database_user";
   public static final String DATABASE_PASSWORD_ALIAS_NAME = "gateway_database_password";
 
   public static DataSource getDataSource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
-    if (POSTGRES_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
+    if (POSTGRESQL_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
       return createPostgresDataSource(gatewayConfig, aliasService);
     } else if (DERBY_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
       return createDerbyDatasource(gatewayConfig, aliasService);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
@@ -33,7 +33,7 @@ public class JDBCUtilsTest {
   @Test
   public void shouldReturnPostgresDataSource() throws Exception {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
-    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRES_DB_TYPE).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRESQL_DB_TYPE).anyTimes();
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(EasyMock.anyString())).andReturn(null).anyTimes();
     EasyMock.replay(gatewayConfig, aliasService);
@@ -43,7 +43,7 @@ public class JDBCUtilsTest {
   @Test
   public void postgresDataSourceShouldHaveProperConnectionProperties() throws AliasServiceException {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
-    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRES_DB_TYPE).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRESQL_DB_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
     EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(5432).anyTimes();
     EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("sampleDatabase");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the expected `gateway.database.type` value for PostgreSQL.

## How was this patch tested?

Updated the relevant JUnit test and executed a manual test round locally.