### PR TITLE
KNOX-2606 - Indicate configured token TTL on UI and ask for confirmation when end-users try to generate a token above the configured limit

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -32,6 +32,7 @@
 
         <script src="libs/bower/jquery/js/jquery-3.5.1.min.js" ></script>
         <script type="text/javascript" src="js/tokengen.js"></script>
+        <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
     
         <script type="text/javascript">
            $(function() {
@@ -65,6 +66,9 @@
                         <label><i class="icon-comment"></i> Comment:</label>
                         <input type="text" name="comment" id="comment" tabindex="1" onkeypress=keypressed(event) autofocus size="255">
 
+                        <label><i class="icon-info"></i> Configured maximum lifetime: </label>
+                        <label id="maximumLifetimeText"></label>
+                        <input type="number" id="maximumLifetimeSeconds" name="maximumLifetimeSeconds" style="display: none;">
                         <label><i class="icon-time"></i> Lifetime (days, hours, mins):</label>
                         <table>
                             <tr>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to avoid misunderstandings and customer escalations, the token generation UI now indicates what is the configured maximum lifetime (`knox.token.ttl` in the relevant topology). In case end-users wants to generate a token that exceeds the configured maximum, a confirmation window is shown where we explain the side effects.

Please note that if `knox.token.ttl` is set to `-1` the topology owner explicitly configured `unlimited lifetime`, so we do not need to check the supplied lifespan.

## How was this patch tested?

Manually tested.

<img width="618" alt="Screen Shot 2021-05-20 at 1 54 02 PM" src="https://user-images.githubusercontent.com/34065904/118978093-35375e80-b977-11eb-8bf6-8716dc4abcc3.png">

<img width="599" alt="Screen Shot 2021-05-20 at 4 59 38 PM" src="https://user-images.githubusercontent.com/34065904/119002034-cd8c0e00-b98c-11eb-8875-9f24e2804533.png">


