### PR TITLE
KNOX-2665 Knox redirecting.jsp parsing error

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/app/redirecting.jsp
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/redirecting.jsp
@@ -65,7 +65,7 @@
     document.addEventListener("load", redirectOnLoad());
 
     function redirectOnLoad() {
-      var originalUrl = <%= originalUrl %>;
+      var originalUrl = "<%= originalUrl %>";
       if (originalUrl != null) {
         redirect(originalUrl);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is a parse error in redirect.jsp 

```
:8443/gateway/knoxss…/home/?refresh=1:49 Uncaught SyntaxError: Unexpected token ':'
```

This happens because the quotes are missing around the original url:

```js
var originalUrl = <%= originalUrl %>;
```

So expression like this is generated into the html:

```js
 var originalUrl = https://localhost:8443/gateway/homepage/home/?refresh=1;
```

## How was this patch tested?

Manually triggered the redirect with logging into knox.