### PR TITLE
KNOX-2704 - Honor request id (correlation id) set by upstream loadbalancer

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -38,6 +38,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
 import org.apache.knox.gateway.audit.api.AuditContext;
@@ -59,6 +60,8 @@ import org.apache.knox.gateway.util.ServletRequestUtils;
 import org.apache.knox.gateway.util.urltemplate.Matcher;
 import org.apache.knox.gateway.util.urltemplate.Parser;
 import org.apache.knox.gateway.util.urltemplate.Template;
+
+import static org.apache.knox.gateway.filter.CorrelationHandler.REQUEST_ID_HEADER_NAME;
 
 public class GatewayFilter implements Filter {
 
@@ -150,7 +153,13 @@ public class GatewayFilter implements Filter {
       }
     }
 
-    assignCorrelationRequestId();
+    /* If request contains X-Request-Id header use it else use random uuid as correlation id */
+    final String req_id = ((HttpServletRequest) servletRequest).getHeader(REQUEST_ID_HEADER_NAME);
+    if (StringUtils.isBlank(req_id)) {
+      assignCorrelationRequestId(UUID.randomUUID().toString());
+    } else {
+      assignCorrelationRequestId(req_id);
+    }
     // Populate Audit/correlation parameters
     AuditContext auditContext = auditService.getContext();
     if(auditContext == null) {
@@ -236,11 +245,11 @@ public class GatewayFilter implements Filter {
   }
 
   // Now creating the correlation context only if required since it may be created upstream in the CorrelationHandler.
-  private void assignCorrelationRequestId() {
+  private void assignCorrelationRequestId(final String requestID) {
     CorrelationService correlationService = CorrelationServiceFactory.getCorrelationService();
     CorrelationContext correlationContext = correlationService.getContext();
     if( correlationContext == null ) {
-      correlationService.attachContext(new Log4jCorrelationContext(UUID.randomUUID().toString(), null, null));
+      correlationService.attachContext(new Log4jCorrelationContext(requestID, null, null));
     }
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -154,11 +154,11 @@ public class GatewayFilter implements Filter {
     }
 
     /* If request contains X-Request-Id header use it else use random uuid as correlation id */
-    final String req_id = ((HttpServletRequest) servletRequest).getHeader(REQUEST_ID_HEADER_NAME);
-    if (StringUtils.isBlank(req_id)) {
+    final String reqID = ((HttpServletRequest) servletRequest).getHeader(REQUEST_ID_HEADER_NAME);
+    if (StringUtils.isBlank(reqID)) {
       assignCorrelationRequestId(UUID.randomUUID().toString());
     } else {
-      assignCorrelationRequestId(req_id);
+      assignCorrelationRequestId(reqID);
     }
     // Populate Audit/correlation parameters
     AuditContext auditContext = auditService.getContext();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/filter/CorrelationHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/filter/CorrelationHandler.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.audit.api.CorrelationService;
 import org.apache.knox.gateway.audit.api.CorrelationServiceFactory;
 import org.apache.knox.gateway.audit.log4j.correlation.Log4jCorrelationContext;
@@ -30,13 +31,17 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 
 public class CorrelationHandler extends HandlerWrapper {
+  public static final String REQUEST_ID_HEADER_NAME = "X-Request-Id";
 
   @Override
   public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
       throws IOException, ServletException {
     CorrelationService correlationService = CorrelationServiceFactory.getCorrelationService();
+    /* If request id is specified use it */
+    final String req_id = request.getHeader(REQUEST_ID_HEADER_NAME);
     correlationService.attachContext(
-            new Log4jCorrelationContext(UUID.randomUUID().toString(), null, null));
+            new Log4jCorrelationContext(StringUtils.isBlank(req_id) ? UUID.randomUUID().toString() : req_id,
+                null, null));
     try {
       super.handle( target, baseRequest, request, response );
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The PR adds a feature where, when a request comes to Knox with  header `X-Request-Id` then use that as a correlation id. This is useful to track requests that originate from other services or LBs and users need ability to trace requests.

## How was this patch tested?
This patch was tested locally on a local cluster.

