### PR TITLE
KNOX-2675 Oozie Console URL on the web UI should be a Knox URL

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/oozie/5.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/oozie/5.0.0/rewrite.xml
@@ -130,4 +130,14 @@
         </content>
     </filter>
 
+    <rule dir="OUT" name="OOZIE/oozie/console-url" pattern="*://*:*/proxy/{**}/">
+        <rewrite template="{gateway.url}/yarn/proxy/{**}"/>
+    </rule>
+
+    <filter name="OOZIE/oozie/jobinfo">
+        <content type="*/json">
+            <apply path="$.actions..consoleUrl" rule="OOZIE/oozie/console-url" />
+        </content>
+    </filter>
+
 </rules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new  rewrite rule which replaces the internal Yarn url to a one using Knox gateway

## How was this patch tested?

I had an environment with Knox and Oozie. I edited the /var/lib/knox/gateway/data/services/oozie/5.0.0/rewrite.xml by adding the changes described in this commit. Then I added a new line to /var/lib/knox/gateway/conf/topologies/some-topology.xml to force Knox to redeploy the affected topology. Then I navigated to https://knox-gateway-host:8443/gateway/some-topology/oozie/, logged in, went to  "All Jobs", selected one, selected the action and on the "Action info" tab I saw that Console URL is a Knox url.