### PR TITLE
KNOX-2679 - Add ability to remove custom attributes from Pac4j cookie

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -99,6 +99,11 @@ public class Pac4jDispatcherFilter implements Filter {
 
   public static final String PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS = "pac4j.session.store.exclude.permissions";
 
+  /* A comma seperated list of attributes that needed to be excluded */
+  public static final String PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES = "pac4j.session.store.exclude.custom.attributes";
+
+  public static final String PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT = "";
+
   public static final String PAC4J_SESSION_STORE_EXCLUDE_GROUPS_DEFAULT = "true";
 
   public static final String PAC4J_SESSION_STORE_EXCLUDE_ROLES_DEFAULT = "true";
@@ -205,6 +210,8 @@ public class Pac4jDispatcherFilter implements Filter {
       setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_ROLES, PAC4J_SESSION_STORE_EXCLUDE_ROLES_DEFAULT);
       /* do we need to exclude permissions? */
       setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS, PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS_DEFAULT);
+      /* do we need to exclude custom attributes? */
+      setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT);
       //decorating client configuration (if needed)
       PAC4J_CLIENT_CONFIGURATION_DECORATOR.decorateClients(clients, properties);
     }

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStore.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStore.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.pac4j.session;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter;
 import org.apache.knox.gateway.services.security.CryptoService;
 import org.apache.knox.gateway.services.security.EncryptionResult;
@@ -39,12 +40,16 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES;
+import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_GROUPS;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_GROUPS_DEFAULT;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS;
@@ -257,6 +262,14 @@ public class KnoxSessionStore<C extends WebContext> implements SessionStore<C> {
                         .equalsIgnoreCase("true")) {
                     profiles.forEach((name, profile) -> profile.removeAttribute("permissions"));
                 }
+              if(!StringUtils.isBlank(sessionStoreConfigs
+                      .getOrDefault(PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT))) {
+                final String customAttributes = sessionStoreConfigs
+                        .getOrDefault(PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT);
+                /* splits the string based on: zero or more whitespace, a literal comma, zero or more whitespace */
+                final List<String> attr = Arrays.asList(customAttributes.split("\\s*,\\s*"));
+                attr.forEach(a -> profiles.forEach((name, profile) -> profile.removeAttribute(a)));
+              }
             }
 
             return profiles;

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStoreTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStoreTest.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_GROUPS;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_GROUPS_DEFAULT;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS;
@@ -82,6 +83,8 @@ public class KnoxSessionStoreTest {
     attributes.put("groups", groups);
     attributes.put("permissions", permissions);
     attributes.put("roles", roles);
+    attributes.put("https://knox.apache.org/SAML/Attributes/groups", groups);
+    attributes.put("https://knox.apache.org/SAML/Attributes/groups2", groups);
     samlProfile.addAttributes(attributes);
 
     /*
@@ -93,11 +96,14 @@ public class KnoxSessionStoreTest {
     Assert.assertNotNull(samlProfile.getAttribute("groups"));
     Assert.assertNotNull(samlProfile.getAttribute("roles"));
     Assert.assertNotNull(samlProfile.getAttribute("permissions"));
+    Assert.assertNotNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups"));
+    Assert.assertNotNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups2"));
 
 
     sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_GROUPS, PAC4J_SESSION_STORE_EXCLUDE_GROUPS_DEFAULT);
     sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_ROLES, PAC4J_SESSION_STORE_EXCLUDE_ROLES_DEFAULT);
     sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS, PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS_DEFAULT);
+    sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, "https://knox.apache.org/SAML/Attributes/groups, https://knox.apache.org/SAML/Attributes/groups2");
 
     final Map<String, CommonProfile> profile = new HashMap<>();
     profile.put("SAML2Client", samlProfile);
@@ -110,6 +116,8 @@ public class KnoxSessionStoreTest {
     Assert.assertNull(samlProfile.getAttribute("groups"));
     Assert.assertNull(samlProfile.getAttribute("roles"));
     Assert.assertNull(samlProfile.getAttribute("permissions"));
+    Assert.assertNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups"));
+    Assert.assertNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups2"));
 
 
     /*
@@ -119,25 +127,32 @@ public class KnoxSessionStoreTest {
     attributes.put("groups", groups);
     attributes.put("permissions", permissions);
     attributes.put("roles", roles);
+    attributes.put("https://knox.apache.org/SAML/Attributes/groups", groups);
+    attributes.put("https://knox.apache.org/SAML/Attributes/groups2", groups);
     samlProfile.addAttributes(attributes);
 
     /* Make sure groups are present */
     Assert.assertNotNull(samlProfile.getAttribute("groups"));
     Assert.assertNotNull(samlProfile.getAttribute("roles"));
     Assert.assertNotNull(samlProfile.getAttribute("permissions"));
+    Assert.assertNotNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups"));
+    Assert.assertNotNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups2"));
 
 
     sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_GROUPS, "false");
     sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_ROLES, "false");
     sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS, "false");
+    sessionStoreConfigs.put(PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, "");
 
     profile.put("SAML2Client", samlProfile);
 
     sessionStore.set(mockContext, Pac4jConstants.USER_PROFILES, profile);
 
-    /* Make sure groups are removed */
+    /* Make sure attributes are not removed */
     Assert.assertNotNull(samlProfile.getAttribute("groups"));
     Assert.assertNotNull(samlProfile.getAttribute("roles"));
     Assert.assertNotNull(samlProfile.getAttribute("permissions"));
+    Assert.assertNotNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups"));
+    Assert.assertNotNull(samlProfile.getAttribute("https://knox.apache.org/SAML/Attributes/groups2"));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
There are cases where IdP sends back custom attributes that might be too big. For instance groups name attribute could be `https://knox.apache.org/SAML/Attributes/groups` which might contain large number of groups that might prevent setting cookies properly. This patch adds the ability to remove custom attributes from pac4j profile cookie.

`pac4j.session.store.exclude.custom.attributes` is the configuration setting and it takes a comma separated list of values. Default is blank string.

## How was this patch tested?
This patch was tested on a local cluster.