### PR TITLE
KNOX-2647: Fix Spark History UI Service Executor Log (stdout/stderr) Links

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/rewrite.xml
@@ -98,4 +98,16 @@
   <rule dir="OUT" name="SPARKHISTORYUI/sparkhistory/outbound/yarn/containerlogs2" pattern="{scheme}://{host}:{port}/node/containerlogs/{**}?{**}">
     <rewrite template="{$frontend[url]}/yarnuiv2/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
   </rule>
+
+  <!-- rewrite JSON response for log locations -->
+  <rule dir="IN" name="SPARKHISTORYUI/sparkhistory/inbound/json/body/jhslogs">
+    <match pattern="{scheme}://{host}:{port}/jobhistory/logs/{**}?{**}"/>
+    <rewrite template="{$frontend[url]}/jobhistory/joblogs/{**}?{**}"/>
+  </rule>
+  <filter name="SPARKHISTORYUI/sparkhistory/inbound/json/body">
+    <content type="*/json">
+      <apply path="$[*]['executorLogs']['stderr']" rule="SPARKHISTORYUI/sparkhistory/inbound/json/body/jhslogs"/>
+      <apply path="$[*]['executorLogs']['stdout']" rule="SPARKHISTORYUI/sparkhistory/inbound/json/body/jhslogs"/>
+    </content>
+  </filter>
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/sparkhistoryui/2.3.0/service.xml
@@ -44,5 +44,8 @@
             <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/headers/jobs" to="response.headers"/>
             <rewrite apply="SPARKHISTORYUI/sparkhistory/outbound/rqheaders" to="request.headers"/>
         </route>
+        <route path="/sparkhistory/api/v1/applications/**">
+            <rewrite apply="SPARKHISTORYUI/sparkhistory/inbound/json/body" to="response.body"/>
+        </route>
     </routes>
 </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a rewrite rule to fix the executor log links here:
![spark-history-ui](https://user-images.githubusercontent.com/373804/130836953-10aeb67b-833c-4b3a-af80-979a8b88806b.png)

When MR JobHistory Server is also running.

## How was this patch tested?

I have applied this patch on our internal cluster and can see that the links now go through Knox instead of pointing directly at the JobHistory Server Web UI endpoint.