### PR TITLE
KNOX-2630. BadUrlTest and BadBackendTest are flaky (amagyar)

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadBackendTest.java
@@ -72,7 +72,7 @@ public class BadBackendTest {
         proxyUri);
     session.getBasicRemote().sendText(message);
 
-    client.awaitClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(), 1000,
+    client.awaitClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(), 5000,
         TimeUnit.MILLISECONDS);
 
     Assert.assertThat(client.close.getCloseCode().getCode(), CoreMatchers.is(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode()));

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -144,7 +144,7 @@ public class BadUrlTest {
         new URI(serverUri.toString() + "gateway/websocket/ws"));
 
     client.awaitClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(),
-        1000, TimeUnit.MILLISECONDS);
+        5000, TimeUnit.MILLISECONDS);
 
     Assert.assertThat(client.close.getCloseCode().getCode(),
         CoreMatchers.is(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

BadUrlTest and BadBackendTest are failing time to time locally, increasing the timeout from 1 second to 5 seems to solve the problem

## How was this patch tested?

Running `mvn test -Dtest=BadBackendTest,BadUrlTest` multiple times.