### PR TITLE
KNOX-2667: Fixed an issue where the rewrite rule is not referenced in the filter

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
@@ -51,6 +51,11 @@
         <rewrite template="{$frontend[url]}/ranger/login.jsp"/>
     </rule>
 
+    <rule dir="OUT" name="RANGERUI/rangerui/outbound/timeout/headers/location">
+        <match pattern="*://*:*/*/*/ranger/logout?originalUrl={**}"/>
+        <rewrite template="https://{$frontend[addr]}/{$frontend[gateway.name]}/knoxsso/knoxauth/logout.jsp?originalUrl={**}"/>
+    </rule>
+
     <filter name="RANGERUI/rangerui/outbound/links">
         <content type="application/javascript">
             <apply path="j_spring_security_check" rule="RANGERUI/rangerui/outbound/extrapath"/>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
@@ -69,6 +69,9 @@
         <content type="application/x-http-headers">
             <apply path="Location" rule="RANGERUI/rangerui/outbound/login/headers/location"/>
         </content>
+	<content type="*/*">
+            <apply path="Location" rule="RANGERUI/rangerui/outbound/timeout/headers/location"/>
+        </content>
     </filter>
 
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
@@ -69,6 +69,11 @@
         <content type="application/x-http-headers">
             <apply path="Location" rule="RANGERUI/rangerui/outbound/login/headers/location"/>
         </content>
+	<content type="*/*">
+            <apply path="Location" rule="RANGERUI/rangerui/outbound/timeout/headers/location"/>
+        </content>
     </filter>
+
+    
 
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/rewrite.xml
@@ -69,11 +69,6 @@
         <content type="application/x-http-headers">
             <apply path="Location" rule="RANGERUI/rangerui/outbound/login/headers/location"/>
         </content>
-	<content type="*/*">
-            <apply path="Location" rule="RANGERUI/rangerui/outbound/timeout/headers/location"/>
-        </content>
     </filter>
-
-    
 
 </rules>


### PR DESCRIPTION
What changes were proposed in this pull request?
Fixed an issue where the rewrite rule is not referenced in the filter

How was this patch tested?
This patch was tested by deploying updated servicedef in knox and test against Ranger changes on CDP cluster.
Manually tested the logout and timeout flow in Ranger redirecting to knox logout.jsp page.