### PR TITLE
KNOX-2705 - Add correlation id to logs as trace_id

### DIFF
--- a/gateway-release/home/conf/gateway-log4j2.xml
+++ b/gateway-release/home/conf/gateway-log4j2.xml
@@ -32,7 +32,7 @@
         </Console>
         <RollingFile name="drfa" fileName="${app.log.dir}/${app.log.file}" filePattern="${app.log.dir}/${app.log.file}.%d{yyyy-MM-dd}">
             <!-- Same as ISO8601 format but without the 'T' (log4j1 compatible) -->
-            <PatternLayout pattern="%d{yyyy-MM-dd' 'HH:mm:ss,SSS} %-5p %c{2} (%F:%M(%L)) - %m%n" />
+            <PatternLayout pattern="%d{yyyy-MM-dd' 'HH:mm:ss,SSS} %X{trace_id} %-5p %c{2} (%F:%M(%L)) - %m%n" />
             <TimeBasedTriggeringPolicy />
         </RollingFile>
 <!--        <RollingFile name="httpclient" fileName="${app.log.dir}/${launcher.name}-http-client.log" filePattern="${app.log.dir}/${launcher.name}-http-client.log.%d{yyyy-MM-dd}">-->

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -154,12 +154,13 @@ public class GatewayFilter implements Filter {
     }
 
     /* If request contains X-Request-Id header use it else use random uuid as correlation id */
-    final String reqID = ((HttpServletRequest) servletRequest).getHeader(REQUEST_ID_HEADER_NAME);
-    if (StringUtils.isBlank(reqID)) {
-      assignCorrelationRequestId(UUID.randomUUID().toString());
-    } else {
-      assignCorrelationRequestId(reqID);
-    }
+    final String reqID =
+        StringUtils.isBlank(((HttpServletRequest) servletRequest).getHeader(REQUEST_ID_HEADER_NAME)) ?
+            UUID.randomUUID().toString() :
+            ((HttpServletRequest) servletRequest).getHeader(REQUEST_ID_HEADER_NAME);
+
+    assignCorrelationRequestId(reqID);
+
     // Populate Audit/correlation parameters
     AuditContext auditContext = auditService.getContext();
     if(auditContext == null) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/filter/CorrelationHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/filter/CorrelationHandler.java
@@ -27,22 +27,28 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.audit.api.CorrelationService;
 import org.apache.knox.gateway.audit.api.CorrelationServiceFactory;
 import org.apache.knox.gateway.audit.log4j.correlation.Log4jCorrelationContext;
+import org.apache.logging.log4j.CloseableThreadContext;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 
 public class CorrelationHandler extends HandlerWrapper {
   public static final String REQUEST_ID_HEADER_NAME = "X-Request-Id";
+  public static final String TRACE_ID = "trace_id";
 
   @Override
   public void handle( String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response )
       throws IOException, ServletException {
     CorrelationService correlationService = CorrelationServiceFactory.getCorrelationService();
-    /* If request id is specified use it */
-    final String req_id = request.getHeader(REQUEST_ID_HEADER_NAME);
+    /* If request contains X-Request-Id header use it else use random uuid as correlation id */
+    final String reqID =
+        StringUtils.isBlank(request.getHeader(REQUEST_ID_HEADER_NAME)) ?
+            UUID.randomUUID().toString() :
+            request.getHeader(REQUEST_ID_HEADER_NAME);
+
     correlationService.attachContext(
-            new Log4jCorrelationContext(StringUtils.isBlank(req_id) ? UUID.randomUUID().toString() : req_id,
+            new Log4jCorrelationContext(reqID,
                 null, null));
-    try {
+    try(CloseableThreadContext.Instance ctc = CloseableThreadContext.put(TRACE_ID, reqID)) {
       super.handle( target, baseRequest, request, response );
     } finally {
       correlationService.detachContext();

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -159,6 +159,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>de.thetaphi</groupId>
             <artifactId>forbiddenapis</artifactId>
         </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds correlation id generated by Knox to gateway logs. In case where a request comes to Knox with header `X-Request-Id` that value is logged instead as trace id. This feature can be turned off by removing `%X{trace_id}` variable from `gateway-log4j2.xml` file.

Correlation is a random UUID or 16 random bytes, in hexadecimal if [generated by nginx](https://www.nginx.com/blog/application-tracing-nginx-plus/). 

One thing to note is that with this PR if correlation id is present it will be logged so it will slightly increase log size. 

## How was this patch tested?
Tested locally on single knox instance.
e.g.

`
curl -k -u guest:guest-password -X GET -H "X-Request-Id: 1234567890ABCD" https://localhost:8443/gateway/sandbox/webhdfs/v1/tmp/hello.txt\?op\=LISTSTATUS
`

```
==> /Users/smore/dev/committer/knox/install/knox-2.0.0-SNAPSHOT/logs/gateway.log <==
2022-02-15 14:05:42,850 1234567890ABCD INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=guest,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: guest

==> /Users/smore/dev/committer/knox/install/knox-2.0.0-SNAPSHOT/logs/gateway-audit.log <==
22/02/15 14:05:43 ||1234567890ABCD|audit|127.0.0.1|WEBHDFS|guest|||authentication|uri|/gateway/sandbox/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS|success|
22/02/15 14:05:43 ||1234567890ABCD|audit|127.0.0.1|WEBHDFS|guest|||authentication|uri|/gateway/sandbox/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS|success|Groups: []
22/02/15 14:05:43 ||1234567890ABCD|audit|127.0.0.1|WEBHDFS|guest|||dispatch|uri|http://localhost:50070/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS&user.name=guest|unavailable|Request method: GET
22/02/15 14:05:44 ||1234567890ABCD|audit|127.0.0.1|WEBHDFS|guest|||dispatch|uri|http://localhost:50070/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS&user.name=guest|failure|
```

`curl -k -u guest:guest-password -X GET  https://localhost:8443/gateway/sandbox/webhdfs/v1/tmp/hello.txt\?op\=LISTSTATUS`

```
==> /Users/smore/dev/committer/knox/install/knox-2.0.0-SNAPSHOT/logs/gateway.log <==
2022-02-15 14:08:39,713 123549b8-8f7f-4301-9d81-dbeefb842652 INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=guest,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: guest

==> /Users/smore/dev/committer/knox/install/knox-2.0.0-SNAPSHOT/logs/gateway-audit.log <==
22/02/15 14:08:39 ||123549b8-8f7f-4301-9d81-dbeefb842652|audit|127.0.0.1|WEBHDFS|guest|||authentication|uri|/gateway/sandbox/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS|success|
22/02/15 14:08:39 ||123549b8-8f7f-4301-9d81-dbeefb842652|audit|127.0.0.1|WEBHDFS|guest|||authentication|uri|/gateway/sandbox/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS|success|Groups: []
22/02/15 14:08:39 ||123549b8-8f7f-4301-9d81-dbeefb842652|audit|127.0.0.1|WEBHDFS|guest|||dispatch|uri|http://localhost:50070/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS&user.name=guest|unavailable|Request method: GET
22/02/15 14:08:40 ||123549b8-8f7f-4301-9d81-dbeefb842652|audit|127.0.0.1|WEBHDFS|guest|||dispatch|uri|http://localhost:50070/webhdfs/v1/tmp/hello.txt?op=LISTSTATUS&user.name=guest|failure|
```