### PR TITLE
KNOX-2639. Build instability because of maven artifact download failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: 'Build and Test'
-        run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -B -V
+        run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V
 # This is failing due to not finding files? - See KNOX-2347
 #      - name: shellcheck
 #        uses: reviewdog/action-shellcheck@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - lscpu
   - docker pull $IMAGE
 script:
-  - $DOCKERRUN $IMAGE mvn -T.75C clean verify -U -Dshellcheck=true -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -B -V
+  - $DOCKERRUN $IMAGE mvn -T.75C clean verify -U -Dshellcheck=true -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V
 git:
   depth: 1000
 cache:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Trying to get rid of build instability errors like this:

```
Error:  Failed to execute goal on project gateway-test-release: Could not resolve dependencies for project org.apache.knox:gateway-test-release:pom:1.6.0-SNAPSHOT: Failed to collect dependencies at org.eclipse.jetty:jetty-util-ajax:jar:9.4.34.v20201102: Failed to read artifact descriptor for org.eclipse.jetty:jetty-util-ajax:jar:9.4.34.v20201102: 
Could not transfer artifact org.eclipse.jetty:jetty-util-ajax:pom:9.4.34.v20201102 from/to central (https://repo.maven.apache.org/maven2): transfer failed for https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-util-ajax/9.4.34.v20201102/jetty-util-ajax-9.4.34.v20201102.pom: 
Connection timed out (Read failed) -> [Help 1]
```

There is a `maven.wagon.http.retryHandler.count` parameter but it doesn't do anything by default because `ConnectException` is not retryable by default, so I had to set `maven.wagon.http.retryHandler.nonRetryableClasses` as well.

This way I can see the retry related messages in the mvn outout.

Many sources recommened `-Dhttp.keepAlive=false` because keepAlive connections are prone to be killed within docker for some reason.

## How was this patch tested?

1.) Enable maven wagon logging to see retries:

```
In apache-maven-3.8.1/conf/logging/simplelogger.properties set:
org.slf4j.simpleLogger.log.org.apache.maven.wagon.providers.http.httpclient=on

```

2.) Simulate Connection Timeout by setting `10.255.255.1 repo.maven.apache.org` in `/etc/hosts`

3.) Run maven command with retry and checked the output:
```
mvn  -Dmaven.wagon.http.retryHandler.count=2 \
 -Dmaven.wagon.http.retryHandler.class=default \
 -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException  \
 -DskipTests  -Dcheckstyle.skip=true -Dfindbugs.skip=true -Dpmd.skip=true -Drat.skip -Ppackage clean install
```

Output:

```
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/velocity/velocity/1.5/velocity-1.5.pom
[INFO] I/O exception (org.apache.maven.wagon.providers.http.httpclient.conn.HttpHostConnectException) caught when processing request to {s}->https://repo.maven.apache.org:443: Connect to repo.maven.apache.org:443 [repo.maven.apache.org/10.255.255.1] failed: Operation timed out (Connection timed out)
[INFO] Retrying request to {s}->https://repo.maven.apache.org:443
[INFO] I/O exception (org.apache.maven.wagon.providers.http.httpclient.conn.HttpHostConnectException) caught when processing request to {s}->https://repo.maven.apache.org:443: Connect to repo.maven.apache.org:443 [repo.maven.apache.org/10.255.255.1] failed: Operation timed out (Connection timed out)
[INFO] Retrying request to {s}->https://repo.maven.apache.org:443
```

