### PR TITLE
KNOX-2616 - Removed trailing slashes service context generation

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ambariui/2.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ambariui/2.2.0/service.xml
@@ -17,7 +17,7 @@
 <service role="AMBARIUI" name="ambariui" version="2.2.0">
     <metadata>
         <type>UI</type>
-        <context>/ambari</context>
+        <context>/ambari/</context>
         <shortDesc>Apache Ambari Web UI</shortDesc>
         <description>The Apache Ambari project is aimed at making Hadoop management simpler by developing software for provisioning, managing, and monitoring Apache Hadoop clusters. 
             Ambari provides an intuitive, easy-to-use Hadoop management web UI backed by its RESTful APIs.</description>

--- a/gateway-service-definitions/src/main/resources/services/atlas/0.1.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/0.1.2.0/service.xml
@@ -18,7 +18,7 @@
 <service role="ATLAS" name="atlas" version="0.1.2.0">
     <metadata>
         <type>UI</type>
-        <context>/atlas</context>
+        <context>/atlas/</context>
         <shortDesc>Atlas UI</shortDesc>
         <description>Apache Atlas provides open metadata management and governance capabilities for organizations to build a catalog of their data assets, 
             classify and govern these assets and provide collaboration capabilities around these data assets for data scientists, analysts and the data governance team.</description>

--- a/gateway-service-definitions/src/main/resources/services/atlas/0.8.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/0.8.0/service.xml
@@ -18,7 +18,7 @@
 <service role="ATLAS" name="atlas" version="0.8.0">
     <metadata>
         <type>UI</type>
-        <context>/atlas</context>
+        <context>/atlas/</context>
         <shortDesc>Atlas UI</shortDesc>
         <description>Apache Atlas provides open metadata management and governance capabilities for organizations to build a catalog of their data assets, 
             classify and govern these assets and provide collaboration capabilities around these data assets for data scientists, analysts and the data governance team.</description>

--- a/gateway-service-definitions/src/main/resources/services/atlas/2.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/2.0.0/service.xml
@@ -17,7 +17,7 @@
 <service role="ATLAS" name="atlas" version="2.0.0">
     <metadata>
         <type>UI</type>
-        <context>/atlas</context>
+        <context>/atlas/</context>
         <shortDesc>Atlas UI</shortDesc>
         <description>Apache Atlas provides open metadata management and governance capabilities for organizations to build a catalog of their data assets, 
             classify and govern these assets and provide collaboration capabilities around these data assets for data scientists, analysts and the data governance team.</description>

--- a/gateway-service-definitions/src/main/resources/services/atlas/2.1.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/2.1.0/service.xml
@@ -17,7 +17,7 @@
 <service role="ATLAS" name="atlas" version="2.1.0">
     <metadata>
         <type>UI</type>
-        <context>/atlas</context>
+        <context>/atlas/</context>
         <shortDesc>Atlas UI</shortDesc>
         <description>Apache Atlas provides open metadata management and governance capabilities for organizations to build a catalog of their data assets,
             classify and govern these assets and provide collaboration capabilities around these data assets for data scientists, analysts and the data governance team.</description>

--- a/gateway-service-definitions/src/main/resources/services/cm-ui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/cm-ui/1.0.0/service.xml
@@ -26,7 +26,7 @@
 <service role="CM-UI" name="cm-ui" version="1.0.0">
     <metadata>
         <type>UI</type>
-        <context>/cmf</context>
+        <context>/cmf/</context>
         <shortDesc>Cloudera Manager Admin Console</shortDesc>
         <description>Cloudera Manager Admin Console is the web-based UI that you use to configure, manage, and monitor CDH.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/druid-coordinator-ui/0.0.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/druid-coordinator-ui/0.0.1/service.xml
@@ -17,7 +17,7 @@
 <service role="DRUID-COORDINATOR-UI" name="druid-coordinator-ui" version="0.0.1">
     <metadata>
         <type>UI</type>
-        <context>/druid-coordinator-ui</context>
+        <context>/druid-coordinator-ui/</context>
         <shortDesc>Druid Coordinator Console</shortDesc>
         <description>The Druid Coordinator exposes a web GUI for displaying cluster information and rule configuration.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/druid-overlord-ui/0.0.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/druid-overlord-ui/0.0.1/service.xml
@@ -17,7 +17,7 @@
 <service role="DRUID-OVERLORD-UI" name="druid-overlord-ui" version="0.0.1">
     <metadata>
         <type>UI</type>
-        <context>/druid-overlord-ui</context>
+        <context>/druid-overlord-ui/</context>
         <shortDesc>Druid Overlord Console</shortDesc>
         <description>The Overlord provides a UI for managing tasks and workers.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/flink/1.10.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/flink/1.10.1/service.xml
@@ -17,7 +17,7 @@
 -->
 <service name="flink" role="FLINK" version="1.10.1">
     <metadata>
-        <context>/flink</context>
+        <context>/flink/</context>
         <description>The Flink Dashboard acts as a single UI for all the Flink jobs running on the YARN cluster.</description>
         <shortDesc>Flink Dashboard</shortDesc>
         <type>UI</type>

--- a/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/service.xml
@@ -18,7 +18,7 @@
 <service role="HDFSUI" name="hdfs" version="3.0.0">
     <metadata>
         <type>UI</type>
-        <context>/hdfs</context>
+        <context>/hdfs/</context>
         <shortDesc>HDFS Namenode UI</shortDesc>
         <description>The namenode UI or the namenode web interface is used to monitor the status of the namenode.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/hue/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hue/1.0.0/service.xml
@@ -17,7 +17,7 @@
 <service role="HUE" name="hue" version="1.0.0">
     <metadata>
         <type>UI</type>
-        <context>/hue</context>
+        <context>/hue/</context>
         <shortDesc>Hue UI</shortDesc>
         <description>Hue UI is a Web interface for analyzing data with Apache Hadoop</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/jobhistoryui/2.7.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/jobhistoryui/2.7.0/service.xml
@@ -18,7 +18,7 @@
 <service role="JOBHISTORYUI" name="jobhistory" version="2.7.0">
     <metadata>
         <type>UI</type>
-        <context>/jobhistory</context>
+        <context>/jobhistory/</context>
         <shortDesc>JobHistory Server Web UI</shortDesc>
         <description>Web User Interface for YARN Jobhistory Server</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.0/service.xml
@@ -18,7 +18,7 @@
 <service role="LIVYSERVER" name="livy" version="0.4.0">
     <metadata>
         <type>API_AND_UI</type>
-        <context>/livy</context>
+        <context>/livy/</context>
         <shortDesc>Livy Server</shortDesc>
         <description>Apache Livy is a service that enables easy interaction with a Spark cluster over a REST interface.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/livy/0.4.3/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/livy/0.4.3/service.xml
@@ -18,7 +18,7 @@
 <service role="LIVYSERVER" name="livy" version="0.4.3">
   <metadata>
     <type>API_AND_UI</type>
-    <context>/livy</context>
+    <context>/livy/</context>
     <shortDesc>Livy Server</shortDesc>
     <description>Apache Livy is a service that enables easy interaction with a Spark cluster over a REST interface.</description>
   </metadata>

--- a/gateway-service-definitions/src/main/resources/services/logsearch/0.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/logsearch/0.5.0/service.xml
@@ -18,7 +18,7 @@
 <service role="LOGSEARCH" name="logsearch" version="0.5.0">
     <metadata>
         <type>UI</type>
-        <context>/logsearch</context>
+        <context>/logsearch/</context>
         <shortDesc>Ambari LogSearch UI</shortDesc>
         <description>The Ambari Log Search UI is a purpose-built web application used to search HDP component logs. 
             The UI is focussed on helping operators quickly access and search logs from a single location. Logs can be filtered by log level, time, component, and can be searched by keyword.</description>

--- a/gateway-service-definitions/src/main/resources/services/nifi-registry/0.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nifi-registry/0.5.0/service.xml
@@ -17,7 +17,7 @@
 <service role="NIFI-REGISTRY" name="nifi-registry" version="0.5.0">
     <metadata>
         <type>UI</type>
-        <context>/nifi-registry-app/nifi-registry</context>
+        <context>/nifi-registry-app/nifi-registry/</context>
         <shortDesc>Nifi Registry UI</shortDesc>
         <description>Registry — a subproject of Apache NiFi — is a complementary application that provides a central location for storage and management of shared resources across one or more instances of NiFi and/or MiNiFi.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/nifi/1.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nifi/1.4.0/service.xml
@@ -17,7 +17,7 @@
 <service role="NIFI" name="nifi" version="1.4.0">
     <metadata>
         <type>UI</type>
-        <context>/nifi-app/nifi</context>
+        <context>/nifi-app/nifi/</context>
         <shortDesc>Nifi UI</shortDesc>
         <description>Apache NiFi supports powerful and scalable directed graphs of data routing, transformation, and system mediation logic.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/nodemanagerui/2.7.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/nodemanagerui/2.7.1/service.xml
@@ -18,7 +18,7 @@
 <service role="NODEUI" name="nodeui" version="2.7.1">
     <metadata>
         <type>UI</type>
-        <context>/node</context>
+        <context>/node/</context>
         <shortDesc>YARN NodeManager UI</shortDesc>
         <description>The NodeManager is responsible for launching and managing containers on a node.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/oozieui/4.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/oozieui/4.2.0/service.xml
@@ -18,7 +18,7 @@
 <service role="OOZIEUI" name="oozieui" version="4.2.0">
     <metadata>
         <type>UI</type>
-        <context>/oozie</context>
+        <context>/oozie/</context>
         <shortDesc>Oozie Web Console</shortDesc>
         <description>Oozie web console is a web-based tool that gives a read-only view about the jobs.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/0.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/0.5.0/service.xml
@@ -17,7 +17,7 @@
 <service role="RANGERUI" name="rangerui" version="0.5.0">
     <metadata>
         <type>UI</type>
-        <context>/ranger</context>
+        <context>/ranger/</context>
         <shortDesc>Ranger Admin Web UI</shortDesc>
         <description>Apache Ranger is a framework to enable, monitor and manage comprehensive data security across the Hadoop platform. Ranger Admin Web UI is a web-based tool that provides a way to configure Ranger.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
@@ -17,7 +17,7 @@
 <service role="RANGERUI" name="rangerui" version="1.0.0">
     <metadata>
         <type>UI</type>
-        <context>/ranger</context>
+        <context>/ranger/</context>
         <shortDesc>Ranger Admin Web UI</shortDesc>
         <description>Apache Ranger is a framework to enable, monitor and manage comprehensive data security across the Hadoop platform. Ranger Admin Web UI is a web-based tool that provides a way to configure Ranger.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/solr/5.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/solr/5.5.0/service.xml
@@ -18,7 +18,7 @@
 <service role="SOLRAPI" name="solr" version="5.5.0">
     <metadata>
         <type>API_AND_UI</type>
-        <context>/solr</context>
+        <context>/solr/</context>
         <shortDesc>SOLR</shortDesc>
         <description>Solr is a popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/solr/6.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/solr/6.0.0/service.xml
@@ -18,7 +18,7 @@
 <service role="SOLR" name="solr" version="6.0.0">
     <metadata>
         <type>API_AND_UI</type>
-        <context>/solr</context>
+        <context>/solr/</context>
         <shortDesc>SOLR</shortDesc>
         <description>Solr is a popular, blazing-fast, open source enterprise search platform built on Apache Lucene™.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/spark3historyui/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/spark3historyui/3.0.0/service.xml
@@ -18,7 +18,7 @@
 <service role="SPARK3HISTORYUI" name="spark3history" version="3.0.0">
     <metadata>
         <type>UI</type>
-        <context>/spark3history</context>
+        <context>/spark3history/</context>
         <shortDesc>Spark3 History Server Web UI</shortDesc>
         <description>Spark3 History Server Web UI provides a comprehensive view of: A list of scheduler stages and tasks - A summary of RDD sizes and memory usage - Environmental information - Information about the running executors.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/1.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/1.4.0/service.xml
@@ -18,7 +18,7 @@
 <service role="SPARKHISTORYUI" name="sparkhistory" version="1.4.0">
     <metadata>
         <type>UI</type>
-        <context>/sparkhistory</context>
+        <context>/sparkhistory/</context>
         <shortDesc>Spark History Server Web UI</shortDesc>
         <description>Spark History Server Web UI provides a comprehensive view of: A list of scheduler stages and tasks - A summary of RDD sizes and memory usage - Environmental information - Information about the running executors.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/service.xml
@@ -18,7 +18,7 @@
 <service role="SPARKHISTORYUI" name="sparkhistory" version="2.3.0">
     <metadata>
         <type>UI</type>
-        <context>/sparkhistory</context>
+        <context>/sparkhistory/</context>
         <shortDesc>Spark History Server Web UI</shortDesc>
         <description>Spark History Server Web UI provides a comprehensive view of: A list of scheduler stages and tasks - A summary of RDD sizes and memory usage - Environmental information - Information about the running executors.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/sparkthriftui/2.1.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkthriftui/2.1.0/service.xml
@@ -18,7 +18,7 @@
 <service role="THRIFTSERVERUI" name="thriftserverui" version="2.1.0">
     <metadata>
         <type>UI</type>
-        <context>/thrift</context>
+        <context>/thrift/</context>
         <shortDesc>Spark Thrift Server UI</shortDesc>
         <description>Spark Thrift server is a service that allows JDBC and ODBC clients to run Spark SQL queries. The Spark Thrift server is a variant of HiveServer2.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/service.xml
@@ -18,7 +18,7 @@
 <service role="YARNUI" name="yarn" version="2.7.0">
     <metadata>
         <type>UI</type>
-        <context>/yarn</context>
+        <context>/yarn/</context>
         <shortDesc>YARN Resource Manager Web UI</shortDesc>
         <description>YARN Resource Manager Web interface (v1)</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/service.xml
@@ -18,7 +18,7 @@
 <service role="YARNUIV2" name="yarnuiv2" version="3.0.0">
      <metadata>
         <type>UI</type>
-        <context>/yarnuiv2</context>
+        <context>/yarnuiv2/</context>
         <shortDesc>YARN Resource Manager Web UI V2</shortDesc>
         <description>YARN Resource Manager Web interface (v2)</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/zeppelinui/0.6.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/zeppelinui/0.6.0/service.xml
@@ -18,7 +18,7 @@
 <service role="ZEPPELINUI" name="zeppelinui" version="0.6.0">
     <metadata>
         <type>UI</type>
-        <context>/zeppelin</context>
+        <context>/zeppelin/</context>
         <shortDesc>Zeppelin Web UI</shortDesc>
         <description>Zeppelin's web user interface allows end-users to explore Zeppelin notebooks.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.0/service.xml
@@ -18,7 +18,7 @@
 <service role="ZEPPELINUI" name="zeppelinui" version="0.8.0">
     <metadata>
         <type>UI</type>
-        <context>/zeppelin</context>
+        <context>/zeppelin/</context>
         <shortDesc>Zeppelin Web UI</shortDesc>
         <description>Zeppelin's web user interface allows end-users to explore Zeppelin notebooks.</description>
     </metadata>

--- a/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.1/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/zeppelinui/0.8.1/service.xml
@@ -18,7 +18,7 @@
 <service role="ZEPPELINUI" name="zeppelinui" version="0.8.1">
     <metadata>
         <type>UI</type>
-        <context>/zeppelin</context>
+        <context>/zeppelin/</context>
         <shortDesc>Zeppelin Web UI</shortDesc>
         <description>Zeppelin's web user interface allows end-users to explore Zeppelin notebooks.</description>
     </metadata>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
@@ -119,7 +119,7 @@ public class ServiceModel implements Comparable<ServiceModel> {
 
   @XmlElement
   public String getContext() {
-    return (serviceMetadata == null ? "/" + getServiceName().toLowerCase(Locale.ROOT) : serviceMetadata.getContext()) + "/";
+    return serviceMetadata == null ? ("/" + getServiceName().toLowerCase(Locale.ROOT)) : serviceMetadata.getContext();
   }
 
   @XmlElement

--- a/gateway-service-metadata/src/test/java/org/apache/knox/gateway/service/metadata/ServiceModelTest.java
+++ b/gateway-service-metadata/src/test/java/org/apache/knox/gateway/service/metadata/ServiceModelTest.java
@@ -125,7 +125,7 @@ public class ServiceModelTest {
     serviceModel.setService(service);
     EasyMock.expect(service.getRole()).andReturn("sampleRole").anyTimes();
     EasyMock.replay(service);
-    assertEquals("/samplerole/", serviceModel.getContext());
+    assertEquals("/samplerole", serviceModel.getContext());
   }
 
   @Test
@@ -136,7 +136,7 @@ public class ServiceModelTest {
     final String context = "/testContext";
     EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
     EasyMock.replay(metadata);
-    assertEquals(context + "/", serviceModel.getContext());
+    assertEquals(context, serviceModel.getContext());
   }
 
   @Test
@@ -176,7 +176,7 @@ public class ServiceModelTest {
     final String context = "/testContext";
     EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
     EasyMock.replay(metadata);
-    assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, context + "/"), serviceModel.getServiceUrl());
+    assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, context), serviceModel.getServiceUrl());
   }
 
   @Test
@@ -199,12 +199,12 @@ public class ServiceModelTest {
     EasyMock.expect(metadata.getContext()).andReturn(context).anyTimes();
     EasyMock.replay(service, metadata);
     assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName,
-        context.replace("{{BACKEND_HOST}}", backendHost) + "/"), serviceModel.getServiceUrl());
+        context.replace("{{BACKEND_HOST}}", backendHost)), serviceModel.getServiceUrl());
 
     final String serviceUrl = "https://serviceHost:8888";
     serviceModel.setServiceUrl(serviceUrl); // backend host comes from the given service URL
     assertEquals(
-        String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, context.replace("{{BACKEND_HOST}}", serviceUrl) + "/"),
+        String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName, context.replace("{{BACKEND_HOST}}", serviceUrl)),
         serviceModel.getServiceUrl());
   }
 
@@ -229,6 +229,6 @@ public class ServiceModelTest {
 
     EasyMock.replay(service, metadata);
     assertEquals(String.format(Locale.ROOT, SERVICE_URL_TEMPLATE, SERVER_SCHEME, SERVER_NAME, SERVER_PORT, gatewayPath, topologyName,
-        context.replace("{{SCHEME}}", "https").replace("{{HOST}}", "localhost").replace("{{PORT}}", "5555") + "/"), serviceModel.getServiceUrl());
+        context.replace("{{SCHEME}}", "https").replace("{{HOST}}", "localhost").replace("{{PORT}}", "5555")), serviceModel.getServiceUrl());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extra trailing slash in the generated service context caused problems.

Additionally, to avoid regression, all UI and API_AND_UI type service definitions were modified to contain the trailing slash except the ones with query parameters. Thanks, @stoty for the deliberate testing.

## How was this patch tested?

Updated JUnit tests and tested many of the supported service UIs in my own cluster.
