### PR TITLE
KNOX-2634 - Disable HA loadbalancing for ODBC driver and make this setting configurable.

### DIFF
--- a/gateway-provider-ha/pom.xml
+++ b/gateway-provider-ha/pom.xml
@@ -106,6 +106,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.ha.dispatch;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -72,6 +73,20 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
   private boolean stickySessionsEnabled = HaServiceConfigConstants.DEFAULT_STICKY_SESSIONS_ENABLED;
   private boolean noFallbackEnabled = HaServiceConfigConstants.DEFAULT_NO_FALLBACK_ENABLED;
   private String stickySessionCookieName = HaServiceConfigConstants.DEFAULT_STICKY_SESSION_COOKIE_NAME;
+  private List<String> disableLoadBalancingForUserAgents = Arrays.asList(HaServiceConfigConstants.DEFAULT_DISABLE_LB_USER_AGENTS);
+
+  /**
+   *  This staticURL is used to track urls when LB is turned off for some clients
+   *  The problem we have with selectively turning off LB is that other clients
+   *  that use LB can change the state from under the current session where LB is
+   *  turned off.
+   *  e.g.
+   *  ODBC Connection established where LB is off. JDBC connection is established
+   *  next where LB is enabled. This changes the active URL under the existing ODBC
+   *  connection which will be an issue.
+   *  This variable keeps track of non-LB'ed url and updated upon failover.
+   */
+  private static String activeURL;
 
   @Override
   public void init() {
@@ -89,8 +104,14 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
       if(stickySessionsEnabled) {
         stickySessionCookieName = serviceConfig.getStickySessionCookieName();
       }
+
+      disableLoadBalancingForUserAgents = serviceConfig.getStickySessionDisabledUserAgents();
+
       setupUrlHashLookup();
     }
+
+    /* setup the active URL for non-LB case */
+    activeURL = haProvider.getActiveURL(getServiceRole());
 
     // Suffix the cookie name by the service to make it unique
     // The cookie path is NOT unique since Knox is stripping the service name.
@@ -118,19 +139,49 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
   protected void executeRequestWrapper(HttpUriRequest outboundRequest,
           HttpServletRequest inboundRequest, HttpServletResponse outboundResponse)
           throws IOException {
-      final Optional<URI> backendURI = setBackendfromHaCookie(outboundRequest, inboundRequest);
-      if(backendURI.isPresent()) {
-          ((HttpRequestBase) outboundRequest).setURI(backendURI.get());
+
+      final String userAgentFromBrowser = StringUtils.isBlank(inboundRequest.getHeader("User-Agent")) ? "" : inboundRequest.getHeader("User-Agent");
+
+      /* disable loadblancing override */
+      boolean disableLB = false;
+
+      /* disable loadbalancing in case a configured user agent is detected to disable LB */
+      if(disableLoadBalancingForUserAgents.stream().anyMatch(c -> userAgentFromBrowser.contains(c))  ) {
+        disableLB = true;
+        LOG.disableHALoadbalancinguserAgent(userAgentFromBrowser, disableLoadBalancingForUserAgents.toString());
       }
+
+      /* if disable LB is set don't bother setting backend from cookie */
+      Optional<URI> backendURI = Optional.empty();
+      if(!disableLB) {
+        backendURI = setBackendfromHaCookie(outboundRequest, inboundRequest);
+        if(backendURI.isPresent()) {
+          ((HttpRequestBase) outboundRequest).setURI(backendURI.get());
+        }
+      }
+
+      /**
+       * case where loadbalancing is enabled
+       * and we have a HTTP request configured not to use LB
+       * use the activeURL
+      */
+      if(loadBalancingEnabled && disableLB) {
+        try {
+          ((HttpRequestBase) outboundRequest).setURI(updateHostURL(outboundRequest.getURI(), activeURL));
+        } catch (final URISyntaxException e) {
+          LOG.errorSettingActiveUrl();
+        }
+      }
+
       executeRequest(outboundRequest, inboundRequest, outboundResponse);
       /**
-       * 1. Load balance when loadbalancing is enabled.
+       * 1. Load balance when loadbalancing is enabled and there are no overrides (disableLB)
        * 2. Loadbalance only when sticky session is enabled but cookie not detected
        *    i.e. when loadbalancing is enabled every request that does not have BACKEND cookie
        *    needs to be loadbalanced. If a request has BACKEND coookie and Loadbalance=on then
        *    there should be no loadbalancing.
        */
-      if (loadBalancingEnabled) {
+      if (loadBalancingEnabled && !disableLB) {
         /* check sticky session enabled */
         if(stickySessionsEnabled) {
           /* loadbalance only when sticky session enabled and no backend url cookie */
@@ -173,13 +224,7 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
                   // Make sure that the url provided is actually a valid backend url
                   if (haProvider.getURLs(getServiceRole()).contains(backendURL)) {
                       try {
-                          URI cookieUri = new URI(backendURL);
-                          URIBuilder uriBuilder = new URIBuilder(outboundRequest.getURI());
-                          uriBuilder.setScheme(cookieUri.getScheme());
-                          uriBuilder.setHost(cookieUri.getHost());
-                          uriBuilder.setPort(cookieUri.getPort());
-                          URI uri = uriBuilder.build();
-                          return Optional.of(uri);
+                        return Optional.of(updateHostURL(outboundRequest.getURI(), backendURL));
                       } catch (URISyntaxException ignore) {
                           // The cookie was invalid so we just don't set it. Knox will pick a backend automatically
                       }
@@ -261,6 +306,9 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
         }
       }
       LOG.failingOverRequest(outboundRequest.getURI().toString());
+
+      /* in case of failover update the activeURL variable */
+      activeURL = outboundRequest.getURI().toString();
       executeRequest(outboundRequest, inboundRequest, outboundResponse);
     } else {
       LOG.maxFailoverAttemptsReached(maxFailoverAttempts, getServiceRole());
@@ -304,6 +352,23 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
     public Cookie[] getCookies() {
       return cookies;
     }
+  }
+
+  /**
+   * A helper function that updates the schema, host and port
+   * of the URI with the provided string URL and returnes a new
+   * URI object
+   * @param source
+   * @param host
+   * @return
+   */
+  private URI updateHostURL(final URI source, final String host) throws URISyntaxException {
+    final URI newUri = new URI(host);
+    final URIBuilder uriBuilder = new URIBuilder(source);
+    uriBuilder.setScheme(newUri.getScheme());
+    uriBuilder.setHost(newUri.getHost());
+    uriBuilder.setPort(newUri.getPort());
+    return uriBuilder.build();
   }
 
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -76,7 +76,7 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
   private List<String> disableLoadBalancingForUserAgents = Arrays.asList(HaServiceConfigConstants.DEFAULT_DISABLE_LB_USER_AGENTS);
 
   /**
-   *  This staticURL is used to track urls when LB is turned off for some clients
+   *  This activeURL is used to track urls when LB is turned off for some clients
    *  The problem we have with selectively turning off LB is that other clients
    *  that use LB can change the state from under the current session where LB is
    *  turned off.
@@ -86,7 +86,7 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
    *  connection which will be an issue.
    *  This variable keeps track of non-LB'ed url and updated upon failover.
    */
-  private static String activeURL;
+  private String activeURL;
 
   @Override
   public void init() {

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
@@ -44,4 +44,10 @@ public interface HaDispatchMessages {
 
   @Message(level = MessageLevel.ERROR, text = "noFallback flag is turned on for sticky session so aborting request without retrying")
   void noFallbackError();
+
+  @Message(level = MessageLevel.INFO, text = "Knox HA loadbalancing disabled, detected user-agent: {0}, configured user-agents to disable loadbalancing: {1}")
+  void disableHALoadbalancinguserAgent(String userAgent, String configuration);
+
+  @Message(level = MessageLevel.ERROR, text = "Error setting non-loadbalanced url to outbound request")
+  void errorSettingActiveUrl();
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServiceConfig.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServiceConfig.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.ha.provider;
 
+import java.util.List;
+
 public interface HaServiceConfig {
   void setServiceName(String name);
 
@@ -57,4 +59,8 @@ public interface HaServiceConfig {
   boolean isNoFallbackEnabled();
 
   void setNoFallbackEnabled(boolean noFallbackEnabled);
+
+  void setDisableStickySessionForUserAgents(List<String> disableStickySessionForUserAgents);
+
+  List<String> getStickySessionDisabledUserAgents();
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/DefaultHaServiceConfig.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/DefaultHaServiceConfig.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.ha.provider.impl;
 
+import java.util.List;
+
 import org.apache.knox.gateway.ha.provider.HaServiceConfig;
 
 public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigConstants {
@@ -40,6 +42,8 @@ public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigC
   private String zookeeperEnsemble;
 
   private String zookeeperNamespace;
+
+  private List<String> disableStickySessionForUserAgents;
 
   public DefaultHaServiceConfig(String name) {
     this.name = name;
@@ -143,5 +147,15 @@ public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigC
   @Override
   public void setNoFallbackEnabled(boolean noFallbackEnabled) {
     isNoFallbackEnabled = noFallbackEnabled;
+  }
+
+  @Override
+  public void setDisableStickySessionForUserAgents(List<String> disableStickySessionForUserAgents) {
+    this.disableStickySessionForUserAgents = disableStickySessionForUserAgents;
+  }
+
+  @Override
+  public List<String> getStickySessionDisabledUserAgents() {
+    return disableStickySessionForUserAgents;
   }
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactory.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactory.java
@@ -17,33 +17,63 @@
  */
 package org.apache.knox.gateway.ha.provider.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.ha.provider.HaDescriptor;
 import org.apache.knox.gateway.ha.provider.HaServiceConfig;
-
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
 
-   public static HaDescriptor createDescriptor() {
-      return new DefaultHaDescriptor();
-   }
+  public static HaDescriptor createDescriptor() {
+    return new DefaultHaDescriptor();
+  }
 
-   public static HaServiceConfig createServiceConfig(String serviceName, String config) {
-      Map<String, String> configMap = parseHaConfiguration(config);
-      String enabledValue = configMap.get(CONFIG_PARAM_ENABLED);
-      String maxFailoverAttempts = configMap.get(CONFIG_PARAM_MAX_FAILOVER_ATTEMPTS);
-      String failoverSleep = configMap.get(CONFIG_PARAM_FAILOVER_SLEEP);
-      String zookeeperEnsemble = configMap.get(CONFIG_PARAM_ZOOKEEPER_ENSEMBLE);
-      String zookeeperNamespace = configMap.get(CONFIG_PARAM_ZOOKEEPER_NAMESPACE);
-      String stickySessionEnabled = configMap.get(CONFIG_STICKY_SESSIONS_ENABLED);
-      String loadBalancingEnabled = configMap.get(CONFIG_LOAD_BALANCING_ENABLED);
-      String stickySessionCookieName = configMap.get(STICKY_SESSION_COOKIE_NAME);
-      String noFallbackEnabled = configMap.get(CONFIG_NO_FALLBACK_ENABLED);
-      return createServiceConfig(serviceName, enabledValue, maxFailoverAttempts, failoverSleep,
-          zookeeperEnsemble, zookeeperNamespace, loadBalancingEnabled, stickySessionEnabled, stickySessionCookieName, noFallbackEnabled);
-   }
+  public static HaServiceConfig createServiceConfig(String serviceName, String config) {
+    final Map<String, String> configMap = parseHaConfiguration(config);
 
+    final String zookeeperEnsemble = configMap.get(CONFIG_PARAM_ZOOKEEPER_ENSEMBLE);
+    final String zookeeperNamespace = configMap.get(CONFIG_PARAM_ZOOKEEPER_NAMESPACE);
+
+    final boolean enabled = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_PARAM_ENABLED, Boolean.toString(DEFAULT_ENABLED)));
+    final int maxFailoverAttempts = Integer.parseInt(configMap.getOrDefault(CONFIG_PARAM_MAX_FAILOVER_ATTEMPTS, Integer.toString(DEFAULT_MAX_FAILOVER_ATTEMPTS)));
+    final int failoverSleep = Integer.parseInt(configMap.getOrDefault(CONFIG_PARAM_FAILOVER_SLEEP, Integer.toString(DEFAULT_FAILOVER_SLEEP)));
+    final boolean stickySessionsEnabled = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_STICKY_SESSIONS_ENABLED, Boolean.toString(DEFAULT_STICKY_SESSIONS_ENABLED)));
+    final boolean loadBalancingEnabled = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_LOAD_BALANCING_ENABLED, Boolean.toString(DEFAULT_LOAD_BALANCING_ENABLED)));
+    final boolean noFallbackEnabled = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_NO_FALLBACK_ENABLED, Boolean.toString(DEFAULT_NO_FALLBACK_ENABLED)));
+    final String stickySessionCookieName = configMap.getOrDefault(STICKY_SESSION_COOKIE_NAME, DEFAULT_STICKY_SESSION_COOKIE_NAME);
+
+    final String disableLoadBalancingForUserAgentsConfig = configMap.getOrDefault(DISABLE_LB_USER_AGENTS, DEFAULT_DISABLE_LB_USER_AGENTS);
+    /* configured user agents are comma separate list which *can* contain whitespaces */
+    List<String> disableLoadBalancingForUserAgents = Collections.EMPTY_LIST;
+    if(StringUtils.isNotBlank(disableLoadBalancingForUserAgentsConfig)) {
+      disableLoadBalancingForUserAgents = Arrays.asList(disableLoadBalancingForUserAgentsConfig
+              .trim()
+              .split("\\s*,\\s*"));
+    }
+    return createServiceConfig(serviceName, enabled, maxFailoverAttempts, failoverSleep, zookeeperEnsemble, zookeeperNamespace, stickySessionsEnabled, loadBalancingEnabled,
+            stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgents);
+  }
+
+  /**
+   * This method should only be used by older tests.
+   * new tests should use the createServiceConfig(String serviceName, String config) method
+   * @param serviceName
+   * @param enabledValue
+   * @param maxFailoverAttemptsValue
+   * @param failoverSleepValue
+   * @param zookeeperEnsemble
+   * @param zookeeperNamespace
+   * @param loadBalancingEnabledValue
+   * @param stickySessionsEnabledValue
+   * @param stickySessionCookieNameValue
+   * @param noFallbackEnabledValue
+   * @return
+   */
+   @Deprecated
    public static HaServiceConfig createServiceConfig(String serviceName, String enabledValue,
                                                      String maxFailoverAttemptsValue, String failoverSleepValue,
                                                      String zookeeperEnsemble, String zookeeperNamespace,
@@ -79,18 +109,29 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
          noFallbackEnabled = Boolean.parseBoolean(noFallbackEnabledValue);
       }
 
-      DefaultHaServiceConfig serviceConfig = new DefaultHaServiceConfig(serviceName);
-      serviceConfig.setEnabled(enabled);
-      serviceConfig.setMaxFailoverAttempts(maxFailoverAttempts);
-      serviceConfig.setFailoverSleep(failoverSleep);
-      serviceConfig.setZookeeperEnsemble(zookeeperEnsemble);
-      serviceConfig.setZookeeperNamespace(zookeeperNamespace);
-      serviceConfig.setStickySessionEnabled(stickySessionsEnabled);
-      serviceConfig.setLoadBalancingEnabled(loadBalancingEnabled);
-      serviceConfig.setStickySessionCookieName(stickySessionCookieName);
-      serviceConfig.setNoFallbackEnabled(noFallbackEnabled);
-      return serviceConfig;
+     return createServiceConfig(serviceName, enabled, maxFailoverAttempts, failoverSleep, zookeeperEnsemble, zookeeperNamespace, stickySessionsEnabled, loadBalancingEnabled,
+             stickySessionCookieName, noFallbackEnabled, Arrays.asList(DEFAULT_DISABLE_LB_USER_AGENTS));
    }
+
+  private static DefaultHaServiceConfig createServiceConfig(final String serviceName, final boolean enabled,
+          final int maxFailoverAttempts, final int failoverSleepValue,
+          final String zookeeperEnsemble, final String zookeeperNamespace,
+          final boolean stickySessionsEnabled, final boolean loadBalancingEnabled,
+          final String stickySessionCookieName,
+          final boolean noFallbackEnabled, final List<String> disableStickySessionForUserAgents) {
+    DefaultHaServiceConfig serviceConfig = new DefaultHaServiceConfig(serviceName);
+    serviceConfig.setEnabled(enabled);
+    serviceConfig.setMaxFailoverAttempts(maxFailoverAttempts);
+    serviceConfig.setFailoverSleep(failoverSleepValue);
+    serviceConfig.setZookeeperEnsemble(zookeeperEnsemble);
+    serviceConfig.setZookeeperNamespace(zookeeperNamespace);
+    serviceConfig.setStickySessionEnabled(stickySessionsEnabled);
+    serviceConfig.setLoadBalancingEnabled(loadBalancingEnabled);
+    serviceConfig.setStickySessionCookieName(stickySessionCookieName);
+    serviceConfig.setNoFallbackEnabled(noFallbackEnabled);
+    serviceConfig.setDisableStickySessionForUserAgents(disableStickySessionForUserAgents);
+    return serviceConfig;
+  }
 
    private static Map<String, String> parseHaConfiguration(String configuration) {
       Map<String, String> parameters = new HashMap<>();

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaServiceConfigConstants.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaServiceConfigConstants.java
@@ -40,6 +40,12 @@ public interface HaServiceConfigConstants {
 
    String STICKY_SESSION_COOKIE_NAME = "stickySessionCookieName";
 
+   /**
+    * Disable loadbalancing feature based on user agent.
+    * The code will look for "contains" match
+    */
+   String DISABLE_LB_USER_AGENTS = "disableLoadBalancingForUserAgents";
+
    int DEFAULT_MAX_FAILOVER_ATTEMPTS = 3;
 
    int DEFAULT_FAILOVER_SLEEP = 1000;
@@ -53,4 +59,6 @@ public interface HaServiceConfigConstants {
    boolean DEFAULT_NO_FALLBACK_ENABLED = false;
 
    String DEFAULT_STICKY_SESSION_COOKIE_NAME = "KNOX_BACKEND";
+
+   String DEFAULT_DISABLE_LB_USER_AGENTS = "ClouderaODBCDriverforApacheHive";
 }

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
@@ -56,6 +56,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.easymock.EasyMock.anyString;
 
@@ -952,9 +953,9 @@ public class DefaultHaDispatchTest {
     dispatch2.init();
 
     /* make sure active URL is what is supposed to be */
-    Assert.assertEquals(provider1.getActiveURL(serviceName1), activeURLField.get(dispatch1));
+    Assert.assertEquals(provider1.getActiveURL(serviceName1), ((AtomicReference<String>)activeURLField.get(dispatch1)).get());
     /* make sure active URL is what is supposed to be */
-    Assert.assertEquals(provider2.getActiveURL(serviceName2), activeURLField.get(dispatch2));
+    Assert.assertEquals(provider2.getActiveURL(serviceName2), ((AtomicReference<String>)activeURLField.get(dispatch2)).get());
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a way to turn off HA loadbalancing based on user agent.
This is done because some non-browser clients such as ODBC drivers do not honor multiple SET-COOKIE headers in response body. This config is to work around that issue. 

This PR proposed a configuration in HA Provider called `disableLoadBalancingForUserAgents` which takes a comma separated list of user agents that should disable the HA loadbalancing ifeature.

Following is an example config 
```
<provider>
             <role>ha</role>
             <name>HaProvider</name>
             <enabled>true</enabled>

             <param>
                 <name>HIVE</name>     <value>enableStickySession=true;enableLoadBalancing=true;enabled=true;maxFailoverAttempts=42;failoverSleep=50;maxRetryAttempts=1;disableLoadBalancingForUserAgents=Test User Agent, Test User Agent2,Test User Agent3 ,Test User Agent4 ;retrySleep=1000</value>
             </param>
</provider>
```

Default value of `disableLoadBalancingForUserAgents=ClouderaODBCDriverforApacheHive`

## How was this patch tested?
This patch was tested on a local cluster