### PR TITLE
KNOX-2633 - Handling supplied client data with multiple '=' signs when generating a token

### DIFF
--- a/gateway-release/home/conf/topologies/homepage.xml
+++ b/gateway-release/home/conf/topologies/homepage.xml
@@ -87,7 +87,7 @@
       </param>
       <param>
          <name>knox.token.client.data</name>
-         <value>homepage_url=homepage/home/</value>
+         <value>homepage_url=homepage/home?profile=token&amp;topologies=sandbox</value>
       </param>
       <param>
          <name>knox.token.exp.server-managed</name>

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -95,7 +95,7 @@ public class TokenResource {
   private static final String TOKEN_TTL_PARAM = "knox.token.ttl";
   private static final String TOKEN_AUDIENCES_PARAM = "knox.token.audiences";
   private static final String TOKEN_TARGET_URL = "knox.token.target.url";
-  private static final String TOKEN_CLIENT_DATA = "knox.token.client.data";
+  static final String TOKEN_CLIENT_DATA = "knox.token.client.data";
   private static final String TOKEN_CLIENT_CERT_REQUIRED = "knox.token.client.cert.required";
   private static final String TOKEN_ALLOWED_PRINCIPALS = "knox.token.allowed.principals";
   private static final String TOKEN_SIG_ALG = "knox.token.sigalg";
@@ -674,7 +674,8 @@ public class TokenResource {
       Map<String,Object> map) {
     String[] kv;
     for (String tokenClientDatum : tokenClientData) {
-      kv = tokenClientDatum.split("=");
+      //client data value may contain the '=' itself. For instance "homepage_url=homepage/home?profile=token&amp;topologies=sandbox"
+      kv = tokenClientDatum.split("=", 2);
       if (kv.length == 2) {
         map.put(kv[0], kv[1]);
       }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -213,7 +213,10 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testGetToken() throws Exception {
-    configureCommonExpectations(Collections.singletonMap("org.apache.knox.gateway.gateway.cluster", "test"), Boolean.TRUE);
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("org.apache.knox.gateway.gateway.cluster", "test");
+    contextExpectations.put(TokenResource.TOKEN_CLIENT_DATA, "sampleClientData=param1=value1&param2=value2");
+    configureCommonExpectations(contextExpectations, Boolean.TRUE);
 
     TokenResource tr = new TokenResource();
     tr.context = context;
@@ -234,6 +237,7 @@ public class TokenServiceResourceTest {
 
     assertNotNull(getTagValue(retString, "token_id"));
     assertTrue(Boolean.parseBoolean(getTagValue(retString, "managed")));
+    assertEquals(getTagValue(retString, "sampleClientData"), "param1=value1&param2=value2");
 
     // Verify the token
     JWT parsedToken = new JWTToken(accessToken);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated the logic which parses configured `knox.token.client.data` to honour values with multiple `=` characters.

## How was this patch tested?

Updated an existing JUnit test case to check `knox.token.client.data` too.

Modified our `homepage` topology to contain the appropriate profile name and the `sandbox` topology, then redeployed Knox. I confirmed the `Homepage` link on the token generation UI pointed to the configured URL and it actually opened the homepage with the proper filters in place.