### PR TITLE
KNOX-2627 - Limiting the number of managed tokens per user

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -262,9 +262,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String KNOX_TOKEN_ALIAS_PERSISTENCE_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.state.alias.persistence.interval";
   private static final String KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.permissive.validation";
   private static final String KNOX_TOKEN_HASH_ALGORITHM = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.hash.algorithm";
+  public static final String KNOX_TOKEN_USER_LIMIT = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.limit.per.user";
   private static final long KNOX_TOKEN_EVICTION_INTERVAL_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
   private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.HOURS.toSeconds(24);
   private static final long KNOX_TOKEN_ALIAS_PERSISTENCE_INTERVAL_DEFAULT = TimeUnit.SECONDS.toSeconds(15);
+  public static final int KNOX_TOKEN_USER_LIMIT_DEFAULT = 10;
   private static final boolean KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED_DEFAULT = false;
 
   private static final String KNOX_HOMEPAGE_PROFILE_PREFIX =  "knox.homepage.profile.";
@@ -1183,6 +1185,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getKnoxTokenHashAlgorithm() {
     return get(KNOX_TOKEN_HASH_ALGORITHM, HmacAlgorithms.HMAC_SHA_256.getName());
+  }
+
+  @Override
+  public int getMaximumNumberOfTokensPerUser() {
+    return getInt(KNOX_TOKEN_USER_LIMIT, KNOX_TOKEN_USER_LIMIT_DEFAULT);
   }
 
   @Override

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -83,4 +83,7 @@ public interface TokenServiceMessages {
 
   @Message( level = MessageLevel.WARN, text = "Invalid duration used for JWT token lifespan ({0}) using the configured TTL for KnoxToken service")
   void invalidLifetimeValue(String lifetimeStr);
+
+  @Message( level = MessageLevel.ERROR, text = "Unable to get token for user {0}: token limit exceeded")
+  void tokenLimitExceeded(String userName);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -703,6 +703,14 @@ public interface GatewayConfig {
   String getKnoxTokenHashAlgorithm();
 
   /**
+   * @return the maximum number of tokens a user can manage at the same time. -1
+   *         means that users are allowed to create/manage as many tokens as they
+   *         want. This configuration only applies when server-managed token state
+   *         is enabled either in gateway-site or at the topology level.
+   */
+  int getMaximumNumberOfTokensPerUser();
+
+  /**
    * @return the list of topologies that should be hidden on Knox homepage
    */
   Set<String> getHiddenTopologiesOnHomepage();

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -812,6 +812,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public int getMaximumNumberOfTokensPerUser() {
+    return 0;
+  }
+
+  @Override
   public Set<String> getHiddenTopologiesOnHomepage() {
     return Collections.emptySet();
   }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/JsonUtils.java
@@ -73,10 +73,10 @@ public class JsonUtils {
   }
 
   public static Object getObjectFromJsonString(String json) {
-    Map<String, String> obj = null;
+    Map<String, Object> obj = null;
     JsonFactory factory = new JsonFactory();
     ObjectMapper mapper = new ObjectMapper(factory);
-    TypeReference<Map<String, String>> typeRef = new TypeReference<Map<String, String>>() {};
+    TypeReference<Map<String, Object>> typeRef = new TypeReference<Map<String, Object>>() {};
     try {
       obj = mapper.readValue(json, typeRef);
     } catch (IOException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on, users are limited to manage only up to a pre-configured number of tokens (defaults to `10`). It's possible to eliminate this limit by setting the new `gateway.knox.token.limit.per.user` to `-1`. In this case, end-users are allowed to manage as many tokens as they want.
This configuration only applies when server-managed token state is enabled either in gateway-site or at the topology level.

## How was this patch tested?

Added new JUnit tests and executed manual test steps using the token generation UI.