### PR TITLE
Knox 2582

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -45,6 +45,6 @@ public interface HadoopAuthMessages {
   @Message( level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path list {1}, letting it through" )
   void unauthenticatedPathBypass(String uri, String unauthPathList);
 
-  @Message( level = MessageLevel.ERROR, text = "Error {1} while checking whether path {0} should be allowed unauthenticated access" )
+  @Message( level = MessageLevel.ERROR, text = "Error while checking whether path {0} should be allowed unauthenticated access : {1}" )
   void unauthenticatedPathError(String path, String error);
 }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -41,4 +41,10 @@ public interface HadoopAuthMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "Using JWT filter to serve the request" )
   void useJwtFilter();
+
+  @Message( level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path list {1}, letting it through" )
+  void unauthenticatedPathBypass(String uri, String unauthPathList);
+
+  @Message( level = MessageLevel.ERROR, text = "Error {1} while checking whether path {0} should be allowed unauthenticated access" )
+  void unauthenticatedPathError(String path, String error);
 }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.knox.gateway.hadoopauth.filter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
@@ -64,7 +63,6 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
-import java.util.StringTokenizer;
 
 import static org.apache.knox.gateway.util.AuthFilterUtils.DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM;
 
@@ -155,16 +153,10 @@ public class HadoopAuthFilter extends
       LOG.initializedJwtFilter();
     }
 
-    /* add default unauthenticated paths list */
-    AuthFilterUtils.parseAndAddUnauthPathList(unAuthenticatedPaths, DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM);
-
-    /* add provided unauthenticated paths list if specified */
     final String unAuthPathString = filterConfig
         .getInitParameter(HADOOP_AUTH_UNAUTHENTICATED_PATHS_PARAM);
-    /* if list specified add it */
-    if (!StringUtils.isBlank(unAuthPathString)) {
-      AuthFilterUtils.parseAndAddUnauthPathList(unAuthenticatedPaths, unAuthPathString);
-    }
+    /* prepare a list of allowed unauthenticated paths */
+    AuthFilterUtils.addUnauthPaths(unAuthenticatedPaths, unAuthPathString, DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM);
   }
 
   @Override

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -170,7 +170,7 @@ public class HadoopAuthFilter extends
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
     /* check for unauthenticated paths to bypass */
     if(doesRequestContainUnauthPath(request)) {
-      checkForUnauthenticatedPaths(request, response, filterChain);
+      continueWithAnonymousSubject(request, response, filterChain);
       return;
     }
     if (shouldUseJwtFilter(jwtFilter, (HttpServletRequest) request)) {
@@ -185,7 +185,7 @@ public class HadoopAuthFilter extends
   protected void doFilter(FilterChain filterChain, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
     /* check for unauthenticated paths to bypass */
     if(doesRequestContainUnauthPath(request)) {
-      checkForUnauthenticatedPaths(request, response, filterChain);
+      continueWithAnonymousSubject(request, response, filterChain);
       return;
     }
     if (shouldUseJwtFilter(jwtFilter, request)) {
@@ -272,8 +272,9 @@ public class HadoopAuthFilter extends
    * @param response
    * @param chain
    */
-  private void checkForUnauthenticatedPaths(final ServletRequest request,
-      final ServletResponse response, final FilterChain chain) {
+  private void continueWithAnonymousSubject(final ServletRequest request,
+      final ServletResponse response, final FilterChain chain)
+      throws ServletException, IOException {
     try {
       /* This path is configured as an unauthenticated path let the request through */
       final Subject sub = new Subject();
@@ -283,9 +284,9 @@ public class HadoopAuthFilter extends
           (HttpServletResponse) response, chain);
 
     } catch (final Exception e) {
-      /* in case anything fails here log and move on */
       LOG.unauthenticatedPathError(
           ((HttpServletRequest) request).getRequestURI(), e.toString());
+      throw e;
     }
   }
 

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -307,7 +307,7 @@ public class HadoopAuthFilter extends
           new PrivilegedExceptionAction<Object>() {
             @Override
             public Object run() throws Exception {
-              chain.doFilter(request, response);
+              chain.doFilter(new AnonymousRequest(request, principal), response);
               return null;
             }
           }
@@ -405,5 +405,35 @@ public class HadoopAuthFilter extends
 
   boolean isJwtSupported() {
     return jwtFilter != null;
+  }
+
+  /**
+   * A wrapper around the request that returns anonymous subject.
+   */
+  private class AnonymousRequest extends HttpServletRequestWrapper {
+    private Principal principal;
+
+    AnonymousRequest(HttpServletRequest req, Principal principal) {
+      super(req);
+      this.principal = principal;
+    }
+
+    /**
+     * The default behavior of this method is to return getRemoteUser()
+     * on the wrapped request object.
+     */
+    @Override
+    public String getRemoteUser() {
+      return principal.getName();
+    }
+
+    /**
+     * The default behavior of this method is to return getUserPrincipal()
+     * on the wrapped request object.
+     */
+    @Override
+    public Principal getUserPrincipal() {
+      return principal;
+    }
   }
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -62,7 +62,7 @@ public interface JWTMessages {
   @Message( level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path list {1}, letting it through" )
   void unauthenticatedPathBypass(String uri, String unauthPathList);
 
-  @Message( level = MessageLevel.ERROR, text = "Error {1} while checking whether path {0} should be allowed unauthenticated access" )
+  @Message( level = MessageLevel.ERROR, text = "Error while checking whether path {0} should be allowed unauthenticated access : {1}" )
   void unauthenticatedPathError(String path, String error);
 
   @Message( level = MessageLevel.WARN, text = "Unable to derive authentication provider URL: {0}" )

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -59,8 +59,11 @@ public interface JWTMessages {
   @Message( level = MessageLevel.DEBUG, text = "Audience claim has been validated." )
   void jwtAudienceValidated();
 
-  @Message( level = MessageLevel.INFO, text = "Path {0} is configured as unauthenticated path, letting the request {1} through" )
-  void unauthenticatedPathBypass(String path, String uri);
+  @Message( level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path list {1}, letting it through" )
+  void unauthenticatedPathBypass(String uri, String unauthPathList);
+
+  @Message( level = MessageLevel.ERROR, text = "Error {1} while checking whether path {0} should be allowed unauthenticated access" )
+  void unauthenticatedPathError(String path, String error);
 
   @Message( level = MessageLevel.WARN, text = "Unable to derive authentication provider URL: {0}" )
   void failedToDeriveAuthenticationProviderUrl(@StackTrace( level = MessageLevel.ERROR) Exception e);

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -126,7 +126,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
       throws IOException, ServletException {
     /* check for unauthenticated paths to bypass */
     if(doesRequestContainUnauthPath(request)) {
-      checkForUnauthenticatedPaths(request, response, chain);
+      continueWithAnonymousSubject(request, response, chain);
       return;
     }
     final Pair<TokenType, String> wireToken = getWireToken(request);
@@ -240,8 +240,9 @@ public class JWTFederationFilter extends AbstractJWTFilter {
    * @param response
    * @param chain
    */
-  private void checkForUnauthenticatedPaths(final ServletRequest request,
-      final ServletResponse response, final FilterChain chain) {
+  private void continueWithAnonymousSubject(final ServletRequest request,
+      final ServletResponse response, final FilterChain chain)
+      throws ServletException, IOException {
     try {
       /* This path is configured as an unauthenticated path let the request through */
       final Subject sub = new Subject();
@@ -251,9 +252,9 @@ public class JWTFederationFilter extends AbstractJWTFilter {
           (HttpServletResponse) response, chain);
 
     } catch (final Exception e) {
-      /* in case anything fails here log and move on */
       LOGGER.unauthenticatedPathError(
           ((HttpServletRequest) request).getRequestURI(), e.toString());
+      throw e;
     }
   }
 

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.knox.gateway.provider.federation.jwt.filter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
@@ -43,7 +42,6 @@ import java.util.Base64;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import java.util.StringTokenizer;
 
 import static org.apache.knox.gateway.util.AuthFilterUtils.DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM;
 
@@ -104,16 +102,10 @@ public class JWTFederationFilter extends AbstractJWTFilter {
       publicKey = CertificateUtils.parseRSAPublicKey(verificationPEM);
     }
 
-    /* add default unauthenticated paths list */
-    AuthFilterUtils.parseAndAddUnauthPathList(unAuthenticatedPaths, DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM);
-
-    /* add provided unauthenticated paths list if specified */
     final String unAuthPathString = filterConfig
         .getInitParameter(JWT_UNAUTHENTICATED_PATHS_PARAM);
-    /* if list specified add it */
-    if (!StringUtils.isBlank(unAuthPathString)) {
-      AuthFilterUtils.parseAndAddUnauthPathList(unAuthenticatedPaths, unAuthPathString);
-    }
+    /* prepare a list of allowed unauthenticated paths */
+    AuthFilterUtils.addUnauthPaths(unAuthenticatedPaths, unAuthPathString, DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM);
 
     configureExpectedParameters(filterConfig);
   }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -68,7 +68,7 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
 
   /* A semicolon separated list of paths that need to bypass authentication */
   private static final String SSO_UNAUTHENTICATED_PATHS_PARAM = "sso.unauthenticated.path.list";
-  private static final String DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM = "favicon.ico";
+  private static final String DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM = "favicon.ico;/knoxtoken/api/v1/jwks.json";
   private String cookieName;
   private String authenticationProviderUrl;
   private String gatewayPath;
@@ -146,11 +146,11 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
     if (ssoCookies.isEmpty()) {
       /* check for unauthenticated paths to bypass */
       for (final String path : unAuthenticatedPaths) {
-        if (req.getRequestURI().contains(path)) {
+        if (req.getPathInfo().equals(path)) {
           /* This path is configured as an unauthenticated path let the request through */
           final Subject sub = new Subject();
           sub.getPrincipals().add(new PrimaryPrincipal("anonymous"));
-          LOGGER.unauthenticatedPathBypass(path, req.getRequestURI());
+          LOGGER.unauthenticatedPathBypass(req.getRequestURI(), unAuthenticatedPaths.toString());
           continueWithEstablishedSecurityContext(sub, req, res, chain);
         }
       }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -67,7 +67,7 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
 
   /* A semicolon separated list of paths that need to bypass authentication */
   private static final String SSO_UNAUTHENTICATED_PATHS_PARAM = "sso.unauthenticated.path.list";
-  private static final String DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM = "favicon.ico;/knoxtoken/api/v1/jwks.json";
+  private static final String DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM = "/favicon.ico;/knoxtoken/api/v1/jwks.json";
   private String cookieName;
   private String authenticationProviderUrl;
   private String gatewayPath;

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SSOCookieFederationFilter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.knox.gateway.provider.federation.jwt.filter;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
@@ -47,9 +46,6 @@ import java.text.ParseException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.StringTokenizer;
-
-import static org.apache.knox.gateway.util.AuthFilterUtils.DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM;
 
 public class SSOCookieFederationFilter extends AbstractJWTFilter {
   private static final JWTMessages LOGGER = MessagesFactory.get( JWTMessages.class );
@@ -106,15 +102,10 @@ public class SSOCookieFederationFilter extends AbstractJWTFilter {
       publicKey = CertificateUtils.parseRSAPublicKey(verificationPEM);
     }
 
-    /* add default unauthenticated paths list */
-    AuthFilterUtils.parseAndAddUnauthPathList(unAuthenticatedPaths, DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM);
-    /* add provided unauthenticated paths list if specified */
     final String unAuthPathString = filterConfig
         .getInitParameter(SSO_UNAUTHENTICATED_PATHS_PARAM);
-    /* if list specified add it */
-    if (!StringUtils.isBlank(unAuthPathString)) {
-      AuthFilterUtils.parseAndAddUnauthPathList(unAuthenticatedPaths, unAuthPathString);
-    }
+    /* prepare a list of allowed unauthenticated paths */
+    AuthFilterUtils.addUnauthPaths(unAuthenticatedPaths, unAuthPathString, DEFAULT_SSO_UNAUTHENTICATED_PATHS_PARAM);
 
     // gateway path for deriving an idp url when missing
     setGatewayPath(filterConfig);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -150,6 +150,7 @@ public abstract class AbstractJWTFilterTest  {
     setTokenOnRequest(request, jwt);
 
     EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+    EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
     EasyMock.expect(request.getQueryString()).andReturn(null);
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -173,6 +174,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -203,6 +205,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -236,6 +239,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -265,6 +269,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -296,6 +301,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -324,6 +330,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -355,6 +362,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -389,6 +397,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -419,6 +428,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -446,6 +456,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
@@ -476,6 +487,7 @@ public abstract class AbstractJWTFilterTest  {
       setGarbledTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
@@ -513,6 +525,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
@@ -554,6 +567,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -581,6 +595,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -609,6 +624,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -644,6 +660,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -680,6 +697,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -710,6 +728,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -757,6 +776,7 @@ public abstract class AbstractJWTFilterTest  {
       setTokenOnRequest(request, jwt_alice);
 
       EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.expect(request.getQueryString()).andReturn(null);
       HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
       EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -815,6 +835,7 @@ public abstract class AbstractJWTFilterTest  {
 
       HttpServletRequest request = createMockRequest(jwt_alice);
       HttpServletResponse response = createMockResponse();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.replay(request, response);
 
       TestFilterChain chain = new TestFilterChain();
@@ -826,6 +847,7 @@ public abstract class AbstractJWTFilterTest  {
       // Do it again, after the token has expired
       request = createMockRequest(jwt_alice);
       response = createMockResponse();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
       EasyMock.replay(request, response);
 
       // Wait for the token to expire
@@ -869,6 +891,7 @@ public abstract class AbstractJWTFilterTest  {
                                                     final SignedJWT jwt,
                                                     final String expectedPrincipal) throws Exception {
     EasyMock.reset(request, response);
+    EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
     setTokenOnRequest(request, jwt);
     EasyMock.replay(request, response);
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -96,6 +96,7 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
             setTokenOnRequest(request, JWTFederationFilter.TOKEN.toLowerCase(Locale.ROOT), jwt.serialize());
 
             EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
             EasyMock.expect(request.getQueryString()).andReturn(null);
             HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
             EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -120,6 +120,7 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
             setTokenOnRequest(request, jwt, JWTFederationFilter.PASSCODE.toLowerCase(Locale.ROOT));
 
             EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
             EasyMock.expect(request.getQueryString()).andReturn(null);
             HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
             EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -147,6 +148,7 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
             setTokenOnRequest(request, jwt, "InvalidBasicAuthUsername");
 
             EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
             EasyMock.expect(request.getQueryString()).andReturn(null);
             HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
             EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -178,6 +180,7 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
             setTokenOnRequest(request, jwt, JWTFederationFilter.TOKEN);
 
             EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
             EasyMock.expect(request.getQueryString()).andReturn(null);
             HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
             EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -209,6 +212,7 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
             setTokenOnRequest(request, JWTFederationFilter.PASSCODE, jwt.serialize());
 
             EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+            EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
             EasyMock.expect(request.getQueryString()).andReturn(null);
             HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
             EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/AuthFilterUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/AuthFilterUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class AuthFilterUtils {
+  public static final String DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM = "/knoxtoken/api/v1/jwks.json";
+
+  /**
+   * A helper method that checks whether request contains
+   * unauthenticated path
+   * @param request
+   * @return
+   */
+  public static boolean doesRequestContainUnauthPath(
+      final Set<String> unAuthenticatedPaths, final ServletRequest request) {
+    /* make sure the path matches EXACTLY to prevent auth bypass */
+    return unAuthenticatedPaths.contains(((HttpServletRequest) request).getPathInfo());
+  }
+
+  /**
+   * A helper method that parses a string and adds to the
+   * provided unauthenticated set.
+   * @param unAuthenticatedPaths
+   * @param list
+   */
+  public static void parseAndAddUnauthPathList(final Set<String> unAuthenticatedPaths, final String list) {
+    final StringTokenizer tokenizer = new StringTokenizer(list, ";,");
+    while (tokenizer.hasMoreTokens()) {
+      unAuthenticatedPaths.add(tokenizer.nextToken());
+    }
+  }
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/AuthFilterUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/AuthFilterUtils.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Set;
@@ -43,10 +45,26 @@ public class AuthFilterUtils {
    * @param unAuthenticatedPaths
    * @param list
    */
-  public static void parseAndAddUnauthPathList(final Set<String> unAuthenticatedPaths, final String list) {
+  public static void parseStringThenAdd(final Set<String> unAuthenticatedPaths, final String list) {
     final StringTokenizer tokenizer = new StringTokenizer(list, ";,");
     while (tokenizer.hasMoreTokens()) {
       unAuthenticatedPaths.add(tokenizer.nextToken());
+    }
+  }
+
+  /**
+   * A method that parses a string (delimiters = ;,) and adds them to the
+   * provided un-authenticated path set.
+   * @param unAuthenticatedPaths
+   * @param list
+   * @param defaultList
+   */
+  public static void addUnauthPaths(final Set<String> unAuthenticatedPaths, final String list, final String defaultList) {
+    /* add default unauthenticated paths list */
+    parseStringThenAdd(unAuthenticatedPaths, defaultList);
+    /* add provided unauthenticated paths list if specified */
+    if (!StringUtils.isBlank(list)) {
+      AuthFilterUtils.parseStringThenAdd(unAuthenticatedPaths, list);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change adds unauthenticated path list support for the following two authentication providers (along with SSOCookieProvider)

- JWTProvider
- HadoopAuthProvider

By default the path `/knoxtoken/api/v1/jwks.json` is added by default. Note that the path has to be exact, i.e. the request path after {gateway}/{topology} should EXACTLY match the configured path. 

Following properties can be used to add more paths to these providers

- hadoop.auth.unauthenticated.path.list
- jwt.unauthenticated.path.list


## How was this patch tested?

This patch was tested on a local cluster. 

