### PR TITLE
KNOX-2638 - Shiro propererties are missing after topology deployment

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
@@ -33,10 +33,6 @@ public class ShiroConfig {
     String sectionName;
     String value;
 
-    params.putIfAbsent("main.invalidRequest.blockSemicolon", "false");
-    params.putIfAbsent("main.invalidRequest.blockBackslash", "false");
-    params.putIfAbsent("main.invalidRequest.blockNonAscii", "false");
-
     for(Entry<String, String> entry : params.entrySet()) {
       int sectionDot = entry.getKey().indexOf('.');
       if (sectionDot > 0) {

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
@@ -28,10 +28,14 @@ public class ShiroConfig {
   private Map<String, Map<String, String>> sections = new LinkedHashMap<>();
 
   public ShiroConfig(Provider provider, String clusterName) {
-    Map<String, String> params = provider.getParams();
+    Map<String, String> params = new LinkedHashMap<>(provider.getParams()); // make a copy since we modify the map
     String name;
     String sectionName;
     String value;
+
+    params.putIfAbsent("main.invalidRequest.blockSemicolon", "false");
+    params.putIfAbsent("main.invalidRequest.blockBackslash", "false");
+    params.putIfAbsent("main.invalidRequest.blockNonAscii", "false");
 
     for(Entry<String, String> entry : params.entrySet()) {
       int sectionDot = entry.getKey().indexOf('.');

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -45,7 +45,6 @@ import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.services.topology.monitor.DescriptorsMonitor;
 import org.apache.knox.gateway.services.topology.monitor.SharedProviderConfigMonitor;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
-import org.apache.knox.gateway.topology.Provider;
 import org.apache.knox.gateway.topology.Service;
 import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.topology.TopologyEvent;
@@ -160,20 +159,9 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         topology.setUri(file.toURI());
         topology.setName(FilenameUtils.removeExtension(file.getName()));
         topology.setTimestamp(file.lastModified());
-        addShiroProperties(topology);
       }
     }
     return topology;
-  }
-
-  private void addShiroProperties(Topology topology) {
-    Provider shiro = topology.getProvider("authentication", "ShiroProvider");
-    if (shiro != null) {
-      Map<String, String> params = shiro.getParams();
-      params.putIfAbsent("main.invalidRequest.blockSemicolon", "false");
-      params.putIfAbsent("main.invalidRequest.blockBackslash", "false");
-      params.putIfAbsent("main.invalidRequest.blockNonAscii", "false");
-    }
   }
 
   private void redeployTopology(Topology topology) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -37,14 +37,15 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.service.definition.ServiceDefinition;
 import org.apache.knox.gateway.service.definition.ServiceDefinitionChangeListener;
 import org.apache.knox.gateway.services.GatewayServices;
-import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClient;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.services.topology.monitor.DescriptorsMonitor;
 import org.apache.knox.gateway.services.topology.monitor.SharedProviderConfigMonitor;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
+import org.apache.knox.gateway.topology.Provider;
 import org.apache.knox.gateway.topology.Service;
 import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.topology.TopologyEvent;
@@ -159,9 +160,20 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         topology.setUri(file.toURI());
         topology.setName(FilenameUtils.removeExtension(file.getName()));
         topology.setTimestamp(file.lastModified());
+        addShiroProperties(topology);
       }
     }
     return topology;
+  }
+
+  private void addShiroProperties(Topology topology) {
+    Provider shiro = topology.getProvider("authentication", "ShiroProvider");
+    if (shiro != null) {
+      Map<String, String> params = shiro.getParams();
+      params.putIfAbsent("main.invalidRequest.blockSemicolon", "false");
+      params.putIfAbsent("main.invalidRequest.blockBackslash", "false");
+      params.putIfAbsent("main.invalidRequest.blockNonAscii", "false");
+    }
   }
 
   private void redeployTopology(Topology topology) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

STR:

1. Have an existing topology (test.xml), see if blockSemicolon/blockBackslash/blockNonAscii are in the get topology output:

```bash
$ curl -u admin:admin-password -k -X GET https://localhost:8443/gateway/admin/api/v1/topologies/test | grep blockSemicolon
<name>main.invalidRequest.blockSemicolon</name>
```

2. Deploy a new topology file (test2.xml)

```bash
cp ./conf/topologies/test.xml ./conf/topologies/test2.xml 
```

3. blockSemicolon/blockBackslash/blockNonAscii are no longer in the orignial test.xml output:

```bash
$ curl -u admin:admin-password  -k -X GET https://localhost:8443/gateway/admin/api/v1/topologies/test | grep  blockSemicolon 
```

The reason why these shiro properties are missing is because we only add these after a topology deployment to the in memory representation of a topology. When we deploy a new topology we also reload all the existing topologies but only redeploy the newly added one.

```java
@Override
public void reloadTopologies() {
  try {
    synchronized (this) {
      Map<File, Topology> oldTopologies = topologies;
      Map<File, Topology> newTopologies = loadTopologies(topologiesDirectory); // <= parse everything from disk
      List<TopologyEvent> events = createChangeEvents(oldTopologies, newTopologies);
      topologies = newTopologies;
      notifyChangeListeners(events); // <= this will redeploy the new topology and add the shiro properties, but those will be missing from all other existing topologies
    }
  } catch (Exception e) {
    // Maybe it makes sense to throw exception
    log.failedToReloadTopologies(e);
  }
} 
```

One open question is whether we wan't to write out these properties to the disk or not.

## How was this patch tested?

This was discovered while investigating the flakiness of an existing test: GatewayAdminTopologyFuncTest.
After the fixed I verified that GatewayAdminTopologyFuncTest is no longer flaky. Existing tests cover this case that's why no new tests were added.

