### PR TITLE
KNOX-2602 - Added the enabled flag and related token service API into the tokens' metadata.

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -223,7 +223,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.DEBUG, text = "Updated metadata for {0} in the database")
   void updatedMetadataInDatabase(String tokenId);
 
-  @Message(level = MessageLevel.DEBUG, text = "Failed to update metadata for {0} in the database")
+  @Message(level = MessageLevel.DEBUG, text = "Failed to save/update metadata for {0} in the database")
   void failedToUpdateMetadataInDatabase(String tokenId);
 
   @Message(level = MessageLevel.ERROR, text = "An error occurred while updating metadata for {0} in the database : {1}")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournal.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournal.java
@@ -50,8 +50,9 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
     protected static final int INDEX_ISSUE_TIME   = 1;
     protected static final int INDEX_EXPIRATION   = 2;
     protected static final int INDEX_MAX_LIFETIME = 3;
-    protected static final int INDEX_USERNAME     = 4;
-    protected static final int INDEX_COMMENT      = 5;
+    protected static final int INDEX_ENABLED      = 4;
+    protected static final int INDEX_USERNAME     = 5;
+    protected static final int INDEX_COMMENT      = 6;
 
     protected static final TokenStateServiceMessages log = MessagesFactory.get(TokenStateServiceMessages.class);
 
@@ -190,7 +191,7 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
 
         @Override
         public String toString() {
-            String[] elements = new String[6];
+            String[] elements = new String[7];
 
             elements[INDEX_TOKEN_ID] = getTokenId();
 
@@ -203,6 +204,9 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
             String maxLifetime = getMaxLifetime();
             elements[INDEX_MAX_LIFETIME] = (maxLifetime != null) ? maxLifetime : "";
 
+            String enabled = getTokenMetadata() == null ? "" : String.valueOf(getTokenMetadata().isEnabled());
+            elements[INDEX_ENABLED] = enabled;
+
             String userName = getTokenMetadata() == null ? "" : (getTokenMetadata().getUserName() == null ? "" : getTokenMetadata().getUserName());
             elements[INDEX_USERNAME] = userName;
 
@@ -210,11 +214,12 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
             elements[INDEX_COMMENT] = comment;
 
             return String.format(Locale.ROOT,
-                                 "%s,%s,%s,%s,%s,%s",
+                                 "%s,%s,%s,%s,%s,%s,%s",
                                  elements[INDEX_TOKEN_ID],
                                  elements[INDEX_ISSUE_TIME],
                                  elements[INDEX_EXPIRATION],
                                  elements[INDEX_MAX_LIFETIME],
+                                 elements[INDEX_ENABLED],
                                  elements[INDEX_USERNAME],
                                  elements[INDEX_COMMENT]);
         }
@@ -228,7 +233,7 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
           */
         static FileJournalEntry parse(final String entry) {
             String[] elements = entry.split(",", -1);
-            if (elements.length < 6) {
+            if (elements.length < 7) {
                 throw new IllegalArgumentException("Invalid journal entry: " + entry);
             }
 
@@ -236,6 +241,7 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
             String issueTime   = elements[INDEX_ISSUE_TIME].trim();
             String expiration  = elements[INDEX_EXPIRATION].trim();
             String maxLifetime = elements[INDEX_MAX_LIFETIME].trim();
+            String enabled     = elements[INDEX_ENABLED].trim();
             String userName    = elements[INDEX_USERNAME].trim();
             String comment     = elements[INDEX_COMMENT].trim();
 
@@ -243,7 +249,7 @@ abstract class FileTokenStateJournal implements TokenStateJournal {
                                         issueTime.isEmpty() ? null : issueTime,
                                         expiration.isEmpty() ? null : expiration,
                                         maxLifetime.isEmpty() ? null : maxLifetime,
-                                        new TokenMetadata(userName.isEmpty() ? null : userName, comment.isEmpty() ? null : comment));
+                                        new TokenMetadata(userName.isEmpty() ? null : userName, comment.isEmpty() ? null : comment, Boolean.parseBoolean(enabled)));
         }
 
     }

--- a/gateway-server/src/main/resources/createKnoxTokenMetadataDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenMetadataDatabaseTable.sql
@@ -13,10 +13,10 @@
 --  License for the specific language governing permissions and limitations under
 --  the License.
 
-CREATE TABLE KNOX_TOKENS (
+CREATE TABLE KNOX_TOKEN_METADATA (
    token_id varchar(128) NOT NULL,
-   issue_time bigint NOT NULL,
-   expiration bigint NOT NULL,
-   max_lifetime bigint NOT NULL,
-   PRIMARY KEY (token_id)
+   md_name varchar(32) NOT NULL,
+   md_value varchar(256) NOT NULL,
+   PRIMARY KEY (token_id, md_name),
+   CONSTRAINT fk_token_id FOREIGN KEY(token_id) REFERENCES KNOX_TOKENS(token_id) ON DELETE CASCADE
 )

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.token.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -292,12 +293,13 @@ public class DefaultTokenStateServiceTest {
     tss.addMetadata(token.getClaim(JWTToken.KNOX_ID_CLAIM), new TokenMetadata(userName));
     assertNotNull(tss.getTokenMetadata(tokenId));
     assertEquals(tss.getTokenMetadata(tokenId).getUserName(), userName);
-    assertTrue(tss.getTokenMetadata(tokenId).getComment().isEmpty());
+    assertNull(tss.getTokenMetadata(tokenId).getComment());
 
     final String comment = "this is my test comment";
-    tss.addMetadata(token.getClaim(JWTToken.KNOX_ID_CLAIM), new TokenMetadata(userName, comment));
+    tss.addMetadata(token.getClaim(JWTToken.KNOX_ID_CLAIM), new TokenMetadata(userName, comment, true));
     assertNotNull(tss.getTokenMetadata(tokenId));
     assertEquals(tss.getTokenMetadata(tokenId).getComment(), comment);
+    assertTrue(tss.getTokenMetadata(tokenId).isEnabled());
   }
 
   protected static JWTToken createMockToken(final long expiration) {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateServiceTest.java
@@ -122,10 +122,11 @@ public class ZookeeperTokenStateServiceTest {
 
     final String userName = "testUser";
     final String comment = "This is my test comment";
-    zktokenStateServiceNode1.addMetadata(tokenId, new TokenMetadata(userName, comment));
+    zktokenStateServiceNode1.addMetadata(tokenId, new TokenMetadata(userName, comment, true));
     Thread.sleep(LONG_TOKEN_STATE_ALIAS_PERSISTENCE_INTERVAL * 1000);
     assertEquals(userName, zktokenStateServiceNode2.getTokenMetadata(tokenId).getUserName());
     assertEquals(comment, zktokenStateServiceNode2.getTokenMetadata(tokenId).getComment());
+    assertTrue(zktokenStateServiceNode2.getTokenMetadata(tokenId).isEnabled());
   }
 
   @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournalTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/state/FileTokenStateJournalTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNull;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.services.token.state.JournalEntry;
 import org.junit.Test;
 
@@ -47,7 +48,7 @@ public class FileTokenStateJournalTest {
         final Long   expiration  = issueTime + TimeUnit.HOURS.toMillis(1);
         final Long   maxLifetime = null;
 
-        doTestParseJournalEntry(tokenId, issueTime, expiration, maxLifetime, "user", null);
+        doTestParseJournalEntry(tokenId, issueTime, expiration, maxLifetime, Boolean.TRUE, "user", null);
     }
 
     @Test
@@ -77,29 +78,32 @@ public class FileTokenStateJournalTest {
 
     @Test
     public void tesParseTokenMetadata() throws Exception {
-      doTestParseJournalEntry("", "", "", "", "userName", "");
-      doTestParseJournalEntry("", "", "", "", "", "comment");
+      doTestParseJournalEntry("", "", "", "", "", "userName", "");
+      doTestParseJournalEntry("", "", "", "", "", "", "comment");
+      doTestParseJournalEntry("", "", "", "", "false", "", "");
     }
 
     @Test
     public void testParseJournalEntry_AllMissing() {
-        doTestParseJournalEntry(null, null, null, " ", null, null);
+        doTestParseJournalEntry(null, null, null, " ", null, null, null);
     }
 
     private void doTestParseJournalEntry(final String tokenId, final Long issueTime, final Long expiration, final Long maxLifetime) {
-      doTestParseJournalEntry(tokenId, issueTime, expiration, maxLifetime, null, null);
+      doTestParseJournalEntry(tokenId, issueTime, expiration, maxLifetime, null, null, null);
     }
 
     private void doTestParseJournalEntry(final String tokenId,
                                          final Long   issueTime,
                                          final Long   expiration,
                                          final Long   maxLifetime,
+                                         final Boolean enabled,
                                          final String userName,
                                          final String comment) {
         doTestParseJournalEntry(tokenId,
                                 (issueTime != null ? issueTime.toString() : null),
                                 (expiration != null ? expiration.toString() : null),
                                 (maxLifetime != null ? maxLifetime.toString() : null),
+                                (enabled != null ? enabled.toString() : null),
                                 userName, comment);
     }
 
@@ -107,6 +111,7 @@ public class FileTokenStateJournalTest {
                                          final String issueTime,
                                          final String expiration,
                                          final String maxLifetime,
+                                         final String enabled,
                                          final String userName,
                                          final String comment) {
         StringBuilder entryStringBuilder =
@@ -116,6 +121,7 @@ public class FileTokenStateJournalTest {
                                                              .append(expiration != null ? expiration : "")
                                                              .append(',')
                                                              .append(maxLifetime != null ? maxLifetime : "")
+                                                             .append(",").append(enabled != null ? enabled : "")
                                                              .append(",").append(userName == null ? "" : userName)
                                                              .append(",").append(comment == null ? "" : comment);
 
@@ -125,6 +131,7 @@ public class FileTokenStateJournalTest {
         assertJournalEntryField(issueTime, entry.getIssueTime());
         assertJournalEntryField(expiration, entry.getExpiration());
         assertJournalEntryField(maxLifetime, entry.getMaxLifetime());
+        assertJournalEntryField(StringUtils.isBlank(enabled) ? "false" : enabled, String.valueOf(entry.getTokenMetadata().isEnabled()));
         assertJournalEntryField(userName, entry.getTokenMetadata().getUserName());
         assertJournalEntryField(comment, entry.getTokenMetadata().getComment());
     }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -103,6 +103,8 @@ public class TokenResource {
   static final String GET_TSS_STATUS_PATH = "/getTssStatus";
   static final String RENEW_PATH = "/renew";
   static final String REVOKE_PATH = "/revoke";
+  static final String ENABLE_PATH = "/enable";
+  static final String DISABLE_PATH = "/disable";
   private static final String TARGET_ENDPOINT_PULIC_CERT_PEM = "knox.token.target.endpoint.cert.pem";
   private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
   private long tokenTTL = TOKEN_TTL_DEFAULT;
@@ -408,6 +410,47 @@ public class TokenResource {
     }
 
     return resp;
+  }
+
+  @POST
+  @Path(ENABLE_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response enable(String tokenId) {
+    return setTokenEnabledFlag(tokenId, true);
+  }
+
+  @POST
+  @Path(DISABLE_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response disable(String tokenId) {
+    return setTokenEnabledFlag(tokenId, false);
+  }
+
+  private Response setTokenEnabledFlag(String tokenId, boolean enabled) {
+    String error = "";
+    if (tokenStateService == null) {
+      error = "Unable to " + (enabled ? "enable" : "disable") + " tokens because token management is not configured";
+    } else {
+      try {
+        final TokenMetadata tokenMetadata = tokenStateService.getTokenMetadata(tokenId);
+        if (enabled && tokenMetadata.isEnabled()) {
+          error = "Token is already enabled";
+        } else if (!enabled && !tokenMetadata.isEnabled()) {
+          error = "Token is already disabled";
+        } else {
+          tokenMetadata.setEnabled(enabled);
+          tokenStateService.addMetadata(tokenId, tokenMetadata);
+        }
+      } catch (UnknownTokenException e) {
+        error = safeGetMessage(e);
+      }
+    }
+    if (error.isEmpty()) {
+      return Response.status(Response.Status.OK).entity("{\n  \"setEnabledFlag\": \"true\",\n  \"isEnabled\": \"" + enabled + "\"\n}\n").build();
+    } else {
+      log.badSetEnabledFlagRequest(getTopologyName(), Tokens.getTokenIDDisplayText(tokenId), error);
+      return Response.status(Response.Status.BAD_REQUEST).entity("{\n  \"setEnabledFlag\": \"false\",\n  \"error\": \"" + error + "\"\n}\n").build();
+    }
   }
 
   private X509Certificate extractCertificate(HttpServletRequest req) {

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -71,6 +71,9 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad revocation request for token {1}: {2}")
   void badRevocationRequest(String topologyName, String tokenDisplayText, String error);
 
+  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad set enabled flag request for token {1}: {2}")
+  void badSetEnabledFlagRequest(String topologyName, String tokenId, String error);
+
   @Message( level = MessageLevel.DEBUG, text = "Knox Token service ({0}) stored state for token {1} ({2})")
   void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.security.token;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -26,41 +27,65 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.knox.gateway.util.JsonUtils;
 
 public class TokenMetadata {
-  private static final String JSON_ELEMENT_USER_NAME = "userName";
-  private static final String JSON_ELEMENT_COMMENT = "comment";
-  private static final String EMPTY_COMMENT = "";
+  public static final String USER_NAME = "userName";
+  public static final String COMMENT = "comment";
+  public static final String ENABLED = "enabled";
 
-  private final String userName;
-  private final String comment;
+  private final Map<String, String> metadataMap = new HashMap<>();
 
   public TokenMetadata(String userName) {
-    this(userName, EMPTY_COMMENT);
+    this(userName, null);
   }
 
   public TokenMetadata(String userName, String comment) {
-    this.userName = userName;
-    this.comment = comment;
+    this(userName, comment, true);
+  }
+
+  public TokenMetadata(String userName, String comment, boolean enabled) {
+    saveMetadata(USER_NAME, userName);
+    saveMetadata(COMMENT, comment);
+    setEnabled(enabled);
+  }
+
+  private void saveMetadata(String key, String value) {
+    if (StringUtils.isNotBlank(value)) {
+      this.metadataMap.put(key, value);
+    }
+  }
+
+  public TokenMetadata(Map<String, String> metadataMap) {
+    this.metadataMap.clear();
+    this.metadataMap.putAll(metadataMap);
+  }
+
+  public Map<String, String> getMetadataMap() {
+    return new HashMap<String, String>(this.metadataMap);
   }
 
   public String getUserName() {
-    return userName;
+    return metadataMap.get(USER_NAME);
   }
 
   public String getComment() {
-    return comment;
+    return metadataMap.get(COMMENT);
+  }
+
+  public void setEnabled(boolean enabled) {
+    saveMetadata(ENABLED, String.valueOf(enabled));
+  }
+
+  public boolean isEnabled() {
+    return Boolean.parseBoolean(metadataMap.get(ENABLED));
   }
 
   public String toJSON() {
-    final Map<String, String> metadataMap = new HashMap<>();
-    metadataMap.put(JSON_ELEMENT_USER_NAME, getUserName());
-    metadataMap.put(JSON_ELEMENT_COMMENT, getComment() == null ? EMPTY_COMMENT : getComment());
     return JsonUtils.renderAsJsonString(metadataMap);
   }
 
   public static TokenMetadata fromJSON(String json) {
     final Map<String, String> metadataMap = JsonUtils.getMapFromJsonString(json);
     if (metadataMap != null) {
-      return new TokenMetadata(metadataMap.get(JSON_ELEMENT_USER_NAME), metadataMap.get(JSON_ELEMENT_COMMENT));
+      return new TokenMetadata(metadataMap);
     }
     throw new IllegalArgumentException("Invalid metadata JSON: " + json);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a new `KNOXTOKEN` service API to enable/disable a Knox-generated token.
Instead of adding another column in the `KNOX_TOKENS` table, a brand new DB table was introduced where an arbitrary number of token metadata can be stored (identified by the given token's ID and the metadata name).
In our alias-based token state management implementations, this is stored as a new JSON field whereas in the file journal-based implementation the new flag is added before the user name.

## How was this patch tested?

Updated and executed JUnit tests.

Additionally, the following manual test steps were executed:

1. Created a token using the tokengen application:

<img width="591" alt="Screen Shot 2021-05-04 at 9 45 52 PM" src="https://user-images.githubusercontent.com/34065904/117061141-1eabc900-ad22-11eb-8f09-8420b8cbd5ca.png">

```
postgres=# select * from knox_tokens kt, knox_token_metadata ktm WHERE kt.token_id = ktm.token_id;
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               | md_name  |                                 md_value                                  
--------------------------------------+---------------+---------------+---------------+--------------------------------------+----------+---------------------------------------------------------------------------
 1e2f286e-9df1-4123-8d41-e6af523d6923 | 1620155983024 | 1620249883013 | 1620760783024 | 1e2f286e-9df1-4123-8d41-e6af523d6923 | enabled  | true
 1e2f286e-9df1-4123-8d41-e6af523d6923 | 1620155983024 | 1620249883013 | 1620760783024 | 1e2f286e-9df1-4123-8d41-e6af523d6923 | userName | admin
 1e2f286e-9df1-4123-8d41-e6af523d6923 | 1620155983024 | 1620249883013 | 1620760783024 | 1e2f286e-9df1-4123-8d41-e6af523d6923 | comment  | comment with a question mark ? and my favorite cartoon tom & jerry !!! :)
(3 rows)
```

2. Tried to enable an already enabled token
```
$ curl -ku admin:admin-password -d "1e2f286e-9df1-4123-8d41-e6af523d6923" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/enable
{
  "setEnabledFlag": "false",
  "error": "Token is already enabled"
}
```
3. Disabled the token
```
$ curl -ku admin:admin-password -d "1e2f286e-9df1-4123-8d41-e6af523d6923" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/disable
{
  "setEnabledFlag": "true",
  "isEnabled": "false"
}
```
```
postgres=# select * from knox_tokens kt, knox_token_metadata ktm WHERE kt.token_id = ktm.token_id AND ktm.md_name = 'enabled';
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               | md_name | md_value 
--------------------------------------+---------------+---------------+---------------+--------------------------------------+---------+----------
 1e2f286e-9df1-4123-8d41-e6af523d6923 | 1620155983024 | 1620249883013 | 1620760783024 | 1e2f286e-9df1-4123-8d41-e6af523d6923 | enabled | false
(1 row)
```
4. Tried to disable an already disabled token
```
$ curl -ku admin:admin-password -d "1e2f286e-9df1-4123-8d41-e6af523d6923" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/disable
{
  "setEnabledFlag": "false",
  "error": "Token is already disabled"
}
```

5. Enabled the token
```
$ curl -ku admin:admin-password -d "1e2f286e-9df1-4123-8d41-e6af523d6923" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/enable
{
  "setEnabledFlag": "true",
  "isEnabled": "true"
}
```
```
postgres=# select * from knox_tokens kt, knox_token_metadata ktm WHERE kt.token_id = ktm.token_id AND ktm.md_name = 'enabled';
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               | md_name | md_value 
--------------------------------------+---------------+---------------+---------------+--------------------------------------+---------+----------
 1e2f286e-9df1-4123-8d41-e6af523d6923 | 1620155983024 | 1620249883013 | 1620760783024 | 1e2f286e-9df1-4123-8d41-e6af523d6923 | enabled | true
(1 row)
```

6. Renewed the token
```
$ curl -ku admin:admin-password -d "@token.txt" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/renew
{
  "renewed": "true",
  "expires": "1620243157437"
}
```
```
postgres=# select * from knox_tokens;
               token_id               |  issue_time   |  expiration   | max_lifetime  
--------------------------------------+---------------+---------------+---------------
 1e2f286e-9df1-4123-8d41-e6af523d6923 | 1620155983024 | 1620243157437 | 1620760783024
(1 row)
```
7. Revoked the token
```
$ curl -ku admin:admin-password -d "@token.txt" -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/revoke
{
  "revoked": "true"
}
```
```
postgres=# select * from knox_tokens kt, knox_token_metadata ktm WHERE kt.token_id = ktm.token_id;
 token_id | issue_time | expiration | max_lifetime | token_id | md_name | md_value 
----------+------------+------------+--------------+----------+---------+----------
(0 rows)
```
