### PR TITLE
KNOX-2672 - Handle aliases in HadoopAuth filter on gateway level too

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -47,4 +47,7 @@ public interface HadoopAuthMessages {
 
   @Message( level = MessageLevel.ERROR, text = "Error while checking whether path {0} should be allowed unauthenticated access : {1}" )
   void unauthenticatedPathError(String path, String error);
+
+  @Message(level=MessageLevel.WARN, text="{1} alias is NOT stored on neither topology ({0}) nor gateway levels.")
+  void noAliasStored(String cluster, String alias);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `HadoopAuthFilter` is now able to lookup aliases in the `__gateway` credential store too.

## How was this patch tested?

Added a new unit test and ran them all.

Additionally, I executed manual testing:
1. saved an alias on the gateway level called `kerberos.keytab` pointing to a non-existing keytab path
  ```
  $ bin/knoxcli.sh create-alias kerberos.keytab --value /tmp/knox.keytab
  kerberos.keytab has been successfully created .
  
  $ bin/knoxcli.sh list-alias
Listing aliases for: __gateway
kerberos.keytab
knox.token.hash.key

2 items.
  ```
2. created a new provider/descriptor pair:
```
$ cat conf/shared-providers/kerberos-providers.json 
{
  "providers": [
    {
      "role": "authentication",
      "name": "HadoopAuth",
      "enabled": "true",
      "params": {
        "config.prefix": "hadoop.auth.config",
        "hadoop.auth.config.type": "kerberos",
        "hadoop.auth.config.signature.secret": "${ALIAS=AUTH_CONFIG_SIGNATURE_SECRET}",
        "hadoop.auth.config.simple.anonymous.allowed": "false",
        "hadoop.auth.config.token.validity": "1800",
        "hadoop.auth.config.cookie.path": "/",
        "hadoop.auth.config.kerberos.principal": "knox",
        "hadoop.auth.config.kerberos.keytab": "${ALIAS=kerberos.keytab}",
        "hadoop.auth.config.kerberos.name.rules": "DEFAULT"
      }
    },
    {
       "role": "identity-assertion",
       "name": "HadoopGroupProvider",
       "enabled": "true",
       "params": {
          "CENTRAL_GROUP_CONFIG_PREFIX": "gateway.group.config."
       }
    }
  ]
}

$ cat conf/descriptors/myKerberosBasedTopology.json 
{
  "provider-config-ref": "kerberos-providers",
  "services": [
    {
      "name": "KNOXTOKEN",
      "params": {
        "knox.token.ttl": "36000"
      }
    }
  ]
}
```
3. Issued a `curl` command to get a Knox token using my newly created `myKerberosBasedTopology`:
```
 $ curl -s -u: -k "https://localhost:8443/gateway/myKerberosBasedTopology/knoxtoken/api/v1/token"
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 500 javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</title>
</head>
<body><h2>HTTP ERROR 500 javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</h2>
<table>
<tr><th>URI:</th><td>/gateway/myKerberosBasedTopology/knoxtoken/api/v1/token</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</td></tr>
<tr><th>SERVLET:</th><td>myKerberosBasedTopology-knox-gateway-servlet</td></tr>
<tr><th>CAUSED BY:</th><td>javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</td></tr>
<tr><th>CAUSED BY:</th><td>javax.servlet.ServletException: javax.servlet.ServletException: javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</td></tr>
<tr><th>CAUSED BY:</th><td>javax.servlet.ServletException: javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</td></tr>
<tr><th>CAUSED BY:</th><td>javax.servlet.ServletException: Keytab does not exist: /tmp/knox.keytab</td></tr>
</table>

</body>
</html>
```
As you can see, the alias was resolved properly to `/tmp/knox.keytab`