### PR TITLE
KNOX-2693 - Redeploying a topology if it was changed regardless of its timestamp

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -230,7 +230,14 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
 
   private boolean shouldMarkTopologyUpdated(Topology newTopology, Topology oldTopology) {
     final boolean timestampUpdated = newTopology.getTimestamp() > oldTopology.getTimestamp();
-    return config.topologyRedeploymentRequiresChanges() ? timestampUpdated && !oldTopology.equals(newTopology) : timestampUpdated;
+    final boolean topologyChanged = !oldTopology.equals(newTopology);
+    if (topologyChanged) {
+      // if topology is changed, an UPDATE event has to be triggered no matter what
+      return true;
+    } else {
+      // topology is not changed
+      return config.topologyRedeploymentRequiresChanges() ? false : timestampUpdated;
+    }
   }
 
   private File calculateAbsoluteTopologiesDir(GatewayConfig config) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If there are subsequent changes to a topology and Knox still processes the one that came earlier it might happen that the second change is disregarded due to timing issues.
The solution is to make sure Knox always triggers an `UPDATE` event regardless of
- the topology file's timestamp
- or the `is change required` condition.

## How was this patch tested?

Updated and ran unit tests as well as conducted manual testing.
