### PR TITLE
KNOX-2677 - HADispatch keeps retrying the same URL on failover

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -308,8 +308,14 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
       inboundRequest.setAttribute(AbstractGatewayFilter.TARGET_REQUEST_URL_ATTRIBUTE_NAME, null);
       // Make sure to remove the cookie ha cookie from the request
       inboundRequest = new StickySessionCookieRemovedRequest(stickySessionCookieName, inboundRequest);
-      URI uri = getDispatchUrl(inboundRequest);
-      ((HttpRequestBase) outboundRequest).setURI(uri);
+
+      try {
+        ((HttpRequestBase) outboundRequest).setURI(
+                updateHostURL(getDispatchUrl(inboundRequest), haProvider.getActiveURL(getServiceRole())));
+      } catch (final URISyntaxException e) {
+        LOG.errorSettingActiveUrl();
+      }
+
       if ( failoverSleep > 0 ) {
         try {
           Thread.sleep(failoverSleep);


### PR DESCRIPTION
If a host is unreachable Knox marks the URL but keeps trying the same URL upon failover.

## What changes were proposed in this pull request?

The new URL is now chosen from haProvider.

## How was this patch tested?

Add these to sandbox.xml:

```xml
<provider>
     <role>ha</role>
     <name>HaProvider</name>
     <enabled>true</enabled>
     <param>
         <name>HIVE</name>
         <value>maxFailoverAttempts=3;failoverSleep=1000;enabled=true;enableStickySession=true;enableLoadBalancing=true</value>
     </param>
</provider>
```

```xml
<service>
    <role>HIVE</role>
    <url>http://deadhost.site</url>
    <url>http://localhost:1701/alive</url>
    <param>
        <name>replayBufferSize</name>
        <value>8</value>
    </param>
</service>
```

Mini HTTP server:

```smalltalk
Teapot on
	GET: '/alive' -> 'OK';
	start.
```

```bash
$  curl -k -u admin:admin-password  https://localhost:8443/gateway/sandbox/hive
```

