### PR TITLE
KNOX-2603 - Caching passcode token verifications

### DIFF
--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -551,7 +551,7 @@ public class HadoopAuthFilterTest {
       expect(filterConfig.getInitParameter(JWTFederationFilter.JWT_UNAUTHENTICATED_PATHS_PARAM)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_ISSUER)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_SIGALG)).andReturn(null).anyTimes();
-      expect(filterConfig.getInitParameter(SignatureVerificationCache.JWT_VERIFIED_CACHE_MAX)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(SignatureVerificationCache.TOKENS_VERIFIED_CACHE_MAX)).andReturn(null).anyTimes();
     }
 
     final ServletContext servletContext = createMock(ServletContext.class);

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -143,7 +143,8 @@ public class JWTFederationFilter extends AbstractJWTFilter {
       } else if (TokenType.Passcode.equals(tokenType)) {
         // Validate the token based on the server-managed metadata
         // The received token value must be a Base64 encoded value of Base64(tokenId)::Base64(rawPasscode)
-        String tokenId = null, passcode = null;
+        String tokenId = null;
+        String passcode = null;
         try {
           final String[] base64DecodedTokenIdAndPasscode = decodeBase64(tokenValue).split("::");
           tokenId = decodeBase64(base64DecodedTokenIdAndPasscode[0]);

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SignatureVerificationCache.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/SignatureVerificationCache.java
@@ -30,8 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class SignatureVerificationCache {
 
-    public static final String JWT_VERIFIED_CACHE_MAX = "jwt.verified.cache.max";
-    public static final int    JWT_VERIFIED_CACHE_MAX_DEFAULT = 250;
+    public static final String TOKENS_VERIFIED_CACHE_MAX = "tokens.verified.cache.max";
+    private static final int   TOKENS_VERIFIED_CACHE_MAX_DEFAULT = 250;
 
     static final String DEFAULT_CACHE_ID = "default-cache";
 
@@ -71,9 +71,9 @@ public class SignatureVerificationCache {
      * @param config The configuration of the provider employing this cache.
      */
     private void initializeVerifiedTokensCache(final FilterConfig config) {
-        int maxCacheSize = JWT_VERIFIED_CACHE_MAX_DEFAULT;
+        int maxCacheSize = TOKENS_VERIFIED_CACHE_MAX_DEFAULT;
 
-        String configValue = config.getInitParameter(JWT_VERIFIED_CACHE_MAX);
+        String configValue = config.getInitParameter(TOKENS_VERIFIED_CACHE_MAX);
         if (configValue != null && !configValue.isEmpty()) {
             try {
                 maxCacheSize = Integer.parseInt(configValue);
@@ -86,32 +86,32 @@ public class SignatureVerificationCache {
     }
 
     /**
-     * Determine if the specified JWT's signature has previously been successfully verified.
+     * Determine if the specified token's signature has previously been successfully verified.
      *
-     * @param jwt A serialized JWT.
+     * @param token A serialized JWT or Passcode token.
      *
      * @return true, if the specified token has been previously verified; Otherwise, false.
      */
-    public boolean hasSignatureBeenVerified(final String jwt) {
-        return (verifiedTokens.getIfPresent(jwt) != null);
+    public boolean hasSignatureBeenVerified(final String token) {
+        return (verifiedTokens.getIfPresent(token) != null);
     }
 
     /**
      * Record a successful token signature verification.
      *
-     * @param jwt A serialized JWT for which the signature has been successfully verified.
+     * @param token A serialized JWT or Passcode token for which the signature has been successfully verified.
      */
-    public void recordSignatureVerification(final String jwt) {
-        verifiedTokens.put(jwt, true);
+    public void recordSignatureVerification(final String token) {
+        verifiedTokens.put(token, true);
     }
 
     /**
      * Explicitly evict the signature verification record from the cache if it exists.
      *
-     * @param jwt The serialized JWT for which the associated signature verification record should be evicted.
+     * @param token The serialized JWT or Passcode token for which the associated signature verification record should be evicted.
      */
-    public void removeSignatureVerificationRecord(final String jwt) {
-         verifiedTokens.asMap().remove(jwt);
+    public void removeSignatureVerificationRecord(final String token) {
+         verifiedTokens.asMap().remove(token);
     }
 
     /**

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -75,6 +75,7 @@ import static org.junit.Assert.fail;
 public abstract class AbstractJWTFilterTest  {
   protected static final String SERVICE_URL = "https://localhost:8888/resource";
   private static final String dnTemplate = "CN={0},OU=Test,O=Hadoop,L=Test,ST=Test,C=US";
+  protected static final String PASSCODE_CLAIM = "passcode";
 
   protected AbstractJWTFilter handler;
   protected static RSAPublicKey publicKey;
@@ -802,7 +803,7 @@ public abstract class AbstractJWTFilterTest  {
 
       Properties props = getProperties();
       props.put(AbstractJWTFilter.JWT_EXPECTED_SIGALG, "RS512");
-      props.put(SignatureVerificationCache.JWT_VERIFIED_CACHE_MAX, "1");
+      props.put(SignatureVerificationCache.TOKENS_VERIFIED_CACHE_MAX, "1");
       props.put(TestFilterConfig.TOPOLOGY_NAME_PROP, "jwt-verification-optimization-test");
       handler.init(new TestFilterConfig(props));
       Assert.assertEquals("Expected no token verification calls yet.",
@@ -856,7 +857,7 @@ public abstract class AbstractJWTFilterTest  {
 
       Properties props = getProperties();
       props.put(AbstractJWTFilter.JWT_EXPECTED_SIGALG, "RS512");
-      props.put(SignatureVerificationCache.JWT_VERIFIED_CACHE_MAX, "1");
+      props.put(SignatureVerificationCache.TOKENS_VERIFIED_CACHE_MAX, "1");
       props.put(TestFilterConfig.TOPOLOGY_NAME_PROP, "jwt-eviction-test");
       handler.init(new TestFilterConfig(props));
       Assert.assertEquals("Expected no token verification calls yet.",
@@ -1009,7 +1010,8 @@ public abstract class AbstractJWTFilterTest  {
             .audience(aud)
             .expirationTime(expires)
             .notBeforeTime(nbf)
-            .claim("scope", "openid");
+            .claim("scope", "openid")
+            .claim(PASSCODE_CLAIM, UUID.randomUUID().toString());
     if (knoxId != null) {
       builder.claim(JWTToken.KNOX_ID_CLAIM, knoxId);
     }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -18,7 +18,21 @@
  */
 package org.apache.knox.gateway.provider.federation;
 
-import com.nimbusds.jwt.SignedJWT;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.HmacAlgorithms;
@@ -37,22 +51,7 @@ import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
-import java.time.Instant;
-import java.util.Date;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.fail;
+import com.nimbusds.jwt.SignedJWT;
 
 @SuppressWarnings({"PMD.JUnit4TestShouldUseBeforeAnnotation", "PMD.JUnit4TestShouldUseTestAnnotation"})
 public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicCredsFederationFilterTest {
@@ -74,7 +73,7 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
       try {
         final long issueTime = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);
         final String subject = (String) jwt.getJWTClaimsSet().getClaim(JWTToken.SUBJECT);
-        final String passcode = UUID.randomUUID().toString();
+        final String passcode = (String) jwt.getJWTClaimsSet().getClaims().get(PASSCODE_CLAIM);
         addTokenState(jwt, issueTime, subject, passcode);
         setTokenOnRequest(request, TestJWTFederationFilter.PASSCODE, generatePasscodeField(getTokenId(jwt), passcode));
       } catch(ParseException e) {
@@ -101,7 +100,7 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
       try {
         final long issueTime = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);
         final String subject = (String) jwt.getJWTClaimsSet().getClaim(JWTToken.SUBJECT);
-        final String passcode = UUID.randomUUID().toString();
+        final String passcode = (String) jwt.getJWTClaimsSet().getClaims().get(PASSCODE_CLAIM);
         addTokenState(jwt, issueTime, subject, passcode);
         setTokenOnRequest(request, authUsername, generatePasscodeField(getTokenId(jwt), passcode));
       } catch(ParseException e) {
@@ -335,11 +334,6 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
 
     @Override
     public void testNotBeforeJWT() throws Exception {
-        // Override to disable N/A test
-    }
-
-    @Override
-    public void testVerificationOptimization() throws Exception {
         // Override to disable N/A test
     }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -353,7 +353,7 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService implem
       }
       issueTime = convertCharArrayToLong(issueTimeStr);
       // Update the in-memory cache to avoid subsequent keystore look-ups for the same state
-      super.setIssueTime(tokenId, issueTime);
+      setIssueTimeInMemory(tokenId, issueTime);
     } catch (UnknownTokenException e) {
       throw e;
     } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to avoid expensive MAC calculation at request verification time, previous successful passcode token verifications are cached and checked when validating a passcode token.

## How was this patch tested?

Updated existing JUnit tests: I made sure common `testVerificationOptimization` is invoked in `TokenIDAsHTTPBasicCredsFederationFilterTest` (where we test passcode tokens)