### PR TITLE
KNOX-2667: Update Ranger Service definition for knox logout/timeout i…

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
@@ -51,6 +51,11 @@
         <rewrite template="{$frontend[url]}/ranger/login.jsp"/>
     </rule>
 
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/timeout/headers/location">
+        <match pattern="*://*:*/*/*/ranger/logout?originalUrl={**}"/>
+        <rewrite template="https://{$frontend[addr]}/{$frontend[gateway.name]}/knoxsso/knoxauth/logout.jsp?originalUrl={**}"/>
+    </rule>
+
     <filter name="RANGERUI/rangerui/outbound/links">
         <content type="application/javascript">
             <apply path="j_spring_security_check" rule="RANGERUI/rangerui/outbound/extrapath"/>


### PR DESCRIPTION
What changes were proposed in this pull request?
Updated Ranger Service definition for knox logout/timeout to support knox logout page in Ranger timeout and logout flow.

How was this patch tested?
This patch was tested by deploying updated servicedef in knox and test against Ranger changes on CDP cluster.
Manually tested the logout and timeout flow in Ranger redirecting to knox logout.jsp page.