### PR TITLE
KNOX-2685 - Show/hide (enable/disable) Knox token management links on Home Page if required alias is created

### DIFF
--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/GeneralProxyInformation.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/GeneralProxyInformation.java
@@ -39,6 +39,10 @@ public class GeneralProxyInformation {
   @ApiModelProperty(value = "The URL referencing the Admin API book in Knox's user guide")
   private String adminApiBookUrl;
 
+  @XmlElement
+  @ApiModelProperty(value = "A boolean flag indicating if Knox token management should be enabled on the Knox Home page")
+  private String enableTokenManagement = "false";
+
   public String getVersion() {
     return version;
   }
@@ -61,6 +65,14 @@ public class GeneralProxyInformation {
 
   public void setAdminApiBookUrl(String adminApiBookUrl) {
     this.adminApiBookUrl = adminApiBookUrl;
+  }
+
+  public String getEnableTokenManagement() {
+    return enableTokenManagement;
+  }
+
+  public void setEnableTokenManagement(String enableTokenManagement) {
+    this.enableTokenManagement = enableTokenManagement;
   }
 
 }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -60,8 +61,11 @@ import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServerInfoService;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.registry.ServiceDefinitionRegistry;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
+import org.apache.knox.gateway.services.security.token.impl.TokenMAC;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.topology.Service;
 import org.apache.knox.gateway.topology.Topology;
@@ -101,9 +105,25 @@ public class KnoxMetadataResource {
           String.format(Locale.ROOT, "https://knox.apache.org/books/knox-%s/user-guide.html#Admin+API", getAdminApiBookVersion(serviceInfoService.getBuildVersion())));
       final GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
       proxyInfo.setAdminUiUrl(getBaseGatewayUrl(config) + "/manager/admin-ui/");
+
+      setTokenManagementEnabledFlag(proxyInfo, gatewayServices);
     }
 
     return proxyInfo;
+  }
+
+  private void setTokenManagementEnabledFlag(final GeneralProxyInformation proxyInfo, final GatewayServices gatewayServices) {
+    try {
+      final AliasService aliasService = gatewayServices.getService(ServiceType.ALIAS_SERVICE);
+      final List<String> aliases = aliasService.getAliasesForCluster(AliasService.NO_CLUSTER_NAME);
+      final boolean tokenManagementEnabled = aliases.contains(TokenMAC.KNOX_TOKEN_HASH_KEY_ALIAS_NAME);
+      proxyInfo.setEnableTokenManagement(Boolean.toString(tokenManagementEnabled));
+      if (!tokenManagementEnabled) {
+        LOG.tokenManagementDisabled();
+      }
+    } catch (AliasServiceException e) {
+      LOG.failedToFetchGatewayAliasList(e.getMessage(), e);
+    }
   }
 
   private String getAdminApiBookVersion(String buildVersion) {

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/MetadataServiceMessages.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/MetadataServiceMessages.java
@@ -31,4 +31,10 @@ public interface MetadataServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to generate public certificate {0}: {1}")
   void failedToGeneratePublicCert(String certificateType, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.ERROR, text = "Failed to fetch Gateway alias list: {0}")
+  void failedToFetchGatewayAliasList(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.WARN, text = "Knox token management is disabled. Please configure knox.token.hash.key Gateway alias for this feature to work")
+  void tokenManagementDisabled();
+
 }

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
@@ -58,7 +58,7 @@
                     <a href="{{ getMetadataAPIUrl('topologies') }}" target="_blank">Topologies</a>
                 </td>
             </tr>
-            <tr *ngIf="this['showTokens']">
+            <tr *ngIf="this.isTokenManagementEnabled() && this['showTokens']">
                 <td>
                     Integration Tokens
                 </td>

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
@@ -78,6 +78,13 @@ export class GeneralProxyInformationComponent implements OnInit {
         return this.getAdminUiUrl().replace(new RegExp('manager/admin-ui/*'), 'homepage/token-management/index.html');
     }
 
+    isTokenManagementEnabled() {
+        if (this.generalProxyInformation) {
+	        return this.generalProxyInformation.enableTokenManagement === 'true';
+	    }
+        return false;
+    }
+
     ngOnInit(): void {
         console.debug('GeneralProxyInformationComponent --> ngOnInit() --> ');
         this.homepageService.getGeneralProxyInformation()

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.ts
@@ -19,5 +19,5 @@ export class GeneralProxyInformation {
     version: string;
     adminUiUrl: string;
     adminApiBookUrl: string;
-    tokenGenerationUrl: string;
+    enableTokenManagement: string;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Token Integration link on the Home page must be hidden if the required `knox.token.hash.key` Gateway-level alias is missing.

## How was this patch tested?

Manual testing.

Without the alias:
<img width="1784" alt="Screenshot 2021-10-31 at 21 09 54" src="https://user-images.githubusercontent.com/34065904/139600404-cd33ace7-df2f-4f92-9e2c-3fd68585d2b1.png">


With the alias (running `bin/knoxcli.sh generate-jwk --saveAlias knox.token.hash.key`):

<img width="1775" alt="Screenshot 2021-10-31 at 21 29 50" src="https://user-images.githubusercontent.com/34065904/139600410-c24e50e2-07ff-4266-bd67-2a94eedb2386.png">
