### PR TITLE
KNOX-2680 - Introducing a central repository for CM service discovery configs

### DIFF
--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscovery.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -323,6 +324,11 @@ class AmbariServiceDiscovery implements ServiceDiscovery {
         }
 
         return cluster;
+    }
+
+    @Override
+    public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
+      throw new UnsupportedOperationException("Filtering Ambari service discovery by service names is not supported!");
     }
 
 }

--- a/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryType.java
+++ b/gateway-discovery-ambari/src/main/java/org/apache/knox/gateway/topology/discovery/ambari/AmbariServiceDiscoveryType.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.ambari;
 
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryType;
 
@@ -26,7 +27,7 @@ public class AmbariServiceDiscoveryType implements ServiceDiscoveryType {
     }
 
     @Override
-    public ServiceDiscovery newInstance() {
+    public ServiceDiscovery newInstance(GatewayConfig gatewayConfig) {
         return new AmbariServiceDiscovery();
     }
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -53,7 +53,7 @@ import java.util.Set;
 /**
  * ClouderaManager-based service discovery implementation.
  */
-public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
+public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, ClusterConfigurationMonitor.ConfigurationChangeListener {
 
   static final String TYPE = "ClouderaManager";
 
@@ -88,12 +88,13 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
 
   private ClouderaManagerClusterConfigurationMonitor configChangeMonitor;
 
+  private final ClouderaManagerServiceDiscoveryRepository repository = ClouderaManagerServiceDiscoveryRepository.getInstance();
 
-  ClouderaManagerServiceDiscovery() {
-    this(false);
+  ClouderaManagerServiceDiscovery(GatewayConfig gatewayConfig) {
+    this(false, gatewayConfig);
   }
 
-  ClouderaManagerServiceDiscovery(boolean debug) {
+  ClouderaManagerServiceDiscovery(boolean debug, GatewayConfig gatewayConfig) {
     GatewayServices gwServices = GatewayServer.getGatewayServices();
     if (gwServices != null) {
       this.aliasService = gwServices.getService(ServiceType.ALIAS_SERVICE);
@@ -101,6 +102,10 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
     }
     this.debug = debug;
     this.configChangeMonitor = getConfigurationChangeMonitor();
+
+    if (gatewayConfig != null) {
+      repository.setCacheEntryTTL(gatewayConfig.getClouderaManagerServiceDiscoveryRepositoryEntryTTL());
+    }
   }
 
   @Override
@@ -135,6 +140,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
             clusterMonitorService.getMonitor(ClouderaManagerClusterConfigurationMonitor.getType());
         if (monitor != null && ClouderaManagerClusterConfigurationMonitor.class.isAssignableFrom(monitor.getClass())) {
           cmMonitor = (ClouderaManagerClusterConfigurationMonitor) monitor;
+          cmMonitor.addListener(this);
         }
       }
     } catch (Exception e) {
@@ -191,9 +197,11 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
 
     log.discoveringCluster(clusterName);
 
+    repository.registerCluster(client.getConfig());
+
     Set<ServiceModel> serviceModels = new HashSet<>();
 
-    ApiServiceList serviceList = getClusterServices(servicesResourceApi, clusterName);
+    List<ApiService> serviceList = getClusterServices(client.getConfig(), servicesResourceApi);
 
     if (serviceList != null) {
       /*
@@ -204,32 +212,30 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
       final ApiService cmService = new ApiService();
       cmService.setName(CM_SERVICE_TYPE.toLowerCase(Locale.ROOT));
       cmService.setType(CM_SERVICE_TYPE);
-      serviceList.addItemsItem(cmService);
+      serviceList.add(cmService);
 
-      for (ApiService service : serviceList.getItems()) {
-        final String serviceName = service.getName();
+      for (ApiService service : serviceList) {
         final List<ServiceModelGenerator> modelGenerators = serviceModelGenerators.get(service.getType());
         if (shouldSkipServiceDiscovery(modelGenerators, includedServices)) {
-          log.skipServiceDiscovery(serviceName, service.getType());
+          log.skipServiceDiscovery(service.getName(), service.getType());
           continue;
         }
-        log.discoveredService(serviceName, service.getType());
+        log.discoveringService(service.getName(), service.getType());
         ApiServiceConfig serviceConfig = null;
         /* no reason to check service config for CM service */
         if(!CM_SERVICE_TYPE.equals(service.getType())) {
-          serviceConfig =
-              getServiceConfig(servicesResourceApi, clusterName, serviceName);
+          serviceConfig = getServiceConfig(client.getConfig(), servicesResourceApi, service);
         }
-        ApiRoleList roleList = getRoles(rolesResourceApi, clusterName, serviceName);
+        ApiRoleList roleList = getRoles(client.getConfig(), rolesResourceApi, clusterName, service);
         if (roleList != null) {
           for (ApiRole role : roleList.getItems()) {
             String roleName = role.getName();
-            log.discoveredServiceRole(roleName, role.getType());
+            log.discoveringServiceRole(roleName, role.getType());
+
             ApiConfigList roleConfig = null;
             /* no reason to check role config for CM service */
-            if(!CM_SERVICE_TYPE.equals(service.getType())) {
-              roleConfig =
-                  getRoleConfig(rolesResourceApi, clusterName, serviceName, roleName);
+            if (!CM_SERVICE_TYPE.equals(service.getType())) {
+              roleConfig = getRoleConfig(client.getConfig(), rolesResourceApi, service, role);
             }
 
             if (modelGenerators != null) {
@@ -244,8 +250,12 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
                 }
               }
             }
+
+            log.discoveredServiceRole(roleName, role.getType());
           }
         }
+
+        log.discoveredService(service.getName(), service.getType());
       }
       ClouderaManagerCluster cluster = new ClouderaManagerCluster(clusterName);
       cluster.addServiceModels(serviceModels);
@@ -271,61 +281,97 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery {
     return true;
   }
 
-  private ApiServiceList getClusterServices(final ServicesResourceApi servicesResourceApi, final String clusterName) {
-    ApiServiceList services = null;
-    try {
-      services = servicesResourceApi.readServices(clusterName, VIEW_SUMMARY);
-    } catch (ApiException e) {
-      log.failedToAccessServiceConfigs(clusterName, e);
+  private List<ApiService> getClusterServices(ServiceDiscoveryConfig serviceDiscoveryConfig, ServicesResourceApi servicesResourceApi) {
+    log.lookupClusterServicesFromRepository();
+    List<ApiService> services = repository.getServices(serviceDiscoveryConfig);
+    if (services == null || services.isEmpty()) {
+      try {
+        log.lookupClusterServicesFromCM();
+        final ApiServiceList serviceList = servicesResourceApi.readServices(serviceDiscoveryConfig.getCluster(), VIEW_SUMMARY);
+        services = serviceList == null ? new ArrayList<>() : serviceList.getItems();
+
+        // make sure that services are populated in the repository
+        services.forEach(service -> repository.addService(serviceDiscoveryConfig, service));
+      } catch (ApiException e) {
+        log.failedToAccessServiceConfigs(serviceDiscoveryConfig.getCluster(), e);
+      }
     }
     return services;
   }
 
-  private ApiServiceConfig getServiceConfig(final ServicesResourceApi servicesResourceApi,
-                                                   final String clusterName,
-                                                   final String serviceName) {
-    ApiServiceConfig serviceConfig = null;
-    try {
-      serviceConfig = servicesResourceApi.readServiceConfig(clusterName, serviceName, VIEW_FULL);
-    } catch (Exception e) {
-      log.failedToAccessServiceConfigs(clusterName, e);
+  private ApiServiceConfig getServiceConfig(ServiceDiscoveryConfig serviceDiscoveryConfig, ServicesResourceApi servicesResourceApi, ApiService service) {
+    log.lookupServiceConfigsFromRepository();
+    // first, try in the service discovery repository
+    ApiServiceConfig serviceConfig = repository.getServiceConfig(serviceDiscoveryConfig, service);
+
+    if (serviceConfig == null) {
+      // no service config in the repository -> query CM
+      try {
+        log.lookupServiceConfigsFromCM();
+        serviceConfig = servicesResourceApi.readServiceConfig(serviceDiscoveryConfig.getCluster(), service.getName(), VIEW_FULL);
+
+        // make sure that service config is populated in the service discovery repository to avoid subsequent CM calls
+        repository.addServiceConfig(serviceDiscoveryConfig, service, serviceConfig);
+      } catch (Exception e) {
+        log.failedToAccessServiceConfigs(serviceDiscoveryConfig.getCluster(), e);
+      }
     }
     return serviceConfig;
   }
 
-  private ApiRoleList getRoles(RolesResourceApi rolesResourceApi,
-                                      String clusterName,
-                                      String serviceName) {
-    ApiRoleList roles = null;
-    try {
-      /* Populate roles for CM Service since they are not discoverable */
-      if(CM_SERVICE_TYPE.equalsIgnoreCase(serviceName)) {
-        roles = new ApiRoleList();
-        final ApiRole cmRole = new ApiRole();
-        cmRole.setName(CM_ROLE_TYPE);
-        cmRole.setType(CM_ROLE_TYPE);
-        roles.addItemsItem(cmRole);
-        return roles;
-      } else {
-        roles = rolesResourceApi.readRoles(clusterName, serviceName, "", VIEW_SUMMARY);
+  private ApiRoleList getRoles(ServiceDiscoveryConfig serviceDiscoveryConfig, RolesResourceApi rolesResourceApi, String clusterName, ApiService service) {
+    log.lookupRolesFromRepository();
+    //first, try in the service discovery repository
+    ApiRoleList roles  = repository.getRoles(serviceDiscoveryConfig, service);
+    if (roles == null || roles.getItems() == null) {
+      // no roles in the repository -> query CM
+      final String serviceName = service.getName();
+      try {
+        log.lookupRolesFromCM();
+        /* Populate roles for CM Service since they are not discoverable */
+        if(CM_SERVICE_TYPE.equalsIgnoreCase(serviceName)) {
+          roles = new ApiRoleList();
+          final ApiRole cmRole = new ApiRole();
+          cmRole.setName(CM_ROLE_TYPE);
+          cmRole.setType(CM_ROLE_TYPE);
+          roles.addItemsItem(cmRole);
+        } else {
+          roles = rolesResourceApi.readRoles(clusterName, serviceName, "", VIEW_SUMMARY);
+        }
+
+        // make sure that role is populated in the service discovery repository to avoid subsequent CM calls
+        repository.addRoles(serviceDiscoveryConfig, service, roles);
+      } catch (Exception e) {
+        log.failedToAccessServiceRoleConfigs(serviceName, "N/A", clusterName, e);
       }
-    } catch (Exception e) {
-      log.failedToAccessServiceRoleConfigs(clusterName, e);
     }
+
     return roles;
   }
 
-  private ApiConfigList getRoleConfig(RolesResourceApi rolesResourceApi,
-                                             String           clusterName,
-                                             String           serviceName,
-                                             String           roleName) {
-    ApiConfigList configList = null;
-    try {
-      configList = rolesResourceApi.readRoleConfig(clusterName, roleName, serviceName, VIEW_FULL);
-    } catch (Exception e) {
-      log.failedToAccessServiceRoleConfigs(clusterName, e);
+  private ApiConfigList getRoleConfig(ServiceDiscoveryConfig serviceDiscoveryConfig, RolesResourceApi rolesResourceApi, ApiService service, ApiRole role) {
+    log.lookupRoleConfigsFromRepository();
+    // first, try in the service discovery repository
+    ApiConfigList configList = repository.getRoleConfigs(serviceDiscoveryConfig, service, role);
+    if (configList == null || configList.getItems() == null) {
+      // no role configs in the repository -> query CM
+      try {
+        log.lookupRoleConfigsFromCM();
+        configList = rolesResourceApi.readRoleConfig(serviceDiscoveryConfig.getCluster(), role.getName(), service.getName(), VIEW_FULL);
+
+        // make sure that role config is populated in the service discovery repository to avoid subsequent CM calls
+        repository.addRoleConfigs(serviceDiscoveryConfig, service, role, configList);
+      } catch (Exception e) {
+        log.failedToAccessServiceRoleConfigs(service.getName(), role.getName(), serviceDiscoveryConfig.getCluster(), e);
+      }
     }
     return configList;
+  }
+
+  @Override
+  public void onConfigurationChange(String source, String clusterName) {
+    log.clearServiceDiscoveryRepository();
+    repository.clear();
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -34,6 +34,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.INFO, text = "Discovered service: {0} ({1})")
   void discoveredService(String serviceName, String serviceType);
 
+  @Message(level = MessageLevel.INFO, text = "Skipping service discovery: {0} ({1})")
+  void skipServiceDiscovery(String serviceName, String serviceType);
+
   @Message(level = MessageLevel.INFO, text = "Discovered service role: {0} ({1})")
   void discoveredServiceRole(String roleName, String roleType);
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -25,17 +25,26 @@ import org.apache.knox.gateway.i18n.messages.StackTrace;
 @Messages(logger="org.apache.knox.gateway.topology.discovery.cm")
 public interface ClouderaManagerServiceDiscoveryMessages {
 
+  @Message(level = MessageLevel.INFO, text = "Discovering cluster: {0} ({1})")
+  void discoveringCluster(String clusterName, String version);
+
   @Message(level = MessageLevel.INFO, text = "Discovered cluster: {0} ({1})")
   void discoveredCluster(String clusterName, String version);
 
   @Message(level = MessageLevel.INFO, text = "Performing cluster discovery for \"{0}\"")
   void discoveringCluster(String clusterName);
 
+  @Message(level = MessageLevel.INFO, text = "Discovering service: {0} ({1}) ...")
+  void discoveringService(String serviceName, String serviceType);
+
   @Message(level = MessageLevel.INFO, text = "Discovered service: {0} ({1})")
   void discoveredService(String serviceName, String serviceType);
 
   @Message(level = MessageLevel.INFO, text = "Skipping service discovery: {0} ({1})")
   void skipServiceDiscovery(String serviceName, String serviceType);
+
+  @Message(level = MessageLevel.INFO, text = "Discovering service role: {0} ({1}) ...")
+  void discoveringServiceRole(String roleName, String roleType);
 
   @Message(level = MessageLevel.INFO, text = "Discovered service role: {0} ({1})")
   void discoveredServiceRole(String roleName, String roleType);
@@ -77,8 +86,8 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   void failedToAccessServiceConfigs(String clusterName, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR,
-           text = "Failed to access the service role configurations for cluster ({0}) discovery: {1}")
-  void failedToAccessServiceRoleConfigs(String clusterName, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+      text = "Failed to access the service role configurations ({0} / {1}) for cluster ({2}) discovery: {3}")
+  void failedToAccessServiceRoleConfigs(String serviceName, String roleName, String clusterName, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
   @Message(level = MessageLevel.ERROR,
            text = "No address for Cloudera Manager service discovery has been configured.")
@@ -213,4 +222,32 @@ public interface ClouderaManagerServiceDiscoveryMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Failed to configure truststore")
   void failedToConfigureTruststore();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up cluster services from service discovery repository...")
+  void lookupClusterServicesFromRepository();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up service configuration from service discovery repository...")
+  void lookupServiceConfigsFromRepository();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up roles from service discovery repository...")
+  void lookupRolesFromRepository();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up role configuration from service discovery repository...")
+  void lookupRoleConfigsFromRepository();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up cluster services from the configured Cloudera Manager discovery endpoint...")
+  void lookupClusterServicesFromCM();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up service configuration from the configured Cloudera Manager discovery endpoint...")
+  void lookupServiceConfigsFromCM();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up roles from the configured Cloudera Manager discovery endpoint...")
+  void lookupRolesFromCM();
+
+  @Message(level = MessageLevel.DEBUG, text = "Looking up role configuration from the configured Cloudera Manager discovery endpoint...")
+  void lookupRoleConfigsFromCM();
+
+  @Message(level = MessageLevel.DEBUG, text = "Clearing service discovery repository...")
+  void clearServiceDiscoveryRepository();
+
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepository.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepository.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
+
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleList;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+class ClouderaManagerServiceDiscoveryRepository {
+
+  private static final ClouderaManagerServiceDiscoveryRepository INSTANCE = new ClouderaManagerServiceDiscoveryRepository();
+  private final Map<RepositoryKey, Cache<ApiService, ServiceDetails>> repository;
+  private long cacheEntryTTL = GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL;
+
+  private ClouderaManagerServiceDiscoveryRepository() {
+    this.repository = new ConcurrentHashMap<>();
+  }
+
+  static ClouderaManagerServiceDiscoveryRepository getInstance() {
+    return INSTANCE;
+  }
+
+  void setCacheEntryTTL(long cacheEntryTTL) {
+    this.cacheEntryTTL = cacheEntryTTL;
+  }
+
+  void clear() {
+    repository.clear();
+  }
+
+  void registerCluster(ServiceDiscoveryConfig serviceDiscoveryConfig) {
+    repository.putIfAbsent(RepositoryKey.of(serviceDiscoveryConfig), Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(cacheEntryTTL)).build());
+  }
+
+  void addService(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service) {
+    getClusterServices(serviceDiscoveryConfig).put(service, new ServiceDetails());
+  }
+
+  List<ApiService> getServices(ServiceDiscoveryConfig serviceDiscoveryConfig) {
+    final Cache<ApiService, ServiceDetails> clusterServices = getClusterServices(serviceDiscoveryConfig);
+    return clusterServices == null ? null
+        : clusterServices.asMap().entrySet().stream().filter(entry -> entry.getValue() != null).map(entry -> entry.getKey())
+            .collect(Collectors.toList());
+  }
+
+  private Cache<ApiService, ServiceDetails> getClusterServices(ServiceDiscoveryConfig serviceDiscoveryConfig) {
+    return repository.get(RepositoryKey.of(serviceDiscoveryConfig));
+  }
+
+  void addServiceConfig(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service, ApiServiceConfig serviceConfig) {
+    final ServiceDetails serviceDetails = getServiceDetails(serviceDiscoveryConfig, service);
+    if (serviceDetails != null) {
+      serviceDetails.setServiceConfig(serviceConfig);
+    }
+  }
+
+  private ServiceDetails getServiceDetails(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service) {
+    return getClusterServices(serviceDiscoveryConfig).getIfPresent(service);
+  }
+
+  ApiServiceConfig getServiceConfig(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service) {
+    final ServiceDetails serviceDetails = getServiceDetails(serviceDiscoveryConfig, service);
+    return serviceDetails == null ? null : serviceDetails.getServiceConfig();
+  }
+
+  void addRoles(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service, ApiRoleList roles) {
+    final ServiceDetails serviceDetails = getServiceDetails(serviceDiscoveryConfig, service);
+    if (serviceDetails != null) {
+      serviceDetails.addRoles(roles);
+    }
+  }
+
+  ApiRoleList getRoles(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service) {
+    final ServiceDetails serviceDetails = getServiceDetails(serviceDiscoveryConfig, service);
+    return serviceDetails == null ? null : serviceDetails.getRoles();
+  }
+
+  void addRoleConfigs(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service, ApiRole role, ApiConfigList roleConfigs) {
+    final ServiceDetails serviceDetails = getServiceDetails(serviceDiscoveryConfig, service);
+    if (serviceDetails != null) {
+      serviceDetails.addRoleConfigs(role, roleConfigs);
+    }
+  }
+
+  ApiConfigList getRoleConfigs(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service, ApiRole role) {
+    final ServiceDetails serviceDetails = getServiceDetails(serviceDiscoveryConfig, service);
+    return serviceDetails == null ? null : serviceDetails.getRoleConfigs(role);
+  }
+
+  private static final class RepositoryKey {
+    private final String address;
+    private final String clusterName;
+
+    private RepositoryKey(String address, String clusterName) {
+      this.address = address;
+      this.clusterName = clusterName;
+    }
+
+    static RepositoryKey of(ServiceDiscoveryConfig serviceDiscoveryConfig) {
+      return new RepositoryKey(serviceDiscoveryConfig.getAddress(), serviceDiscoveryConfig.getCluster());
+    }
+
+    String getAddress() {
+      return address;
+    }
+
+    String getClusterName() {
+      return clusterName;
+    }
+
+    @Override
+    public int hashCode() {
+      return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public String toString() {
+      return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+  }
+
+  private static class ServiceDetails {
+    private ApiServiceConfig serviceConfig;
+    private Map<ApiRole, ApiConfigList> roleConfigsMap = new ConcurrentHashMap<>();
+
+    public ApiServiceConfig getServiceConfig() {
+      return serviceConfig;
+    }
+
+    public void setServiceConfig(ApiServiceConfig serviceConfig) {
+      this.serviceConfig = serviceConfig;
+    }
+
+    public ApiRoleList getRoles() {
+      ApiRoleList roles = new ApiRoleList();
+      for (ApiRole role : roleConfigsMap.keySet()) {
+        roles = roles.addItemsItem(role);
+      }
+      return roles;
+    }
+
+    public void addRoles(ApiRoleList roles) {
+      for (ApiRole role : roles.getItems()) {
+        roleConfigsMap.put(role, new ApiConfigList());
+      }
+    }
+
+    public ApiConfigList getRoleConfigs(ApiRole role) {
+      return roleConfigsMap.get(role);
+    }
+
+    public void addRoleConfigs(ApiRole role, ApiConfigList roleConfigs) {
+      roleConfigsMap.put(role, roleConfigs);
+    }
+
+    @Override
+    public int hashCode() {
+      return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public String toString() {
+      return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+  }
+
+}

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryType.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryType.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm;
 
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryType;
 
@@ -30,8 +31,8 @@ public class ClouderaManagerServiceDiscoveryType implements ServiceDiscoveryType
   }
 
   @Override
-  public ServiceDiscovery newInstance() {
-    return new ClouderaManagerServiceDiscovery();
+  public ServiceDiscovery newInstance(GatewayConfig gatewayConfig) {
+    return new ClouderaManagerServiceDiscovery(gatewayConfig);
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/DiscoveryApiClient.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/DiscoveryApiClient.java
@@ -57,6 +57,10 @@ public class DiscoveryApiClient extends ApiClient {
     configure(aliasService, keystoreService);
   }
 
+  ServiceDiscoveryConfig getConfig() {
+    return config;
+  }
+
   boolean isKerberos() {
     return isKerberos;
   }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepositoryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepositoryTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleList;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+
+public class ClouderaManagerServiceDiscoveryRepositoryTest {
+
+  private static ClouderaManagerServiceDiscoveryRepository repository = ClouderaManagerServiceDiscoveryRepository.getInstance();
+
+  private static ServiceDiscoveryConfig serviceDiscoveryConfig;
+
+  @BeforeClass
+  public static void init() {
+    serviceDiscoveryConfig = EasyMock.createNiceMock(ServiceDiscoveryConfig.class);
+    EasyMock.expect(serviceDiscoveryConfig.getAddress()).andReturn("https://cm_host:7183/cmf").anyTimes();
+    EasyMock.expect(serviceDiscoveryConfig.getCluster()).andReturn("Cluster 1").anyTimes();
+    EasyMock.replay(serviceDiscoveryConfig);
+  }
+
+  @Before
+  public void setUp() {
+    repository.clear();
+    assertNull(repository.getServices(serviceDiscoveryConfig));
+    repository.setCacheEntryTTL(GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL);
+  }
+
+  @Test
+  public void testRegisterCluster() throws Exception {
+    assertNull(repository.getServices(serviceDiscoveryConfig));
+    repository.registerCluster(serviceDiscoveryConfig);
+    final List<ApiService> services = repository.getServices(serviceDiscoveryConfig);
+    assertNotNull(services);
+    assertTrue(services.isEmpty());
+  }
+
+  @Test
+  public void testAddService() throws Exception {
+    final String serviceName = "HDFS-1";
+    repository.registerCluster(serviceDiscoveryConfig);
+    assertFalse(containsService(serviceName));
+    final ApiService service = EasyMock.createNiceMock(ApiService.class);
+    EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
+    EasyMock.replay(service);
+    repository.addService(serviceDiscoveryConfig, service);
+    assertTrue(containsService(serviceName));
+  }
+
+  @Test
+  public void testAddServiceConfig() throws Exception {
+    final String serviceName = "HDFS-1";
+    final String serviceConfigName = "myServiceConfigName";
+    final String serviceConfigValue = "myServiceConfigValue";
+    repository.registerCluster(serviceDiscoveryConfig);
+    final ApiService service = EasyMock.createNiceMock(ApiService.class);
+    EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
+    final ApiConfig serviceConfig = EasyMock.createNiceMock(ApiConfig.class);
+    EasyMock.expect(serviceConfig.getName()).andReturn(serviceConfigName).anyTimes();
+    EasyMock.expect(serviceConfig.getValue()).andReturn(serviceConfigValue).anyTimes();
+    final ApiServiceConfig serviceConfigs = EasyMock.createNiceMock(ApiServiceConfig.class);
+    EasyMock.expect(serviceConfigs.getItems()).andReturn(Collections.singletonList(serviceConfig)).anyTimes();
+    EasyMock.replay(service, serviceConfig, serviceConfigs);
+    assertFalse(containsServiceConfig(service, serviceConfigName, serviceConfigValue));
+    repository.addService(serviceDiscoveryConfig, service);
+    repository.addServiceConfig(serviceDiscoveryConfig, service, serviceConfigs);
+    assertTrue(containsServiceConfig(service, serviceConfigName, serviceConfigValue));
+  }
+
+  @Test
+  public void testAddRole() throws Exception {
+    final String serviceName = "HDFS-1";
+    final String roleName = "NAMENODE-1";
+    repository.registerCluster(serviceDiscoveryConfig);
+    final ApiService service = EasyMock.createNiceMock(ApiService.class);
+    EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
+    final ApiRole role = EasyMock.createNiceMock(ApiRole.class);
+    EasyMock.expect(role.getName()).andReturn(roleName).anyTimes();
+    final ApiRoleList roles = EasyMock.createNiceMock(ApiRoleList.class);
+    EasyMock.expect(roles.getItems()).andReturn(Collections.singletonList(role)).anyTimes();
+    EasyMock.replay(service, role, roles);
+    assertFalse(containsRole(service, roleName));
+    repository.addService(serviceDiscoveryConfig, service);
+    repository.addRoles(serviceDiscoveryConfig, service, roles);
+    assertTrue(containsRole(service, roleName));
+  }
+
+  @Test
+  public void testAddRoleConfig() throws Exception {
+    final String serviceName = "HDFS-1";
+    final String roleName = "NAMENODE-1";
+    final String roleConfigName = "myRoleConfig";
+    final String roleConfigValue = "myRoleConfigValue";
+
+    repository.registerCluster(serviceDiscoveryConfig);
+    final ApiService service = EasyMock.createNiceMock(ApiService.class);
+    EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
+    final ApiRole role = EasyMock.createNiceMock(ApiRole.class);
+    EasyMock.expect(role.getName()).andReturn(roleName).anyTimes();
+    final ApiRoleList roles = EasyMock.createNiceMock(ApiRoleList.class);
+    EasyMock.expect(roles.getItems()).andReturn(Collections.singletonList(role)).anyTimes();
+    final ApiConfig roleConfig = EasyMock.createNiceMock(ApiConfig.class);
+    EasyMock.expect(roleConfig.getName()).andReturn(roleConfigName).anyTimes();
+    EasyMock.expect(roleConfig.getValue()).andReturn(roleConfigValue).anyTimes();
+    final ApiConfigList roleConfigs = EasyMock.createNiceMock(ApiConfigList.class);
+    EasyMock.expect(roleConfigs.getItems()).andReturn(Collections.singletonList(roleConfig)).anyTimes();
+    EasyMock.replay(service, role, roles, roleConfig, roleConfigs);
+    assertFalse(containsRoleConfig(service, role, roleConfigName, roleConfigValue));
+    repository.addService(serviceDiscoveryConfig, service);
+    repository.addRoles(serviceDiscoveryConfig, service, roles);
+    repository.addRoleConfigs(serviceDiscoveryConfig, service, role, roleConfigs);
+    assertTrue(containsRoleConfig(service, role, roleConfigName, roleConfigValue));
+  }
+
+  @Test
+  public void testCacheAutoEviction() throws Exception {
+    final long entryTTL = 1;
+    repository.setCacheEntryTTL(entryTTL);
+    testAddService();
+    TimeUnit.SECONDS.sleep(entryTTL + 1);
+    assertFalse(containsService("HDFS-1"));
+  }
+
+  private boolean containsService(String serviceName) {
+    final List<ApiService> services = repository.getServices(serviceDiscoveryConfig);
+    if (services != null && !services.isEmpty()) {
+      return services.stream().anyMatch(service -> service.getName().equals(serviceName));
+    }
+    return false;
+  }
+
+  private boolean containsServiceConfig(ApiService service, String serviceConfigName, String serviceConfigValue) {
+    final ApiServiceConfig serviceConfigs = repository.getServiceConfig(serviceDiscoveryConfig, service);
+    if (serviceConfigs != null && serviceConfigs.getItems() != null) {
+      return serviceConfigs.getItems().stream()
+          .anyMatch(serviceConfig -> serviceConfig.getName().equals(serviceConfigName) && serviceConfig.getValue().equals(serviceConfigValue));
+    }
+    return false;
+  }
+
+  private boolean containsRole(ApiService service, String roleName) {
+    final ApiRoleList roles = repository.getRoles(serviceDiscoveryConfig, service);
+    if (roles != null && roles.getItems() != null) {
+      return roles.getItems().stream().anyMatch(role -> role.getName().equals(roleName));
+    }
+    return false;
+  }
+
+  private boolean containsRoleConfig(ApiService service, ApiRole role, String roleConfigName, String roleConfigValue) {
+    final ApiConfigList roleConfigs = repository.getRoleConfigs(serviceDiscoveryConfig, service, role);
+    if (roleConfigs != null && roleConfigs.getItems() != null) {
+      return roleConfigs.getItems().stream()
+          .anyMatch(roleConfig -> roleConfig.getName().equals(roleConfigName) && roleConfig.getValue().equals(roleConfigValue));
+    }
+    return false;
+  }
+}

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -1179,7 +1179,7 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     // Invoke the service discovery
     ClouderaManagerServiceDiscovery cmsd = new ClouderaManagerServiceDiscovery(true);
-    ServiceDiscovery.Cluster cluster = cmsd.discover(sdConfig, clusterName, mockClient);
+    ServiceDiscovery.Cluster cluster = cmsd.discover(gwConf, sdConfig, clusterName, Collections.emptySet(), mockClient);
     assertNotNull(cluster);
     assertEquals(clusterName, cluster.getName());
     return cluster;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -257,6 +257,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_REPOSITORY_CACHE_ENTRY_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.repository.cache.entry.ttl";
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
@@ -1166,6 +1167,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval() {
     return getLong(CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL, -1L);
+  }
+
+  @Override
+  public long getClouderaManagerServiceDiscoveryRepositoryEntryTTL() {
+    return getLong(CLOUDERA_MANAGER_SERVICE_DISCOVERY_REPOSITORY_CACHE_ENTRY_TTL, DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL);
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/DummyServiceDiscovery.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/DummyServiceDiscovery.java
@@ -20,6 +20,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,5 +69,10 @@ public class DummyServiceDiscovery implements ServiceDiscovery {
     @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName) {
         return DUMMY;
+    }
+
+    @Override
+    public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
+      return DUMMY;
     }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/DummyServiceDiscoveryType.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/DummyServiceDiscoveryType.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.test.extension;
 
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryType;
 
@@ -26,7 +27,7 @@ public class DummyServiceDiscoveryType implements ServiceDiscoveryType {
     }
 
     @Override
-    public ServiceDiscovery newInstance() {
+    public ServiceDiscovery newInstance(GatewayConfig gatewayConfig) {
         return new DummyServiceDiscovery();
     }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/PropertiesFileServiceDiscovery.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/PropertiesFileServiceDiscovery.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,11 @@ class PropertiesFileServiceDiscovery implements ServiceDiscovery {
                                              String                 clusterName) {
         Map<String, ServiceDiscovery.Cluster> clusters = discover(discoveryConfig);
         return clusters.get(clusterName);
+    }
+
+    @Override
+    public ServiceDiscovery.Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
+      return discover(gwConfig, config, clusterName);
     }
 
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/PropertiesFileServiceDiscoveryType.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/PropertiesFileServiceDiscoveryType.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.test.extension;
 
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryType;
 
@@ -29,7 +30,7 @@ public class PropertiesFileServiceDiscoveryType implements
     }
 
     @Override
-    public ServiceDiscovery newInstance() {
+    public ServiceDiscovery newInstance(GatewayConfig gatewayConfig) {
         return new PropertiesFileServiceDiscovery();
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/SneakyServiceDiscoveryImpl.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/SneakyServiceDiscoveryImpl.java
@@ -20,6 +20,8 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
+import java.util.Collection;
+
 public class SneakyServiceDiscoveryImpl implements ServiceDiscovery {
     @Override
     public String getType() {
@@ -28,6 +30,11 @@ public class SneakyServiceDiscoveryImpl implements ServiceDiscovery {
 
     @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName) {
+        return null;
+    }
+
+    @Override
+    public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
         return null;
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/SneakyServiceDiscoveryType.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/discovery/test/extension/SneakyServiceDiscoveryType.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.test.extension;
 
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryType;
 
@@ -26,7 +27,7 @@ public class SneakyServiceDiscoveryType implements ServiceDiscoveryType {
     }
 
     @Override
-    public ServiceDiscovery newInstance() {
+    public ServiceDiscovery newInstance(GatewayConfig gatewayConfig) {
         return new SneakyServiceDiscoveryImpl();
     }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -109,6 +109,8 @@ public interface GatewayConfig {
 
   String PROXYUSER_SERVICES_IGNORE_DOAS = "gateway.proxyuser.services.ignore.doas";
 
+  long DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL = 600; // 10 minutes
+
   /**
    * The location of the gateway configuration.
    * Subdirectories will be: topologies
@@ -681,6 +683,11 @@ public interface GatewayConfig {
    * @return the monitoring interval (in milliseconds) of Cloudera Manager advanced service discovery configuration
    */
   long getClouderaManagerAdvancedServiceDiscoveryConfigurationMonitoringInterval();
+
+  /**
+   * @return the entry TTL in seconds in CM service discovery repository cache where we store service/role configurations
+   */
+  long getClouderaManagerServiceDiscoveryRepositoryEntryTTL();
 
   /**
    * @return true, if state for tokens issued by the Knox Token service should be managed by Knox.

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ServiceDiscovery.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ServiceDiscovery.java
@@ -18,6 +18,7 @@ package org.apache.knox.gateway.topology.discovery;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -47,6 +48,18 @@ public interface ServiceDiscovery {
      * @return The discovered service data for the specified cluster
      */
     Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName);
+
+    /**
+     * Discover details for a single cluster filtered by the given <code>services</code> list.
+     *
+     * @param gwConfig The gateway configuration
+     * @param config The configuration for the discovery invocation
+     * @param clusterName The name of a particular cluster
+     * @param includedServices The list of service names to be discovered. If that's set to <code>null</code> or <code>an empty collection</code>, all services within the given cluster will be discovered.
+     *
+     * @return The discovered service data for the specified cluster
+     */
+    Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices);
 
 
     /**

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ServiceDiscoveryType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/discovery/ServiceDiscoveryType.java
@@ -16,6 +16,8 @@
  */
 package org.apache.knox.gateway.topology.discovery;
 
+import org.apache.knox.gateway.config.GatewayConfig;
+
 /**
  * ServiceDiscovery extensions must implement this interface to add support for a new discovery source.
  *
@@ -35,6 +37,6 @@ public interface ServiceDiscoveryType {
      *
      * @return A new instance of the ServiceDiscovery implementation provided by this type.
      */
-    ServiceDiscovery newInstance();
+    ServiceDiscovery newInstance(GatewayConfig gatewayConfig);
 
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -792,6 +792,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public long getClouderaManagerServiceDiscoveryRepositoryEntryTTL() {
+    return 0;
+  }
+
+  @Override
   public boolean isServerManagedTokenStateEnabled() {
     return false;
   }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -42,6 +42,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -301,6 +302,11 @@ public class SimpleDescriptorHandlerFuncTest {
           return null;
         }
       };
+    }
+
+    @Override
+    public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
+      return null;
     }
   }
 }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -266,7 +266,7 @@ public class SimpleDescriptorHandlerFuncTest {
     }
 
     @Override
-    public ServiceDiscovery newInstance() {
+    public ServiceDiscovery newInstance(GatewayConfig gatewayConfig) {
       return new NoOpServiceDiscovery();
     }
   }
@@ -306,7 +306,7 @@ public class SimpleDescriptorHandlerFuncTest {
 
     @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
-      return null;
+      return discover(gwConfig, config, clusterName);
     }
   }
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -43,6 +43,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -247,7 +248,8 @@ public class SimpleDescriptorHandler {
             discoveryInstances.put(discoveryType, sd);
         }
 
-        return sd.discover(config, sdc, desc.getCluster());
+        final Collection<String> includedServices = desc.getServices().stream().map(service -> service.getName()).collect(Collectors.toSet());
+        return sd.discover(config, sdc, desc.getCluster(), includedServices);
     }
 
 

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -71,7 +71,7 @@ public class SimpleDescriptorHandler {
      */
     public static final String RESULT_REFERENCE = "reference";
 
-    private static final String DEFAULT_DISCOVERY_TYPE = "AMBARI";
+    private static final String DEFAULT_DISCOVERY_TYPE = "ClouderaManager";
 
     private static final String[] PROVIDER_CONFIG_FILE_EXTENSIONS;
     static {
@@ -241,7 +241,7 @@ public class SimpleDescriptorHandler {
         // Use the cached discovery object for the required type, if it has already been loaded
         ServiceDiscovery sd = discoveryInstances.get(discoveryType);
         if (sd == null) {
-            sd = ServiceDiscoveryFactory.get(discoveryType, gatewayServices);
+            sd = ServiceDiscoveryFactory.get(discoveryType, config, gatewayServices);
             if (sd == null) {
                 throw new IllegalArgumentException("Unsupported service discovery type: " + discoveryType);
             }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two major changes are included (in two separate commits):
- the first is that Knox only discovers services that are actually listed in the given descriptor (instead of discovering the entire cluster)
- from now on, Knox maintains an in-memory repository of discovered data (cluster, service, and role configs). I used Caffeine as the cache implementation with the default of 10 mins of cache entry TTL.

## How was this patch tested?

Added/updated new/existing uni tests and ran comprehensive manual tests with different combinations of descriptors and services.