### PR TITLE
KNOX-2692 - Topology redeployment can be configured to require changes in topologies

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -185,6 +185,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String DESCRIPTORS_DIR_NAME = "descriptors";
   public static final String REMOTE_ALIAS_SERVICE_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.enabled";
   public static final String STRICT_TOPOLOGY_VALIDATION = GATEWAY_CONFIG_FILE_PREFIX + ".strict.topology.validation";
+  private static final String TOPOLOGY_REDEPLOYMENT_REQUIRES_CHANGES = GATEWAY_CONFIG_FILE_PREFIX + ".topology.redeploy.requires.changes";
 
   /**
    * Comma-separated list of topology names, which should be forcibly treated as read-only.
@@ -1128,6 +1129,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public boolean isTopologyValidationEnabled() {
     final String result = get(STRICT_TOPOLOGY_VALIDATION, Boolean.toString(DEFAULT_STRICT_TOPOLOGY_VALIDATION));
     return Boolean.parseBoolean(result);
+  }
+
+  @Override
+  public boolean topologyRedeploymentRequiresChanges() {
+    return getBoolean(TOPOLOGY_REDEPLOYMENT_REQUIRES_CHANGES, false);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -218,7 +218,7 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
     for (Entry<File, Topology> newTopology : newTopologies.entrySet()) {
       if (oldTopologies.containsKey(newTopology.getKey())) {
         Topology oldTopology = oldTopologies.get(newTopology.getKey());
-        if (newTopology.getValue().getTimestamp() > oldTopology.getTimestamp() && !oldTopology.equals(newTopology.getValue())) {
+        if (shouldMarkTopologyUpdated(newTopology.getValue(), oldTopology)) {
           events.add(new TopologyEvent(TopologyEvent.Type.UPDATED, newTopology.getValue()));
         }
       } else {
@@ -226,6 +226,11 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
       }
     }
     return events;
+  }
+
+  private boolean shouldMarkTopologyUpdated(Topology newTopology, Topology oldTopology) {
+    final boolean timestampUpdated = newTopology.getTimestamp() > oldTopology.getTimestamp();
+    return config.topologyRedeploymentRequiresChanges() ? timestampUpdated && !oldTopology.equals(newTopology) : timestampUpdated;
   }
 
   private File calculateAbsoluteTopologiesDir(GatewayConfig config) {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -639,6 +639,15 @@ public interface GatewayConfig {
   boolean isTopologyValidationEnabled();
 
   /**
+   * @return true if topology re-deployment requires an actual change in the
+   *         topology. Defaults to <code>false</code> to be backward compatible
+   *         with previous chanages.
+   *
+   * @since 2.0.0
+   */
+  boolean topologyRedeploymentRequiresChanges();
+
+  /**
    * Returns a list of services that need service name appended to
    * X-Forward-Context header as a result of which the new header would look
    * /{gateway}/{sandbox}/{serviceName}

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -767,6 +767,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public boolean topologyRedeploymentRequiresChanges() {
+    return false;
+  }
+
+  @Override
   public List<String> getXForwardContextAppendServices() {
     return null;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To support backward compatibility, a new Gateway-level configuration is introduced to allow end-users to configure if they require changes in topologies for redeployment or a simple `touch` is enough (relying on the topology file's timestamp).

## How was this patch tested?

Updated and executed JUnit tests. In addition to unit testing, I ran the following manual test steps:
- redeployed Knox w/ my changes
- confirmed that `touch conf/topologies/sandbox.xml` re-deployed the `sandbox` topology
- edit `gateway-site.xml` (set `gateway.topology.redeploy.requires.changes=true`) and re-started Knox
- confirmed that
  - `touch conf/topologies/sandbox.xml` did not re-deploy the `sandbox` topology
  - `bin/knoxcli.sh redeploy --cluster sandbox` re-deployed the `sandbox` topology
