### PR TITLE
KNOX-2598 - Added SSL connection support for PostgreSQL database type in JDBC token state management

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -277,6 +277,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String GATEWAY_DATABASE_HOST =  GATEWAY_CONFIG_FILE_PREFIX + ".database.host";
   private static final String GATEWAY_DATABASE_PORT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.port";
   private static final String GATEWAY_DATABASE_NAME =  GATEWAY_CONFIG_FILE_PREFIX + ".database.name";
+  private static final String GATEWAY_DATABASE_SSL_ENABLED =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.enabled";
+  private static final String GATEWAY_DATABASE_VERIFY_SERVER_CERT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.verify.server.cert";
+  private static final String GATEWAY_DATABASE_TRUSTSTORE_FILE =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.truststore.file";
 
   public GatewayConfigImpl() {
     init();
@@ -1258,4 +1261,20 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public String getDatabaseName() {
     return get(GATEWAY_DATABASE_NAME, "GATEWAY_DATABASE");
   }
+
+  @Override
+  public boolean isDatabaseSslEnabled() {
+    return getBoolean(GATEWAY_DATABASE_SSL_ENABLED, false);
+  }
+
+  @Override
+  public boolean verifyDatabaseSslServerCertificate() {
+    return getBoolean(GATEWAY_DATABASE_VERIFY_SERVER_CERT, true);
+  }
+
+  @Override
+  public String getDatabaseSslTruststoreFileName() {
+    return get(GATEWAY_DATABASE_TRUSTSTORE_FILE);
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -756,4 +756,10 @@ public interface GatewayConfig {
 
   String getDatabaseName();
 
+  boolean isDatabaseSslEnabled();
+
+  boolean verifyDatabaseSslServerCertificate();
+
+  String getDatabaseSslTruststoreFileName();
+
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -874,4 +874,22 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return null;
   }
 
+
+  @Override
+  public boolean isDatabaseSslEnabled() {
+    return false;
+  }
+
+
+  @Override
+  public boolean verifyDatabaseSslServerCertificate() {
+    return false;
+  }
+
+
+  @Override
+  public String getDatabaseSslTruststoreFileName() {
+    return null;
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Made it possible to connect to an SSL-enabled PostgreSQL server using an SSL connection. To be able to achieve our goals here I needed to introduce the following `gateway-site.xml` configuration:
- `gateway.database.ssl.enabled` - whether SSL should be enabled when connection to the configured PostgreSQL server. Defaults to `false`.
- `gateway.database.ssl.verify.server.cert` - a boolean flag that may allows SSL connections to be made without validating the server's certificate. This is more convenient for some applications but is less secure as it allows "man in the middle" attacks. Defaults to `true` (i.e. the server's certificate is validated by default)
- `gateway.database.ssl.truststore.file` - the SSL root certificate's file path (only used if `gateway.database.ssl.verify.server.cert=true`)

The password for `gateway.database.ssl.truststore.file` must be stored as `gateway_database_ssl_truststore_password` alias for the Gateway.

## How was this patch tested?

Updated and ran JUnit tests. In addition to unit testing I also executed manual testing as follows:
1. re-configured my local PostgreSQL server to enable SSL
2. confirmed that I can connect to the server using SSL:
```
$ export PGSSLCERT=/usr/local/var/postgresql\@10/data/root.crt; export PGSSLKEY=/usr/local/var/postgresql\@10/data/server.key; psql "sslmode=verify-full host=smolnar-MBP15.local dbname=postgres"
psql (13.2, server 10.16)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, bits: 256, compression: off)
Type "help" for help.

postgres=# select * from knox_tokens;
               token_id               |  issue_time   |  expiration   | max_lifetime  | username | comment 
--------------------------------------+---------------+---------------+---------------+----------+---------
 d4ad8ccf-551d-4440-812f-a719e5b12e14 | 1619467272691 | 1622059272678 | 1620072072691 | admin    | 
(5 rows)
```
3. Redeployed the Knox Gateway and configured `JDBCTokenStateService` as token management backend (non-SSL this time):
```
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.JDBCTokenStateService</value>
    </property>
     <property>
        <name>gateway.database.type</name>
        <value>postgresql</value>
    </property>
    <property>
        <name>gateway.database.host</name>
        <value>smolnar-MBP15.local</value>
    </property>
    <property>
        <name>gateway.database.port</name>
        <value>5432</value>
    </property>
    <property>
        <name>gateway.database.name</name>
        <value>postgres</value>
    </property>
```
4. Started the server, generated a token, and confirmed it was saved in the DB.
5. Created the `gateway_database_ssl_truststore_password` using `knoxcli`
5. Enabled SSL connection (`gateway.database.ssl.enabled = true`, `gateway.database.ssl.truststore.file = /usr/local/var/postgresql@10/data/root.crt`) and repeated step 4.
6. Disabled server certificate validation (`gateway.database.ssl.verify.server.cert = false`) and repeated step 4.

