### PR TITLE
KNOX-2544 - Token-based providers should cache successful (including …

### DIFF
--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -33,6 +33,7 @@ import org.apache.knox.gateway.GatewayFilter;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
+import org.apache.knox.gateway.provider.federation.jwt.filter.SignatureVerificationCache;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.topology.Topology;
@@ -171,10 +172,11 @@ public class HadoopAuthFilterTest {
       expect(filterConfig.getInitParameter(JWTFederationFilter.TOKEN_VERIFICATION_PEM)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_ISSUER)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_SIGALG)).andReturn(null).anyTimes();
-      expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_VERIFIED_CACHE_MAX)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(SignatureVerificationCache.JWT_VERIFIED_CACHE_MAX)).andReturn(null).anyTimes();
     }
 
     final ServletContext servletContext = createMock(ServletContext.class);
+    expect(servletContext.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn("test").anyTimes();
     expect(servletContext.getAttribute("signer.secret.provider.object")).andReturn(null).atLeastOnce();
     if (isJwtSupported) {
       expect(servletContext.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(null).anyTimes();

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -73,4 +73,7 @@ public interface JWTMessages {
             text = "Missing token passcode." )
   void missingTokenPasscode();
 
+  @Message( level = MessageLevel.INFO, text = "Initialized token signature verification cache for the {0} topology." )
+  void initializedSignatureVerificationCache(String topology);
+
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SignatureVerificationCache.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SignatureVerificationCache.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.provider.federation.jwt.filter;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
+
+import javax.servlet.FilterConfig;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A shared record of tokens for which the signature has been verified.
+ */
+public class SignatureVerificationCache {
+
+    public static final String JWT_VERIFIED_CACHE_MAX = "jwt.verified.cache.max";
+    public static final int    JWT_VERIFIED_CACHE_MAX_DEFAULT = 250;
+
+    static final String DEFAULT_CACHE_ID = "default-cache";
+
+    static JWTMessages log = MessagesFactory.get( JWTMessages.class );
+
+    private static final ConcurrentHashMap<String, SignatureVerificationCache> instances = new ConcurrentHashMap<>();
+
+    private Cache<String, Boolean> verifiedTokens;
+
+    /**
+     * Caches are topology-specific because the configuration is defined at the provider level.
+     *
+     * @param topology The topology for which the cache is being requested, or null if the default is sufficient.
+     * @param config   The FilterConfig associated with the calling provider.
+     *
+     * @return A SignatureVerificationCache for the specified topology, or the default one if no topology is specified.
+     */
+    @SuppressWarnings("PMD.SingletonClassReturningNewInstance")
+    public static SignatureVerificationCache getInstance(final String topology, final FilterConfig config) {
+        String cacheId = topology != null ? topology : DEFAULT_CACHE_ID;
+        return instances.computeIfAbsent(cacheId, c -> initializeCacheForTopology(cacheId, config));
+    }
+
+    private static SignatureVerificationCache initializeCacheForTopology(final String topology, final FilterConfig config) {
+        SignatureVerificationCache cache = new SignatureVerificationCache(config);
+        log.initializedSignatureVerificationCache(topology);
+        return cache;
+    }
+
+    private SignatureVerificationCache(final FilterConfig config) {
+        initializeVerifiedTokensCache(config);
+    }
+
+    /**
+     * Initialize the cache for token verification records.
+     *
+     * @param config The configuration of the provider employing this cache.
+     */
+    private void initializeVerifiedTokensCache(final FilterConfig config) {
+        int maxCacheSize = JWT_VERIFIED_CACHE_MAX_DEFAULT;
+
+        String configValue = config.getInitParameter(JWT_VERIFIED_CACHE_MAX);
+        if (configValue != null && !configValue.isEmpty()) {
+            try {
+                maxCacheSize = Integer.parseInt(configValue);
+            } catch (NumberFormatException e) {
+                log.invalidVerificationCacheMaxConfiguration(configValue);
+            }
+        }
+
+        verifiedTokens = Caffeine.newBuilder().maximumSize(maxCacheSize).build();
+    }
+
+    /**
+     * Determine if the specified JWT's signature has previously been successfully verified.
+     *
+     * @param jwt A serialized JWT.
+     *
+     * @return true, if the specified token has been previously verified; Otherwise, false.
+     */
+    public boolean hasSignatureBeenVerified(final String jwt) {
+        return (verifiedTokens.getIfPresent(jwt) != null);
+    }
+
+    /**
+     * Record a successful token signature verification.
+     *
+     * @param jwt A serialized JWT for which the signature has been successfully verified.
+     */
+    public void recordSignatureVerification(final String jwt) {
+        verifiedTokens.put(jwt, true);
+    }
+
+    /**
+     * Explicitly evict the signature verification record from the cache if it exists.
+     *
+     * @param jwt The serialized JWT for which the associated signature verification record should be evicted.
+     */
+    public void removeSignatureVerificationRecord(final String jwt) {
+         verifiedTokens.asMap().remove(jwt);
+    }
+
+    /**
+     * @return The size of the cache.
+     */
+    public long getSize() {
+        return verifiedTokens.estimatedSize();
+    }
+
+    /**
+     * Remove any entries which should be evicted from the cache.
+     */
+    public void performMaintenance() {
+        verifiedTokens.cleanUp();
+    }
+
+    /**
+     * Clear the contents of the cache.
+     */
+    public void clear() {
+        verifiedTokens.asMap().clear();
+    }
+}

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TestFilterConfig.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TestFilterConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.provider.federation;
+
+import org.apache.knox.gateway.services.GatewayServices;
+import org.easymock.EasyMock;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import java.util.Enumeration;
+import java.util.Properties;
+
+public class TestFilterConfig implements FilterConfig {
+    public static final String TOPOLOGY_NAME_PROP = "test-topology-name";
+
+    Properties props;
+
+    public TestFilterConfig() {
+        this.props = new Properties();
+    }
+
+    public TestFilterConfig(Properties props) {
+        this.props = props;
+    }
+
+    @Override
+    public String getFilterName() {
+        return null;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        String topologyName = props.getProperty(TOPOLOGY_NAME_PROP);
+        if (topologyName == null) {
+            topologyName = "jwt-test-topology";
+        }
+        ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+        EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn(topologyName).anyTimes();
+        EasyMock.replay(context);
+        return context;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return props.getProperty(name, null);
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        return null;
+    }
+
+}

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -314,6 +314,11 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
         // Override to disable N/A test
     }
 
+    @Override
+    public void testVerificationOptimization_NoTokenID() throws Exception {
+        // Override to disable N/A test
+    }
+
     /**
      * Very basic TokenStateService implementation for these tests only
      */

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTTestUtils.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTTestUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.provider.federation.jwt.filter;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Date;
+import java.util.UUID;
+
+public class JWTTestUtils {
+
+    public static SignedJWT getJWT(String issuer, String sub, Date expires, RSAPrivateKey privateKey)
+            throws Exception {
+        return getJWT(issuer, sub, expires, new Date(), privateKey, JWSAlgorithm.RS256.getName());
+    }
+
+    public static SignedJWT getJWT(String issuer, String sub, Date expires, Date nbf, RSAPrivateKey privateKey,
+                               String signatureAlgorithm)
+            throws Exception {
+        return getJWT(issuer, sub, "bar", expires, nbf, privateKey, signatureAlgorithm);
+    }
+
+    public static SignedJWT getJWT(String issuer, String sub, String aud, Date expires, Date nbf, RSAPrivateKey privateKey,
+                               String signatureAlgorithm) throws Exception {
+        return getJWT(issuer, sub, aud, expires, nbf, privateKey, signatureAlgorithm, String.valueOf(UUID.randomUUID()));
+    }
+
+    public static SignedJWT getJWT(final String issuer,
+                                   final String sub,
+                                   final String aud,
+                                   final Date expires,
+                                   final Date nbf,
+                                   final RSAPrivateKey privateKey,
+                                   final String signatureAlgorithm,
+                                   final String knoxId)
+            throws Exception {
+        JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder();
+        builder.issuer(issuer)
+                .subject(sub)
+                .audience(aud)
+                .expirationTime(expires)
+                .notBeforeTime(nbf)
+                .claim("scope", "openid");
+        if (knoxId != null) {
+            builder.claim(JWTToken.KNOX_ID_CLAIM, knoxId);
+        }
+        JWTClaimsSet claims = builder.build();
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.parse(signatureAlgorithm)).build();
+
+        SignedJWT signedJWT = new SignedJWT(header, claims);
+        JWSSigner signer = new RSASSASigner(privateKey);
+
+        signedJWT.sign(signer);
+
+        return signedJWT;
+    }
+
+}

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/SignatureVerificationCacheTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/SignatureVerificationCacheTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.provider.federation.jwt.filter;
+
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.knox.gateway.provider.federation.TestFilterConfig;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SignatureVerificationCacheTest {
+
+    private static RSAPrivateKey privateKey;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair KPair = kpg.generateKeyPair();
+        privateKey = (RSAPrivateKey) KPair.getPrivate();
+    }
+
+    /**
+     * Verify that the default SignatureVerificationCache instance is returned when no topology is specified.
+     */
+    @Test
+    public void testSignatureVerificationCacheWithoutTopology() throws Exception {
+        SignatureVerificationCache cache = SignatureVerificationCache.getInstance(null, new TestFilterConfig());
+        assertNotNull(cache);
+        SignatureVerificationCache defaultCache =
+            SignatureVerificationCache.getInstance(SignatureVerificationCache.DEFAULT_CACHE_ID, new TestFilterConfig());
+        assertNotNull(defaultCache);
+        assertEquals("Expected the default cache when no topology is specified.", defaultCache, cache);
+    }
+
+    /**
+     * Verify that the topology-specific SignatureVerificationCache instance is returned when a topology is specified.
+     */
+    @Test
+    public void testSignatureVerificationCacheForTopology() throws Exception {
+        final String topologyName = "test-topology-explicit";
+        final Properties filterProps = new Properties();
+        filterProps.setProperty(TestFilterConfig.TOPOLOGY_NAME_PROP, topologyName);
+        final TestFilterConfig filterConfig = new TestFilterConfig(filterProps);
+
+        SignatureVerificationCache ref1 = SignatureVerificationCache.getInstance(topologyName, filterConfig);
+        assertNotNull(ref1);
+
+        SignatureVerificationCache ref2 = SignatureVerificationCache.getInstance(topologyName, filterConfig);
+        assertNotNull(ref2);
+        assertEquals("Expected the same cache when the same topology is explicitly specified.", ref1, ref2);
+
+        SignatureVerificationCache ref3 = SignatureVerificationCache.getInstance(topologyName + "-2", filterConfig);
+        assertNotNull(ref3);
+        assertNotEquals("Expected a different cache when a different topology is explicitly specified.", ref2, ref3);
+    }
+
+    @Test
+    public void testSignatureVerificationCacheLifecycle() throws Exception {
+        final String topologyName = "test-topology-lifecycle";
+        final Properties filterProps = new Properties();
+        filterProps.setProperty(TestFilterConfig.TOPOLOGY_NAME_PROP, topologyName);
+        final TestFilterConfig filterConfig = new TestFilterConfig(filterProps);
+
+        SignatureVerificationCache cache = SignatureVerificationCache.getInstance(topologyName, filterConfig);
+        assertNotNull(cache);
+
+        // Create a JWT
+        SignedJWT jwt = createTestJWT();
+        String serializedJWT = jwt.serialize();
+
+        // Verify that there is not yet any signature verification record for this JWT
+        assertFalse("JWT signature verification should NOT have been recored yet.",
+                    cache.hasSignatureBeenVerified(serializedJWT));
+
+        // Record the signature verification for this JWT
+        cache.recordSignatureVerification(serializedJWT);
+        assertTrue("JWT signature verification should have been recored yet.",
+                    cache.hasSignatureBeenVerified(serializedJWT));
+
+        // Explicitly remove the signature verification record for this JWT
+        cache.removeSignatureVerificationRecord(serializedJWT);
+        assertFalse("JWT signature verification record should no longer be in the cache.",
+                    cache.hasSignatureBeenVerified(serializedJWT));
+    }
+
+    @Test
+    public void testSignatureVerificationCacheClear() throws Exception {
+        final int jwtCount = 5;
+        final String topologyName = "test-topology-clear";
+        final Properties filterProps = new Properties();
+        filterProps.setProperty(TestFilterConfig.TOPOLOGY_NAME_PROP, topologyName);
+        final TestFilterConfig filterConfig = new TestFilterConfig(filterProps);
+
+        SignatureVerificationCache cache = SignatureVerificationCache.getInstance(topologyName, filterConfig);
+        assertNotNull(cache);
+
+        // Create test JWTs
+        List<SignedJWT> testJWTs = new ArrayList<>();
+        List<String> serializedJWTs = new ArrayList<>();
+        for (int i = 0 ; i < jwtCount ; i++) {
+            testJWTs.add(createTestJWT());
+            serializedJWTs.add(testJWTs.get(i).serialize());
+        }
+
+        // Verify that there is not yet any signature verification record for the test JWTs
+        assertEquals("There should not yet be any records in the cache.", 0, cache.getSize());
+
+        // Record the signature verification for the test JWTs
+        for (int i = 0 ; i < jwtCount ; i++) {
+            cache.recordSignatureVerification(serializedJWTs.get(i));
+        }
+        assertEquals("Unexpected cache size.", jwtCount, cache.getSize());
+
+        // Explicitly remove all signature verification records from the cache
+        cache.clear();
+        assertEquals("Cache should be empty after clear() is invoked.", 0, cache.getSize());
+
+        // Verify that there is no longer any signature verification record for the test JWTs
+        for (int i = 0 ; i < jwtCount ; i++) {
+            assertFalse("JWT signature verification record should no longer be in the cache.",
+                        cache.hasSignatureBeenVerified(serializedJWTs.get(i)));
+        }
+    }
+
+    private SignedJWT createTestJWT() throws Exception {
+        return JWTTestUtils.getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER,
+                                   "alice",
+                                   new Date(System.currentTimeMillis() + 5000),
+                                   privateKey);
+    }
+
+}


### PR DESCRIPTION
…3rd-party) token verifications

## What changes were proposed in this pull request?

This is a return to KNOX-2544 to address some shortcomings with the previous attempt. With these changes:
- Third-party JWTs (any without the internal Knox UUID) are supported in the signature verification caching optimization.
- The cache has been separated from the JWT providers, such that it can be shared by multiple instances of the same JWT provider associated with the a single topology. The caches are still topology specific; They're just no longer bound to a single JWT provider(i.e., filter) instance.

## How was this patch tested?

- `mvn -Ppackage,release clean install`
- Modified AbstractJWTFilterTest and HadoopAuthFilterTest
- Added org.apache.knox.gateway.provider.federation.jwt.filter.SignatureVerificationCacheTest
- Still performing manual testing, but wanted to get the review started.
