### PR TITLE
KNOX-2597 - Falling back to AliasBasedTokenStateService in case of DB configuration issues

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -46,14 +46,18 @@
         </script>
 
     </head>
-    <body class="login" style="">
+    <body class="login" style="" onload="setTokenStateServiceStatus()">
         <!-- Page content
         ================================================== -->
+
         <section id="signin-container" style="margin-top: 4.5px;">
             <form action="" method="get" accept-charset="utf-8">
                 <fieldset>
                     <div class="fields">
                         <h3>Token Generation</h3>
+                        <label id="tokenStateServiceStatusInfo" style="color: green;"></label>
+                        <label id="tokenStateServiceStatusError" style="color: red;"></label>
+                        <label id="tokenStateServiceStatusWarning" style="color: yellow;"></label>
                         <label><i class="icon-info"></i> Token Generation enables integration and API invocations by using the
                          token as an authorization bearer token. Copy the JWT token from the resulting text area and protect it
                          securely from others as this token represents your identity and is active until expired.</label>

--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -52,6 +52,63 @@ function b64DecodeUnicode(str) {
     }).join(''));
 }
 
+function displayInfo(infoMsg) {
+    $('#tokenStateServiceStatusInfo').show();
+    $('#tokenStateServiceStatusInfo').text(infoMsg);
+    $('#tokenStateServiceStatusError').hide();
+    $('#tokenStateServiceStatusWarning').hide();
+}
+
+function displayWarning(warningMsg) {
+    $('#tokenStateServiceStatusWarning').show();
+    $('#tokenStateServiceStatusWarning').text(warningMsg);
+    $('#tokenStateServiceStatusError').hide();
+    $('#tokenStateServiceStatusInfo').hide();
+}
+
+function disableTokenGen(errorMsg) {
+    $('#tokenStateServiceStatusError').show();
+    $('#tokenStateServiceStatusError').text(errorMsg);
+    $('#tokenStateServiceStatusInfo').hide();
+    $('#tokenStateServiceStatusWarning').hide();
+    document.getElementById('genToken').disabled = true;
+    document.getElementById('lifespan').disabled = true;
+}
+
+function setTokenStateServiceStatus() {
+    var pathname = window.location.pathname;
+    var topologyContext = pathname.replace(loginPageSuffix, "");
+    var baseURL = topologyContext.substring(0, topologyContext.lastIndexOf('/'));
+    baseURL = baseURL.substring(0, baseURL.lastIndexOf('/') + 1);
+    var getTssStausURL = topologyContext + 'knoxtoken/api/v1/token/getTssStatus';
+    var request = ((window.XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"));
+    request.open("GET", getTssStausURL, true);
+    request.send(null);
+    request.onreadystatechange = function() {
+        if (request.readyState == 4) {
+            if (request.status==200) {
+                var resp = JSON.parse(request.responseText);
+                var tokenManagementEnabled = resp.tokenManagementEnabled;
+                if (tokenManagementEnabled === 'true') {
+                    var allowedTssForTokengen = resp.allowedTssForTokengen;
+                    if (allowedTssForTokengen == 'true') {
+                        var actualTssBackend = resp.actualTssBackend;
+                        if (actualTssBackend == 'AliasBasedTokenStateService') {
+                            displayWarning('Token management backend is configured to store tokens in keystores. This is only valid non-HA environments!');
+                        } else {
+                            displayInfo('Token management backend is properly configured for HA and production deployments.');
+                        }
+                    } else {
+                        disableTokenGen('Token management backend initialization failed, token generation disabled.');
+                    }
+                } else {
+                    disableTokenGen('Token management is disabled');
+                }
+            }
+        }
+    }
+}
+
 var gen = function() {
     var pathname = window.location.pathname;
     var topologyContext = pathname.replace(loginPageSuffix, "");;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -710,4 +710,7 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.INFO, text = "Using {0} implementation for {1}")
   void usingServiceImplementation(String implementation, String serviceType);
+
+  @Message(level = MessageLevel.ERROR, text = "Error while initiatalizing {0}: {1}")
+  void errorInitializingService(String implementation, String error, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following features are implemented by this change:
- if there is a misconfiguration in JDBCTokenState service, the AliasBasedTokenStateService is going to be used instead of failing the Knox Gateway at startup
- a new REST API is added to get the status of the token management backend
- on the `tokengen` UI there is new information displayed about token management

## How was this patch tested?

Updated and executed JUnit test. I also run manual testing:

1. Token management is disabled in the `homepage` topology
<img width="590" alt="Screen Shot 2021-04-29 at 10 25 03 AM" src="https://user-images.githubusercontent.com/34065904/116528018-99688480-a8db-11eb-838a-ab61abf2f4c9.png">

2. Token management is set to DB, but I misconfigured it in `gateway-site.xml` -> falling back to `AliasBasedtokenStateService`
<img width="592" alt="Screen Shot 2021-04-29 at 10 21 13 AM" src="https://user-images.githubusercontent.com/34065904/116527966-8c4b9580-a8db-11eb-8eb6-cb7d9c43bc3a.png">

3. Token management is set to DB, but I misconfigured it in `gateway-site.xml` -> falling back to `AliasBasedtokenStateService`. I also set `knox.token.exp.tokengen.allowed.tss.backends` in the `homepage.xml` to `JDBCTokenStateService`
<img width="584" alt="Screen Shot 2021-04-29 at 10 28 15 AM" src="https://user-images.githubusercontent.com/34065904/116528118-b9984380-a8db-11eb-8957-47daf53e81c4.png">

4. Token management is set to DB and made sure it's properly configured
<img width="585" alt="Screen Shot 2021-04-29 at 10 27 16 AM" src="https://user-images.githubusercontent.com/34065904/116528132-be5cf780-a8db-11eb-9f94-0178e6063e8c.png">
