### PR TITLE
KNOX-2635 - GatewayAppFuncTest is flaky

### DIFF
--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -88,7 +89,7 @@ public class GatewayAppFuncTest {
 
   @After
   public void cleanupTest() throws Exception {
-    FileUtils.cleanDirectory( new File( config.getGatewayTopologyDir() ) );
+    cleanTopologyDir();
     // Test run should not fail if deleting deployment files is not successful.
     // Deletion has been already done by TopologyService.
     FileUtils.deleteQuietly( new File( config.getGatewayDeploymentDir() ) );
@@ -536,6 +537,7 @@ public class GatewayAppFuncTest {
     } finally {
       gateway.stop();
       config.setGatewayDeploymentsBackupAgeLimit( oldVersionLimit );
+      cleanTopologyDir();
       startGatewayServer();
     }
 
@@ -646,9 +648,14 @@ public class GatewayAppFuncTest {
     } finally {
       gateway.stop();
       config.setDefaultTopologyName( null );
+      cleanTopologyDir();
       startGatewayServer();
     }
 
     LOG_EXIT();
+  }
+
+  private void cleanTopologyDir() throws IOException {
+    FileUtils.cleanDirectory(new File(config.getGatewayTopologyDir()));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Typical failure look like:

```
[ERROR]   GatewayAppFuncTest.testMultiApps:338 1 expectation failed.
Expected status code <200> but was <404>. 
```

It happens in test which are running right after testDeploymentCleanup or testDefaultTopology. These tests restart the gateway service during the test run.

The subsequent test overwrite the topology file which are used by all tests but file access date granularity is 1 second (msec part is always 000, this is likley FS specific) therefore the topology is never redeployed.

Adding clean up logic in between these restarts seem to solve the issue.

## How was this patch tested?

```bash
mvn test -Dtest=GatewayAppFuncTest   
while [ $? -eq 0 ]; do
    mvn test -Dtest=GatewayAppFuncTest   
done
```