### PR TITLE
KNOX-2626. Support MySQL in JDBCTokenStateService

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -405,6 +405,10 @@
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
 
         <!-- ********** ********** ********** ********** ********** ********** -->
         <!-- ********** Test Dependencies                           ********** -->

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
         <opensaml.version>3.4.5</opensaml.version>
         <pac4j.version>4.3.0</pac4j.version>
         <postgresql.version>42.2.19</postgresql.version>
+        <mysql.version>8.0.25</mysql.version>
         <protobuf.version>3.14.0</protobuf.version>
         <rest-assured.version>4.3.3</rest-assured.version>
         <shiro.version>1.7.0</shiro.version>
@@ -2059,7 +2060,11 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql.version}</version>
+            </dependency>
             <!-- pac4j Dependencies -->
             <dependency>
                 <groupId>org.pac4j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Until now, JDBCTokenStateService only supported Postgres and Derby databases. This patch adds MySql support. There are two ways to define a MySql data source, either via a full connection string or by individual properties.

## How was this patch tested?

Tested with a local MySql with and without SSL. I used the following images:

```
$ docker pull mysql/mysql-server:latest
$ docker pull cyprien/mysql-tls:5.7
```

1.

In gateway-site, I set `gateway.database.type=mysql` plus added the connection properties/connection url. 
I created a token at `https://localhost:8443/gateway/homepage/tokengen/index.html` and inspected the KNOX_TOKENS and KNOX_TOKEN_METADATA tables in the database.

2.

For the SSL test I used the following MySql config:

```
[client]
protocol=tcp
port=3306
[mysqld]
bind-address=0.0.0.0
port=3306
ssl-ca=/Users/attilamagyar/tools/mysql-8.0.25-macos11-x86_64/certs/ca.pem
ssl-cert=/Users/attilamagyar/tools/mysql-8.0.25-macos11-x86_64/certs/server-cert.pem
ssl-key=/Users/attilamagyar/tools/mysql-8.0.25-macos11-x86_64/certs/server-key.pem
ssl=true
require_secure_transport = ON
```

I created a truststore with and without ca.pem, and enabled certificate validation `gateway.database.ssl.verify.server.cert`. Verified that it only worked with the proper truststore.

3.

I used the following API calls to validate revoke and renew functionality.

```
curl -H "X-XSRF-Header: admin" -d <tokenId>  -X POST --cookie "hadoop-jwt=..." -vvv -k -u admin:admin-password https://localhost:8443/knoxtoken/api/v1/token/revoke
```

```
curl -H "X-XSRF-Header: admin" -d <tokenId>  -X POST --cookie "hadoop-jwt=..." -vvv -k -u admin:admin-password https://localhost:8443/knoxtoken/api/v1/token/renew```
