### PR TITLE
KNOX-2623 - Lifespan attributes are optional on token generation UI and default to 1 hour

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -67,15 +67,18 @@
                         <label><i class="icon-info"></i> Configured maximum lifetime: </label>
                         <label id="maximumLifetimeText"></label>
                         <input type="number" id="maximumLifetimeSeconds" name="maximumLifetimeSeconds" style="display: none;">
-                        <label><i class="icon-time"></i> Lifetime (days, hours, mins):</label>
-                        <table>
-                            <tr>
-                                <td><input type="number" id="lt_days" name="lt_days" step="1" min="0" max="3650" value="1" size="3"></td> <!-- 10 years limit -->
-                                <td><input type="number" id="lt_hours" name="lt_hours" step="1" min="0" max="23" value="0" size="3"></td>
-                                <td><input type="number" id="lt_mins" name="lt_mins" step="1" min="0" max="59" value="0" size="3"></td>
-                            </tr>
-                        </table>
-                        <label style="display: none; color: red;" id="invalidLifetimeText"><i class="icon-warning"></i>Invalid lifetime!</label>
+                        <div id="lifespanFields" style="display: none;">
+                            <input id="lifespanInputEnabled" name="lifespanInputEnabled" type="text" style="display: none" value="false" />
+                            <label><i class="icon-time"></i> Lifetime (days, hours, mins):</label>
+                            <table>
+                                <tr>
+                                    <td><input type="number" id="lt_days" name="lt_days" step="1" min="0" max="3650" value="0" size="3"></td> <!-- 10 years limit -->
+                                    <td><input type="number" id="lt_hours" name="lt_hours" step="1" min="0" max="23" value="1" size="3"></td>
+                                    <td><input type="number" id="lt_mins" name="lt_mins" step="1" min="0" max="59" value="0" size="3"></td>
+                                </tr>
+                            </table>
+                            <label style="display: none; color: red;" id="invalidLifetimeText"><i class="icon-warning"></i>Invalid lifetime!</label>
+                        </div>
                     </div>
                     <span id="errorBox" class="help-inline" style="color:white;display:none;"><span class="errorMsg"></span>
                         <i class="icon-warning-sign" style="color:#ae2817;"></i>

--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -107,12 +107,21 @@ function setTokenStateServiceStatus() {
 
                 $('#maximumLifetimeText').text(resp.maximumLifetimeText);
                 $('#maximumLifetimeSeconds').text(resp.maximumLifetimeSeconds);
+
+                if (resp.lifespanInputEnabled === "true") {
+                    $('#lifespanFields').show();
+                    document.getElementById("lifespanInputEnabled").value = "true";
+                }
             }
         }
     }
 }
 
-function validateLifespan(days, hours, mins) {
+function validateLifespan(lifespanInputEnabled, days, hours, mins) {
+    if (lifespanInputEnabled === "false") {
+        return true;
+    }
+
     //show possible contraint violations
     days.reportValidity();
     hours.reportValidity();
@@ -174,12 +183,16 @@ var gen = function() {
     var lt_days = form.lt_days.value;
     var lt_hours = form.lt_hours.value;
     var lt_mins = form.lt_mins.value;
+    var lifespanInputEnabled = form.lifespanInputEnabled.value;
     var _gen = function() {
         var apiUrl = tokenURL;
-        //Instantiate HTTP Request
-        var params = '?lifespan=P' + lt_days + "DT" + lt_hours + "H" + lt_mins + "M";  //we need to support Java's Duration pattern
+        var params = "";
+        if (lifespanInputEnabled === "true") {
+            params = params + '?lifespan=P' + lt_days + "DT" + lt_hours + "H" + lt_mins + "M";  //we need to support Java's Duration pattern
+        }
+
         if (form.comment.value != '') {
-            params = params + '&comment=' + encodeURIComponent(form.comment.value);
+            params = params + (lifespanInputEnabled === "true" ? "&" : "?") + 'comment=' + encodeURIComponent(form.comment.value);
         }
         var request = ((window.XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"));
         request.open("GET", apiUrl + params, true);
@@ -217,7 +230,7 @@ var gen = function() {
         }
     }
 
-    if (validateLifespan(form.lt_days, form.lt_hours, form.lt_mins) && validateComment(form.comment)) {
+    if (validateLifespan(lifespanInputEnabled, form.lt_days, form.lt_hours, form.lt_mins) && validateComment(form.comment)) {
         if (maximumLifetimeExceeded(form.maximumLifetimeSeconds.textContent, lt_days, lt_hours, lt_mins)) {
             swal({
                 title: "Warning",

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -104,6 +104,8 @@ public class TokenResource {
   private static final String TSS_ALLOWED_BACKEND_FOR_TOKENGEN = "allowedTssForTokengen";
   private static final String TSS_MAXIMUM_LIFETIME_SECONDS = "maximumLifetimeSeconds";
   private static final String TSS_MAXIMUM_LIFETIME_TEXT = "maximumLifetimeText";
+  private static final String LIFESPAN_INPUT_ENABLED_PARAM = "knox.token.lifespan.input.enabled";
+  private static final String LIFESPAN_INPUT_ENABLED_TEXT = "lifespanInputEnabled";
   private static final long TOKEN_TTL_DEFAULT = 30000L;
   static final String TOKEN_API_PATH = "knoxtoken/api/v1";
   static final String RESOURCE_PATH = TOKEN_API_PATH + "/token";
@@ -278,6 +280,9 @@ public class TokenResource {
     } else {
       tokenStateServiceStatusMap.put(TSS_STATUS_IS_MANAGEMENT_ENABLED, "false");
     }
+    final String lifespanInputEnabledValue = context.getInitParameter(LIFESPAN_INPUT_ENABLED_PARAM);
+    final Boolean lifespanInputEnabled = lifespanInputEnabledValue == null ? Boolean.TRUE : Boolean.parseBoolean(lifespanInputEnabledValue);
+    tokenStateServiceStatusMap.put(LIFESPAN_INPUT_ENABLED_TEXT, lifespanInputEnabled.toString());
   }
 
   private void populateAllowedTokenStateBackendForTokenGenApp(final String actualTokenServiceName) {

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -857,6 +857,7 @@ public class TokenServiceResourceTest {
     if (expectedAllowedTssFlag != null) {
       assertEquals(statusMap.get("allowedTssForTokengen"), expectedAllowedTssFlag);
     }
+    assertTrue(Boolean.parseBoolean(statusMap.get("lifespanInputEnabled")));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default, lifespan attributes (day, hour, and minute spinners) are displayed on the token generation UI. However, end-users have a way to hide these input fields by setting a newly introduced topology-level configuration, called `knox.token.lifespan.input.enabled`, to `false`.
In this case, the generated token will have the configured/default token TTL.
I also made the default value of the lifespan attributes to 1 hour.

## How was this patch tested?

Updated the JUnit tests and executed several manual testing locally (with and w/o the lifespan properties).