### PR TITLE
KNOX-2690 - Service URLs are missing from Knox UI after a temporary discovery failure

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
@@ -194,36 +194,6 @@ class AmbariServiceDiscovery implements ServiceDiscovery {
         return TYPE;
     }
 
-
-    @Override
-    public Map<String, Cluster> discover(GatewayConfig gatewayConfig, ServiceDiscoveryConfig discoveryConfig) {
-        Map<String, Cluster> clusters = new HashMap<>();
-
-        init(gatewayConfig);
-
-        String discoveryAddress = discoveryConfig.getAddress();
-
-        // Invoke Ambari REST API to discover the available clusters
-        String clustersDiscoveryURL = String.format(Locale.ROOT, "%s" + AMBARI_CLUSTERS_URI, discoveryAddress);
-
-        JSONObject json = restClient.invoke(clustersDiscoveryURL, discoveryConfig.getUser(), discoveryConfig.getPasswordAlias());
-
-        // Parse the cluster names from the response, and perform the cluster discovery
-        JSONArray clusterItems = (JSONArray) json.get("items");
-        for (Object clusterItem : clusterItems) {
-            String clusterName = (String) ((JSONObject)((JSONObject) clusterItem).get("Clusters")).get("cluster_name");
-            try {
-                Cluster c = discover(gatewayConfig, discoveryConfig, clusterName);
-                clusters.put(clusterName, c);
-            } catch (Exception e) {
-                log.clusterDiscoveryError(clusterName, e);
-            }
-        }
-
-        return clusters;
-    }
-
-
     @Override
     public Cluster discover(GatewayConfig gatewayConfig, ServiceDiscoveryConfig config, String clusterName) {
         AmbariCluster cluster = null;

--- a/gateway-discovery-ambari/src/test/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryTest.java
+++ b/gateway-discovery-ambari/src/test/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryTest.java
@@ -197,30 +197,6 @@ public class AmbariServiceDiscoveryTest {
     }
 
     @Test
-    public void testBulkClusterDiscovery() throws Exception {
-        final String discoveryAddress = "http://ambarihost:8080";
-        final String clusterName = "anotherCluster";
-        ServiceDiscovery sd = new TestAmbariServiceDiscovery(clusterName);
-
-        GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
-        EasyMock.replay(gc);
-
-        ServiceDiscoveryConfig sdc = EasyMock.createNiceMock(ServiceDiscoveryConfig.class);
-        EasyMock.expect(sdc.getAddress()).andReturn(discoveryAddress).anyTimes();
-        EasyMock.expect(sdc.getUser()).andReturn(null).anyTimes();
-        EasyMock.replay(sdc);
-
-        Map<String, ServiceDiscovery.Cluster> clusters = sd.discover(gc, sdc);
-        assertNotNull(clusters);
-        assertEquals(1, clusters.size());
-        ServiceDiscovery.Cluster cluster = clusters.get(clusterName);
-        assertNotNull(cluster);
-        assertEquals(clusterName, cluster.getName());
-        assertTrue(AmbariCluster.class.isAssignableFrom(cluster.getClass()));
-        assertEquals(6, ((AmbariCluster) cluster).getComponents().size());
-    }
-
-    @Test
     public void testClusterDiscoveryWithExternalComponentConfigAugmentation() throws Exception {
         final String discoveryAddress = "http://ambarihost:8080";
         final String clusterName = "myCluster";

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -1178,7 +1178,7 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     // Invoke the service discovery
     ClouderaManagerServiceDiscovery cmsd = new ClouderaManagerServiceDiscovery(true);
-    ServiceDiscovery.Cluster cluster = cmsd.discover(gwConf, sdConfig, clusterName, mockClient);
+    ServiceDiscovery.Cluster cluster = cmsd.discover(sdConfig, clusterName, mockClient);
     assertNotNull(cluster);
     assertEquals(clusterName, cluster.getName());
     return cluster;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -707,4 +707,9 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Error while initiatalizing {0}: {1}")
   void errorInitializingService(String implementation, String error, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.ERROR,
+          text = "Unable to complete service discovery for cluster {0} topology = {1}.")
+  void failedToDiscoverClusterServices(String clusterName, String topologyName,
+                                       @StackTrace(level = MessageLevel.DEBUG) Exception e);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/monitor/DescriptorsMonitor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/monitor/DescriptorsMonitor.java
@@ -34,6 +34,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.topology.impl.DefaultTopologyService;
+import org.apache.knox.gateway.topology.simple.DiscoveryException;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorHandler;
 
 public class DescriptorsMonitor extends FileAlterationListenerAdaptor implements FileFilter {
@@ -123,6 +124,8 @@ public class DescriptorsMonitor extends FileAlterationListenerAdaptor implements
       for (List<String> descs : providerConfigReferences.values()) {
         descs.remove(descriptorName);
       }
+    } catch (DiscoveryException e) {
+      LOG.failedToDiscoverClusterServices(e.getClusterName(), e.getTopologyName(), e);
     } catch (Exception e) {
       LOG.simpleDescriptorHandlingError(file.getName(), e);
     }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/DummyServiceDiscovery.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/DummyServiceDiscovery.java
@@ -66,11 +66,6 @@ public class DummyServiceDiscovery implements ServiceDiscovery {
     }
 
     @Override
-    public Map<String, Cluster> discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config) {
-        return CLUSTERS;
-    }
-
-    @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName) {
         return DUMMY;
     }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/PropertiesFileServiceDiscovery.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/PropertiesFileServiceDiscovery.java
@@ -45,9 +45,7 @@ class PropertiesFileServiceDiscovery implements ServiceDiscovery {
         return TYPE;
     }
 
-    @Override
-    public Map<String, ServiceDiscovery.Cluster> discover(GatewayConfig gatewayConfig,
-                                                          ServiceDiscoveryConfig discoveryConfig) {
+    private Map<String, ServiceDiscovery.Cluster> discover(ServiceDiscoveryConfig discoveryConfig) {
 
         Map<String, ServiceDiscovery.Cluster> result = new HashMap<>();
 
@@ -110,7 +108,7 @@ class PropertiesFileServiceDiscovery implements ServiceDiscovery {
     public ServiceDiscovery.Cluster discover(GatewayConfig          gwConfig,
                                              ServiceDiscoveryConfig discoveryConfig,
                                              String                 clusterName) {
-        Map<String, ServiceDiscovery.Cluster> clusters = discover(gwConfig, discoveryConfig);
+        Map<String, ServiceDiscovery.Cluster> clusters = discover(discoveryConfig);
         return clusters.get(clusterName);
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/SneakyServiceDiscoveryImpl.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/SneakyServiceDiscoveryImpl.java
@@ -20,17 +20,10 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
-import java.util.Map;
-
 public class SneakyServiceDiscoveryImpl implements ServiceDiscovery {
     @Override
     public String getType() {
         return "ActualType";
-    }
-
-    @Override
-    public Map<String, Cluster> discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config) {
-        return null;
     }
 
     @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
@@ -823,38 +823,24 @@ public class SimpleDescriptorHandlerTest {
 
     @Test
     public void shouldAllowKnoxServiceWithoutUrlsAndParams() throws Exception {
-      final String clusterName = "testCluster";
       File providerConfig =  File.createTempFile("testKnoxProvider", ".xml");
       FileUtils.write(providerConfig, TEST_PROVIDER_CONFIG, StandardCharsets.UTF_8);
-
-      final File discoveryConfig = File.createTempFile("testKnoxDiscoveryConfig", ".properties");
-      final Properties discoveryProperties = new Properties();
-      discoveryProperties.setProperty(clusterName + ".name", clusterName);
-
-      try (OutputStream outputStream = Files.newOutputStream(discoveryConfig.toPath())){
-          discoveryProperties.store(outputStream, null);
-      }
 
       File topologyFile = null;
       try {
         final File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
         final GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
 
-        final SimpleDescriptor testDescriptor = EasyMock.createNiceMock(SimpleDescriptor.class);
-        EasyMock.expect(testDescriptor.getName()).andReturn("testKnoxDescriptor").anyTimes();
-        EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
-        EasyMock.expect(testDescriptor.getDiscoveryAddress()).andReturn(discoveryConfig.getAbsolutePath()).anyTimes();
-        EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn("PROPERTIES_FILE").anyTimes();
-        EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
-        EasyMock.expect(testDescriptor.getCluster()).andReturn(clusterName).anyTimes();
+        final SimpleDescriptorImpl testDescriptor = new SimpleDescriptorImpl();
+        testDescriptor.setProviderConfig(providerConfig.getAbsolutePath());
 
         final SimpleDescriptor.Service knoxService = EasyMock.createNiceMock(SimpleDescriptor.Service.class);
         EasyMock.expect(knoxService.getName()).andReturn("KNOX").anyTimes();
         EasyMock.expect(knoxService.getURLs()).andReturn(null).anyTimes();
         EasyMock.expect(knoxService.getParams()).andReturn(null).anyTimes();
         List<SimpleDescriptor.Service> serviceMocks = Collections.singletonList(knoxService);
-        EasyMock.expect(testDescriptor.getServices()).andReturn(serviceMocks).anyTimes();
-        EasyMock.replay(gc, knoxService, testDescriptor);
+        testDescriptor.setServices(serviceMocks);
+        EasyMock.replay(gc, knoxService);
 
         final Map<String, File> handleResult = SimpleDescriptorHandler.handle(gc, testDescriptor, destDir, destDir);
         topologyFile = handleResult.get(SimpleDescriptorHandler.RESULT_TOPOLOGY);
@@ -865,7 +851,6 @@ public class SimpleDescriptorHandlerTest {
         assertThat(topologyXml, hasXPath("/topology/service/role", is(equalTo("KNOX"))));
       } finally {
         providerConfig.delete();
-        discoveryConfig.delete();
         if (topologyFile != null) {
           topologyFile.delete();
         }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ServiceDiscovery.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ServiceDiscovery.java
@@ -37,18 +37,6 @@ public interface ServiceDiscovery {
      */
     String getType();
 
-
-    /**
-     * Discover details of all the clusters known to the target registry.
-     *
-     * @param gwConfig The gateway configuration
-     * @param config The configuration for the discovery invocation
-     *
-     * @return A Map of the discovered service data, keyed by the cluster name.
-     */
-    Map<String, Cluster> discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config);
-
-
     /**
      * Discover details for a single cluster.
      *

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -279,13 +279,28 @@ public class SimpleDescriptorHandlerFuncTest {
     }
 
     @Override
-    public Map<String, Cluster> discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config) {
-      return Collections.emptyMap();
-    }
-
-    @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName) {
-      return null;
+      return new Cluster() {
+        @Override
+        public String getName() {
+          return null;
+        }
+
+        @Override
+        public List<String> getServiceURLs(String serviceName) {
+          return null;
+        }
+
+        @Override
+        public List<String> getServiceURLs(String serviceName, Map<String, String> serviceParams) {
+          return null;
+        }
+
+        @Override
+        public ZooKeeperConfig getZooKeeperConfiguration(String serviceName) {
+          return null;
+        }
+      };
     }
   }
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/DiscoveryException.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/DiscoveryException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.topology.simple;
+
+public class DiscoveryException extends RuntimeException {
+    private final String clusterName;
+    private final String topologyName;
+
+    public DiscoveryException(String clusterName, String topologyName) {
+        this.clusterName = clusterName;
+        this.topologyName = topologyName;
+    }
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public String getTopologyName() {
+        return topologyName;
+    }
+}

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -110,7 +110,7 @@ public class SimpleDescriptorHandler {
         if (shouldPerformDiscovery(desc)) {
             cluster = performDiscovery(config, desc, gatewayServices);
             if (cluster == null) {
-                log.failedToDiscoverClusterServices(desc.getName());
+                throw new DiscoveryException(desc.getCluster(), desc.getName());
             }
         } else {
             log.discoveryNotConfiguredForDescriptor(desc.getName());

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
@@ -32,10 +32,6 @@ public interface SimpleDescriptorMessages {
             text = "The \"{0}\" descriptor does not include discovery-type.")
     void missingDiscoveryTypeInDescriptor(String descriptorName);
 
-    @Message(level = MessageLevel.ERROR,
-            text = "Unable to complete service discovery for cluster {0}.")
-    void failedToDiscoverClusterServices(String descriptorName);
-
     @Message(level = MessageLevel.WARN,
             text = "No valid URLs were discovered for {0} in the {1} cluster.")
     void failedToDiscoverClusterServiceURLs(String serviceName, String clusterName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When CM is intermittently unavailable, Knox still regenerates topologies with an empty service list. It should skip topology regeneration and log the error instead.

This patch fixes it by throwing an exception and avoiding the topology regeneration in case of a discovery failure.

The patch also removes some unused code around discovery.

## How was this patch tested?

Changed `discovery-address` in `/var/lib/knox/gateway/conf/descriptors/cdp-proxy.json` to an invalid address.

Checked the logs for the error message:

```
2021-11-12 11:14:41,394 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(215)) - Performing cluster discovery for "Cluster 1"
2021-11-12 11:14:41,396 ERROR discovery.cm (ClouderaManagerServiceDiscovery.java:getClusterServices(276)) - Failed to access the service configurations for cluster (Cluster 1) discovery: com.cloudera.api.swagger.client.ApiException: java.net.ConnectException: Failed to connect to amagyar-2.amagyar.***/***7180
2021-11-12 11:14:41,396 ERROR knox.gateway (DefaultTopologyService.java:onFileChange(870)) - Unable to complete service discovery for cluster Cluster 1 topology = cdp-proxy.
```

Verified that the URL-s are still present on the Knox UI.
