### PR TITLE
KNOX-2599 - Improve tokengen UI

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -61,10 +61,10 @@
                         <label><i class="icon-info"></i> Token Generation enables integration and API invocations by using the
                          token as an authorization bearer token. Copy the JWT token from the resulting text area and protect it
                          securely from others as this token represents your identity and is active until expired.</label>
-                        <!--
+
                         <label><i class="icon-comment"></i> Comment:</label>
-                        <input type="text" name="comment" id="comment" tabindex="1" onkeypress=keypressed(event) autofocus>
-                        -->
+                        <input type="text" name="comment" id="comment" tabindex="1" onkeypress=keypressed(event) autofocus size="255">
+
                         <label><i class="icon-time"></i> Lifetime (days, hours, mins):</label>
                         <table>
                             <tr>

--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -65,14 +65,15 @@
                         <label><i class="icon-comment"></i> Comment:</label>
                         <input type="text" name="comment" id="comment" tabindex="1" onkeypress=keypressed(event) autofocus>
                         -->
-                        <label><i class="icon-time"></i> Lifetime (days):</label>
-                        <select name="lifespan" id="lifespan" tabindex="1" onkeypress=keypressed(event)>
-                        	<option value="1">1 days</option>
-                        	<option value="7">7 days</option>
-                        	<option value="30">30 days</option>
-                        	<option value="90">90 days</option>
-                        	<option value="120">120 days</option>
-                       	</select>
+                        <label><i class="icon-time"></i> Lifetime (days, hours, mins):</label>
+                        <table>
+                            <tr>
+                                <td><input type="number" id="lt_days" name="lt_days" step="1" min="0" max="3650" value="1" size="3"></td> <!-- 10 years limit -->
+                                <td><input type="number" id="lt_hours" name="lt_hours" step="1" min="0" max="23" value="0" size="3"></td>
+                                <td><input type="number" id="lt_mins" name="lt_mins" step="1" min="0" max="59" value="0" size="3"></td>
+                            </tr>
+                        </table>
+                        <label style="display: none; color: red;" id="invalidLifetimeText"><i class="icon-warning"></i>Invalid lifetime!</label>
                     </div>
                     <span id="errorBox" class="help-inline" style="color:white;display:none;"><span class="errorMsg"></span>
                         <i class="icon-warning-sign" style="color:#ae2817;"></i>

--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -125,6 +125,9 @@ var gen = function() {
         var apiUrl = tokenURL;
         //Instantiate HTTP Request
         var params = '?lifespan=P' + lt_days + "DT" + lt_hours + "H" + lt_mins + "M";  //we need to support Java's Duration pattern
+        if (form.comment.value != '') {
+            params = params + '&comment=' + encodeURIComponent(form.comment.value);
+        }
         var request = ((window.XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"));
         request.open("GET", apiUrl + params, true);
         request.send(null);

--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -110,6 +110,7 @@ function setTokenStateServiceStatus() {
 }
 
 var gen = function() {
+	$('#invalidLifetimeText').hide();
     var pathname = window.location.pathname;
     var topologyContext = pathname.replace(loginPageSuffix, "");;
     var baseURL = topologyContext.substring(0, topologyContext.lastIndexOf('/'));
@@ -117,14 +118,13 @@ var gen = function() {
     var tokenURL = topologyContext + knoxtokenURL;
     var form = document.forms[0];
     //var comment = form.comment.value;
-    var lifespan = form.lifespan.value;
+    var lt_days = form.lt_days.value;
+    var lt_hours = form.lt_hours.value;
+    var lt_mins = form.lt_mins.value;
     var _gen = function() {
         var apiUrl = tokenURL;
         //Instantiate HTTP Request
-        var params = '';
-        if (lifespan != '') {
-        	params = '?lifespan=' + lifespan;
-        }
+        var params = '?lifespan=P' + lt_days + "DT" + lt_hours + "H" + lt_mins + "M";  //we need to support Java's Duration pattern
         var request = ((window.XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"));
         request.open("GET", apiUrl + params, true);
         request.send(null);
@@ -161,5 +161,9 @@ var gen = function() {
         }
     }
 
-    _gen();
+    if (lt_days == '0' && lt_hours == '0' && lt_mins == '0') {
+        $('#invalidLifetimeText').show();
+    } else {
+        _gen();
+    }
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -23,6 +23,8 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
@@ -70,7 +72,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 @Singleton
 @Path(TokenResource.RESOURCE_PATH)
 public class TokenResource {
-  private static final String LIFESPAN_DAYS = "lifespan";
+  static final String LIFESPAN = "lifespan";
   private static final String EXPIRES_IN = "expires_in";
   private static final String TOKEN_TYPE = "token_type";
   private static final String ACCESS_TOKEN = "access_token";
@@ -101,7 +103,6 @@ public class TokenResource {
   static final String RENEW_PATH = "/renew";
   static final String REVOKE_PATH = "/revoke";
   private static final String TARGET_ENDPOINT_PULIC_CERT_PEM = "knox.token.target.endpoint.cert.pem";
-  private static final long MILLIS_IN_DAY = 86400000L;
   private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
   private long tokenTTL = TOKEN_TTL_DEFAULT;
   private List<String> targetAudiences = new ArrayList<>();
@@ -534,26 +535,23 @@ public class TokenResource {
 
   private long getExpiry() {
     long expiry = 0L;
-    long millis = 0L;
+    long millis = tokenTTL;
 
-    String lifetimeStr = request.getParameter(LIFESPAN_DAYS);
+    String lifetimeStr = request.getParameter(LIFESPAN);
     if (lifetimeStr == null || lifetimeStr.isEmpty()) {
       if (tokenTTL == -1) {
         return -1;
       }
-      millis = tokenTTL;
     }
     else {
       try {
-        // lifetime is in days
-        long lifetime = Long.parseLong(lifetimeStr);
-        if (lifetime * MILLIS_IN_DAY <= tokenTTL) {
-          millis = lifetime * MILLIS_IN_DAY;
+        long lifetime = Duration.parse(lifetimeStr).toMillis();
+        if (lifetime <= tokenTTL) {
+          millis = lifetime;
         }
       }
-      catch (NumberFormatException e) {
+      catch (DateTimeParseException e) {
         log.invalidLifetimeValue(lifetimeStr);
-        millis = tokenTTL;
       }
     }
     expiry = System.currentTimeMillis() + millis;

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -73,6 +73,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 @Path(TokenResource.RESOURCE_PATH)
 public class TokenResource {
   static final String LIFESPAN = "lifespan";
+  static final String COMMENT = "comment";
   private static final String EXPIRES_IN = "expires_in";
   private static final String TOKEN_TYPE = "token_type";
   private static final String ACCESS_TOKEN = "access_token";
@@ -508,7 +509,8 @@ public class TokenResource {
                                      System.currentTimeMillis(),
                                      expires,
                                      maxTokenLifetime.orElse(tokenStateService.getDefaultMaxLifetimeDuration()));
-          tokenStateService.addMetadata(tokenId, new TokenMetadata(p.getName()));
+          final String comment = request.getParameter(COMMENT);
+          tokenStateService.addMetadata(tokenId, new TokenMetadata(p.getName(), StringUtils.isBlank(comment) ? null : comment));
           log.storedToken(getTopologyName(), Tokens.getTokenDisplayText(accessToken), Tokens.getTokenIDDisplayText(tokenId));
         }
 

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -78,6 +78,6 @@ public interface TokenServiceMessages {
           text = "Renewal is disabled for the Knox Token service ({0}). Responding with the expiration from the token {1} ({2})")
   void renewalDisabled(String topologyName, String tokenDisplayText, String tokenId);
 
-  @Message( level = MessageLevel.WARN, text = "Invalid number used for JWT token lifespan ({0}) using the configured TTL for KnoxToken service")
+  @Message( level = MessageLevel.WARN, text = "Invalid duration used for JWT token lifespan ({0}) using the configured TTL for KnoxToken service")
   void invalidLifetimeValue(String lifetimeStr);
 }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -855,6 +855,7 @@ public class TokenServiceResourceTest {
     }
   }
 
+  @Test
   public void testGettingTokenWithLifespanLessThanConfiguredTTL() throws Exception {
     final Map<String, String> contextExpectations = new HashMap<>();
     contextExpectations.put("knox.token.ttl", "172800000"); // 2 days


### PR DESCRIPTION
## What changes were proposed in this pull request?

- let end-users declare a more refined lifespan
- let end-users add a comment to the generated

## How was this patch tested?

Updated and ran JUnit tests. Additionally, I did manual testing.

1. Tested a wrong lifetime:
<img width="584" alt="Screen Shot 2021-04-30 at 1 31 30 AM" src="https://user-images.githubusercontent.com/34065904/116630810-3ff06c00-a954-11eb-987a-32d1c401d1e6.png">

2. Tested custom lifespan (token generated at 30 Apr 2021 01:32:14 AM)
<img width="589" alt="Screen Shot 2021-04-30 at 1 32 35 AM" src="https://user-images.githubusercontent.com/34065904/116630821-44b52000-a954-11eb-990a-4335240e3e7b.png">

3. Saved comment with tricky characters:
<img width="607" alt="Screen Shot 2021-04-30 at 1 34 17 AM" src="https://user-images.githubusercontent.com/34065904/116630828-4aab0100-a954-11eb-83be-6191d28cd11e.png">

```
postgres=# select * from knox_tokens where token_id = '0dd15ada-4986-4de8-a261-001668af93f5';
               token_id               |  issue_time   |  expiration   | max_lifetime  | username |                                  comment                                  
--------------------------------------+---------------+---------------+---------------+----------+---------------------------------------------------------------------------
 0dd15ada-4986-4de8-a261-001668af93f5 | 1619739244250 | 1619825644246 | 1620344044250 | admin    | comment with a question mark ? and my favorite cartoon tom & jerry !!! :)
(1 row)
```
