### PR TITLE
KNOX-2670 - Deleting unnecessary removeToken override from AliasBasedTokenStateService

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -410,11 +409,6 @@ public class AliasBasedTokenStateService extends DefaultTokenStateService implem
       }
     }
     return isUnknown;
-  }
-
-  @Override
-  protected void removeToken(final String tokenId) throws UnknownTokenException {
-    removeTokens(Collections.singleton(tokenId));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

See the root cause analysis in https://issues.apache.org/jira/browse/KNOX-2670.
Additional note: the newly implemented `triesToRevokeOwnToken(String, String)` method solves the original issue 1 layer above, but the problem with the `AliasBasedTokenStateService` would still exist w/o removing the `removeToken(String)` method.

## How was this patch tested?

I ran Junit tests and I executed the steps I used for reproducing the original issue (I temporary removed the `triesToRevokeOwnToken(String, String)` call to make sure my change actually solves the issue).
