### PR TITLE
KNOX-2662 - Added TLS certs into General Proxy Information for the token profile

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dto/HomePageProfile.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dto/HomePageProfile.java
@@ -79,6 +79,6 @@ public class HomePageProfile {
   }
 
   public static Collection<String> getTokenProfileElements() {
-    return Arrays.asList(GPI_VERSION, GPI_TOKENS);
+    return Arrays.asList(GPI_VERSION, GPI_CERT, GPI_TOKENS);
   }
 }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dto/HomePageProfileTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dto/HomePageProfileTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 import org.junit.Test;
@@ -69,6 +70,13 @@ public class HomePageProfileTest {
   @Test
   public void testGeneralProxyInformationTokens() throws Exception {
     doTestGeneralProxyInformationElement(HomePageProfile.GPI_TOKENS);
+  }
+
+  @Test
+  public void testTokenProfileElements() throws Exception {
+    final Collection<String> tokenProfileElements = HomePageProfile.getTokenProfileElements();
+    assertEquals(3, tokenProfileElements.size());
+    assertTrue(tokenProfileElements.containsAll(Arrays.asList(HomePageProfile.GPI_VERSION, HomePageProfile.GPI_CERT, HomePageProfile.GPI_TOKENS)));
   }
 
   private void doTestGeneralProxyInformationElement(String gpiElement) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `General Proxy Information` section is extended with Knox's TLS public certs when the `token` profile is used.

## How was this patch tested?

Added relevant JUnit tests and did a manual test round too:

<img width="1778" alt="Screenshot 2021-09-14 at 9 56 53" src="https://user-images.githubusercontent.com/34065904/133219140-7a2c0d48-7086-4a02-a67c-e9b434915153.png">
