### PR TITLE
KNOX-2657 - Token generation page improvements:

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -80,7 +80,7 @@
                             <label style="display: none; color: red;" id="invalidLifetimeText"><i class="icon-warning"></i>Invalid lifetime!</label>
                         </div>
                     </div>
-                    <span id="errorBox" class="help-inline" style="color:white;display:none;"><span class="errorMsg"></span>
+                    <span id="errorBox" class="help-inline" style="color:red;display:none;"><span class="errorMsg"></span>
                         <i class="icon-warning-sign" style="color:#ae2817;"></i>
                     </span>
                     <div style="align-content: center; width: 25%;">

--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -185,6 +185,8 @@ var gen = function() {
     var lt_mins = form.lt_mins.value;
     var lifespanInputEnabled = form.lifespanInputEnabled.value;
     var _gen = function() {
+        $('#errorBox').hide();
+        $('#resultBox').hide();
         var apiUrl = tokenURL;
         var params = "";
         if (lifespanInputEnabled === "true") {
@@ -209,8 +211,7 @@ var gen = function() {
                     var decodedToken = b64DecodeUnicode(accessToken.split(".")[1]);
                     var jwtjson = JSON.parse(decodedToken);
                     $('#accessPasscode').text(resp.passcode);
-                    var date = new Date(resp.expires_in);
-                    $('#expiry').text(date.toLocaleString());
+                    $('#expiry').text(new Date(resp.expires_in).toLocaleString());
                     $('#user').text(jwtjson.sub);
                     var homepageURL = resp.homepage_url;
                     $('#homepage_url').html("<a href=\"" + baseURL + homepageURL + "\">Homepage URL</a>");
@@ -223,7 +224,11 @@ var gen = function() {
                 	window.location.reload();
                   }
                   else {
-                    $('#errorBox .errorMsg').text("Response from " + request.responseURL + " - " + request.status + ": " + request.statusText);
+                    var errorMsg = "Response from " + request.responseURL + " - " + request.status + ": " + request.statusText;
+                    if (request.responseText) {
+                        errorMsg += " (" + request.responseText + ")";
+                    }
+                    $('#errorBox .errorMsg').text(errorMsg);
                   }
                 }
             }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/KnoxToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/KnoxToken.java
@@ -22,7 +22,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
-public class KnoxToken implements Comparable<KnoxToken>{
+public class KnoxToken implements Comparable<KnoxToken> {
   // SimpleDateFormat is not thread safe must use as a ThreadLocal
   private static final ThreadLocal<DateFormat> KNOX_TOKEN_TS_FORMAT = ThreadLocal
       .withInitial(() -> new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.getDefault()));
@@ -53,12 +53,24 @@ public class KnoxToken implements Comparable<KnoxToken>{
     return KNOX_TOKEN_TS_FORMAT.get().format(new Date(issueTime));
   }
 
+  public long getIssueTimeLong() {
+    return issueTime;
+  }
+
   public String getExpiration() {
     return KNOX_TOKEN_TS_FORMAT.get().format(new Date(expiration));
   }
 
+  public long getExpirationLong() {
+    return expiration;
+  }
+
   public String getMaxLifetime() {
     return KNOX_TOKEN_TS_FORMAT.get().format(new Date(maxLifetime));
+  }
+
+  public long getMaxLifetimeLong() {
+    return maxLifetime;
   }
 
   public TokenMetadata getMetadata() {

--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -34,8 +34,8 @@
             <tbody>
             <tr *ngFor="let knoxToken of mf.data">
                 <td>{{knoxToken.tokenId}}</td>
-                <td>{{knoxToken.issueTime}}</td>
-                <td>{{knoxToken.expiration}}</td>
+                <td>{{formatDateTime(knoxToken.issueTimeLong)}}</td>
+                <td>{{formatDateTime(knoxToken.expirationLong)}}</td>
                 <td>{{knoxToken.metadata.comment}}</td>
                 <td>
                     <button *ngIf="knoxToken.metadata.enabled" (click)="disableToken(knoxToken.tokenId);">Disable</button>

--- a/knox-token-management-ui/token-management/app/token.management.component.ts
+++ b/knox-token-management-ui/token-management/app/token.management.component.ts
@@ -71,4 +71,8 @@ export class TokenManagementComponent implements OnInit {
     gotoTokenGenerationPage() {
         window.open(this.tokenGenerationPageURL, '_blank');
     }
+
+    formatDateTime(dateTime: number) {
+        return new Date(dateTime).toLocaleString();
+    }
 }


### PR DESCRIPTION
- error box is decorated and hidden when not required
- result box is displayed upon successful token generation
- date/time information on token management and token generation page uses the same format and time zone

## What changes were proposed in this pull request?

Implemented the changes listed in KNOX-2657

## How was this patch tested?

Manual testing (UI changes, we have no automated UI tests yet).

<img width="1759" alt="Screenshot 2021-09-08 at 15 06 50" src="https://user-images.githubusercontent.com/34065904/132516902-e264f541-3873-4d7c-a953-ecb7a0144fe7.png">
<img width="1780" alt="Screenshot 2021-09-08 at 15 07 02" src="https://user-images.githubusercontent.com/34065904/132516914-ee735f23-75c7-4406-9f42-7948d4d292b2.png">
<img width="1768" alt="Screenshot 2021-09-08 at 15 19 50" src="https://user-images.githubusercontent.com/34065904/132517031-689f91a9-64a2-4df3-834b-a615f7cc96b9.png">
