### PR TITLE
KNOX-2600 - It's now possible to setup a PostgreSQL connection using a JDBC URL

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -274,6 +274,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   //Gateway Database related properties
   private static final String GATEWAY_DATABASE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".database.type";
+  private static final String GATEWAY_DATABASE_CONN_URL = GATEWAY_CONFIG_FILE_PREFIX + ".database.connection.url";
   private static final String GATEWAY_DATABASE_HOST =  GATEWAY_CONFIG_FILE_PREFIX + ".database.host";
   private static final String GATEWAY_DATABASE_PORT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.port";
   private static final String GATEWAY_DATABASE_NAME =  GATEWAY_CONFIG_FILE_PREFIX + ".database.name";
@@ -1245,6 +1246,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getDatabaseType() {
     return get(GATEWAY_DATABASE_TYPE, "none");
+  }
+
+  @Override
+  public String getDatabaseConnectionUrl() {
+    return get(GATEWAY_DATABASE_CONN_URL);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
@@ -45,12 +45,16 @@ public class JDBCUtils {
 
   private static DataSource createPostgresDataSource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
     final PGSimpleDataSource postgresDataSource = new PGSimpleDataSource();
-    postgresDataSource.setDatabaseName(gatewayConfig.getDatabaseName());
-    postgresDataSource.setServerNames(new String[] { gatewayConfig.getDatabaseHost() });
-    postgresDataSource.setPortNumbers(new int[] { gatewayConfig.getDatabasePort() });
-    postgresDataSource.setUser(getDatabaseUser(aliasService));
-    postgresDataSource.setPassword(getDatabasePassword(aliasService));
-    configurePostgreSQLSsl(gatewayConfig, aliasService, postgresDataSource);
+    if (gatewayConfig.getDatabaseConnectionUrl() != null) {
+      postgresDataSource.setUrl(gatewayConfig.getDatabaseConnectionUrl());
+    } else {
+      postgresDataSource.setDatabaseName(gatewayConfig.getDatabaseName());
+      postgresDataSource.setServerNames(new String[] { gatewayConfig.getDatabaseHost() });
+      postgresDataSource.setPortNumbers(new int[] { gatewayConfig.getDatabasePort() });
+      postgresDataSource.setUser(getDatabaseUser(aliasService));
+      postgresDataSource.setPassword(getDatabasePassword(aliasService));
+      configurePostgreSQLSsl(gatewayConfig, aliasService, postgresDataSource);
+    }
     return postgresDataSource;
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
@@ -106,6 +106,24 @@ public class JDBCUtilsTest {
   }
 
   @Test
+  public void testGetPostgreSqlDatasourceFromJdbcConnectionUrl() throws AliasServiceException {
+    final String connectionUrl = "jdbc:postgresql://postgresql_host:1234/testDb?user=smolnar&password=secret&ssl=true&sslmode=verify-ca&sslrootcert=/var/lib/knox/gateway/conf/postgresql/root.crt";
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.POSTGRESQL_DB_TYPE).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseConnectionUrl()).andReturn(connectionUrl).anyTimes();
+    EasyMock.replay(gatewayConfig);
+    final PGSimpleDataSource dataSource = (PGSimpleDataSource) JDBCUtils.getDataSource(gatewayConfig, null);
+    assertEquals("postgresql_host", dataSource.getServerNames()[0]);
+    assertEquals(1234, dataSource.getPortNumbers()[0]);
+    assertEquals("testDb", dataSource.getDatabaseName());
+    assertEquals("smolnar", dataSource.getUser());
+    assertEquals("secret", dataSource.getPassword());
+    assertTrue(dataSource.isSsl());
+    assertEquals(dataSource.getSslRootCert(), "/var/lib/knox/gateway/conf/postgresql/root.crt");
+    EasyMock.verify(gatewayConfig);
+  }
+
+  @Test
   public void shouldReturnDerbyDataSource() throws Exception {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -750,6 +750,8 @@ public interface GatewayConfig {
 
   String getDatabaseType();
 
+  String getDatabaseConnectionUrl();
+
   String getDatabaseHost();
 
   int getDatabasePort();

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -860,6 +860,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getDatabaseConnectionUrl() {
+    return null;
+  }
+
+  @Override
   public String getDatabaseHost() {
     return null;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of declaring connection properties one-by-one in `gateway-site.xml` a simple `connection URL` is enough to create connections to PostgreSQL DB server.

## How was this patch tested?

Updated and ran JUnit tests as well as executing the following manual test steps:
1. Configured the Knox Gateway as follows and started it successfully
```
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.JDBCTokenStateService</value>
    </property>
     <property>
        <name>gateway.database.type</name>
        <value>postgresql</value>
    </property>
    <property>
        <name>gateway.database.connection.url</name>
        <value>jdbc:postgresql://smolnar-MBP15.local:5432/postgres?user=postgres&amp;ssl=true&amp;sslmode=verify-full&amp;sslrootcert=/usr/local/var/postgresql@10/data/root.crt</value>
    </property>
```
2. Generated some tokens with our `tokengen` application
3. Confirmed that the tokens were successfully saved in my local PostgreSQL DB