### PR TITLE
KNOX-2628 - Metadata and issue time aliases are removed too during token revocation

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -431,10 +431,12 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService implem
       unpersistedState.removeAll(unpersistedToRemove);
     }
 
-    // Add the max lifetime aliases to the list of aliases to remove
+    // Add the max lifetime, metadata and issue time aliases to the list of aliases to remove
     Set<String> aliasesToRemove = new HashSet<>(tokenIds);
     for (String tokenId : tokenIds) {
       aliasesToRemove.add(tokenId + TOKEN_MAX_LIFETIME_POSTFIX);
+      aliasesToRemove.add(tokenId + TOKEN_META_POSTFIX);
+      aliasesToRemove.add(tokenId + TOKEN_ISSUE_TIME_POSTFIX);
     }
 
     if (!aliasesToRemove.isEmpty()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the missing alias names while removing a token from the keystore (and from memory).

## How was this patch tested?

Repeated the same steps as described in the JIRA and confirmed that all token aliases were removed from the credential store.
