### PR TITLE
KNOX-2620 - Using the proper signature algorithm name in JWKS endpoint

### DIFF
--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/JWKSResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/JWKSResourceTest.java
@@ -17,35 +17,40 @@
  */
 package org.apache.knox.gateway.service.knoxtoken;
 
-import com.nimbusds.jose.JOSEException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreSpi;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.cert.Certificate;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Collections;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Response;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
-import org.apache.knox.gateway.services.GatewayServices;
-import org.apache.knox.gateway.services.ServiceType;
-import org.apache.knox.gateway.services.security.KeystoreService;
-import org.apache.knox.gateway.services.security.KeystoreServiceException;
-import org.apache.knox.gateway.services.security.token.impl.JWT;
-import org.apache.knox.gateway.services.security.token.impl.JWTToken;
-import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStoreException;
-import java.security.PublicKey;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.text.ParseException;
-import java.util.Collections;
 
 /**
  * Unit tests for JWKS Resource
@@ -57,7 +62,6 @@ public class JWKSResourceTest {
   private ServletContext context;
   private HttpServletRequest request;
   private GatewayServices services;
-  private JWKSResource jwksResource;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
@@ -69,49 +73,51 @@ public class JWKSResourceTest {
     privateKey = (RSAPrivateKey) KPair.getPrivate();
   }
 
-  private void init() throws KeystoreServiceException, KeyStoreException {
-    final KeystoreService ks = EasyMock.createNiceMock(KeystoreService.class);
+  @Before
+  public void init() throws Exception {
     services = EasyMock.createNiceMock(GatewayServices.class);
     context = EasyMock.createNiceMock(ServletContext.class);
     request = EasyMock.createNiceMock(HttpServletRequest.class);
 
-    jwksResource = EasyMock.partialMockBuilder(JWKSResource.class)
-        .addMockedMethod("getPublicKey", String.class).createMock();
-
-    EasyMock.expect(services.getService(ServiceType.KEYSTORE_SERVICE))
-        .andReturn(ks).anyTimes();
-    EasyMock.expect(
-        context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE))
-        .andReturn(services).anyTimes();
-    EasyMock.expect(jwksResource.getPublicKey(null)).andReturn(publicKey)
-        .anyTimes();
-    EasyMock.replay(jwksResource, context, request, services, ks);
+    final KeystoreService ks = EasyMock.createNiceMock(KeystoreService.class);
+    final KeyStoreSpi keyStoreSpi = EasyMock.createNiceMock(KeyStoreSpi.class);
+    final KeyStore keystore = new KeyStoreMock(keyStoreSpi, null, "test");
+    keystore.load(null);
+    EasyMock.expect(ks.getSigningKeystore(null)).andReturn(keystore).anyTimes();
+    final Certificate cert = EasyMock.createNiceMock(Certificate.class);
+    EasyMock.expect(keyStoreSpi.engineGetCertificate(EasyMock.anyString())).andReturn(cert).anyTimes();
+    EasyMock.expect(cert.getPublicKey()).andReturn(publicKey).anyTimes();
+    EasyMock.expect(services.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(ks).anyTimes();
+    EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(EasyMock.createNiceMock(AliasService.class)).anyTimes();
+    EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services).anyTimes();
+    final GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(config.getSigningKeyAlias()).andReturn(null).anyTimes();
+    EasyMock.expect(context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(config).anyTimes();
+    EasyMock.replay(context, request, services, ks, keyStoreSpi, cert, config);
   }
 
   @Test
-  public void testJWKSrequest()
-      throws KeystoreServiceException, KeyStoreException {
-    init();
-    Response retResponse = jwksResource.getJwksResponse();
-    Assert.assertEquals(Response.Status.OK.getStatusCode(),
-        retResponse.getStatus());
+  public void testJWKSrequest() throws Exception {
+    final JWKSResource jwksResource = new JWKSResource();
+    jwksResource.context = context;
+    jwksResource.request = request;
+    jwksResource.init();
+    final Response retResponse = jwksResource.getJwksResponse();
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), retResponse.getStatus());
   }
 
   /**
    * End to End test that verifies the token acquired from JWKS endpoint.
-   *
-   * @throws KeystoreServiceException
-   * @throws KeyStoreException
-   * @throws ParseException
-   * @throws JOSEException
    */
   @Test
-  public void testE2E()
-      throws KeystoreServiceException, KeyStoreException, ParseException,
-      JOSEException {
-    init();
+  public void testE2E() throws Exception {
     /* get a signed JWT token */
     final JWT testToken = getTestToken("RS256");
+
+    final JWKSResource jwksResource = new JWKSResource();
+    jwksResource.context = context;
+    jwksResource.request = request;
+    jwksResource.init();
     /* get JWKS keyset */
     final Response retResponse = jwksResource.getJwksResponse();
 
@@ -140,6 +146,13 @@ public class JWKSResourceTest {
     final JWSSigner signer = new RSASSASigner(privateKey, true);
     token.sign(signer);
     return token;
+  }
+
+  private static final class KeyStoreMock extends KeyStore {
+
+    protected KeyStoreMock(KeyStoreSpi keyStoreSpi, Provider provider, String type) {
+      super(keyStoreSpi, provider, type);
+    }
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Populating and returning the appropriate signature algorithm in the response of Knox's JWKS endpoint.

## How was this patch tested?

Updated and ran `org.apache.knox.gateway.service.knoxtoken.JWKSResourceTest` successfully.
In addition to uni testing I re-deployed Knox locally and invoked the updated JWKS endpoint:
```
curl -iku admin:admin-password https://localhost:8443/gateway/homepage/knoxtoken/api/v1/jwks.json
HTTP/1.1 200 OK
Date: Wed, 09 Jun 2021 21:29:26 GMT
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1;mode=block
Content-Type: application/json
Content-Length: 462

{
	"keys": [{
		"kty": "RSA",
		"e": "AQAB",
		"use": "sig",
		"kid": "1jmRkVmXLeT-XYd5D8SVccjvNRaqiHypUhZCsIgOoSU",
		"alg": "RS256",
		"n": "mQ57g6fP3KeCAnGR9CuWzh4qBbNQZeCPU6mb47mxu3SF-KPuHSwvJwhnxlBPpzIC-IbpZjg5EnOfXC9sEZMB2VxFeUAkHOqq8K0nMFDaTXLekaoCDAMYwQXhP3SlHiYcWm2B1JqfDgfG492UBONRZmeE-qOGycad0E8NhREfoMVJGWSpYP-kI9qPRs3fNw3UpVpc69AGU9KuAu5VnmuV6wsik_ZkC3EjAS6UrUbfDF2gDczWTyBHlw-JcjKrWahCdBf0XoKSE1tqF7gvdrvASVdtjfiT8aUjFaYj7NfvJHPgc1tdshzEy814dH6myJ-YssjRLuBmSkn17AbAB5BM5w"
	}]
}
```