### PR TITLE
KNOX-2661 - Consolidated HTTP methods in TokenResource

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -39,6 +39,7 @@ import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -405,7 +406,7 @@ public class TokenResource {
     return Response.status(Response.Status.OK).entity(JsonUtils.renderAsJsonString(tokenStateServiceStatusMap)).build();
   }
 
-  @POST
+  @PUT
   @Path(RENEW_PATH)
   @Produces({APPLICATION_JSON})
   public Response renew(String token) {
@@ -474,7 +475,7 @@ public class TokenResource {
     return resp;
   }
 
-  @POST
+  @DELETE
   @Path(REVOKE_PATH)
   @Produces({APPLICATION_JSON})
   public Response revoke(String token) {

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -70,7 +70,7 @@ export class TokenManagementService {
     revokeToken(tokenId: string) {
         let xheaders = new HttpHeaders();
         xheaders = this.addJsonHeaders(xheaders);
-        return this.http.post(this.revokeKnoxTokenUrl, tokenId, {headers: xheaders, responseType: 'text'})
+        return this.http.request('DELETE', this.revokeKnoxTokenUrl, {headers: xheaders, body: tokenId, responseType: 'text'})
             .toPromise()
             .then(response => response)
             .catch((err: HttpErrorResponse) => {


### PR DESCRIPTION
## What changes were proposed in this pull request?

There were some public API endpoints in `TokenResource` with wrong HTTP methods. I changed hem and now the resource looks like this:
- GET - `/knoxtoken/api/v1/token`
- GET - `/knoxtoken/api/v1/token/getUserTokens`
- GET - `/knoxtoken/api/v1/token/getTssStatus`
- POST - `/knoxtoken/api/v1/token`
- PUT - `/knoxtoken/api/v1/token/renew`
- PUT - `/knoxtoken/api/v1/token/enable`
- PUT - `/knoxtoken/api/v1/token/disable`
- DELETE - `/knoxtoken/api/v1/token/revoke`

## How was this patch tested?

Ran manual test steps (including token management UI operations and `curl` requests)