### PR TITLE
KNOX-2651 - NPE when token value is missing

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -16,10 +16,12 @@
  */
 package org.apache.knox.gateway.provider.federation.jwt;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
 import org.apache.knox.gateway.i18n.messages.StackTrace;
+import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
 
 @Messages(logger="org.apache.knox.gateway.provider.federation.jwt")
 public interface JWTMessages {
@@ -87,4 +89,7 @@ public interface JWTMessages {
 
   @Message( level = MessageLevel.ERROR, text = "Token is disabled: {0}" )
   void disabledToken(String tokenId);
+
+  @Message( level = MessageLevel.INFO, text = "Missing token: {0}")
+  void missingTokenFromHeader(Pair<JWTFederationFilter.TokenType, String> wireToken);
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -126,7 +126,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
     }
     final Pair<TokenType, String> wireToken = getWireToken(request);
 
-    if (wireToken != null) {
+    if (wireToken != null && wireToken.getLeft() != null && wireToken.getRight() != null) {
       TokenType tokenType  = wireToken.getLeft();
       String    tokenValue = wireToken.getRight();
 

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -166,6 +166,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
       }
     } else {
       // no token provided in header
+      log.missingTokenFromHeader(wireToken);
       ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There can be a NPE when there is a space between the username and password.

## How was this patch tested?

```
$ curl -vvv -iku Token: xxxx https://localhost:8443/gateway/sandbox/webhdfs/v1/?op=LISTSTATUS
```