### PR TITLE
KNOX-2650 - Loading token management page can be slow if there are lots of tokens

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -17,17 +17,6 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.services.ServiceLifecycleException;
-import org.apache.knox.gateway.services.security.AliasService;
-import org.apache.knox.gateway.services.security.token.KnoxToken;
-import org.apache.knox.gateway.services.security.token.TokenMetadata;
-import org.apache.knox.gateway.services.security.token.TokenStateServiceException;
-import org.apache.knox.gateway.services.security.token.UnknownTokenException;
-import org.apache.knox.gateway.util.JDBCUtils;
-import org.apache.knox.gateway.util.Tokens;
-
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,6 +27,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.token.KnoxToken;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.TokenStateServiceException;
+import org.apache.knox.gateway.services.security.token.UnknownTokenException;
+import org.apache.knox.gateway.util.JDBCUtils;
+import org.apache.knox.gateway.util.Tokens;
 
 public class JDBCTokenStateService extends DefaultTokenStateService {
   private AliasService aliasService; // connection username/pw and passcode HMAC secret are stored here

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -17,18 +17,6 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -39,6 +27,17 @@ import org.apache.knox.gateway.services.security.token.TokenStateServiceExceptio
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.util.JDBCUtils;
 import org.apache.knox.gateway.util.Tokens;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 public class JDBCTokenStateService extends DefaultTokenStateService {
   private AliasService aliasService; // connection username/pw and passcode HMAC secret are stored here
@@ -297,16 +296,11 @@ public class JDBCTokenStateService extends DefaultTokenStateService {
 
   @Override
   public Collection<KnoxToken> getTokens(String userName) {
-    final Collection<KnoxToken> tokens = new TreeSet<>();
     try {
-      tokens.addAll(tokenDatabase.getTokens(userName));
-      for (KnoxToken token : tokens) {
-        token.setMetadata(tokenDatabase.getTokenMetadata(token.getTokenId()));
-      }
+      return tokenDatabase.getTokens(userName);
     } catch (SQLException e) {
       log.errorFetchingTokensForUserFromDatabase(userName, e.getMessage(), e);
+      return Collections.emptyList();
     }
-    return tokens;
   }
-
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
@@ -17,8 +17,12 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.knox.gateway.services.security.token.KnoxToken;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 
+import javax.sql.DataSource;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -29,17 +33,12 @@ import java.sql.Statement;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
-import javax.sql.DataSource;
-
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.IOUtils;
-import org.apache.knox.gateway.services.security.token.KnoxToken;
-import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TokenStateDatabase {
   private static final String TOKENS_TABLE_CREATE_SQL_FILE_NAME = "createKnoxTokenDatabaseTable.sql";
@@ -57,9 +56,9 @@ public class TokenStateDatabase {
   private static final String ADD_METADATA_SQL = "INSERT INTO " + TOKEN_METADATA_TABLE_NAME + "(token_id, md_name, md_value) VALUES(?, ?, ?)";
   private static final String UPDATE_METADATA_SQL = "UPDATE " + TOKEN_METADATA_TABLE_NAME + " SET md_value = ? WHERE token_id = ? AND md_name = ?";
   private static final String GET_METADATA_SQL = "SELECT md_name, md_value FROM " + TOKEN_METADATA_TABLE_NAME + " WHERE token_id = ?";
-  private static final String GET_TOKENS_BY_USER_NAME_SQL = "SELECT kt.token_id, kt.issue_time, kt.expiration, kt.max_lifetime FROM " + TOKENS_TABLE_NAME
-      + " kt, " + TOKEN_METADATA_TABLE_NAME + " ktm WHERE kt.token_id = ktm.token_id AND ktm.md_name = '" + TokenMetadata.USER_NAME
-      + "' AND ktm.md_value = ? ORDER BY kt.issue_time";
+  private static final String GET_TOKENS_BY_USER_NAME_SQL = "SELECT kt.token_id, kt.issue_time, kt.expiration, kt.max_lifetime, ktm.md_name, ktm.md_value FROM " + TOKENS_TABLE_NAME
+      + " kt, " + TOKEN_METADATA_TABLE_NAME + " ktm WHERE kt.token_id = ktm.token_id AND kt.token_id IN (SELECT token_id FROM " + TOKEN_METADATA_TABLE_NAME + " WHERE md_name = '" + TokenMetadata.USER_NAME + "' AND md_value = ? )"
+      + " ORDER BY kt.issue_time";
 
   private final DataSource dataSource;
 
@@ -192,24 +191,34 @@ public class TokenStateDatabase {
         final Map<String, String> metadataMap = new HashMap<>();
         while (rs.next()) {
           String metadataName = rs.getString(1);
-          metadataMap.put(metadataName, metadataName.equals(TokenMetadata.PASSCODE) ? new String(Base64.decodeBase64(rs.getString(2).getBytes(UTF_8)), UTF_8) : rs.getString(2));
+          metadataMap.put(metadataName, decodeMetadata(metadataName, rs.getString(2)));
         }
         return metadataMap.isEmpty() ? null : new TokenMetadata(metadataMap);
       }
     }
   }
 
+  private static String decodeMetadata(String metadataName, String metadataValue) {
+    return metadataName.equals(TokenMetadata.PASSCODE) ? new String(Base64.decodeBase64(metadataValue.getBytes(UTF_8)), UTF_8) : metadataValue;
+  }
+
   Collection<KnoxToken> getTokens(String userName) throws SQLException {
-    final Collection<KnoxToken> tokens = new TreeSet<>();
+    Map<String, KnoxToken> tokenMap = new LinkedHashMap<>();
     try (Connection connection = dataSource.getConnection(); PreparedStatement getTokenIdsStatement = connection.prepareStatement(GET_TOKENS_BY_USER_NAME_SQL)) {
       getTokenIdsStatement.setString(1, userName);
       try (ResultSet rs = getTokenIdsStatement.executeQuery()) {
         while(rs.next()) {
-          tokens.add(new KnoxToken(rs.getString(1), rs.getLong(2), rs.getLong(3), rs.getLong(4)));
+          String tokenId = rs.getString(1);
+          long issueTime = rs.getLong(2);
+          long expiration = rs.getLong(3);
+          long maxLifeTime = rs.getLong(4);
+          String metaName = rs.getString(5);
+          String metaValue = rs.getString(6);
+          KnoxToken token = tokenMap.computeIfAbsent(tokenId, id -> new KnoxToken(tokenId, issueTime, expiration, maxLifeTime));
+          token.addMetadata(metaName, decodeMetadata(metaName, metaValue));
         }
-        return tokens;
+        return tokenMap.values();
       }
     }
   }
-
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
@@ -17,12 +17,8 @@
  */
 package org.apache.knox.gateway.services.token.impl;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.IOUtils;
-import org.apache.knox.gateway.services.security.token.KnoxToken;
-import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-import javax.sql.DataSource;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -37,8 +33,12 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import javax.sql.DataSource;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
+import org.apache.knox.gateway.services.security.token.KnoxToken;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
 
 public class TokenStateDatabase {
   private static final String TOKENS_TABLE_CREATE_SQL_FILE_NAME = "createKnoxTokenDatabaseTable.sql";

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
@@ -28,6 +28,11 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,25 +57,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class JDBCTokenStateServiceTest {
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.derby.drda.NetworkServerControl;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.token.KnoxToken;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.TokenMAC;
@@ -51,6 +52,25 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class JDBCTokenStateServiceTest {
 
@@ -128,6 +148,55 @@ public class JDBCTokenStateServiceTest {
 
     assertEquals(expiration, getLongTokenAttributeFromDatabase(tokenId, TokenStateDatabase.GET_TOKEN_EXPIRATION_SQL));
     assertEquals(issueTime + maxLifetimeDuration, getLongTokenAttributeFromDatabase(tokenId, TokenStateDatabase.GET_MAX_LIFETIME_SQL));
+  }
+
+  @Test
+  public void testAddTokensForMultipleUsers() throws Exception {
+    String user1 = "user1";
+    String user2 = "user2";
+    String id1 = "token1";
+    String id2 = "token2";
+    String id3 = "token3";
+
+    long issueTime1 = 1;
+    long expiration1 = 1;
+    String comment1 = "comment1";
+
+    long issueTime2 = 2;
+    long expiration2 = 2;
+    String comment2 = "comment2";
+
+    long issueTime3 = 3;
+    long expiration3 = 3;
+    String comment3 = "comment3";
+
+    truncateDatabase();
+
+    saveToken(user1, id1, issueTime1, expiration1, comment1);
+    saveToken(user1, id2, issueTime2, expiration2, comment2);
+    saveToken(user2, id3, issueTime3, expiration3, comment3);
+
+    List<KnoxToken> user1Tokens = new ArrayList<>(jdbcTokenStateService.getTokens(user1));
+    assertEquals(2, user1Tokens.size());
+    assertToken(user1Tokens.get(0), id1, expiration1, comment1, issueTime1);
+    assertToken(user1Tokens.get(1), id2, expiration2, comment2, issueTime2);
+
+    List<KnoxToken> user2Tokens = new ArrayList<>(jdbcTokenStateService.getTokens(user2));
+    assertEquals(1, user2Tokens.size());
+    assertToken(user2Tokens.get(0), id3, expiration3, comment3, issueTime3);
+  }
+
+  private void assertToken(KnoxToken knoxToken, String tokenId, long expiration, String comment, long issueTime) {
+    SimpleDateFormat df = new SimpleDateFormat(KnoxToken.DATE_FORMAT, Locale.getDefault());
+    assertEquals(tokenId, knoxToken.getTokenId());
+    assertEquals(df.format(new Date(issueTime)), knoxToken.getIssueTime());
+    assertEquals(df.format(new Date(expiration)), knoxToken.getExpiration());
+    assertEquals(comment, knoxToken.getMetadata().getComment());
+  }
+
+  private void saveToken(String user, String tokenId, long issueTime, long expiration, String comment) {
+    jdbcTokenStateService.addToken(tokenId, issueTime, expiration);
+    jdbcTokenStateService.addMetadata(tokenId, new TokenMetadata(user, comment));
   }
 
   @Test(expected = UnknownTokenException.class)

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/KnoxToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/KnoxToken.java
@@ -19,13 +19,15 @@ package org.apache.knox.gateway.services.security.token;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
 
-public class KnoxToken implements Comparable<KnoxToken> {
+public class KnoxToken implements Comparable<KnoxToken>{
+  public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   // SimpleDateFormat is not thread safe must use as a ThreadLocal
   private static final ThreadLocal<DateFormat> KNOX_TOKEN_TS_FORMAT = ThreadLocal
-      .withInitial(() -> new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault()));
+      .withInitial(() -> new SimpleDateFormat(DATE_FORMAT, Locale.getDefault()));
 
   private final String tokenId;
   private final long issueTime;
@@ -34,7 +36,7 @@ public class KnoxToken implements Comparable<KnoxToken> {
   private TokenMetadata metadata;
 
   public KnoxToken(String tokenId, long issueTime, long expiration, long maxLifetimeDuration) {
-    this(tokenId, issueTime, expiration, maxLifetimeDuration, null);
+    this(tokenId, issueTime, expiration, maxLifetimeDuration, new TokenMetadata(Collections.emptyMap()));
   }
 
   public KnoxToken(String tokenId, long issueTime, long expiration, long maxLifetime, TokenMetadata metadata) {
@@ -84,5 +86,9 @@ public class KnoxToken implements Comparable<KnoxToken> {
   @Override
   public int compareTo(KnoxToken other) {
     return Long.compare(this.issueTime, other.issueTime);
+  }
+
+  public void addMetadata(String name, String value) {
+    metadata.add(name, value);
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
@@ -117,4 +117,8 @@ public class TokenMetadata {
   public int hashCode() {
     return HashCodeBuilder.reflectionHashCode(this);
   }
+
+  public void add(String name, String value) {
+    metadataMap.put(name, value);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Having lots of tokens causes slowness when loading the token management page. The reason is that the token metadata is loaded in a separate query and for each token we open a new connection when running the query.

This patch merges the 2 queries into one.

## How was this patch tested?

1. Creating few hundred tokens
2. Loading the token management page