### PR TITLE
KNOX-2698 - Upgrade json-smart to 2.4.7 due to CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <jna.version>5.6.0</jna.version>
         <joda-time.version>2.10.8</joda-time.version>
         <json-path.version>2.5.0</json-path.version>
-        <json-smart.version>2.4.1</json-smart.version>
+        <json-smart.version>2.4.7</json-smart.version>
         <junit.version>4.13.2</junit.version>
         <lang-tag.version>1.5</lang-tag.version>
         <libpam4j.version>1.11</libpam4j.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

New JSON smart version

## How was this patch tested?

```
$ mvn dependency:tree | grep json-smart
```