### PR TITLE
V1.6.0

### DIFF
--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/Urls.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/Urls.java
@@ -72,6 +72,16 @@ public class Urls {
   }
 
   /**
+   * Does the provided URL contain UserInfo
+   * @param url
+   * @return true if a URL contains userInfo else false
+   * @throws MalformedURLException
+   */
+  public static boolean containsUserInfo(String url) throws MalformedURLException {
+    return (new URL(url).getUserInfo() != null);
+  }
+
+  /**
    * Compute the domain name from an URL.
    *
    * @param url a given URL

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/UrlsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/UrlsTest.java
@@ -18,6 +18,8 @@
 package org.apache.knox.gateway.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -94,4 +96,9 @@ public class UrlsTest {
     assertEquals( "%3F", Urls.encode( "?" ) );
   }
 
+  @Test
+  public void testContainsUserInfo() throws Exception {
+    assertTrue(Urls.containsUserInfo( "https://www.local.com:8443aa@google.com"));
+    assertFalse(Urls.containsUserInfo( "https://www.local.com:8443/google.com"));
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Invalidate any originalUrl being used in the flow for KnoxSSO that contains user information (username and password).
There is no reason for an SSO flow to result in username and password being sent by the browser as part of the URL and would represent poor credential hygiene.

This change explicitly checks the incoming originalUrl for the existence of userInfo and if the url contains it the flow is disrupted as possible phishing attack.

## How was this patch tested?

Existing unit tests and new unit tests added for Urls.containsUserInfo method.
Manually tested a url with userinfo and observed expected behavior.
Manually tested a valid url and observed normal KnoxSSO flow success.