### PR TITLE
KNOX-2608 - JWT tokens issues by Knox should have 'kid' and 'jku' as part of JOSE Headers

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -16,6 +16,8 @@
  */
 package org.apache.knox.gateway.services.security.token.impl;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.ArrayList;
@@ -66,7 +68,25 @@ public class JWTToken implements JWT {
   }
 
   public JWTToken(String alg, String[] claimsArray, List<String> audiences, boolean managed) {
-    JWSHeader header = new JWSHeader(new JWSAlgorithm(alg));
+    JWSHeader header = null;
+    try {
+      header = new JWSHeader(new JWSAlgorithm(alg),
+      null,
+      null,
+      null,
+      claimsArray[5] != null ? new URI(claimsArray[5]) : null, // JKU
+      null,
+      null,
+      null,
+      null,
+      null,
+       claimsArray[4] != null ? claimsArray[4] : null, // KID
+      null,
+      null);
+    } catch (URISyntaxException e) {
+      /* in event of bad URI exception fall back to using just algo in header */
+      header = new JWSHeader(new JWSAlgorithm(alg));
+    }
 
     if(claimsArray == null || claimsArray.length < 6) {
       log.missingClaims(claimsArray.length);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -80,7 +80,7 @@ public class JWTToken implements JWT {
       null,
       null,
       null,
-       claimsArray[4] != null ? claimsArray[4] : null, // KID
+      claimsArray[4] != null ? claimsArray[4] : null, // KID
       null,
       null);
     } catch (URISyntaxException e) {

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -69,18 +70,25 @@ public class JWTTokenTest {
 
   @Test
   public void testTokenCreation() throws Exception {
+    final String KID = "E0LDZulQ0XE_otJ5aoQtQu-RnXv8hU-M9U4dD7vDioA";
+    final String JKU = "https://localhost:8443/gateway/token/knoxtoken/api/v1/jwks.json";
+    final String ALGO = "RS256";
     String[] claims = new String[6];
     claims[0] = "KNOXSSO";
     claims[1] = "john.doe@example.com";
     claims[2] = "https://login.example.com";
     claims[3] = Long.toString( ( System.currentTimeMillis()/1000 ) + 300);
-    claims[4] = "E0LDZulQ0XE_otJ5aoQtQu-RnXv8hU-M9U4dD7vDioA";
-    claims[5] = null;
-    JWT token = new JWTToken("RS256", claims);
+    claims[4] = KID;
+    claims[5] = JKU;
+    JWT token = new JWTToken(ALGO, claims);
 
     assertEquals("KNOXSSO", token.getIssuer());
     assertEquals("john.doe@example.com", token.getSubject());
     assertEquals("https://login.example.com", token.getAudience());
+
+    assertTrue("Missing KID claim in JWT header", token.getHeader().contains(KID));
+    assertTrue("Missing JKU claim in JWT header", token.getHeader().contains("jwks.json"));
+    assertTrue("Missing ALG claim in JWT header", token.getHeader().contains(ALGO));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding 'kid' and 'jku' claims as part of JOSE Headers for tokens issued by Knox

## How was this patch tested?
This patch was tested locally. Added unit tests.