### PR TITLE
KNOX-2703 - Configuring JWT type at creation/verification time

### DIFF
--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -564,6 +564,7 @@ public class HadoopAuthFilterTest {
       expect(filterConfig.getInitParameter(JWTFederationFilter.JWT_UNAUTHENTICATED_PATHS_PARAM)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_ISSUER)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(AbstractJWTFilter.JWT_EXPECTED_SIGALG)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.ALLOWED_JWS_TYPES)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(SignatureVerificationCache.TOKENS_VERIFIED_CACHE_MAX)).andReturn(null).anyTimes();
     }
 

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -72,6 +72,7 @@ import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 import org.apache.knox.gateway.services.security.token.impl.TokenMAC;
 
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSHeader;
 import org.apache.knox.gateway.util.Tokens;
 
@@ -105,6 +106,7 @@ public abstract class AbstractJWTFilter implements Filter {
   private String expectedSigAlg;
   protected String expectedPrincipalClaim;
   protected String expectedJWKSUrl;
+  protected Set<JOSEObjectType> allowedJwsTypes;
 
   private TokenStateService tokenStateService;
   private TokenMAC tokenMAC;
@@ -451,7 +453,7 @@ public abstract class AbstractJWTFilter implements Filter {
         if (publicKey != null) {
           verified = authority.verifyToken(token, publicKey);
         } else if (expectedJWKSUrl != null) {
-          verified = authority.verifyToken(token, expectedJWKSUrl, expectedSigAlg);
+          verified = authority.verifyToken(token, expectedJWKSUrl, expectedSigAlg, allowedJwsTypes);
         } else {
           verified = authority.verifyToken(token);
         }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.provider.federation;
 
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
@@ -1053,7 +1054,7 @@ public abstract class AbstractJWTFilterTest  {
     }
 
     @Override
-    public boolean verifyToken(JWT token, String jwksurl, String algorithm) {
+    public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) {
      return false;
     }
   }

--- a/gateway-release/home/conf/topologies/homepage.xml
+++ b/gateway-release/home/conf/topologies/homepage.xml
@@ -97,6 +97,10 @@
           <name>knox.token.renewer.whitelist</name>
           <value>admin</value>
       </param>
+      <param>
+          <name>knox.token.type</name>
+          <value>JWT</value>
+      </param>
    </service>
    <application>
       <name>tokengen</name>

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.service.knoxsso;
 
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.KeyLengthException;
@@ -66,6 +67,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.knox.gateway.services.GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE;
 import static org.junit.Assert.assertEquals;
@@ -816,7 +818,7 @@ public class WebSSOResourceTest {
     }
 
     @Override
-    public boolean verifyToken(JWT token, String jwksurl, String algorithm) {
+    public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) {
      return false;
     }
   }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -98,6 +98,7 @@ public class TokenResource {
   private static final String ENDPOINT_PUBLIC_CERT = "endpoint_public_cert";
   private static final String BEARER = "Bearer";
   private static final String TOKEN_TTL_PARAM = "knox.token.ttl";
+  private static final String TOKEN_TYPE_PARAM = "knox.token.type";
   private static final String TOKEN_AUDIENCES_PARAM = "knox.token.audiences";
   private static final String TOKEN_TARGET_URL = "knox.token.target.url";
   static final String TOKEN_CLIENT_DATA = "knox.token.client.data";
@@ -128,6 +129,7 @@ public class TokenResource {
   private static final String TARGET_ENDPOINT_PULIC_CERT_PEM = "knox.token.target.endpoint.cert.pem";
   private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
   private long tokenTTL = TOKEN_TTL_DEFAULT;
+  private String tokenType;
   private String tokenTTLAsText;
   private List<String> targetAudiences = new ArrayList<>();
   private String tokenTargetUrl;
@@ -211,6 +213,9 @@ public class TokenResource {
         log.invalidTokenTTLEncountered(ttl);
       }
     }
+
+    this.tokenType = context.getInitParameter(TOKEN_TYPE_PARAM);
+
     tokenTTLAsText = getTokenTTLAsText();
 
     tokenTargetUrl = context.getInitParameter(TOKEN_TARGET_URL);
@@ -666,7 +671,8 @@ public class TokenResource {
           .setAlgorithm(signatureAlgorithm)
           .setExpires(expires)
           .setManaged(managedToken)
-          .setJku(jku);
+          .setJku(jku)
+          .setType(tokenType);
       if (!targetAudiences.isEmpty()) {
         jwtAttributesBuilder.setAudiences(targetAudiences);
       }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
@@ -1513,7 +1514,7 @@ public class TokenServiceResourceTest {
     }
 
     @Override
-    public boolean verifyToken(JWT token, String jwksurl, String algorithm) {
+    public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) {
      return false;
     }
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
@@ -31,9 +31,10 @@ public class JWTokenAttributes {
   private final char[] signingKeystorePassphrase;
   private final boolean managed;
   private final String jku;
+  private final String type;
 
   JWTokenAttributes(Principal principal, List<String> audiences, String algorithm, long expires, String signingKeystoreName, String signingKeystoreAlias,
-      char[] signingKeystorePassphrase, boolean managed, String jku) {
+      char[] signingKeystorePassphrase, boolean managed, String jku, String type) {
     super();
     this.principal = principal;
     this.audiences = audiences;
@@ -44,6 +45,7 @@ public class JWTokenAttributes {
     this.signingKeystorePassphrase = signingKeystorePassphrase;
     this.managed = managed;
     this.jku = jku;
+    this.type = type;
   }
 
   public Principal getPrincipal() {
@@ -81,4 +83,9 @@ public class JWTokenAttributes {
   public String getJku() {
     return jku;
   }
+
+  public String getType() {
+    return type;
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
@@ -34,6 +34,7 @@ public class JWTokenAttributesBuilder {
   private char[] signingKeystorePassphrase;
   private boolean managed;
   private String jku;
+  private String type;
 
   public JWTokenAttributesBuilder setPrincipal(Subject subject) {
     return setPrincipal((Principal) subject.getPrincipals().toArray()[0]);
@@ -88,9 +89,14 @@ public class JWTokenAttributesBuilder {
     return this;
   }
 
+  public JWTokenAttributesBuilder setType(String type) {
+    this.type = type;
+    return this;
+  }
+
   public JWTokenAttributes build() {
     return new JWTokenAttributes(principal, (audiences == null ? Collections.emptyList() : audiences), algorithm, expires, signingKeystoreName, signingKeystoreAlias,
-        signingKeystorePassphrase, managed, jku);
+        signingKeystorePassphrase, managed, jku, type);
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAuthority.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAuthority.java
@@ -18,8 +18,11 @@
 package org.apache.knox.gateway.services.security.token;
 
 import java.security.interfaces.RSAPublicKey;
+import java.util.Set;
 
 import org.apache.knox.gateway.services.security.token.impl.JWT;
+
+import com.nimbusds.jose.JOSEObjectType;
 
 public interface JWTokenAuthority {
 
@@ -29,5 +32,5 @@ public interface JWTokenAuthority {
 
   boolean verifyToken(JWT token, RSAPublicKey publicKey) throws TokenServiceException;
 
-  boolean verifyToken(JWT token, String jwksurl, String algorithm) throws TokenServiceException;
+  boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException;
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWT.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWT.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.security.token.impl;
 
 import java.util.Date;
 
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
@@ -61,6 +62,8 @@ public interface JWT {
   String getClaims();
 
   JWSAlgorithm getSignatureAlgorithm();
+
+  JOSEObjectType getType();
 
   void sign(JWSSigner signer);
 

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
@@ -17,6 +17,13 @@
  */
 package org.apache.knox.gateway.services.security.token.impl;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPrivateKey;
@@ -30,18 +37,12 @@ import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class JWTTokenTest {
   private static final String JWT_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE0MTY5MjkxMDksImp0aSI6ImFhN2Y4ZDBhOTVjIiwic2NvcGVzIjpbInJlcG8iLCJwdWJsaWNfcmVwbyJdfQ.XCEwpBGvOLma4TCoh36FU7XhUbcskygS81HE1uHLf0E";
@@ -289,5 +290,15 @@ public class JWTTokenTest {
       assertEquals("Invalid JWS header: The algorithm \"alg\" header parameter must be for signatures",
           ex.getMessage());
     }
+  }
+
+  @Test
+  public void testTokenType() throws Exception {
+    JWT token = new JWTToken("RS256", null, null, false, null);
+    assertNull(token.getType());
+
+    final String tokenType = "at+jwt";
+    token = new JWTToken("RS256", null, null, false, tokenType);
+    assertEquals(token.getType(), new JOSEObjectType(tokenType));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Knox supports two new topology-level properties from now on:
- `knox.token.type` - this can be set as a `KNOXTOKEN` service parameter. If this is configured the generated JWT header will have this as the `typ` property
- `knox.token.allowed.jws.types` - this can be set as a `JWTProvider` provider parameter. Defaults to `JWT`. Please note, this configuration is only applied if token verification goes through the JWKS verification path as described in #216 .

## How was this patch tested?

Unit tested as well as executed manual test runs w/ different combinations of these new params.