### PR TITLE
KNOX-2534. Allow alias to be used in pac4j topology block

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -216,9 +216,9 @@ public class Pac4jDispatcherFilter implements Filter {
 
   private String resolveAlias(String clusterName, String key, String value) throws ServletException {
     if (value.startsWith("${ALIAS=") && value.endsWith("}")) {
-      String alias = value.substring("${ALIAS=".length());
+      String alias = value.substring("${ALIAS=".length(), value.length() - 1);
       try {
-        return new String(aliasService.getPasswordFromAliasForCluster(clusterName, alias.substring(0, alias.length() - 1)));
+        return new String(aliasService.getPasswordFromAliasForCluster(clusterName, alias));
       } catch (AliasServiceException e) {
         throw new ServletException("Unable to retrieve alias for config: " + key, e);
       }

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -23,8 +23,8 @@ import org.apache.knox.gateway.pac4j.Pac4jMessages;
 import org.apache.knox.gateway.pac4j.config.ClientConfigurationDecorator;
 import org.apache.knox.gateway.pac4j.config.Pac4jClientConfigurationDecorator;
 import org.apache.knox.gateway.pac4j.session.KnoxSessionStore;
-import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.CryptoService;
@@ -72,7 +72,7 @@ import java.util.Map;
  * @since 0.8.0
  */
 public class Pac4jDispatcherFilter implements Filter {
-
+  private static final String ALIAS_PREFIX = "${ALIAS=";
   private static Pac4jMessages log = MessagesFactory.get(Pac4jMessages.class);
 
   private static final ClientConfigurationDecorator PAC4J_CLIENT_CONFIGURATION_DECORATOR = new Pac4jClientConfigurationDecorator();
@@ -215,8 +215,8 @@ public class Pac4jDispatcherFilter implements Filter {
   }
 
   private String resolveAlias(String clusterName, String key, String value) throws ServletException {
-    if (value.startsWith("${ALIAS=") && value.endsWith("}")) {
-      String alias = value.substring("${ALIAS=".length(), value.length() - 1);
+    if (value.startsWith(ALIAS_PREFIX) && value.endsWith("}")) {
+      String alias = value.substring(ALIAS_PREFIX.length(), value.length() - 1);
       try {
         return new String(aliasService.getPasswordFromAliasForCluster(clusterName, alias));
       } catch (AliasServiceException e) {

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/Pac4jProviderTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/Pac4jProviderTest.java
@@ -36,9 +36,11 @@ import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.Cookie;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -367,4 +369,68 @@ public class Pac4jProviderTest {
         assertEquals(USERNAME, adapter.getTestIdentifier());
     }
 
+    @Test
+    public void testResolvesAlias() throws Exception {
+        final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+        EasyMock.expect(aliasService.getPasswordFromAliasForCluster(CLUSTER_NAME, KnoxSessionStore.PAC4J_PASSWORD, true))
+                .andReturn(PAC4J_PASSWORD.toCharArray()).anyTimes();
+        EasyMock.expect(aliasService.getPasswordFromAliasForCluster(CLUSTER_NAME, KnoxSessionStore.PAC4J_PASSWORD))
+                .andReturn(PAC4J_PASSWORD.toCharArray()).anyTimes();
+        EasyMock.expect(aliasService.getPasswordFromAliasForCluster(CLUSTER_NAME, "my-secret-alias"))
+                .andReturn("my-oidc-secret".toCharArray()).atLeastOnce();
+        EasyMock.replay(aliasService);
+
+        GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
+        EasyMock.expect(services.getService(ServiceType.CRYPTO_SERVICE)).andReturn(new DefaultCryptoService());
+        EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService);
+        EasyMock.replay(services);
+
+        ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+        EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
+        EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn(CLUSTER_NAME);
+        EasyMock.replay(context);
+
+        new Pac4jDispatcherFilter().init(
+            new FilterConfigStub(context)
+                .addInitParam(Pac4jDispatcherFilter.PAC4J_CALLBACK_URL, PAC4J_CALLBACK_URL)
+                .addInitParam("clientName", "OidcClient")
+                .addInitParam("oidc.secret", "${ALIAS=my-secret-alias}")
+                .addInitParam("oidc.id", "test-id")
+        );
+        EasyMock.verify(aliasService);
+    }
+
+    private class FilterConfigStub implements FilterConfig {
+        private ServletContext context;
+        private Properties properties = new Properties();
+
+        public FilterConfigStub(ServletContext context) {
+            this.context = context;
+        }
+
+        public FilterConfigStub addInitParam(String name, String value) {
+            properties.setProperty(name, value);
+            return this;
+        }
+
+        @Override
+        public String getFilterName() {
+            return null;
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return context;
+        }
+
+        @Override
+        public String getInitParameter(String s) {
+            return properties.getProperty(s, null);
+        }
+
+        @Override
+        public Enumeration<String> getInitParameterNames() {
+            return (Enumeration<String>) properties.propertyNames();
+        }
+    }
 }

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/Pac4jProviderTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/Pac4jProviderTest.java
@@ -404,7 +404,7 @@ public class Pac4jProviderTest {
         private ServletContext context;
         private Properties properties = new Properties();
 
-        public FilterConfigStub(ServletContext context) {
+        FilterConfigStub(ServletContext context) {
             this.context = context;
         }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The patch makes possible to use an alias in pac4j provider config so that `oidc.secret` is no longer need to be hardcoded in the topology as plain text.


## How was this patch tested?

Added an alias for oidc.secret in knoxsso.xml.

```
<param>
  <name>oidc.secret</name>                  
  <value>${ALIAS=myOidcSecret}</value>
</param>
```

Created the alias with knoxcli.

```bash
$ bin/knoxcli.sh create-alias myOidcSecret --value <my-secret> --cluster knoxsso
````

Tested authentication with auth0.com.