### PR TITLE
KNOX-2664 - Let end-users revoke their own tokens

### DIFF
--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -822,6 +822,12 @@ public class TokenServiceResourceTest {
   }
 
   @Test
+  public void testTokenRevocation_Enabled_RevokeOwnToken() throws Exception {
+    final Response renewalResponse = doTestTokenRevocation(true, null, createTestSubject(USER_NAME));
+    validateSuccessfulRevocationResponse(renewalResponse);
+  }
+
+  @Test
   public void testKidJkuClaims() throws Exception {
     final Map<String, String> contextExpectations = new HashMap<>();
     contextExpectations.put("knox.token.ttl", "60000");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Users can revoke tokens created for them even they are not listed in `knox.token.renewer.whitelist`
## How was this patch tested?

Added a new JUnit test case and ran manual test steps:

1. installed the new version of Knox
2. logged into the Knox Home page as `guest` (this user is not added into `knox.token.renewer.whitelist` in to `homepage` topology)
3. generated a token on the token generation page
4. revoked the previously generated token on the token management page successfully
