### PR TITLE
KNOX-2689 - Redeploying a topology only if it was actually changed

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -333,7 +333,7 @@ public class GatewayServer {
   public static void redeployTopologies( String topologyName  ) {
     TopologyService ts = getGatewayServices().getService(ServiceType.TOPOLOGY_SERVICE);
     ts.reloadTopologies();
-    ts.redeployTopologies(topologyName);
+    ts.redeployTopology(topologyName);
   }
 
   private void cleanupTopologyDeployments() {
@@ -638,7 +638,7 @@ public class GatewayServer {
     List<String> autoDeploys = config.getAutoDeployTopologyNames();
     if (autoDeploys != null) {
       for (String topologyName : autoDeploys) {
-        monitor.redeployTopologies(topologyName);
+        monitor.redeployTopology(topologyName);
       }
     }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -79,6 +79,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -88,6 +89,8 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
     TopologyProvider, FileFilter, FileAlterationListener, ServiceDefinitionChangeListener {
 
   private static final JAXBContext jaxbContext = getJAXBContext();
+  private static final String TOPOLOGY_CLOSING_XML_ELEMENT = "</topology>";
+  private static final String REDEPLOY_TIME_TEMPLATE = "   <redeployTime>%d</redeployTime>\n" + TOPOLOGY_CLOSING_XML_ELEMENT;
 
   private static final Auditor auditor = AuditServiceFactory.getAuditService().getAuditor(
     AuditConstants.DEFAULT_AUDITOR_NAME, AuditConstants.KNOX_SERVICE_NAME,
@@ -179,32 +182,21 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         }
       }
 
-      long start = System.currentTimeMillis();
-      long limit = 1000L; // One second.
-      long elapsed = 1;
-      while (elapsed <= limit) {
-        try {
-          long origTimestamp = topologyFile.lastModified();
-          long setTimestamp = Math.max(System.currentTimeMillis(), topologyFile.lastModified() + elapsed);
-          if(topologyFile.setLastModified(setTimestamp)) {
-            long newTimstamp = topologyFile.lastModified();
-            if(newTimstamp > origTimestamp) {
-              break;
-            } else {
-              Thread.sleep(10);
-              elapsed = System.currentTimeMillis() - start;
-            }
-          } else {
-            auditor.audit(Action.REDEPLOY, topology.getName(), ResourceType.TOPOLOGY,
-                ActionOutcome.FAILURE);
-            log.failedToRedeployTopology(topology.getName());
-            break;
-          }
-        } catch (InterruptedException e) {
-          auditor.audit(Action.REDEPLOY, topology.getName(), ResourceType.TOPOLOGY, ActionOutcome.FAILURE);
-          log.failedToRedeployTopology(topology.getName(), e);
-          Thread.currentThread().interrupt();
-        }
+      // Since KNOX-2689, updating the topology file's timestamp is not enough.
+      // We need to make an actual change in the topology XML to redeploy it
+      // This change is: updating a new XML element called redeployTime
+      try {
+        final String currentTopologyContent = FileUtils.readFileToString(topologyFile, StandardCharsets.UTF_8);
+        String updated = currentTopologyContent.replaceAll("^*<redeployTime>.*", "");
+
+        //add the current timestamp
+        updated = updated.replace(TOPOLOGY_CLOSING_XML_ELEMENT, String.format(Locale.getDefault(), REDEPLOY_TIME_TEMPLATE, System.currentTimeMillis()));
+
+        //save the updated content in the file
+        FileUtils.write(topologyFile, updated, StandardCharsets.UTF_8);
+      } catch (IOException e) {
+        auditor.audit(Action.REDEPLOY, topology.getName(), ResourceType.TOPOLOGY, ActionOutcome.FAILURE);
+        log.failedToRedeployTopology(topology.getName(), e);
       }
     } catch (SAXException e) {
       auditor.audit(Action.REDEPLOY, topology.getName(), ResourceType.TOPOLOGY, ActionOutcome.FAILURE);
@@ -226,7 +218,7 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
     for (Entry<File, Topology> newTopology : newTopologies.entrySet()) {
       if (oldTopologies.containsKey(newTopology.getKey())) {
         Topology oldTopology = oldTopologies.get(newTopology.getKey());
-        if (newTopology.getValue().getTimestamp() > oldTopology.getTimestamp()) {
+        if (newTopology.getValue().getTimestamp() > oldTopology.getTimestamp() && !oldTopology.equals(newTopology.getValue())) {
           events.add(new TopologyEvent(TopologyEvent.Type.UPDATED, newTopology.getValue()));
         }
       } else {
@@ -326,14 +318,12 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
   }
 
   @Override
-  public void redeployTopologies(String topologyName) {
-
+  public void redeployTopology(String topologyName) {
     for (Topology topology : getTopologies()) {
       if (topologyName == null || topologyName.equals(topology.getName())) {
         redeployTopology(topology);
       }
     }
-
   }
 
   @Override
@@ -344,7 +334,9 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         Map<File, Topology> newTopologies = loadTopologies(topologiesDirectory);
         List<TopologyEvent> events = createChangeEvents(oldTopologies, newTopologies);
         topologies = newTopologies;
-        notifyChangeListeners(events);
+        if (!events.isEmpty()) {
+          notifyChangeListeners(events);
+        }
       }
     } catch (Exception e) {
       // Maybe it makes sense to throw exception

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/builder/BeanPropertyTopologyBuilder.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/builder/BeanPropertyTopologyBuilder.java
@@ -29,6 +29,7 @@ public class BeanPropertyTopologyBuilder implements TopologyBuilder {
     private String name;
     private String defaultService;
     private boolean isGenerated;
+    private long redeployTime;
     private List<Provider> providers;
     private List<Service> services;
     private List<Application> applications;
@@ -55,6 +56,15 @@ public class BeanPropertyTopologyBuilder implements TopologyBuilder {
 
     public boolean isGenerated() {
         return isGenerated;
+    }
+
+    public BeanPropertyTopologyBuilder redeployTime(String redeployTime) {
+      this.redeployTime = Long.parseLong(redeployTime);
+      return this;
+    }
+
+    public long getRedeployTime() {
+      return redeployTime;
     }
 
     public BeanPropertyTopologyBuilder defaultService(String defaultService) {
@@ -99,6 +109,7 @@ public class BeanPropertyTopologyBuilder implements TopologyBuilder {
         topology.setName(name);
         topology.setDefaultServicePath(defaultService);
         topology.setGenerated(isGenerated);
+        topology.setRedeployTime(redeployTime);
 
         for (Provider provider : providers) {
             topology.addProvider(provider);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/xml/KnoxFormatXmlTopologyRules.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/xml/KnoxFormatXmlTopologyRules.java
@@ -36,6 +36,7 @@ public class KnoxFormatXmlTopologyRules extends AbstractRulesModule {
   private static final String VERSION_TAG = "version";
   private static final String DEFAULT_SERVICE_TAG = "path";
   private static final String GENERATED_TAG = "generated";
+  private static final String REDEPLOY_TIME_TAG = "redeployTime";
   private static final String APPLICATION_TAG = "application";
   private static final String SERVICE_TAG = "service";
   private static final String ROLE_TAG = "role";
@@ -64,6 +65,7 @@ public class KnoxFormatXmlTopologyRules extends AbstractRulesModule {
     forPattern( ROOT_TAG + "/" + VERSION_TAG ).callMethod("version").usingElementBodyAsArgument();
     forPattern( ROOT_TAG + "/" + DEFAULT_SERVICE_TAG ).callMethod("defaultService").usingElementBodyAsArgument();
     forPattern( ROOT_TAG + "/" + GENERATED_TAG ).callMethod("generated").usingElementBodyAsArgument();
+    forPattern( ROOT_TAG + "/" + REDEPLOY_TIME_TAG ).callMethod("redeployTime").usingElementBodyAsArgument();
 
     forPattern( ROOT_TAG + "/" + APPLICATION_TAG ).createObject().ofType( Application.class ).then().setNext( "addApplication" );
     forPattern( ROOT_TAG + "/" + APPLICATION_TAG + "/" + ROLE_TAG ).setBeanProperty();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -1088,7 +1088,7 @@ public class KnoxCLI extends Configured implements Tool {
       ts.reloadTopologies();
       if (cluster != null) {
         if (validateClusterName(cluster, ts)) {
-          ts.redeployTopologies(cluster);
+          ts.redeployTopology(cluster);
         }
         else {
           out.println("Invalid cluster name provided. Nothing to redeploy.");

--- a/gateway-server/src/main/resources/conf/topology-v1.xsd
+++ b/gateway-server/src/main/resources/conf/topology-v1.xsd
@@ -105,6 +105,8 @@ limitations under the License.
                     </h:complexType>
                 </h:element>
 
+                <h:element name="redeployTime" type="h:long" minOccurs="0"/>
+
             </h:sequence>
         </h:complexType>
     </h:element>

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -85,10 +85,7 @@ public class DefaultTopologyServiceTest {
   }
 
   private File createFile(File parent, String name, InputStream content, long timestamp) throws IOException {
-    File file = new File(parent, name);
-    if (!file.exists()) {
-      FileUtils.touch(file);
-    }
+    File file = touchFile(parent, name);
     try(OutputStream output = FileUtils.openOutputStream(file)) {
       assertNotNull(content);
       IOUtils.copy(content, output);
@@ -97,6 +94,14 @@ public class DefaultTopologyServiceTest {
     assertTrue("Failed to create test file " + file.getAbsolutePath(), file.exists());
     assertTrue("Failed to populate test file " + file.getAbsolutePath(), file.length() > 0);
 
+    return file;
+  }
+
+  private File touchFile(File parent, String name) throws IOException {
+    final File file = new File(parent, name);
+    if (!file.exists()) {
+      FileUtils.touch(file);
+    }
     return file;
   }
 
@@ -703,6 +708,47 @@ public class DefaultTopologyServiceTest {
     } finally {
       FileUtils.deleteQuietly(dir);
       setGatewayServices(null);
+    }
+  }
+
+  @Test
+  public void testTopologyNotRedeployedIfNotChanged() throws Exception {
+    final File dir = createDir();
+    try {
+      final String topologyFileName = "one.xml";
+      final File topologyDir = new File(dir, "topologies");
+      createFile(topologyDir, topologyFileName, "org/apache/knox/gateway/topology/file/topology-one.xml", topologyDir.lastModified());
+      final TestTopologyListener topoListener = new TestTopologyListener();
+      final TopologyService topologyService = new DefaultTopologyService();
+      final Map<String, String> c = new HashMap<>();
+
+      final GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+      EasyMock.expect(config.getGatewayTopologyDir()).andReturn(topologyDir.getAbsolutePath()).anyTimes();
+      EasyMock.replay(config);
+      topologyService.init(config, c);
+      topologyService.addTopologyChangeListener(topoListener);
+      topologyService.reloadTopologies();
+      assertThat(topoListener.events.size(), is(1));
+      List<TopologyEvent> events = topoListener.events.get(0);
+      assertThat(events.size(), is(1));
+      assertThat(events.get(0).getType(), is(TopologyEvent.Type.CREATED));
+      topoListener.events.clear();
+
+      // actually update the file
+      TestUtils.updateFile(topologyDir, topologyFileName, "host-one", "host-one-b");
+      topologyService.reloadTopologies();
+      assertThat(topoListener.events.size(), is(1));
+      events = topoListener.events.get(0);
+      assertThat(events.size(), is(1));
+      assertThat(events.get(0).getType(), is(TopologyEvent.Type.UPDATED));
+      topoListener.events.clear();
+
+      // simply touch the file, but not change it -> this should not trigger any update event
+      touchFile(topologyDir, topologyFileName);
+      topologyService.reloadTopologies();
+      assertThat(topoListener.events.size(), is(0));
+    } finally {
+      FileUtils.deleteQuietly(dir);
     }
   }
 

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/beans/BeanConverter.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/beans/BeanConverter.java
@@ -31,6 +31,7 @@ public class BeanConverter {
     topologyResource.setPath(topology.getDefaultServicePath());
     topologyResource.setUri(topology.getUri());
     topologyResource.setGenerated(topology.isGenerated());
+    topologyResource.setRedeployTime(topology.getRedeployTime());
     for ( org.apache.knox.gateway.topology.Provider provider : topology.getProviders() ) {
       topologyResource.getProviders().add( getProvider(provider) );
     }
@@ -50,6 +51,7 @@ public class BeanConverter {
     deploymentTopology.setDefaultServicePath(topology.getPath());
     deploymentTopology.setUri(topology.getUri());
     deploymentTopology.setGenerated(topology.isGenerated());
+    deploymentTopology.setRedeployTime(topology.getRedeployTime());
     for ( Provider provider : topology.getProviders() ) {
       deploymentTopology.addProvider( getProvider(provider) );
     }

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/beans/Topology.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/beans/Topology.java
@@ -42,6 +42,9 @@ public class Topology {
   @XmlElement(name="generated")
   private boolean isGenerated;
 
+  @XmlElement(name="redeployTime")
+  private long redeployTime;
+
   @XmlElement(name="provider")
   @XmlElementWrapper(name="gateway")
   public List<Provider> providers;
@@ -93,6 +96,14 @@ public class Topology {
 
   public void setGenerated(boolean isGenerated) {
     this.isGenerated = isGenerated;
+  }
+
+  public long getRedeployTime() {
+    return redeployTime;
+  }
+
+  public void setRedeployTime(long redeployTime) {
+    this.redeployTime = redeployTime;
   }
 
   public List<Service> getServices() {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
@@ -38,7 +38,7 @@ public interface TopologyService extends Service, ServiceDefinitionChangeListene
 
   void deployTopology(Topology t);
 
-  void redeployTopologies(String topologyName);
+  void redeployTopology(String topologyName);
 
   void addTopologyChangeListener(TopologyListener listener);
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Topology.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Topology.java
@@ -38,6 +38,7 @@ public class Topology {
   private String defaultServicePath;
   private long timestamp;
   private boolean isGenerated;
+  private long redeployTime = -1L;
   public List<Provider> providerList = new ArrayList<>();
   private Map<String,Map<String,Provider>> providerMap = new HashMap<>();
   public List<Service> services = new ArrayList<>();
@@ -91,6 +92,14 @@ public class Topology {
 
   public boolean isGenerated() {
     return isGenerated;
+  }
+
+  public long getRedeployTime() {
+    return redeployTime;
+  }
+
+  public void setRedeployTime(long redeployTime) {
+    this.redeployTime = redeployTime;
   }
 
   public Collection<Service> getServices() {
@@ -167,6 +176,7 @@ public class Topology {
                                 .append(providerList.stream().sorted(providerComparator).collect(Collectors.toList()))
                                 .append(services.stream().sorted(serviceComparator).collect(Collectors.toList()))
                                 .append(applications.stream().sorted(appComparator).collect(Collectors.toList()))
+                                .append(getRedeployTime())
                                 .build();
   }
 
@@ -188,7 +198,9 @@ public class Topology {
       if (equalProviders(other)) {  // Providers
         if (equalServices(other)) { // Services
           if (equalApplications(other)) { // Applications
-            return true;
+            if (getRedeployTime() == other.getRedeployTime()) {
+              return true;
+            }
           }
         }
       }

--- a/gateway-test-utils/src/main/java/org/apache/knox/test/TestUtils.java
+++ b/gateway-test-utils/src/main/java/org/apache/knox/test/TestUtils.java
@@ -230,4 +230,14 @@ public class TestUtils {
     LOG.debug( "execute: reponse=" + response );
     return response;
   }
+
+  public static void updateFile(File parent, String name, String from, String to) throws IOException {
+    final File file = new File(parent, name);
+    if (file.exists()) {
+      final String current = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+      final String updated = current.replace(from, to);
+      FileUtils.write(file, updated, StandardCharsets.UTF_8);
+    }
+  }
+
 }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAppFuncTest.java
@@ -483,7 +483,9 @@ public class GatewayAppFuncTest {
       startGatewayServer();
 
       String topoStr = TestUtils.merge( DAT, "test-dynamic-app-topology.xml", params );
-      File topoFile = new File( config.getGatewayTopologyDir(), "test-topology.xml" );
+      final File topologyDir = new File(config.getGatewayTopologyDir());
+      final String topologyFileName = "test-topology.xml";
+      File topoFile = new File(topologyDir, topologyFileName);
       FileUtils.writeStringToFile( topoFile, topoStr, StandardCharsets.UTF_8 );
       topos.reloadTopologies();
 
@@ -501,9 +503,9 @@ public class GatewayAppFuncTest {
           .when().get( clusterUrl + "/dynamic-app-path" );
 
       TestUtils.waitUntilNextSecond();
-      FileUtils.touch( topoFile );
-
+      TestUtils.updateFile(topologyDir, topologyFileName, "dummy", "dummy_1");
       topos.reloadTopologies();
+
       String[] topoDirs2 = deployDir.list();
       assertThat( topoDirs2, is(arrayWithSize(2)) );
       assertThat( topoDirs2, hasItemInArray(topoDirs1[0]) );
@@ -518,7 +520,7 @@ public class GatewayAppFuncTest {
           .when().get( clusterUrl + "/dynamic-app-path" );
 
       TestUtils.waitUntilNextSecond();
-      FileUtils.touch( topoFile );
+      TestUtils.updateFile(topologyDir, topologyFileName, "dummy", "dummy_2");
       topos.reloadTopologies();
 
       String[] topoDirs3 = deployDir.list();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayDeployFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayDeployFuncTest.java
@@ -160,6 +160,9 @@ public class GatewayDeployFuncTest {
         .gotoRoot()
         .addTag( "service" )
         .addTag( "role" ).addText( "test-service-role" )
+        .gotoRoot()
+        .addTag( "service" )
+        .addTag( "role" ).addText( "dummyService" )
         .gotoRoot();
   }
 
@@ -212,6 +215,7 @@ public class GatewayDeployFuncTest {
 
     // Redeploy and make sure the timestamp is updated.
     topoTimestampBefore = descriptor.lastModified();
+    TestUtils.updateFile(new File(config.getGatewayTopologyDir()), "test-cluster.xml", "dummyService", "dummyService_1");
     GatewayServer.redeployTopologies( "test-cluster" );
     writeTime = System.currentTimeMillis();
     topoTimestampAfter = descriptor.lastModified();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapDynamicGroupFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapDynamicGroupFuncTest.java
@@ -21,7 +21,6 @@ import static io.restassured.RestAssured.given;
 import static org.apache.knox.test.TestUtils.LOG_ENTER;
 import static org.apache.knox.test.TestUtils.LOG_EXIT;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
@@ -83,8 +82,7 @@ public class GatewayLdapDynamicGroupFuncTest {
     driver.stop();
     driver.start();
 
-    File descriptor = new File( driver.config.getGatewayTopologyDir(), cluster + ".xml" );
-    assertTrue(descriptor.setLastModified(System.currentTimeMillis()));
+    TestUtils.updateFile(new File(driver.config.getGatewayTopologyDir()), cluster + ".xml", "dummyService", "dummyService_1");
 
     serviceUrl = driver.getClusterUrl() + "/test-service-path/test-service-resource";
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
@@ -165,6 +163,11 @@ public class GatewayLdapDynamicGroupFuncTest {
         .gotoRoot()
         .addTag( "service" )
         .addTag( "role" ).addText( "test-service-role" )
+        .gotoRoot()
+
+        .gotoRoot()
+        .addTag( "service" )
+        .addTag( "role" ).addText( "dummyService" )
         .gotoRoot();
   }
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapGroupFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapGroupFuncTest.java
@@ -21,7 +21,6 @@ import static io.restassured.RestAssured.given;
 import static org.apache.knox.test.TestUtils.LOG_ENTER;
 import static org.apache.knox.test.TestUtils.LOG_EXIT;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
@@ -76,8 +75,7 @@ public class GatewayLdapGroupFuncTest {
     driver.stop();
     driver.start();
 
-    File descriptor = new File( driver.config.getGatewayTopologyDir(), cluster + ".xml" );
-    assertTrue(descriptor.setLastModified(System.currentTimeMillis()));
+    TestUtils.updateFile(new File(driver.config.getGatewayTopologyDir()), cluster + ".xml", "dummyService", "dummyService_1");
 
     serviceUrl = driver.getClusterUrl() + "/test-service-path/test-service-resource";
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
@@ -157,7 +155,13 @@ public class GatewayLdapGroupFuncTest {
         .gotoRoot()
         .addTag( "service" )
         .addTag( "role" ).addText( "test-service-role" )
+        .gotoRoot()
+
+        .gotoRoot()
+        .addTag( "service" )
+        .addTag( "role" ).addText( "dummyService" )
         .gotoRoot();
+
   }
 
   @Test( timeout = TestUtils.MEDIUM_TIMEOUT )

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapPosixGroupFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayLdapPosixGroupFuncTest.java
@@ -37,7 +37,6 @@ import static io.restassured.RestAssured.given;
 import static org.apache.knox.test.TestUtils.LOG_ENTER;
 import static org.apache.knox.test.TestUtils.LOG_EXIT;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Functional test to verify : looking up ldap groups from directory
@@ -80,8 +79,7 @@ public class GatewayLdapPosixGroupFuncTest {
     driver.stop();
     driver.start();
 
-    File descriptor = new File( driver.config.getGatewayTopologyDir(), cluster + ".xml" );
-    assertTrue(descriptor.setLastModified(System.currentTimeMillis()));
+    TestUtils.updateFile(new File(driver.config.getGatewayTopologyDir()), cluster + ".xml", "dummyService", "dummyService_1");
 
     serviceUrl = driver.getClusterUrl() + "/test-service-path/test-service-resource";
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
@@ -162,6 +160,11 @@ public class GatewayLdapPosixGroupFuncTest {
         .gotoRoot()
         .addTag( "service" )
         .addTag( "role" ).addText( "test-service-role" )
+        .gotoRoot()
+
+        .gotoRoot()
+        .addTag( "service" )
+        .addTag( "role" ).addText( "dummyService" )
         .gotoRoot();
   }
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/Knox242FuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/Knox242FuncTest.java
@@ -21,7 +21,6 @@ import static io.restassured.RestAssured.given;
 import static org.apache.knox.test.TestUtils.LOG_ENTER;
 import static org.apache.knox.test.TestUtils.LOG_EXIT;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
@@ -85,8 +84,7 @@ public class Knox242FuncTest {
     driver.stop();
     driver.start();
 
-    File descriptor = new File( driver.config.getGatewayTopologyDir(), cluster + ".xml" );
-    assertTrue(descriptor.setLastModified(System.currentTimeMillis()));
+    TestUtils.updateFile(new File(driver.config.getGatewayTopologyDir()), cluster + ".xml", "dummyService", "dummyService_1");
 
     serviceUrl = driver.getClusterUrl() + "/test-service-path/test-service-resource";
     TestUtils.awaitNon404HttpStatus( new URL( serviceUrl ), 10000, 100 );
@@ -182,6 +180,11 @@ public class Knox242FuncTest {
         .gotoRoot()
         .addTag( "service" )
         .addTag( "role" ).addText( "test-service-role" )
+        .gotoRoot()
+
+        .gotoRoot()
+        .addTag( "service" )
+        .addTag( "role" ).addText( "dummyService" )
         .gotoRoot();
   }
 

--- a/gateway-test/src/test/resources/org/apache/knox/gateway/GatewayAppFuncTest/test-dynamic-app-topology.xml
+++ b/gateway-test/src/test/resources/org/apache/knox/gateway/GatewayAppFuncTest/test-dynamic-app-topology.xml
@@ -50,5 +50,9 @@
     <application>
         <name>dynamic-app</name>
         <url>dynamic-app-path</url>
+        <param>
+          <name>dynamix.app.param</name>
+          <value>dummy</value>
+        </param>
     </application>
 </topology>


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on, a topology is redeployed only, and only if, there is a change within the topology itself. Not directly in the topology file, because Knox does not count adding/removing comments in the topology as an update. The change has to be a meaningful change such as a change in any of the services, providers, applications, or topology-level attributes.

With this change in place, the possibility to redeploy a topology, by simply touching it, is removed. Instead, clients should use KnoxCLI like this:
```
knoxcli.sh redeploy --cluster topologyName

E.g. knoxcli.sh redeploy --cluster sandbox
```
## How was this patch tested?

Updated and executed JUnit tests:
```
$ mvn clean -Dshellcheck=true verify -Prelease,package
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  26:06 min
[INFO] Finished at: 2021-11-15T15:37:32+01:00
[INFO] ------------------------------------------------------------------------
```

In addition to unit testing, I ran the following E2E test steps after redeploying and starting the Knox Gateway:
1. touched `sandbox.xml` -> Knox did not redeploy the topology
1. ran `knoxcli.sh redeploy --cluster sandbox` -> Knox redeployed `sandbox` successfully
1. edited and saved a `WEBHDFS`'s service definition on the Admin UI -> Knox redeployed `sandbox` successfully

Repeated steps 1 and 2 with other topologies too.