### PR TITLE
KNOX-2674 - Upgrade junit to 4.13.2 due to CVE-2020-15250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <joda-time.version>2.10.8</joda-time.version>
         <json-path.version>2.5.0</json-path.version>
         <json-smart.version>2.3</json-smart.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
         <lang-tag.version>1.5</lang-tag.version>
         <libpam4j.version>1.11</libpam4j.version>
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

JUnit version was updated to 4.13.2.

## How was this patch tested?

```
$ mvn dependency:tree | grep junit
```