### PR TITLE
KNOX-2671 - From knox homepage clicking logout returns 500 error code

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/service.xml
+++ b/gateway-applications/src/main/resources/applications/knoxauth/service.xml
@@ -20,7 +20,6 @@
         <policy role="webappsec"/>
         <policy role="authentication"/>
         <policy role="rewrite"/>
-        <policy role="identity-assertion"/>
         <policy role="authorization"/>
     </policies>
     <routes>
@@ -28,7 +27,6 @@
             <policies>
                 <policy role="webappsec"/>
                 <policy role="authentication" name="Anonymous"/>
-                <policy role="identity-assertion"/>
                 <policy role="authorization"/>
                 <policy role="rewrite"/>
             </policies>
@@ -37,7 +35,6 @@
             <policies>
                 <policy role="webappsec"/>
                 <policy role="authentication" name="Anonymous"/>
-                <policy role="identity-assertion"/>
                 <policy role="authorization"/>
                 <policy role="rewrite"/>
             </policies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
For global logout, the requests goes to the knoxauth app which is configured to use identity-assertion provider which can throw "Subject not found" exception in case of Pac4J authentication provider. This PR also fixes an issue where delete cookie method now uses samesite property.

## How was this patch tested?
Patch was tested on a local cluster.