### PR TITLE
KNOX-2699 - Hide Enable/Disable button for expired tokens

### DIFF
--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -35,11 +35,12 @@
             <tr *ngFor="let knoxToken of mf.data">
                 <td>{{knoxToken.tokenId}}</td>
                 <td>{{formatDateTime(knoxToken.issueTimeLong)}}</td>
-                <td>{{formatDateTime(knoxToken.expirationLong)}}</td>
+                <td *ngIf="!isTokenExpired(knoxToken.expirationLong)" style="color: green">{{formatDateTime(knoxToken.expirationLong)}}</td>
+                <td *ngIf="isTokenExpired(knoxToken.expirationLong)" style="color: red">{{formatDateTime(knoxToken.expirationLong)}}</td>
                 <td>{{knoxToken.metadata.comment}}</td>
                 <td>
-                    <button *ngIf="knoxToken.metadata.enabled" (click)="disableToken(knoxToken.tokenId);">Disable</button>
-                    <button *ngIf="!knoxToken.metadata.enabled" (click)="enableToken(knoxToken.tokenId);">Enable</button>
+                    <button *ngIf="knoxToken.metadata.enabled && !isTokenExpired(knoxToken.expirationLong)" (click)="disableToken(knoxToken.tokenId);">Disable</button>
+                    <button *ngIf="!knoxToken.metadata.enabled && !isTokenExpired(knoxToken.expirationLong)" (click)="enableToken(knoxToken.tokenId);">Enable</button>
                     <button (click)="revokeToken(knoxToken.tokenId);">Revoke</button>
                 </td>
             </tr>

--- a/knox-token-management-ui/token-management/app/token.management.component.ts
+++ b/knox-token-management-ui/token-management/app/token.management.component.ts
@@ -75,4 +75,9 @@ export class TokenManagementComponent implements OnInit {
     formatDateTime(dateTime: number) {
         return new Date(dateTime).toLocaleString();
     }
+
+    isTokenExpired(expiration: number): boolean {
+        return Date.now() > expiration;
+    }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expired tokens cannot be enabled/disabled on the token management page going forward.
In addition to this, I improved visualization too: token expiration data is shown in `red` for expired tokens and in `green` for the valid ones.


## How was this patch tested?

Manually tested as described in the JIRA:

<img width="1777" alt="Screenshot 2022-01-05 at 13 56 20" src="https://user-images.githubusercontent.com/34065904/148222378-d94d25ec-816c-477b-bdd1-9d5681595731.png">
