### PR TITLE
KNOX-2601: ZeppelinUI creates multiple sessions when going via Knox

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.1/service.xml
@@ -98,5 +98,10 @@
     </route>
 
   </routes>
-  <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch"/>
+  <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch" ha-classname="org.apache.knox.gateway.ha.dispatch.ConfigurableHADispatch" use-two-way-ssl="false">
+    <param>
+      <name>responseExcludeHeaders</name>
+      <value>WWW-AUTHENTICATE</value>
+    </param>
+  </dispatch>
 </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Zeppelin uses JSESSIONID to identify a session. Zeppelin UI service definition uses DefaultDispatch which prevents "SET-COOKIE" response header from being set causing Zeppelin to create multiple sessions with KnoxSSO. The change uses ConfigurableDispatch instead of DefaultDispatch.


## How was this patch tested?

The patch was locally tested

