### PR TITLE
KNOX-2618 - INFO level logging added about removing expired tokens from the DB

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -193,6 +193,9 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "An error occurred while removing token {0} from the database : {1}")
   void errorRemovingTokenFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.INFO, text = "Removing {0} expired token(s) from the database: {1}")
+  void removingExpiredTokensFromDatabase(int size, String expiredTokensList);
+
   @Message(level = MessageLevel.DEBUG, text = "{0} expired tokens have been removed from the database")
   void removedTokensFromDatabase(int size);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of logging the number of expired tokens removed from the DB at `DEBUG` level, Knox logs the 

## How was this patch tested?

Tested manually:
```
2021-06-08 12:45:54,837 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(570)) - Knox Token service (homepage) issued token eyJqa3...sHsZgg (ab56217a...aa2afedee2bc)
2021-06-08 12:45:56,445 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(570)) - Knox Token service (homepage) issued token eyJqa3...qC7Kag (99212174...e50a90ccffa5)
2021-06-08 12:45:57,793 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(570)) - Knox Token service (homepage) issued token eyJqa3...WG117A (9bf33980...be4eb1ac08dc)
2021-06-08 12:45:58,925 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(570)) - Knox Token service (homepage) issued token eyJqa3...RC_BwQ (895a34a8...69d0574a7324)
2021-06-08 12:45:59,887 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(570)) - Knox Token service (homepage) issued token eyJqa3...qZUNtw (65bf1dfa...b52853a1053f)
2021-06-08 12:46:00,754 INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(570)) - Knox Token service (homepage) issued token eyJqa3...RnkKRA (3a7824b7...a37942c02ce9)
...
2021-06-08 12:47:09,483 INFO  token.state (JDBCTokenStateService.java:evictExpiredTokens(218)) - Removing 6 expired token(s) from the database: 895a34a8...69d0574a7324, ab56217a...aa2afedee2bc, 3a7824b7...a37942c02ce9, 65bf1dfa...b52853a1053f, 99212174...e50a90ccffa5, 9bf33980...be4eb1ac08dc
2021-06-08 12:47:09,491 INFO  token.state (DefaultTokenStateService.java:getExpiredTokens(372)) - Evicting expired token 3a7824b7...a37942c02ce9
2021-06-08 12:47:09,492 INFO  token.state (DefaultTokenStateService.java:getExpiredTokens(372)) - Evicting expired token 895a34a8...69d0574a7324
2021-06-08 12:47:09,492 INFO  token.state (DefaultTokenStateService.java:getExpiredTokens(372)) - Evicting expired token ab56217a...aa2afedee2bc
2021-06-08 12:47:09,492 INFO  token.state (DefaultTokenStateService.java:getExpiredTokens(372)) - Evicting expired token 99212174...e50a90ccffa5
2021-06-08 12:47:09,492 INFO  token.state (DefaultTokenStateService.java:getExpiredTokens(372)) - Evicting expired token 9bf33980...be4eb1ac08dc
2021-06-08 12:47:09,492 INFO  token.state (DefaultTokenStateService.java:getExpiredTokens(372)) - Evicting expired token 65bf1dfa...b52853a1053f
```