### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 script:
   - $DOCKERRUN $IMAGE mvn -T.75C clean verify -U -Dshellcheck=true -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V
 git:
-  depth: 1000
+  depth: 3
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.