### PR TITLE
KNOX-2646. The tokenLimitPerUser check doesn't always work.

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -740,8 +740,4 @@ public class TokenResource {
     String message = t.getMessage();
     return message != null ? message : "null";
   }
-
-  void setTokenLimitPerUser(int tokenLimitPerUser) { // visible for testing
-    this.tokenLimitPerUser = tokenLimitPerUser;
-  }
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -605,7 +605,7 @@ public class TokenResource {
 
     if (tokenStateService != null) {
       if (tokenLimitPerUser != -1) { // if -1 => unlimited tokens for all users
-        if (tokenStateService.getTokens(p.getName()).size() == tokenLimitPerUser) {
+        if (tokenStateService.getTokens(p.getName()).size() >= tokenLimitPerUser) {
           log.tokenLimitExceeded(p.getName());
           return Response.status(Response.Status.FORBIDDEN).entity("{ \"Unable to get token - token limit exceeded.\" }").build();
         }
@@ -741,4 +741,7 @@ public class TokenResource {
     return message != null ? message : "null";
   }
 
+  void setTokenLimitPerUser(int tokenLimitPerUser) { // visible for testing
+    this.tokenLimitPerUser = tokenLimitPerUser;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have an equality check when checking the max number of tokens per user. But if the user already have N number of tokens, and later the admin changes the gateway.knox.token.limit.per.user to a smaller number then this check will never trigger.

## How was this patch tested?

1. Having no limit and generating N tokens
2. Changing gateway.knox.token.limit.per.user to a lower number than N and restarting the service
3. Trying to generate one more token and getting a limit exception