### PR TITLE
[KNOX-2622] Support Deflate Encoding for the Inbound Response

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponse.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponse.java
@@ -126,7 +126,7 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
   }
 
   private void setContentEncoding(String name, String value) {
-    if (name.equalsIgnoreCase("Content-Encoding")) {
+    if ("Content-Encoding".equalsIgnoreCase(name)) {
       contentEncoding = value;
     }
   }
@@ -187,10 +187,10 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
       inBuffer.reset();
 
       final InputStream unFilteredStream;
-      if(isGzip || contentEncoding.equalsIgnoreCase("gzip")) {
+      if(isGzip || "gzip".equalsIgnoreCase(contentEncoding)) {
         unFilteredStream = new GzipCompressorInputStream(inBuffer, true);
         outStream = new GZIPOutputStream(output, STREAM_BUFFER_SIZE);
-      } else if (contentEncoding.equalsIgnoreCase("deflate")) {
+      } else if ("deflate".equalsIgnoreCase(contentEncoding)) {
         unFilteredStream = new InflaterInputStream(inBuffer);
         outStream = new DeflaterOutputStream(output);
       } else {

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponse.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponse.java
@@ -55,7 +55,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.InflaterInputStream;
 
 import static org.apache.knox.gateway.filter.rewrite.impl.UrlRewriteUtil.getRewriteFilterConfig;
 import static org.apache.knox.gateway.filter.rewrite.impl.UrlRewriteUtil.pickFirstRuleWithEqualsIgnoreCasePathMatch;
@@ -90,6 +92,7 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
   private String xForwardedHostname;
   private String xForwardedPort;
   private String xForwardedScheme;
+  private String contentEncoding;
 
   public UrlRewriteResponse( FilterConfig config, HttpServletRequest request, HttpServletResponse response ) {
     super( response );
@@ -102,6 +105,7 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
     this.bodyFilterName = config.getInitParameter( UrlRewriteServletFilter.RESPONSE_BODY_FILTER_PARAM );
     this.headersFilterName = config.getInitParameter( UrlRewriteServletFilter.RESPONSE_HEADERS_FILTER_PARAM );
     this.headersFilterConfig = getRewriteFilterConfig( rewriter.getConfig(), headersFilterName, UrlRewriteServletFilter.HEADERS_MIME_TYPE );
+    this.contentEncoding = "";
   }
 
   protected boolean ignoreHeader( String name ) {
@@ -121,11 +125,18 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
     return value;
   }
 
+  private void setContentEncoding(String name, String value) {
+    if (name.equalsIgnoreCase("Content-Encoding")) {
+      contentEncoding = value;
+    }
+  }
+
   // Ignore the Content-Length from the dispatch respond since the respond body may be rewritten.
   @Override
   public void setHeader( String name, String value ) {
     if( !ignoreHeader( name) ) {
       value = rewriteValue( value, pickFirstRuleWithEqualsIgnoreCasePathMatch( headersFilterConfig, name ) );
+      setContentEncoding(name, value);
       super.setHeader( name, value );
     }
   }
@@ -136,6 +147,7 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
     if( !ignoreHeader( name ) ) {
       String rule = pickFirstRuleWithEqualsIgnoreCasePathMatch( headersFilterConfig, name );
       value = rewriteValue( value, rule );
+      setContentEncoding(name, value);
       super.addHeader( name, value );
     }
   }
@@ -175,14 +187,18 @@ public class UrlRewriteResponse extends GatewayResponseWrapper implements Params
       inBuffer.reset();
 
       final InputStream unFilteredStream;
-      if(isGzip) {
+      if(isGzip || contentEncoding.equalsIgnoreCase("gzip")) {
         unFilteredStream = new GzipCompressorInputStream(inBuffer, true);
+        outStream = new GZIPOutputStream(output, STREAM_BUFFER_SIZE);
+      } else if (contentEncoding.equalsIgnoreCase("deflate")) {
+        unFilteredStream = new InflaterInputStream(inBuffer);
+        outStream = new DeflaterOutputStream(output);
       } else {
         unFilteredStream = inBuffer;
+        outStream = output;
       }
       String charset = MimeTypes.getCharset( mimeType, StandardCharsets.UTF_8.name() );
       inStream = filter.filter( unFilteredStream, charset, rewriter, this, UrlRewriter.Direction.OUT, filterContentConfig );
-      outStream = (isGzip) ? new GZIPOutputStream(output, STREAM_BUFFER_SIZE) : output;
     } else {
       inStream = input;
       outStream = output;

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponseTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/UrlRewriteResponseTest.java
@@ -170,9 +170,9 @@ public class UrlRewriteResponseTest {
     Path outputFile = Files.createTempFile("output", "test");
     try {
       try(OutputStream outputStream = Files.newOutputStream(inputFile);
-          OutputStream outStream = contentType.equalsIgnoreCase("gzip") ?
+          OutputStream outStream = "gzip".equalsIgnoreCase(contentType) ?
                   new GZIPOutputStream( outputStream ) :
-                  contentType.equalsIgnoreCase("deflate") ? new DeflaterOutputStream( outputStream ) : outputStream) {
+                  "deflate".equalsIgnoreCase(contentType) ? new DeflaterOutputStream( outputStream ) : outputStream) {
         outStream.write(content.getBytes(StandardCharsets.UTF_8));
       }
 
@@ -182,9 +182,9 @@ public class UrlRewriteResponseTest {
       }
 
       try(InputStream inputStream = Files.newInputStream(outputFile);
-          InputStream inStream = contentType.equalsIgnoreCase("gzip") ?
+          InputStream inStream = "gzip".equalsIgnoreCase(contentType) ?
                   new GZIPInputStream(inputStream) :
-                  contentType.equalsIgnoreCase("deflate") ? new InflaterInputStream(inputStream) : inputStream) {
+                  "deflate".equalsIgnoreCase(contentType) ? new InflaterInputStream(inputStream) : inputStream) {
         assertThat(String.valueOf(IOUtils.toCharArray(inStream, StandardCharsets.UTF_8)), is(content));
       }
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Knox only supports the Content-Encoding "gzip" and the Content-Encoding "deflate" is not supported. When the upstream server (such as Livy 0.7 Server) returns a response which is deflated, Knox does not know how to decode it.

The current code only considers the "gzip" format and the "deflate" format is not considered. We should also handle the case when the format is "deflate" and use InflaterInputStream to read the in-bound response and use DeflaterOutputStream to write the out-bound response.

Here is the JIRA (https://issues.apache.org/jira/browse/KNOX-2622) that describes this issue.

## How was this patch tested?
Existing unit tests and newly added unit tests.


Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
