### PR TITLE
KNOX-2642. Incorrect message format indexes

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryMessages.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryMessages.java
@@ -45,11 +45,11 @@ public interface AmbariServiceDiscoveryMessages {
     void errorAccessingConfigurationChangeMonitor(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 
     @Message(level = MessageLevel.ERROR,
-             text = "Failed to load service discovery URL definition configuration: {1}")
+             text = "Failed to load service discovery URL definition configuration: {0}")
     void failedToLoadServiceDiscoveryURLDefConfiguration(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 
     @Message(level = MessageLevel.ERROR,
-             text = "Failed to load ZooKeeper configuration property mappings: {1}")
+             text = "Failed to load ZooKeeper configuration property mappings: {0}")
     void failedToLoadZooKeeperConfigurationMapping(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 
     @Message(level = MessageLevel.ERROR,

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/impl/i18n/KnoxShiroMessages.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/impl/i18n/KnoxShiroMessages.java
@@ -35,7 +35,7 @@ public interface KnoxShiroMessages {
   @Message(level = MessageLevel.INFO, text = "Could not login: {0}")
   void failedLoginInfo(AuthenticationToken token);
 
-  @Message( level = MessageLevel.DEBUG, text = "Failed to Authenticate with LDAP server: {1}" )
+  @Message( level = MessageLevel.DEBUG, text = "Failed to Authenticate with LDAP server: {0}" )
   void failedLoginStackTrace( @StackTrace( level = MessageLevel.DEBUG ) Exception e );
 
   @Message(level = MessageLevel.INFO, text = "Successfully logged in: {0}, {1}")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -666,12 +666,6 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.ERROR, text = "The path to the keystore is not accessible: {0}" )
   void keystoreFileIsNotAccessible(String path);
 
-  @Message( level = MessageLevel.ERROR, text = "Failed to add credential: {1}" )
-  void failedToAddCredential( @StackTrace( level = MessageLevel.DEBUG ) Exception e );
-
-  @Message(level = MessageLevel.ERROR, text = "Failed to remove credential: {1}")
-  void failedToRemoveCredential(@StackTrace(level = MessageLevel.DEBUG) Exception e);
-
   @Message(level = MessageLevel.INFO, text = "Starting service: {0}")
   void startingService(String serviceTypeName);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -199,7 +199,7 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.DEBUG, text = "{0} expired tokens have been removed from the database")
   void removedTokensFromDatabase(int size);
 
-  @Message(level = MessageLevel.ERROR, text = "An error occurred while removing expired tokens from the database : {1}")
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while removing expired tokens from the database : {0}")
   void errorRemovingTokensFromDatabase(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.DEBUG, text = "Fetched issue time for {0} from the database : {1}")

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/MetadataServiceMessages.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/MetadataServiceMessages.java
@@ -25,7 +25,7 @@ import org.apache.knox.gateway.i18n.messages.StackTrace;
 @Messages(logger = "org.apache.knox.gateway.service.metadata")
 public interface MetadataServiceMessages {
 
-  @Message(level = MessageLevel.ERROR, text = "Failed to fetch public certificate: {1}")
+  @Message(level = MessageLevel.ERROR, text = "Failed to fetch public certificate: {0}")
   void failedToFetchPublicCert(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR, text = "Failed to generate public certificate {0}: {1}")

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/discovery/advanced/AdvanceServiceDiscoveryConfigurationMessages.java
@@ -30,7 +30,7 @@ public interface AdvanceServiceDiscoveryConfigurationMessages {
   @Message(level = MessageLevel.INFO, text = "Monitoring advanced service discovery configuration changes is disabled.")
   void disableMonitoring();
 
-  @Message(level = MessageLevel.ERROR, text = "Error while monitoring CM advanced configuration: {1}")
+  @Message(level = MessageLevel.ERROR, text = "Error while monitoring CM advanced configuration: {0}")
   void failedToMonitorClouderaManagerAdvancedConfiguration(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.INFO, text = "Notifying listeners due to advanced service discovery configuration changes in {0}...")


### PR DESCRIPTION
## What changes were proposed in this pull request?

MessageFormat is zero based but there are multiple places where we use 1 based indexing, therefore the arguments are not visible in the log.

Such as: 

```
@Message( level = MessageLevel.DEBUG, text = "Failed to Authenticate with LDAP server: {1}" )
```

## How was this patch tested?

Manually:

Before the fix:
```
logs/gateway.log:2021-08-16 12:53:44,692 DEBUG knox.gateway (KnoxLdapRealm.java:doGetAuthenticationInfo(204)) - Failed to Authenticate with LDAP server: {1}
```

After the fix:

```
logs/gateway.log:2021-08-16 12:55:44,074 DEBUG knox.gateway (KnoxLdapRealm.java:doGetAuthenticationInfo(204)) - Failed to Authenticate with LDAP server: org.apache.shiro.authc.AuthenticationException: LDAP authentication failed.
```