### PR TITLE
Knox 2655

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@ Release build file for the Apache Knox Gateway
 <property name="gateway-project" value="knox"/>
 <property name="gateway-artifact" value="knox"/>
 <property name="knoxshell-artifact" value="knoxshell"/>
-<property name="gateway-version" value="1.6.0-SNAPSHOT"/>
+<property name="gateway-version" value="2.0.0-SNAPSHOT"/>
 <property name="release-manager" value="kminder"/>
 
 <property name="gateway-home" value="${gateway-artifact}-${gateway-version}"/>

--- a/gateway-adapter/pom.xml
+++ b/gateway-adapter/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-adapter</artifactId>

--- a/gateway-admin-ui/pom.xml
+++ b/gateway-admin-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-admin-ui</artifactId>

--- a/gateway-applications/pom.xml
+++ b/gateway-applications/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-applications</artifactId>

--- a/gateway-applications/src/main/resources/applications/knoxauth/app/logout.jsp
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/logout.jsp
@@ -142,7 +142,7 @@
                 // do nothing
                 // we are probably not going to be able to
                 // remove the cookie due to this error but it
-                // isn't necessarily not going to work.
+                // is not necessarily not going to work.
                 }
                 setCookie.append("; HttpOnly");
                 setCookie.append("; Secure");
@@ -152,9 +152,7 @@
             } catch (Exception e) {
                 return "";
             }
-            response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
-            response.setHeader("Location", globalLogoutPageURL);
-            return;
+       }
     %>
   </head>
   

--- a/gateway-demo-ldap-launcher/pom.xml
+++ b/gateway-demo-ldap-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-demo-ldap-launcher</artifactId>
     <name>gateway-demo-ldap-launcher</name>

--- a/gateway-demo-ldap/pom.xml
+++ b/gateway-demo-ldap/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-demo-ldap</artifactId>

--- a/gateway-discovery-ambari/pom.xml
+++ b/gateway-discovery-ambari/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-discovery-ambari</artifactId>

--- a/gateway-discovery-cm/pom.xml
+++ b/gateway-discovery-cm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-docker/pom.xml
+++ b/gateway-docker/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-docker</artifactId>
 

--- a/gateway-i18n-logging-log4j/pom.xml
+++ b/gateway-i18n-logging-log4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-log4j</artifactId>

--- a/gateway-i18n-logging-sl4j/pom.xml
+++ b/gateway-i18n-logging-sl4j/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-i18n-logging-sl4j</artifactId>

--- a/gateway-i18n/pom.xml
+++ b/gateway-i18n/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-i18n</artifactId>

--- a/gateway-openapi-ui/pom.xml
+++ b/gateway-openapi-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-openapi-ui</artifactId>

--- a/gateway-performance-test/pom.xml
+++ b/gateway-performance-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-performance-test</artifactId>

--- a/gateway-provider-ha/pom.xml
+++ b/gateway-provider-ha/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-ha</artifactId>

--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-common</artifactId>

--- a/gateway-provider-identity-assertion-concat/pom.xml
+++ b/gateway-provider-identity-assertion-concat/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-concat</artifactId>

--- a/gateway-provider-identity-assertion-hadoop-groups/pom.xml
+++ b/gateway-provider-identity-assertion-hadoop-groups/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-hadoop-groups</artifactId>

--- a/gateway-provider-identity-assertion-pseudo/pom.xml
+++ b/gateway-provider-identity-assertion-pseudo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-pseudo</artifactId>

--- a/gateway-provider-identity-assertion-regex/pom.xml
+++ b/gateway-provider-identity-assertion-regex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-regex</artifactId>

--- a/gateway-provider-identity-assertion-switchcase/pom.xml
+++ b/gateway-provider-identity-assertion-switchcase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-identity-assertion-switchcase</artifactId>

--- a/gateway-provider-jersey/pom.xml
+++ b/gateway-provider-jersey/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-jersey</artifactId>

--- a/gateway-provider-rewrite-common/pom.xml
+++ b/gateway-provider-rewrite-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-common</artifactId>

--- a/gateway-provider-rewrite-func-hostmap-static/pom.xml
+++ b/gateway-provider-rewrite-func-hostmap-static/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-provider-rewrite-func-hostmap-static</artifactId>

--- a/gateway-provider-rewrite-func-inbound-query-param/pom.xml
+++ b/gateway-provider-rewrite-func-inbound-query-param/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-provider-rewrite-func-inbound-query-param</artifactId>
     <name>gateway-provider-rewrite-func-inbound-url</name>

--- a/gateway-provider-rewrite-func-service-registry/pom.xml
+++ b/gateway-provider-rewrite-func-service-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-func-service-registry</artifactId>

--- a/gateway-provider-rewrite-step-encrypt-uri/pom.xml
+++ b/gateway-provider-rewrite-step-encrypt-uri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-encrypt-uri</artifactId>

--- a/gateway-provider-rewrite-step-secure-query/pom.xml
+++ b/gateway-provider-rewrite-step-secure-query/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite-step-secure-query</artifactId>

--- a/gateway-provider-rewrite/pom.xml
+++ b/gateway-provider-rewrite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-rewrite</artifactId>

--- a/gateway-provider-security-authc-anon/pom.xml
+++ b/gateway-provider-security-authc-anon/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-authc-anon</artifactId>

--- a/gateway-provider-security-authz-acls/pom.xml
+++ b/gateway-provider-security-authz-acls/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-provider-security-authz-acls</artifactId>
     <name>gateway-provider-security-authz-acls</name>

--- a/gateway-provider-security-authz-composite/pom.xml
+++ b/gateway-provider-security-authz-composite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-provider-security-authz-composite</artifactId>
     <name>gateway-provider-security-authz-composite</name>

--- a/gateway-provider-security-clientcert/pom.xml
+++ b/gateway-provider-security-clientcert/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-clientcert</artifactId>

--- a/gateway-provider-security-hadoopauth/pom.xml
+++ b/gateway-provider-security-hadoopauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-provider-security-hadoopauth</artifactId>

--- a/gateway-provider-security-jwt/pom.xml
+++ b/gateway-provider-security-jwt/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-jwt</artifactId>

--- a/gateway-provider-security-pac4j/pom.xml
+++ b/gateway-provider-security-pac4j/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-pac4j</artifactId>

--- a/gateway-provider-security-preauth/pom.xml
+++ b/gateway-provider-security-preauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-preauth</artifactId>

--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-shiro</artifactId>

--- a/gateway-provider-security-webappsec/pom.xml
+++ b/gateway-provider-security-webappsec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-provider-security-webappsec</artifactId>

--- a/gateway-release-common/pom.xml
+++ b/gateway-release-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gateway-release-common</artifactId>

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-release</artifactId>

--- a/gateway-server-launcher/pom.xml
+++ b/gateway-server-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-server-launcher</artifactId>

--- a/gateway-server-xforwarded-filter/pom.xml
+++ b/gateway-server-xforwarded-filter/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-server-xforwarded-filter</artifactId>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-server</artifactId>

--- a/gateway-service-admin/pom.xml
+++ b/gateway-service-admin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-admin</artifactId>

--- a/gateway-service-as/pom.xml
+++ b/gateway-service-as/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-service-as</artifactId>
 

--- a/gateway-service-definitions/pom.xml
+++ b/gateway-service-definitions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-definitions</artifactId>

--- a/gateway-service-hashicorp-vault/pom.xml
+++ b/gateway-service-hashicorp-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-hashicorp-vault</artifactId>

--- a/gateway-service-hbase/pom.xml
+++ b/gateway-service-hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-hbase</artifactId>

--- a/gateway-service-health/pom.xml
+++ b/gateway-service-health/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-health</artifactId>

--- a/gateway-service-hive/pom.xml
+++ b/gateway-service-hive/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-hive</artifactId>

--- a/gateway-service-impala/pom.xml
+++ b/gateway-service-impala/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-impala</artifactId>

--- a/gateway-service-jkg/pom.xml
+++ b/gateway-service-jkg/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-jkg</artifactId>

--- a/gateway-service-knoxsso/pom.xml
+++ b/gateway-service-knoxsso/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-knoxsso</artifactId>

--- a/gateway-service-knoxssout/pom.xml
+++ b/gateway-service-knoxssout/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-service-knoxssout</artifactId>

--- a/gateway-service-knoxtoken/pom.xml
+++ b/gateway-service-knoxtoken/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-knoxtoken</artifactId>

--- a/gateway-service-livy/pom.xml
+++ b/gateway-service-livy/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-livy</artifactId>

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-metadata</artifactId>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/GeneralProxyInformation.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/GeneralProxyInformation.java
@@ -39,6 +39,10 @@ public class GeneralProxyInformation {
   @ApiModelProperty(value = "The URL referencing the Admin API book in Knox's user guide")
   private String adminApiBookUrl;
 
+  @XmlElement
+  @ApiModelProperty(value = "A boolean flag indicating if Knox token management should be enabled on the Knox Home page")
+  private String enableTokenManagement = "false";
+
   public String getVersion() {
     return version;
   }
@@ -61,6 +65,14 @@ public class GeneralProxyInformation {
 
   public void setAdminApiBookUrl(String adminApiBookUrl) {
     this.adminApiBookUrl = adminApiBookUrl;
+  }
+
+  public String getEnableTokenManagement() {
+    return enableTokenManagement;
+  }
+
+  public void setEnableTokenManagement(String enableTokenManagement) {
+    this.enableTokenManagement = enableTokenManagement;
   }
 
 }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -60,8 +61,11 @@ import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServerInfoService;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.registry.ServiceDefinitionRegistry;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
+import org.apache.knox.gateway.services.security.token.impl.TokenMAC;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.topology.Service;
 import org.apache.knox.gateway.topology.Topology;
@@ -101,9 +105,25 @@ public class KnoxMetadataResource {
           String.format(Locale.ROOT, "https://knox.apache.org/books/knox-%s/user-guide.html#Admin+API", getAdminApiBookVersion(serviceInfoService.getBuildVersion())));
       final GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
       proxyInfo.setAdminUiUrl(getBaseGatewayUrl(config) + "/manager/admin-ui/");
+
+      setTokenManagementEnabledFlag(proxyInfo, gatewayServices);
     }
 
     return proxyInfo;
+  }
+
+  private void setTokenManagementEnabledFlag(final GeneralProxyInformation proxyInfo, final GatewayServices gatewayServices) {
+    try {
+      final AliasService aliasService = gatewayServices.getService(ServiceType.ALIAS_SERVICE);
+      final List<String> aliases = aliasService.getAliasesForCluster(AliasService.NO_CLUSTER_NAME);
+      final boolean tokenManagementEnabled = aliases.contains(TokenMAC.KNOX_TOKEN_HASH_KEY_ALIAS_NAME);
+      proxyInfo.setEnableTokenManagement(Boolean.toString(tokenManagementEnabled));
+      if (!tokenManagementEnabled) {
+        LOG.tokenManagementDisabled();
+      }
+    } catch (AliasServiceException e) {
+      LOG.failedToFetchGatewayAliasList(e.getMessage(), e);
+    }
   }
 
   private String getAdminApiBookVersion(String buildVersion) {

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/MetadataServiceMessages.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/MetadataServiceMessages.java
@@ -31,4 +31,10 @@ public interface MetadataServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to generate public certificate {0}: {1}")
   void failedToGeneratePublicCert(String certificateType, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.ERROR, text = "Failed to fetch Gateway alias list: {0}")
+  void failedToFetchGatewayAliasList(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.WARN, text = "Knox token management is disabled. Please configure knox.token.hash.key Gateway alias for this feature to work")
+  void tokenManagementDisabled();
+
 }

--- a/gateway-service-nifi-registry/pom.xml
+++ b/gateway-service-nifi-registry/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-nifi-registry</artifactId>

--- a/gateway-service-nifi/pom.xml
+++ b/gateway-service-nifi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-nifi</artifactId>

--- a/gateway-service-remoteconfig/pom.xml
+++ b/gateway-service-remoteconfig/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-remoteconfig</artifactId>

--- a/gateway-service-rm/pom.xml
+++ b/gateway-service-rm/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-rm</artifactId>

--- a/gateway-service-session/pom.xml
+++ b/gateway-service-session/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-session</artifactId>

--- a/gateway-service-storm/pom.xml
+++ b/gateway-service-storm/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-storm</artifactId>

--- a/gateway-service-test/pom.xml
+++ b/gateway-service-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-test</artifactId>

--- a/gateway-service-tgs/pom.xml
+++ b/gateway-service-tgs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-tgs</artifactId>

--- a/gateway-service-vault/pom.xml
+++ b/gateway-service-vault/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-service-vault</artifactId>

--- a/gateway-service-webhdfs/pom.xml
+++ b/gateway-service-webhdfs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-service-webhdfs</artifactId>

--- a/gateway-shell-launcher/pom.xml
+++ b/gateway-shell-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell-launcher</artifactId>

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell-release</artifactId>

--- a/gateway-shell-samples/pom.xml
+++ b/gateway-shell-samples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell-samples</artifactId>

--- a/gateway-shell/pom.xml
+++ b/gateway-shell/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-shell</artifactId>

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-spi</artifactId>

--- a/gateway-test-release-utils/pom.xml
+++ b/gateway-test-release-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-test-release</artifactId>

--- a/gateway-test-release/webhdfs-kerb-test/pom.xml
+++ b/gateway-test-release/webhdfs-kerb-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webhdfs-kerb-test</artifactId>

--- a/gateway-test-release/webhdfs-test/pom.xml
+++ b/gateway-test-release/webhdfs-test/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <artifactId>gateway-test-release</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>webhdfs-test</artifactId>
     <name>webhdfs-test</name>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <description>Tests for WebHDFS integration with Knox</description>
 
     <dependencies>

--- a/gateway-test-utils/pom.xml
+++ b/gateway-test-utils/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-test-utils</artifactId>

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-test</artifactId>

--- a/gateway-topology-hadoop-xml/pom.xml
+++ b/gateway-topology-hadoop-xml/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-topology-hadoop-xml</artifactId>

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-topology-simple</artifactId>

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>gateway-util-common</artifactId>

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/Urls.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/Urls.java
@@ -72,6 +72,16 @@ public class Urls {
   }
 
   /**
+   * Does the provided URL contain UserInfo
+   * @param url
+   * @return true if a URL contains userInfo else false
+   * @throws MalformedURLException
+   */
+  public static boolean containsUserInfo(String url) throws MalformedURLException {
+    return (new URL(url).getUserInfo() != null);
+  }
+
+  /**
    * Compute the domain name from an URL.
    *
    * @param url a given URL

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/UrlsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/UrlsTest.java
@@ -94,4 +94,9 @@ public class UrlsTest {
     assertEquals( "%3F", Urls.encode( "?" ) );
   }
 
+  @Test
+  public void testContainsUserInfo() throws Exception {
+    assertEquals(true, Urls.containsUserInfo( "https://www.local.com:8443aa@google.com"));
+    assertEquals(false, Urls.containsUserInfo( "https://www.local.com:8443/google.com"));
+  }
 }

--- a/gateway-util-configinjector/pom.xml
+++ b/gateway-util-configinjector/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-util-configinjector</artifactId>
 

--- a/gateway-util-launcher/pom.xml
+++ b/gateway-util-launcher/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>gateway-util-launcher</artifactId>
     <name>gateway-util-launcher</name>

--- a/gateway-util-urltemplate/pom.xml
+++ b/gateway-util-urltemplate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gateway-util-urltemplate</artifactId>

--- a/hadoop-examples/pom.xml
+++ b/hadoop-examples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hadoop-examples</artifactId>

--- a/knox-cli-launcher/pom.xml
+++ b/knox-cli-launcher/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>gateway</artifactId>
         <groupId>org.apache.knox</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>knox-cli-launcher</artifactId>

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
@@ -58,7 +58,7 @@
                     <a href="{{ getMetadataAPIUrl('topologies') }}" target="_blank">Topologies</a>
                 </td>
             </tr>
-            <tr *ngIf="this['showTokens']">
+            <tr *ngIf="this.isTokenManagementEnabled() && this['showTokens']">
                 <td>
                     Integration Tokens
                 </td>

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
@@ -78,6 +78,13 @@ export class GeneralProxyInformationComponent implements OnInit {
         return this.getAdminUiUrl().replace(new RegExp('manager/admin-ui/*'), 'homepage/token-management/index.html');
     }
 
+    isTokenManagementEnabled() {
+        if (this.generalProxyInformation) {
+	        return this.generalProxyInformation.enableTokenManagement === 'true';
+	    }
+        return false;
+    }
+
     ngOnInit(): void {
         console.debug('GeneralProxyInformationComponent --> ngOnInit() --> ');
         this.homepageService.getGeneralProxyInformation()

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.ts
@@ -19,5 +19,5 @@ export class GeneralProxyInformation {
     version: string;
     adminUiUrl: string;
     adminApiBookUrl: string;
-    tokenGenerationUrl: string;
+    enableTokenManagement: string;
 }

--- a/knox-homepage-ui/pom.xml
+++ b/knox-homepage-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>knox-homepage-ui</artifactId>

--- a/knox-token-management-ui/pom.xml
+++ b/knox-token-management-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.knox</groupId>
         <artifactId>gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>knox-token-management-ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.knox</groupId>
     <artifactId>gateway</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>gateway</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Invalidate any originalUrl being used in the flow for KnoxSSO that contains user information (username and password).
There is no reason for an SSO flow to result in username and password being sent by the browser as part of the URL and would represent poor credential hygiene.

This change explicitly checks the incoming originalUrl for the existence of userInfo and if the url contains it the flow is disrupted as possible phishing attack.

## How was this patch tested?

Existing unit tests and new unit tests added for Urls.containsUserInfo method.
Manually tested a url with userinfo and observed expected behavior.
Manually tested a valid url and observed normal KnoxSSO flow success.
