### PR TITLE
KNOX-2659 - Travis build failure: '/usr/bin/mvn': Operation not permitted.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ language: minimal
 matrix:
   fast_finish: true
   include:
-    - env: IMAGE=maven:3-jdk-8-slim-buster
-    - env: IMAGE=maven:3-jdk-11-slim-buster
+    - env: IMAGE=csanchez/maven:3-openjdk-8
+    - env: IMAGE=csanchez/maven:3-openjdk-11
     - name: Linux ARM64
-      env: IMAGE=maven:3-jdk-11-slim-buster
+      env: IMAGE=csanchez/maven:3-openjdk-11
       arch: arm64-graviton2
       virt: lxd
       group: edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ language: minimal
 matrix:
   fast_finish: true
   include:
-    - env: IMAGE=maven:3-jdk-8
-    - env: IMAGE=maven:3-jdk-11
+    - env: IMAGE=maven:3-jdk-8-slim
+    - env: IMAGE=maven:3-jdk-11-slim
     - name: Linux ARM64
-      env: IMAGE=maven:3-jdk-11
+      env: IMAGE=maven:3-jdk-11-slim
       arch: arm64-graviton2
       virt: lxd
       group: edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ language: minimal
 matrix:
   fast_finish: true
   include:
-    - env: IMAGE=maven:3-jdk-8-slim
-    - env: IMAGE=maven:3-jdk-11-slim
+    - env: IMAGE=maven:3-jdk-8-slim-buster
+    - env: IMAGE=maven:3-jdk-11-slim-buster
     - name: Linux ARM64
-      env: IMAGE=maven:3-jdk-11-slim
+      env: IMAGE=maven:3-jdk-11-slim-buster
       arch: arm64-graviton2
       virt: lxd
       group: edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,18 @@ matrix:
       os: linux
       dist: focal
 
-addons:
-  apt:
-    packages:
-      - docker-ce
 env:
   global:
   - DOCKERRUN="docker run --rm -v $PWD:/src -v $HOME/.m2:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -w /src"
 services:
   - docker
 before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker --version
   - lscpu
   - docker pull $IMAGE
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,18 +29,17 @@ matrix:
       group: edge
       os: linux
       dist: focal
-    
+
+addons:
+  apt:
+    packages:
+      - docker-ce
 env:
   global:
   - DOCKERRUN="docker run --rm -v $PWD:/src -v $HOME/.m2:/root/.m2 -v /var/run/docker.sock:/var/run/docker.sock -w /src"
 services:
   - docker
 before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - docker --version
   - lscpu
   - docker pull $IMAGE
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ language: minimal
 matrix:
   fast_finish: true
   include:
-    - env: IMAGE=csanchez/maven:3-openjdk-8
-    - env: IMAGE=csanchez/maven:3-openjdk-11
+    - env: IMAGE=maven:3-jdk-8
+    - env: IMAGE=maven:3-jdk-11
     - name: Linux ARM64
-      env: IMAGE=csanchez/maven:3-openjdk-11
+      env: IMAGE=maven:3-jdk-11
       arch: arm64-graviton2
       virt: lxd
       group: edge
@@ -36,6 +36,11 @@ env:
 services:
   - docker
 before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker --version
   - lscpu
   - docker pull $IMAGE
 script:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Travis builds are failing with:

```
Status: Downloaded newer image for maven:3-jdk-8
travis_time:end:1f172450:start=1631006005539129433,finish=1631006018654506434,duration=13115377001,event=before_install
[0Ktravis_fold:end:before_install.2
[0Ktravis_time:start:06b9262b
[0K$ $DOCKERRUN $IMAGE mvn -T.75C clean verify -U -Dshellcheck=true -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V
ls: cannot access '/usr/bin/mvn': Operation not permitted
Error: Could not find or load main class org.codehaus.plexus.classworlds.launcher.Launcher
```

Let's try this and see what happens.

