### PR TITLE
KNOX-2666 - Add support for gateway name in rewrite rules

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/FrontendFunctionProcessor.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/FrontendFunctionProcessor.java
@@ -67,6 +67,7 @@ public class FrontendFunctionProcessor implements UrlRewriteFunctionProcessor<Fr
       resolvers.put( "path", new FixedResolver( frontend.getPath() ) );
     }
     resolvers.put( "topology", new FixedResolver( (String)environment.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE) ) );
+    resolvers.put( "gateway.name", new FixedResolver( (String)environment.getAttribute(GatewayServices.GATEWAY_NAME) ) );
     resolvers.put( "address", resolvers.get( "addr" ) );
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -810,6 +810,7 @@ public class GatewayServer {
     context.setAttribute( GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE, topoName );
     context.setAttribute( "org.apache.knox.gateway.frontend.uri", getFrontendUri( context, config ) );
     context.setAttribute( GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE, config );
+    context.setAttribute( GatewayServices.GATEWAY_NAME, config.getGatewayPath());
     // Add support for JSPs.
     context.setAttribute(
         "org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern",

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/GatewayServices.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/GatewayServices.java
@@ -26,6 +26,7 @@ public interface GatewayServices extends Service,
 
   String GATEWAY_CLUSTER_ATTRIBUTE = "org.apache.knox.gateway.gateway.cluster";
   String GATEWAY_SERVICES_ATTRIBUTE = "org.apache.knox.gateway.gateway.services";
+  String GATEWAY_NAME = "org.apache.knox.gateway.gateway.name";
 
   Collection<ServiceType> getServiceTypes();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR exposes a variable `{$frontend[gateway.name]}` for gateway name.

## How was this patch tested?
Tested on a local cluster.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
