### PR TITLE
KNOX-2707 - Virtual Group Mapping Provider

### DIFF
--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -104,6 +104,11 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.velocity</groupId>

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
@@ -33,18 +33,18 @@ public interface IdentityAsserterMessages {
   @Message( level = MessageLevel.WARN, text = "Invalid mapping parameter name: Missing required group name.")
   void missingVirtualGroupName();
 
-  @Message( level = MessageLevel.WARN, text = "Invalid mapping, parse error: {2}. At {0}={1}")
+  @Message( level = MessageLevel.WARN, text = "Invalid mapping {0}={1}, Parse error: {2}")
   void parseError(String key, String script, SyntaxException e);
 
-  @Message( level = MessageLevel.WARN, text = "Invalid result: {2}. Expected boolean when evaluating: {1}. For virtualGroup: {0}")
+  @Message( level = MessageLevel.WARN, text = "Invalid result: {2}. Expected boolean when evaluating group {0} mapping value {1}.")
   void invalidResult(String virtualGroupName, Ast ast, Object result);
 
-  @Message( level = MessageLevel.DEBUG, text = "Adding user: {0} to virtual group: {1} using predicate: {2}")
+  @Message( level = MessageLevel.DEBUG, text = "Adding user {0} to group {1} based on predicate {2}")
   void addingUserToVirtualGroup(String username, String virtualGroupName, Ast ast);
 
-  @Message( level = MessageLevel.DEBUG, text = "Checking user: {0} (with groups: {1}) whether to add virtualGroup: {2} using predicate: {3}")
+  @Message( level = MessageLevel.DEBUG, text = "Checking whether user {0} (with group(s) {1}) should be added to group {2} based on predicate {3}")
   void checkingVirtualGroup(String userName, Set<String> userGroups, String virtualGroupName, Ast ast);
 
-  @Message( level = MessageLevel.DEBUG, text = "User: {0} (with groups: {1}) added to virtual groups: {2}")
-  void virtualGroups(String userName, Set<String> strings, Set<String> virtualGroups);
+  @Message( level = MessageLevel.DEBUG, text = "User {0} (with group(s) {1}) added to group(s) {2}")
+  void virtualGroups(String userName, Set<String> userGroups, Set<String> virtualGroups);
 }

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
-import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.AbstractSyntaxTree;
 import org.apache.knox.gateway.plang.SyntaxException;
 
 @Messages(logger="org.apache.knox.gateway")
@@ -37,13 +37,13 @@ public interface IdentityAsserterMessages {
   void parseError(String key, String script, SyntaxException e);
 
   @Message( level = MessageLevel.WARN, text = "Invalid result: {2}. Expected boolean when evaluating group {0} mapping value {1}.")
-  void invalidResult(String virtualGroupName, Ast ast, Object result);
+  void invalidResult(String virtualGroupName, AbstractSyntaxTree ast, Object result);
 
   @Message( level = MessageLevel.DEBUG, text = "Adding user {0} to group {1} based on predicate {2}")
-  void addingUserToVirtualGroup(String username, String virtualGroupName, Ast ast);
+  void addingUserToVirtualGroup(String username, String virtualGroupName, AbstractSyntaxTree ast);
 
   @Message( level = MessageLevel.DEBUG, text = "Checking whether user {0} (with group(s) {1}) should be added to group {2} based on predicate {3}")
-  void checkingVirtualGroup(String userName, Set<String> userGroups, String virtualGroupName, Ast ast);
+  void checkingVirtualGroup(String userName, Set<String> userGroups, String virtualGroupName, AbstractSyntaxTree ast);
 
   @Message( level = MessageLevel.DEBUG, text = "User {0} (with group(s) {1}) added to group(s) {2}")
   void virtualGroups(String userName, Set<String> userGroups, Set<String> virtualGroups);

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
@@ -30,10 +30,10 @@ public interface IdentityAsserterMessages {
   @Message( level = MessageLevel.ERROR, text = "Required subject/identity not available.  Check authentication/federation provider for proper configuration." )
   void subjectNotAvailable();
 
-  @Message( level = MessageLevel.WARN, text = "Virtual group name is missing after dot character.")
+  @Message( level = MessageLevel.WARN, text = "Invalid mapping parameter name: Missing required group name.")
   void missingVirtualGroupName();
 
-  @Message( level = MessageLevel.WARN, text = "Parse error: {2}. At {0}={1}")
+  @Message( level = MessageLevel.WARN, text = "Invalid mapping, parse error: {2}. At {0}={1}")
   void parseError(String key, String script, SyntaxException e);
 
   @Message( level = MessageLevel.WARN, text = "Invalid result: {2}. Expected boolean when evaluating: {1}. For virtualGroup: {0}")
@@ -42,12 +42,9 @@ public interface IdentityAsserterMessages {
   @Message( level = MessageLevel.DEBUG, text = "Adding user: {0} to virtual group: {1} using predicate: {2}")
   void addingUserToVirtualGroup(String username, String virtualGroupName, Ast ast);
 
-  @Message( level = MessageLevel.DEBUG, text = "Not adding user: {0} to virtual group: {1} using predicate: {2}")
-  void notAddingUserToVirtualGroup(String username, String virtualGroupName, Ast ast);
-
   @Message( level = MessageLevel.DEBUG, text = "Checking user: {0} (with groups: {1}) whether to add virtualGroup: {2} using predicate: {3}")
   void checkingVirtualGroup(String userName, Set<String> userGroups, String virtualGroupName, Ast ast);
 
-  @Message( level = MessageLevel.INFO, text = "User: {0} (with groups: {1}) added to virtual groups: {2}")
+  @Message( level = MessageLevel.DEBUG, text = "User: {0} (with groups: {1}) added to virtual groups: {2}")
   void virtualGroups(String userName, Set<String> strings, Set<String> virtualGroups);
 }

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
@@ -17,12 +17,37 @@
  */
 package org.apache.knox.gateway;
 
+import java.util.Set;
+
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
+import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.SyntaxException;
 
 @Messages(logger="org.apache.knox.gateway")
 public interface IdentityAsserterMessages {
   @Message( level = MessageLevel.ERROR, text = "Required subject/identity not available.  Check authentication/federation provider for proper configuration." )
   void subjectNotAvailable();
+
+  @Message( level = MessageLevel.WARN, text = "Virtual group name is missing after dot character.")
+  void missingVirtualGroupName();
+
+  @Message( level = MessageLevel.WARN, text = "Parse error: {2}. At {0}={1}")
+  void parseError(String key, String script, SyntaxException e);
+
+  @Message( level = MessageLevel.WARN, text = "Invalid result: {2}. Expected boolean when evaluating: {1}. For virtualGroup: {0}")
+  void invalidResult(String virtualGroupName, Ast ast, Object result);
+
+  @Message( level = MessageLevel.DEBUG, text = "Adding user: {0} to virtual group: {1} using predicate: {2}")
+  void addingUserToVirtualGroup(String username, String virtualGroupName, Ast ast);
+
+  @Message( level = MessageLevel.DEBUG, text = "Not adding user: {0} to virtual group: {1} using predicate: {2}")
+  void notAddingUserToVirtualGroup(String username, String virtualGroupName, Ast ast);
+
+  @Message( level = MessageLevel.DEBUG, text = "Checking user: {0} (with groups: {1}) whether to add virtualGroup: {2} using predicate: {3}")
+  void checkingVirtualGroup(String userName, Set<String> userGroups, String virtualGroupName, Ast ast);
+
+  @Message( level = MessageLevel.INFO, text = "User: {0} (with groups: {1}) added to virtual groups: {2}")
+  void virtualGroups(String userName, Set<String> strings, Set<String> virtualGroups);
 }

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
@@ -40,7 +40,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.IdentityAsserterMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.AbstractSyntaxTree;
 import org.apache.knox.gateway.plang.Parser;
 import org.apache.knox.gateway.plang.SyntaxException;
 import org.apache.knox.gateway.security.GroupPrincipal;
@@ -77,8 +77,8 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
     virtualGroupMapper = new VirtualGroupMapper(loadVirtualGroups(filterConfig));
   }
 
-  private Map<String, Ast> loadVirtualGroups(FilterConfig filterConfig) {
-    Map<String, Ast> predicateToGroupMapping = new HashMap<>();
+  private Map<String, AbstractSyntaxTree> loadVirtualGroups(FilterConfig filterConfig) {
+    Map<String, AbstractSyntaxTree> predicateToGroupMapping = new HashMap<>();
     loadVirtualGroupConfig(filterConfig, predicateToGroupMapping);
     if (predicateToGroupMapping.isEmpty() && filterConfig.getServletContext() != null) {
       loadVirtualGroupConfig(filterConfig.getServletContext(), predicateToGroupMapping);
@@ -89,10 +89,10 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
     return predicateToGroupMapping;
   }
 
-  private void loadVirtualGroupConfig(FilterConfig config, Map<String, Ast> result) {
+  private void loadVirtualGroupConfig(FilterConfig config, Map<String, AbstractSyntaxTree> result) {
     for (String paramName : virtualGroupParameterNames(config.getInitParameterNames())) {
       try {
-        Ast ast = parser.parse(config.getInitParameter(paramName));
+        AbstractSyntaxTree ast = parser.parse(config.getInitParameter(paramName));
         result.put(paramName.substring(VIRTUAL_GROUP_MAPPING_PREFIX.length()).trim(), ast);
       } catch (SyntaxException e) {
         LOG.parseError(paramName, config.getInitParameter(paramName), e);
@@ -100,10 +100,10 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
     }
   }
 
-  private void loadVirtualGroupConfig(ServletContext context, Map<String, Ast> result) {
+  private void loadVirtualGroupConfig(ServletContext context, Map<String, AbstractSyntaxTree> result) {
     for (String paramName : virtualGroupParameterNames(context.getInitParameterNames())) {
       try {
-        Ast ast = parser.parse(context.getInitParameter(paramName));
+        AbstractSyntaxTree ast = parser.parse(context.getInitParameter(paramName));
         result.put(paramName.substring(VIRTUAL_GROUP_MAPPING_PREFIX.length()).trim(), ast);
       } catch (SyntaxException e) {
         LOG.parseError(paramName, context.getInitParameter(paramName), e);

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
@@ -150,7 +150,7 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
     mappedPrincipalName = mapUserPrincipal(mappedPrincipalName);
     String[] mappedGroups = mapGroupPrincipalsBase(mappedPrincipalName, subject);
     String[] groups = mapGroupPrincipals(mappedPrincipalName, subject);
-    String[] virtualGroups = virtualGroupMapper.virtualGroupsOfUser(mappedPrincipalName, groups(subject), request).toArray(new String[0]);
+    String[] virtualGroups = virtualGroupMapper.mapGroups(mappedPrincipalName, groups(subject), request).toArray(new String[0]);
     groups = combineGroupMappings(mappedGroups, groups);
     groups = combineGroupMappings(virtualGroups, groups);
 

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
@@ -48,7 +48,7 @@ import org.apache.knox.gateway.security.principal.PrincipalMappingException;
 import org.apache.knox.gateway.security.principal.SimplePrincipalMapper;
 
 public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilter {
-  public static final String VIRTUAL_GROUP_MAPPING_PREFIX = "virtual.group.mapping.";
+  public static final String VIRTUAL_GROUP_MAPPING_PREFIX = "group.mapping.";
   private IdentityAsserterMessages LOG = MessagesFactory.get(IdentityAsserterMessages.class);
 
   public static final String GROUP_PRINCIPAL_MAPPING = "group.principal.mapping";

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
@@ -42,7 +42,7 @@ public class VirtualGroupMapper {
     /**
      *  @return all virtual groups where the corresponding predicate matches
      */
-    public Set<String> virtualGroupsOfUser(String username, Set<String> groups, ServletRequest request) {
+    public Set<String> mapGroups(String username, Set<String> groups, ServletRequest request) {
         Set<String> virtualGroups = new HashSet<>();
         for (Map.Entry<String, Ast> each : virtualGroupToPredicateMap.entrySet()) {
             String virtualGroupName = each.getKey();
@@ -50,8 +50,6 @@ public class VirtualGroupMapper {
             if (evalPredicate(virtualGroupName, username, groups, predicate, request)) {
                 virtualGroups.add(virtualGroupName);
                 LOG.addingUserToVirtualGroup(username, virtualGroupName, predicate);
-            } else {
-                LOG.notAddingUserToVirtualGroup(username, virtualGroupName, predicate);
             }
         }
         LOG.virtualGroups(username, groups, virtualGroups);

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
@@ -28,14 +28,14 @@ import javax.servlet.http.HttpSession;
 import org.apache.knox.gateway.IdentityAsserterMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.plang.Arity;
-import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.AbstractSyntaxTree;
 import org.apache.knox.gateway.plang.Interpreter;
 
 public class VirtualGroupMapper {
     private final IdentityAsserterMessages LOG = MessagesFactory.get(IdentityAsserterMessages.class);
-    private final Map<String, Ast> virtualGroupToPredicateMap;
+    private final Map<String, AbstractSyntaxTree> virtualGroupToPredicateMap;
 
-    public VirtualGroupMapper(Map<String, Ast> virtualGroupToPredicateMap) {
+    public VirtualGroupMapper(Map<String, AbstractSyntaxTree> virtualGroupToPredicateMap) {
         this.virtualGroupToPredicateMap = virtualGroupToPredicateMap;
     }
 
@@ -44,9 +44,9 @@ public class VirtualGroupMapper {
      */
     public Set<String> mapGroups(String username, Set<String> groups, ServletRequest request) {
         Set<String> virtualGroups = new HashSet<>();
-        for (Map.Entry<String, Ast> each : virtualGroupToPredicateMap.entrySet()) {
+        for (Map.Entry<String, AbstractSyntaxTree> each : virtualGroupToPredicateMap.entrySet()) {
             String virtualGroupName = each.getKey();
-            Ast predicate = each.getValue();
+            AbstractSyntaxTree predicate = each.getValue();
             if (evalPredicate(virtualGroupName, username, groups, predicate, request)) {
                 virtualGroups.add(virtualGroupName);
                 LOG.addingUserToVirtualGroup(username, virtualGroupName, predicate);
@@ -59,7 +59,7 @@ public class VirtualGroupMapper {
     /**
      * @return true if the user should be added to the virtual group based on the given predicate
      */
-    private boolean evalPredicate(String virtualGroupName, String userName, Set<String> ldapGroups, Ast predicate, ServletRequest request) {
+    private boolean evalPredicate(String virtualGroupName, String userName, Set<String> ldapGroups, AbstractSyntaxTree predicate, ServletRequest request) {
         Interpreter interpreter = new Interpreter();
         interpreter.addConstant("username", userName);
         interpreter.addConstant("groups", new ArrayList<>(ldapGroups));

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.identityasserter.common.filter;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.apache.knox.gateway.IdentityAsserterMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.plang.Arity;
+import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.Interpreter;
+
+public class VirtualGroupMapper {
+    private final IdentityAsserterMessages LOG = MessagesFactory.get(IdentityAsserterMessages.class);
+    private final Map<String, Ast> virtualGroupToPredicateMap;
+
+    public VirtualGroupMapper(Map<String, Ast> virtualGroupToPredicateMap) {
+        this.virtualGroupToPredicateMap = virtualGroupToPredicateMap;
+    }
+
+    /**
+     *  @return all virtual groups where the corresponding predicate matches
+     */
+    public Set<String> virtualGroupsOfUser(String username, Set<String> groups, ServletRequest request) {
+        Set<String> virtualGroups = new HashSet<>();
+        for (Map.Entry<String, Ast> each : virtualGroupToPredicateMap.entrySet()) {
+            String virtualGroupName = each.getKey();
+            Ast predicate = each.getValue();
+            if (evalPredicate(virtualGroupName, username, groups, predicate, request)) {
+                virtualGroups.add(virtualGroupName);
+                LOG.addingUserToVirtualGroup(username, virtualGroupName, predicate);
+            } else {
+                LOG.notAddingUserToVirtualGroup(username, virtualGroupName, predicate);
+            }
+        }
+        LOG.virtualGroups(username, groups, virtualGroups);
+        return virtualGroups;
+    }
+
+    /**
+     * @return true if the user should be added to the virtual group based on the given predicate
+     */
+    private boolean evalPredicate(String virtualGroupName, String userName, Set<String> ldapGroups, Ast predicate, ServletRequest request) {
+        Interpreter interpreter = new Interpreter();
+        interpreter.addConstant("username", userName);
+        interpreter.addConstant("groups", new ArrayList<>(ldapGroups));
+        addRequestFunctions(request, interpreter);
+        LOG.checkingVirtualGroup(userName, ldapGroups, virtualGroupName, predicate);
+        Object result = interpreter.eval(predicate);
+        if (!(result instanceof Boolean)) {
+            LOG.invalidResult(virtualGroupName, predicate, result);
+            return false;
+        }
+        return (boolean)result;
+    }
+
+    private void addRequestFunctions(ServletRequest req, Interpreter interpreter) {
+        if (req instanceof HttpServletRequest) {
+            interpreter.addFunction("request-attribute", Arity.UNARY, params ->
+                    ensureNotNull(req.getAttribute((String)params.get(0))));
+            interpreter.addFunction("request-header", Arity.UNARY, params ->
+                    ensureNotNull(((HttpServletRequest) req).getHeader((String)params.get(0))));
+            interpreter.addFunction("session", Arity.UNARY, params ->
+                    ensureNotNull(sessionAttribute((HttpServletRequest) req, (String)params.get(0))));
+        }
+    }
+
+    private String ensureNotNull(Object value) {
+        return value == null ? "" : value.toString();
+    }
+
+    private Object sessionAttribute(HttpServletRequest req, String key) {
+        HttpSession session = req.getSession(false);
+        return session != null ? session.getAttribute(key) : "";
+    }
+}

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
@@ -111,7 +111,7 @@ public class VirtualGroupMapperTest {
     }
 
     private Set<String> virtualGroups(String user1, List<String> ldapGroups) {
-        return mapper.virtualGroupsOfUser(user1, new HashSet<>(ldapGroups), null);
+        return mapper.mapGroups(user1, new HashSet<>(ldapGroups), null);
     }
 
     private static Set<String> setOf(String... strings) {

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.AbstractSyntaxTree;
 import org.apache.knox.gateway.plang.Parser;
 import org.junit.Test;
 
@@ -46,7 +46,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testEverybodyGroup() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
                 put("everybody", parser.parse("true"));
         }});
         assertEquals(setOf("everybody"), virtualGroups("user1", emptyList()));
@@ -55,7 +55,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testNobodyGroup() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
             put("nobody", parser.parse("false"));
         }});
         assertEquals(0, virtualGroups("user1", emptyList()).size());
@@ -64,7 +64,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testMember() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
             put("vg1", parser.parse("(member 'g1')"));
             put("vg2", parser.parse("(member 'g2')"));
             put("both", parser.parse("(and (member 'g1') (member 'g2'))"));
@@ -78,7 +78,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testAtLeastOne() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
             put("at-least-one", parser.parse("(!= 0 (size groups))"));
         }});
         assertEquals(0, virtualGroups("user1", emptyList()).size());
@@ -89,7 +89,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testEmptyGroup() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
             put("empty", parser.parse("(= 0 (size groups))"));
         }});
         assertEquals(setOf("empty"), virtualGroups("user1", emptyList()));
@@ -98,7 +98,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testMatchUser() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
             put("users", parser.parse("(match username 'user_\\d+')"));
         }});
         assertEquals(setOf("users"), virtualGroups("user_1", emptyList()));
@@ -108,7 +108,7 @@ public class VirtualGroupMapperTest {
 
     @Test
     public void testMatchGroup() {
-        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+        mapper = new VirtualGroupMapper(new HashMap<String, AbstractSyntaxTree>(){{
             put("grp", parser.parse("(match groups 'grp_\\d+')"));
         }});
         assertEquals(setOf("grp"), virtualGroups("user1", singletonList("grp_1")));

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +37,12 @@ import org.junit.Test;
 public class VirtualGroupMapperTest {
     private Parser parser = new Parser();
     private VirtualGroupMapper mapper;
+
+    @Test
+    public void testWithEmptyConfig() {
+        mapper = new VirtualGroupMapper(Collections.emptyMap());
+        assertEquals(Collections.emptySet(), virtualGroups("user1", emptyList()));
+    }
 
     @Test
     public void testEverybodyGroup() {

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapperTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.identityasserter.common.filter;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.knox.gateway.plang.Ast;
+import org.apache.knox.gateway.plang.Parser;
+import org.junit.Test;
+
+@SuppressWarnings("PMD.NonStaticInitializer")
+public class VirtualGroupMapperTest {
+    private Parser parser = new Parser();
+    private VirtualGroupMapper mapper;
+
+    @Test
+    public void testEverybodyGroup() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+                put("everybody", parser.parse("true"));
+        }});
+        assertEquals(setOf("everybody"), virtualGroups("user1", emptyList()));
+        assertEquals(setOf("everybody"), virtualGroups("user2", asList("a", "b", "c")));
+    }
+
+    @Test
+    public void testNobodyGroup() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+            put("nobody", parser.parse("false"));
+        }});
+        assertEquals(0, virtualGroups("user1", emptyList()).size());
+        assertEquals(0, virtualGroups("user2", asList("a", "b", "c")).size());
+    }
+
+    @Test
+    public void testMember() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+            put("vg1", parser.parse("(member 'g1')"));
+            put("vg2", parser.parse("(member 'g2')"));
+            put("both", parser.parse("(and (member 'g1') (member 'g2'))"));
+            put("none", parser.parse("(not (or (member 'g1') (member 'g2')))"));
+        }});
+        assertEquals(setOf("vg1"), virtualGroups("user1", singletonList("g1")));
+        assertEquals(setOf("vg2"), virtualGroups("user2", singletonList("g2")));
+        assertEquals(setOf("vg1","vg2", "both"), virtualGroups("user3", asList("g1", "g2")));
+        assertEquals(setOf("none"), virtualGroups("user4", singletonList("g4")));
+    }
+
+    @Test
+    public void testAtLeastOne() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+            put("at-least-one", parser.parse("(!= 0 (size groups))"));
+        }});
+        assertEquals(0, virtualGroups("user1", emptyList()).size());
+        assertEquals(setOf("at-least-one"), virtualGroups("user2", singletonList("g1")));
+        assertEquals(setOf("at-least-one"), virtualGroups("user3", asList("g1", "g2")));
+        assertEquals(setOf("at-least-one"), virtualGroups("user4", asList("g1", "g2", "g3")));
+    }
+
+    @Test
+    public void testEmptyGroup() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+            put("empty", parser.parse("(= 0 (size groups))"));
+        }});
+        assertEquals(setOf("empty"), virtualGroups("user1", emptyList()));
+        assertEquals(0, virtualGroups("user2", singletonList("any")).size());
+    }
+
+    @Test
+    public void testMatchUser() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+            put("users", parser.parse("(match username 'user_\\d+')"));
+        }});
+        assertEquals(setOf("users"), virtualGroups("user_1", emptyList()));
+        assertEquals(setOf("users"), virtualGroups("user_2", emptyList()));
+        assertEquals(0, virtualGroups("user2", emptyList()).size());
+    }
+
+    @Test
+    public void testMatchGroup() {
+        mapper = new VirtualGroupMapper(new HashMap<String, Ast>(){{
+            put("grp", parser.parse("(match groups 'grp_\\d+')"));
+        }});
+        assertEquals(setOf("grp"), virtualGroups("user1", singletonList("grp_1")));
+        assertEquals(setOf("grp"), virtualGroups("user2", asList("any", "grp_2")));
+        assertEquals(0, virtualGroups("user3", singletonList("grp2")).size());
+        assertEquals(0, virtualGroups("user4", emptyList()).size());
+    }
+
+    private Set<String> virtualGroups(String user1, List<String> ldapGroups) {
+        return mapper.virtualGroupsOfUser(user1, new HashSet<>(ldapGroups), null);
+    }
+
+    private static Set<String> setOf(String... strings) {
+        return new HashSet<>(Arrays.asList(strings));
+    }
+}

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
@@ -29,14 +29,16 @@ import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +46,7 @@ import static org.junit.Assert.assertTrue;
 public class CommonIdentityAssertionFilterTest {
   private String username;
   private Filter filter;
+  private Set<String> calculatedGroups = new HashSet<>();
 
   @Before
   public void setUp() {
@@ -67,13 +70,8 @@ public class CommonIdentityAssertionFilterTest {
 
       @Override
       protected String[] combineGroupMappings(String[] mappedGroups, String[] groups) {
-        String[] combined = super.combineGroupMappings(mappedGroups, groups);
-        assertEquals("LARRY", username);
-        assertTrue("Should be greater than 2", combined.length > 2);
-        assertTrue(combined[0], combined[0].equalsIgnoreCase("EVERYONE"));
-        assertTrue(combined[1].equalsIgnoreCase("USERS") || combined[1].equalsIgnoreCase("ADMIN"));
-        assertTrue(combined[2], combined[2].equalsIgnoreCase("USERS") || combined[2].equalsIgnoreCase("ADMIN"));
-        return combined;
+        calculatedGroups.addAll(Arrays.asList(super.combineGroupMappings(mappedGroups, groups)));
+        return super.combineGroupMappings(mappedGroups, groups);
       }
     };
   }
@@ -85,6 +83,14 @@ public class CommonIdentityAssertionFilterTest {
         andReturn("*=everyone;").once();
     EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).
         andReturn("ljm=lmccay;").once();
+    EasyMock.expect(config.getInitParameterNames()).
+            andReturn(Collections.enumeration(Arrays.asList(
+                    CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING,
+                    CommonIdentityAssertionFilter.PRINCIPAL_MAPPING,
+                    CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")))
+            .anyTimes();
+    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")).
+            andReturn("(and (member 'users') (member 'admin'))").anyTimes();
     EasyMock.replay( config );
 
     final HttpServletRequest request = EasyMock.createNiceMock( HttpServletRequest.class );
@@ -93,12 +99,7 @@ public class CommonIdentityAssertionFilterTest {
     final HttpServletResponse response = EasyMock.createNiceMock( HttpServletResponse.class );
     EasyMock.replay( response );
 
-    final FilterChain chain = new FilterChain() {
-      @Override
-      public void doFilter(ServletRequest request, ServletResponse response)
-          throws IOException, ServletException {
-      }
-    };
+    final FilterChain chain = (req, resp) -> {};
 
     Subject subject = new Subject();
     subject.getPrincipals().add(new PrimaryPrincipal("larry"));
@@ -107,14 +108,11 @@ public class CommonIdentityAssertionFilterTest {
     try {
       Subject.doAs(
         subject,
-        new PrivilegedExceptionAction<Object>() {
-          @Override
-          public Object run() throws Exception {
-            filter.init(config);
-            filter.doFilter(request, response, chain);
-            return null;
-          }
-        });
+              (PrivilegedExceptionAction<Object>) () -> {
+                filter.init(config);
+                filter.doFilter(request, response, chain);
+                return null;
+              });
     }
     catch (PrivilegedActionException e) {
       Throwable t = e.getCause();
@@ -128,5 +126,9 @@ public class CommonIdentityAssertionFilterTest {
         throw new ServletException(t);
       }
     }
+
+    assertEquals("LARRY", username);
+    assertTrue("Should be greater than 2", calculatedGroups.size() > 2);
+    assertTrue(calculatedGroups.containsAll(Arrays.asList("everyone", "USERS", "ADMIN", "test-virtual-group")));
   }
 }

--- a/gateway-provider-identity-assertion-hadoop-groups/src/test/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilterTest.java
+++ b/gateway-provider-identity-assertion-hadoop-groups/src/test/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilterTest.java
@@ -175,7 +175,7 @@ public class HadoopGroupProviderFilterTest {
             "(&amp;(|(objectclass=person)(objectclass=applicationProcess))(cn={0}))")
         .anyTimes();
     EasyMock.expect(config.getInitParameterNames())
-        .andReturn(Collections.enumeration((keysList))).anyTimes();
+            .andStubAnswer(() -> Collections.enumeration((keysList)));
 
     EasyMock.replay( config );
     EasyMock.replay( context );

--- a/gateway-provider-identity-assertion-pseudo/src/main/java/org/apache/knox/gateway/identityasserter/filter/IdentityAsserterDeploymentContributor.java
+++ b/gateway-provider-identity-assertion-pseudo/src/main/java/org/apache/knox/gateway/identityasserter/filter/IdentityAsserterDeploymentContributor.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.identityasserter.filter;
 
+import static org.apache.knox.gateway.identityasserter.common.filter.CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX;
+
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor;
 import org.apache.knox.gateway.topology.Provider;
@@ -37,9 +39,11 @@ public class IdentityAsserterDeploymentContributor extends AbstractIdentityAsser
     super.contributeProvider(context, provider);
     String mappings = provider.getParams().get(PRINCIPAL_MAPPING_PARAM_NAME);
     String groupMappings = provider.getParams().get(GROUP_PRINCIPAL_MAPPING_PARAM_NAME);
-
     context.getWebAppDescriptor().createContextParam().paramName(PRINCIPAL_MAPPING_PARAM_NAME).paramValue(mappings);
     context.getWebAppDescriptor().createContextParam().paramName(GROUP_PRINCIPAL_MAPPING_PARAM_NAME).paramValue(groupMappings);
+    provider.getParamsList().stream()
+            .filter(each -> each.getName().startsWith(VIRTUAL_GROUP_MAPPING_PREFIX))
+            .forEach(each -> context.getWebAppDescriptor().createContextParam().paramName(each.getName()).paramValue(each.getValue()));
   }
 
   @Override

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/AbstractSyntaxTree.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/AbstractSyntaxTree.java
@@ -29,15 +29,15 @@ import java.util.List;
  * The parser generates the following AST:
  *      [or, true, [and, false, true]]
  */
-public class Ast {
-    private final List<Ast> children = new ArrayList<>();
+public class AbstractSyntaxTree {
+    private final List<AbstractSyntaxTree> children = new ArrayList<>();
     private final String token;
 
-    public Ast(String token) {
+    public AbstractSyntaxTree(String token) {
         this.token = token;
     }
 
-    public void addChild(Ast child) {
+    public void addChild(AbstractSyntaxTree child) {
         children.add(child);
     }
 
@@ -55,15 +55,16 @@ public class Ast {
     }
 
     public boolean isNumber() {
-        if (token == null) {
-            return false;
+        boolean result = false;
+        if (token != null) {
+            try {
+                numValue();
+                result = true;
+            } catch (NumberFormatException e) {
+                // NaN
+            }
         }
-        try {
-            numValue();
-            return true;
-        } catch (NumberFormatException e) {
-            return false;
-        }
+        return result;
     }
 
     public Number numValue() {
@@ -75,6 +76,9 @@ public class Ast {
     }
 
     public String strValue() {
+        if (!isStr()) {
+            throw new InterpreterException("Token: " + token + " is not a String");
+        }
         return token.substring(1, token.length() -1);
     }
 
@@ -90,7 +94,7 @@ public class Ast {
         return children.get(0).token();
     }
 
-    public List<Ast> functionParameters() {
+    public List<AbstractSyntaxTree> functionParameters() {
         return children.subList(1, children.size());
     }
 }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Arity.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Arity.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import java.util.List;
+
+public interface Arity {
+    void check(String function, List<?> params);
+    Arity UNARY = Arity.of(1);
+    Arity BINARY = Arity.of(2);
+
+    static Arity of(int count) {
+        return (methodName, params) -> {
+            if (params.size() != count) {
+                throw new ArityException(methodName, count, params.size());
+            }
+        };
+    }
+    static Arity min(int count) {
+        return (methodName, params) -> {
+            if (params.size() < count) {
+                throw new ArityException("wrong number of arguments in call to '" + methodName
+                        + "'. Expected at least " + count + " got " + params.size() + ".");
+            }
+        };
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/ArityException.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/ArityException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.plang;
+
+public class ArityException extends InterpreterException {
+    public ArityException(String funcName, int formalCount, int actualCount) {
+        super("Wrong number of arguments in call to '" + funcName
+                + "'. Expected " + formalCount + " got " + actualCount + ".");
+    }
+
+    public ArityException(String message) {
+        super(message);
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Ast.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Ast.java
@@ -20,6 +20,15 @@ package org.apache.knox.gateway.plang;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Abstract Syntax Tree of the code.
+ *
+ * For example from the following code:
+ *      (or true (and false true))
+ *
+ * The parser generates the following AST:
+ *      [or, true, [and, false, true]]
+ */
 public class Ast {
     private final List<Ast> children = new ArrayList<>();
     private final String token;

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Ast.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Ast.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Ast {
+    private final List<Ast> children = new ArrayList<>();
+    private final String token;
+
+    public Ast(String token) {
+        this.token = token;
+    }
+
+    public void addChild(Ast child) {
+        children.add(child);
+    }
+
+    @Override
+    public String toString() {
+        return isAtom() ? token : children.toString();
+    }
+
+    public String token() {
+        return token;
+    }
+
+    public boolean isStr() {
+        return token != null && token.startsWith("'") && token.endsWith("'");
+    }
+
+    public boolean isNumber() {
+        if (token == null) {
+            return false;
+        }
+        try {
+            numValue();
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    public Number numValue() {
+        try {
+            return Long.parseLong(token);
+        } catch (NumberFormatException e) {
+            return Double.parseDouble(token);
+        }
+    }
+
+    public String strValue() {
+        return token.substring(1, token.length() -1);
+    }
+
+    public boolean isAtom() {
+        return !"(".equals(token);
+    }
+
+    public boolean isFunction() {
+        return !children.isEmpty();
+    }
+
+    public String functionName() {
+        return children.get(0).token();
+    }
+
+    public List<Ast> functionParameters() {
+        return children.subList(1, children.size());
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Interpreter.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Interpreter.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Interpreter {
+    private static final Logger LOG = LogManager.getLogger(Interpreter.class);
+    private final Map<String, SpecialForm> specialForms = new HashMap<>();
+    private final Map<String, Func> functions = new HashMap<>();
+    private final Map<String, Object> constants = new HashMap<>();
+
+    public interface Func {
+        Object call(List<Object> parameters);
+    }
+
+    private interface SpecialForm {
+        Object call(List<Ast> parameters);
+    }
+
+    public Interpreter() {
+        specialForms.put("or", args -> {
+            Arity.min(1).check("or", args);
+            return args.stream().anyMatch(each -> (boolean)eval(each));
+        });
+        specialForms.put("and", args -> {
+            Arity.min(1).check("and", args);
+            return args.stream().allMatch(each -> (boolean)eval(each));
+        });
+        addFunction("not", Arity.UNARY, args -> !(boolean)args.get(0));
+        addFunction("=", Arity.BINARY, args -> equalTo(args.get(0), args.get(1)));
+        addFunction("!=", Arity.BINARY, args -> !equalTo(args.get(0), args.get(1)));
+        addFunction("match", Arity.BINARY, args ->
+            args.get(0) instanceof String
+                ? Pattern.matches((String)args.get(1), (String)args.get(0))
+                : ((List<String>)(args.get(0))).stream().anyMatch(each -> Pattern.matches((String)args.get(1), each))
+        );
+        addFunction("size", Arity.UNARY, args -> ((Collection<?>) args.get(0)).size());
+        addFunction("empty", Arity.UNARY, args -> ((Collection<?>) args.get(0)).isEmpty());
+        addFunction("username", Arity.UNARY, args -> constants.get("username").equals(args.get(0)));
+        addFunction("member", Arity.UNARY, args -> ((List<String>)constants.get("groups")).contains((String)args.get(0)));
+        addFunction("lowercase", Arity.UNARY, args -> ((String)args.get(0)).toLowerCase(Locale.getDefault()));
+        addFunction("uppercase", Arity.UNARY, args -> ((String)args.get(0)).toUpperCase(Locale.getDefault()));
+        addFunction("print", Arity.min(1), args -> { // for debugging
+            args.forEach(arg -> LOG.info(arg == null ? "null" : arg.toString()));
+            return false;
+        });
+        constants.put("true", true);
+        constants.put("false", false);
+    }
+
+    private static boolean equalTo(Object a, Object b) {
+        if (a instanceof Number && b instanceof Number) {
+            return Double.compare(((Number)a).doubleValue(), ((Number)b).doubleValue()) == 0;
+        } else {
+            return a.equals(b);
+        }
+    }
+
+    public void addConstant(String name, Object value) {
+        constants.put(name, value);
+    }
+
+    public void addFunction(String name, Arity arity, Func func) {
+        functions.put(name, parameters -> {
+            arity.check(name, parameters);
+            return func.call(parameters);
+        });
+    }
+
+    public Object eval(Ast ast) {
+        try {
+            if (ast == null) {
+                return null;
+            } else if (ast.isAtom()) {
+                return ast.isStr() ? ast.strValue() : ast.isNumber() ? ast.numValue() : lookupConstant(ast);
+            } else if (ast.isFunction()) {
+                SpecialForm specialForm = specialForms.get(ast.functionName());
+                if (specialForm != null) {
+                    return specialForm.call(ast.functionParameters());
+                } else {
+                    Func func = functions.get(ast.functionName());
+                    if (func == null) {
+                        throw new UndefinedSymbolException(ast.functionName(), "function");
+                    }
+                    return func.call(ast.functionParameters().stream().map(this::eval).collect(toList()));
+                }
+            } else {
+                throw new InterpreterException("Unknown token: " + ast.token());
+            }
+        } catch (ClassCastException e) {
+            throw new TypeException("Type error at: " + ast, e);
+        }
+    }
+
+    private Object lookupConstant(Ast ast) {
+        Object var = constants.get(ast.token());
+        if (var == null) {
+            throw new UndefinedSymbolException(ast.token(), "variable");
+        }
+        return var;
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Interpreter.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Interpreter.java
@@ -40,7 +40,7 @@ public class Interpreter {
     }
 
     private interface SpecialForm {
-        Object call(List<Ast> parameters);
+        Object call(List<AbstractSyntaxTree> parameters);
     }
 
     public Interpreter() {
@@ -93,7 +93,7 @@ public class Interpreter {
         });
     }
 
-    public Object eval(Ast ast) {
+    public Object eval(AbstractSyntaxTree ast) {
         try {
             if (ast == null) {
                 return null;
@@ -118,7 +118,7 @@ public class Interpreter {
         }
     }
 
-    private Object lookupConstant(Ast ast) {
+    private Object lookupConstant(AbstractSyntaxTree ast) {
         Object var = constants.get(ast.token());
         if (var == null) {
             throw new UndefinedSymbolException(ast.token(), "variable");

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/InterpreterException.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/InterpreterException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+public class InterpreterException extends RuntimeException {
+    public InterpreterException(String message) {
+        super(message);
+    }
+
+    public InterpreterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Parser.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Parser.java
@@ -23,12 +23,12 @@ import java.io.StringReader;
 
 public class Parser {
 
-    public Ast parse(String str) {
+    public AbstractSyntaxTree parse(String str) {
         if (str == null || str.trim().equals("")) {
             return null;
         }
         try (PushbackReader reader = new PushbackReader(new StringReader(str))) {
-            Ast ast = parse(reader);
+            AbstractSyntaxTree ast = parse(reader);
             String rest = peek(reader);
             if (rest != null) {
                 throw new SyntaxException("Unexpected closing " + rest);
@@ -39,10 +39,10 @@ public class Parser {
         }
     }
 
-    private Ast parse(PushbackReader reader) throws IOException {
+    private AbstractSyntaxTree parse(PushbackReader reader) throws IOException {
         String token = nextToken(reader);
         if ("(".equals(token)) {
-            Ast children = new Ast(token);
+            AbstractSyntaxTree children = new AbstractSyntaxTree(token);
             while (!")".equals(peek(reader))) {
                 children.addChild(parse(reader));
             }
@@ -53,7 +53,7 @@ public class Parser {
         } else if ("".equals(token)) {
             throw new SyntaxException("Missing closing )");
         } else {
-            return new Ast(token);
+            return new AbstractSyntaxTree(token);
         }
     }
 

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Parser.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/Parser.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import java.io.IOException;
+import java.io.PushbackReader;
+import java.io.StringReader;
+
+public class Parser {
+
+    public Ast parse(String str) {
+        if (str == null || str.trim().equals("")) {
+            return null;
+        }
+        try (PushbackReader reader = new PushbackReader(new StringReader(str))) {
+            Ast ast = parse(reader);
+            String rest = peek(reader);
+            if (rest != null) {
+                throw new SyntaxException("Unexpected closing " + rest);
+            }
+            return ast;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Ast parse(PushbackReader reader) throws IOException {
+        String token = nextToken(reader);
+        if ("(".equals(token)) {
+            Ast children = new Ast(token);
+            while (!")".equals(peek(reader))) {
+                children.addChild(parse(reader));
+            }
+            nextToken(reader); // skip )
+            return children;
+        } else if (")".equals(token)) {
+            throw new SyntaxException("Unexpected closing )");
+        } else if ("".equals(token)) {
+            throw new SyntaxException("Missing closing )");
+        } else {
+            return new Ast(token);
+        }
+    }
+
+    private String nextToken(PushbackReader reader) throws IOException {
+        String chr = peek(reader);
+        if ("'".equals(chr)) {
+            return parseString(reader);
+        }
+        if ("(".equals(chr) || ")".equals(chr)) {
+            return String.valueOf((char) reader.read());
+        }
+        return parseAtom(reader);
+    }
+
+    private String parseAtom(PushbackReader reader) throws IOException {
+        StringBuilder buffer = new StringBuilder();
+        int chr = reader.read();
+        while (chr != -1 && !Character.isWhitespace(chr) && ')' != chr) {
+            buffer.append((char)chr);
+            chr = reader.read();
+        }
+        if (chr == ')') {
+            reader.unread(')');
+        }
+        return buffer.toString();
+    }
+
+    private String parseString(PushbackReader reader) throws IOException {
+        StringBuilder str = new StringBuilder();
+        str.append((char)reader.read());
+        int chr = reader.read();
+        while (chr != -1 && '\'' != chr) {
+            str.append((char)chr);
+            chr = reader.read();
+        }
+        if (chr == -1) {
+            throw new SyntaxException("Unterminated string");
+        }
+        return str.append("'").toString();
+    }
+
+    private String peek(PushbackReader reader) throws IOException {
+        int chr = reader.read();
+        while (chr != -1 && Character.isWhitespace(chr)) {
+            chr = reader.read();
+        }
+        if (chr == -1) {
+            return null;
+        }
+        reader.unread(chr);
+        return String.valueOf((char) chr);
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/SyntaxException.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/SyntaxException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+public class SyntaxException extends InterpreterException {
+    public SyntaxException(String message) {
+        super(message);
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/TypeException.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/TypeException.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+public class TypeException extends InterpreterException {
+    public TypeException(String message, Throwable exception) {
+        super(message, exception);
+    }
+}

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/UndefinedSymbolException.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/plang/UndefinedSymbolException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import java.util.Locale;
+
+public class UndefinedSymbolException extends InterpreterException {
+    public UndefinedSymbolException(String name, String type) {
+        super(String.format(Locale.getDefault(), "Undefined %s: %s", type, name));
+    }
+}

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/InterpreterTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/InterpreterTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class InterpreterTest {
+    Interpreter interpreter = new Interpreter();
+    Parser parser = new Parser();
+
+    @Test
+    public void testEmpty() {
+        assertNull(eval(null));
+        assertNull(eval(""));
+        assertNull(eval(" "));
+    }
+
+    @Test
+    public void testBooleans() {
+        assertTrue((boolean)eval("true"));
+        assertFalse((boolean)eval("false"));
+    }
+
+    @Test
+    public void testEq() {
+        assertTrue((boolean)eval("(= true true)"));
+        assertTrue((boolean)eval("(= false false)"));
+        assertFalse((boolean)eval("(= true false)"));
+        assertFalse((boolean)eval("(= false true)"));
+        assertFalse((boolean)eval("(= 'apple' 'orange')"));
+        assertTrue((boolean)eval("(= 'apple' 'apple')"));
+        assertTrue((boolean)eval("(= 0 0)"));
+        assertTrue((boolean)eval("(= -10.33242 -10.33242)"));
+    }
+
+    @Test
+    public void testNotEq() {
+        assertFalse((boolean)eval("(!= true true)"));
+        assertFalse((boolean)eval("(!= false false)"));
+        assertTrue((boolean)eval("(!= true false)"));
+        assertTrue((boolean)eval("(!= false true)"));
+        assertTrue((boolean)eval("(!= 'apple' 'orange')"));
+        assertFalse((boolean)eval("(!= 'apple' 'apple')"));
+        assertFalse((boolean)eval("(!= 0 0)"));
+        assertFalse((boolean)eval("(!= -10.33242 -10.33242)"));
+    }
+
+    @Test
+    public void testCmpDifferentTypes() {
+        assertTrue((boolean)eval("(= 1.0 1)"));
+        assertFalse((boolean)eval("(!= 1.0 1)"));
+        assertTrue((boolean)eval("(!= 1.0 2)"));
+        assertFalse((boolean)eval("(= 1.0 2)"));
+        assertTrue((boolean)eval("(!= '12' 12)"));
+        assertFalse((boolean)eval("(= 12 '12')"));
+    }
+
+    @Test
+    public void testOr() {
+        assertTrue((boolean)eval("(or true true)"));
+        assertTrue((boolean)eval("(or true false)"));
+        assertTrue((boolean)eval("(or false true)"));
+        assertFalse((boolean)eval("(or false false)"));
+        assertTrue((boolean)eval("(or false false false true false)"));
+        assertFalse((boolean)eval("(or false false false false false)"));
+    }
+
+    @Test
+    public void testAnd() {
+        assertTrue((boolean)eval("(and true true)"));
+        assertFalse((boolean)eval("(and false false)"));
+        assertFalse((boolean)eval("(and true false)"));
+        assertFalse((boolean)eval("(and false true)"));
+        assertFalse((boolean)eval("(and true true true false)"));
+        assertTrue((boolean)eval("(and true true true true)"));
+    }
+
+    @Test
+    public void testNot() {
+        assertFalse((boolean)eval("(not true)"));
+        assertTrue((boolean)eval("(not false)"));
+        assertFalse((boolean)eval("(not (not false))"));
+        assertTrue((boolean)eval("(not (not true))"));
+    }
+
+    @Test
+    public void testComplex() {
+        assertTrue((boolean)eval("(and (not false) (or (not (or (not true) (not false) )) true))"));
+    }
+
+    @Test(expected = TypeException.class)
+    public void testTypeError() {
+        eval("(size 12)");
+    }
+
+    @Test
+    public void testStrings() {
+        assertEquals("", eval("''"));
+        assertEquals(" a b c ", eval("' a b c '"));
+    }
+
+    @Test
+    public void testMatchString() {
+        assertTrue((boolean)eval("(match 'user1' 'user\\d+')"));
+        assertTrue((boolean)eval("(match 'user12' 'user\\d+')"));
+        assertFalse((boolean)eval("(match 'user12d' 'user\\d+')"));
+        assertFalse((boolean)eval("(match 'user' 'user\\d+')"));
+        assertFalse((boolean)eval("(match '12' 'user\\d+')"));
+        assertTrue((boolean)eval("(match 'hive' 'hive|joe')"));
+        assertTrue((boolean)eval("(match 'joe' 'hive|joe')"));
+        assertFalse((boolean)eval("(match 'tom' 'hive|joe')"));
+        assertFalse((boolean)eval("(match 'hive1' 'hive|joe')"));
+        assertFalse((boolean)eval("(match '0joe' 'hive|joe')"));
+    }
+
+    @Test
+    public void testMatchList() {
+        interpreter.addConstant("groups", singletonList("grp1"));
+        assertTrue((boolean)eval("(match groups 'grp\\d+')"));
+        interpreter.addConstant("groups", singletonList("grp12"));
+        assertTrue((boolean)eval("(match groups 'grp\\d+')"));
+        interpreter.addConstant("groups", singletonList("grp12d"));
+        assertFalse((boolean)eval("(match groups 'grp\\d+')"));
+        interpreter.addConstant("groups", singletonList("grp"));
+        assertFalse((boolean)eval("(match groups 'grp\\d+')"));
+        interpreter.addConstant("groups", singletonList("12"));
+        assertFalse((boolean)eval("(match groups 'grp\\d+')"));
+        interpreter.addConstant("groups", asList("12", "grp12"));
+        assertTrue((boolean)eval("(match groups 'grp\\d+')"));
+    }
+
+    @Test
+    public void testFuncEmpty() {
+        interpreter.addConstant("groups", emptyList());
+        assertTrue((boolean)eval("(empty groups)"));
+        interpreter.addConstant("groups", singletonList("grp1"));
+        assertFalse((boolean)eval("(empty groups)"));
+    }
+
+    @Test
+    public void testLowerUpper() {
+        assertEquals("apple", eval("(lowercase 'APPLE')"));
+        assertEquals("APPLE", eval("(uppercase 'apple')"));
+    }
+
+    @Test
+    public void testShortCircuitConditionals() {
+        assertTrue((boolean)eval("(or true (invalid-expression 1 2 3))"));
+        assertFalse((boolean)eval("(and false (invalid-expression 1 2 3))"));
+    }
+
+    private Object eval(String script) {
+        return interpreter.eval(parser.parse(script));
+    }
+}

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/ParserTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/ParserTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.plang;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Locale;
+
+public class ParserTest {
+    @Test
+    public void testEmpty() {
+        assertEquals(null, parse(""));
+        assertEquals(null, parse(" "));
+        assertEquals(null, parse(null));
+    }
+
+    @Test
+    public void testUnexpectedClosingParen() {
+        parse(")", "unexpected closing )");
+        parse("())", "unexpected closing )");
+        parse("() )", "unexpected closing )");
+        parse("() ) ", "unexpected closing )");
+        parse("(a (b) ))", "unexpected closing )");
+        parse("( a (  b ( c (d   (e   (f ( g  ) )  )) ) ) ))", "unexpected closing )");
+    }
+
+    @Test
+    public void testMissingClosingParen() {
+        parse("(", "missing closing )");
+        parse(" (", "missing closing )");
+        parse("( ", "missing closing )");
+        parse("  (a", "missing closing )");
+        parse("  (a ()", "missing closing )");
+        parse("  (a (b ( ) ) ", "missing closing )");
+        parse("( a (  b ( c (d   (e   (f ( g  ) )  )) ) ", "missing closing )");
+    }
+
+    @Test
+    public void testValidSingle() {
+        assertEquals("[]", parse("()").toString());
+        assertEquals("[]", parse("( )").toString());
+        assertEquals("[]", parse(" ( ) ").toString());
+        assertEquals("[a]", parse("(a)").toString());
+        assertEquals("[a]", parse("( a)").toString());
+        assertEquals("[a]", parse("(a )").toString());
+        assertEquals("[a]", parse("( a )").toString());
+        assertEquals("[a]", parse(" ( a ) ").toString());
+    }
+
+    @Test
+    public void testValidNested1() {
+        assertEquals("[a, [b]]", parse("(a (b))").toString());
+        assertEquals("[a, [b]]", parse(" (a (b))").toString());
+        assertEquals("[a, [b]]", parse(" ( a ( b))").toString());
+        assertEquals("[a, [b]]", parse(" ( a ( b )) ").toString());
+        assertEquals("[a, [b]]", parse(" ( a ( b ) ) ").toString());
+        assertEquals("[a, [b]]", parse("(a (b) )").toString());
+    }
+
+    @Test
+    public void testValidNested2() {
+        assertEquals("[a, [b, c, [d]], e]", parse("(a (b c (d)) e)").toString());
+        assertEquals("[a, [b, c, [d]], e]", parse("(a ( b c ( d)) e)").toString());
+        assertEquals("[a, [b, c, [d]], e]", parse("(a (b c (d ) ) e)").toString());
+        assertEquals("[a, [b, c, [d]], e]", parse(" (a ( b c (d )) e )").toString());
+        assertEquals("[a, [b, c, [d]], e]", parse(" (a   ( b c (  d )  ) e ) ").toString());
+    }
+
+    @Test
+    public void testValidNested3() {
+        assertEquals("[ab, [cd], ef]", parse("(ab (cd) ef)").toString());
+        assertEquals("[ab, [cd], ef]", parse("(ab ( cd) ef)").toString());
+        assertEquals("[ab, [cd], ef]", parse("(ab ( cd ) ef)").toString());
+        assertEquals("[ab, [cd], ef]", parse(" ( ab ( cd ) ef ) ").toString());
+    }
+
+    @Test
+    public void testValidNested4() {
+        assertEquals("[a, [b, [c, [d, [e, [f, [g]]]]]]]", parse("(a (b (c (d (e (f (g)))))))").toString());
+        assertEquals("[a, [b, [c, [d, [e, [f, [g]]]]]]]", parse("( a (  b (c (d   (e (f ( g))  )) )))").toString());
+        assertEquals("[a, [b, [c, [d, [e, [f, [g]]]]]]]", parse("( a (  b (c (d   (e (f ( g) )  )) ) ) )").toString());
+        assertEquals("[a, [b, [c, [d, [e, [f, [g]]]]]]]", parse("( a (  b ( c (d   (e   (f ( g  ) )  )) ) ) )").toString());
+    }
+
+    @Test
+    public void testValidStrings() {
+        assertEquals("''", parse("''").toString());
+        assertEquals("' '", parse("' '").toString());
+        assertEquals("'abc'", parse("'abc'").toString());
+        assertEquals("'a (bc'", parse("'a (bc'").toString());
+        assertEquals("'ab)c'", parse("'ab)c'").toString());
+        assertEquals("'ab) c'", parse("'ab) c'").toString());
+        assertEquals("'abc'", parse(" 'abc' ").toString());
+        assertEquals("'ab c'", parse(" 'ab c' ").toString());
+        assertEquals("'a   b c'", parse(" 'a   b c' ").toString());
+        assertEquals("['abc']", parse("('abc')").toString());
+        assertEquals("['abc']", parse("( 'abc')").toString());
+        assertEquals("['abc']", parse("( 'abc'  )").toString());
+        assertEquals("[' a b c ']", parse(" ( ' a b c '  ) ").toString());
+        assertEquals("[['a', [''], ['b c', 'd']]]", parse(" ( ('a' ('') ('b c' 'd') )) ").toString());
+    }
+
+    @Test
+    public void testInvalidStrings() {
+        parse("'", "unterminated string");
+        parse(" ' ", "unterminated string");
+        parse(" 'a ", "unterminated string");
+        parse(" 'a b ", "unterminated string");
+        parse("( 'a b ", "unterminated string");
+        parse(" 'a b ) ", "unterminated string");
+    }
+
+    @Test
+    public void testNumbers() {
+        assertEquals("0", parse("0").toString());
+        assertEquals("1", parse("1").toString());
+        assertEquals("-1", parse("-1").toString());
+        assertEquals("+1", parse("+1").toString());
+        assertEquals("1.2342424", parse("1.2342424").toString());
+    }
+
+    private static Ast parse(String script) {
+        Parser parser = new Parser();
+        return parser.parse(script);
+    }
+
+    private static void parse(String script, String message) {
+        Parser parser = new Parser();
+        try {
+            parser.parse(script);
+            fail("Expected syntax error with message: " + message);
+        } catch (SyntaxException e) {
+            assertTrue(
+                    "Expected syntax error: " + message + " but got: " + e.getMessage(),
+                    e.getMessage().toLowerCase(Locale.getDefault()).contains(message.toLowerCase(Locale.getDefault())));
+        }
+    }
+}

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/ParserTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/ParserTest.java
@@ -138,7 +138,7 @@ public class ParserTest {
         assertEquals("1.2342424", parse("1.2342424").toString());
     }
 
-    private static Ast parse(String script) {
+    private static AbstractSyntaxTree parse(String script) {
         Parser parser = new Parser();
         return parser.parse(script);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A more flexible way to map principals to groups than the existing `group.principal.mapping` mechanism in `CommonIdentityAssertionFilter`.

This patch extends the existing `CommonIdentityAssertionFilter` with a new way to map virtual groups to users.

The syntax allows us to map a virtual group to a user, using arbitrary predicates expressed in a parenthesized prefix notation language.

```
<name>virtual.group.mapping.VIRTUAL-GROUP-NAME</name>
<value>PREDICATE</value>
```

The existing mappings like `principal.mapping` and `group.principal.mapping` are still supported by the provider.

## How was this patch tested?

Manually tested with the following shiro + provider config.

### Shiro config

```xml
        <provider>
            <role>authentication</role>
            <name>ShiroProvider</name>
            <enabled>true</enabled>
            <param>
                <name>sessionTimeout</name>
                <value>30</value>
            </param>
            <param>
                <name>main.ldapRealm</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
            </param>
            <param>
                <name>main.ldapContextFactory</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory</name>
                <value>$ldapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm.userDnTemplate</name>
                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.url</name>
                <value>ldap://localhost:33389</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
                <value>simple</value>
            </param>
            <param>
                <name>urls./**</name>
                <value>authcBasic</value>
            </param>
            <!-- needed to get the groups from ldap -->
            <param>
                <name>main.ldapRealm.authorizationEnabled</name>
                <value>true</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.systemUsername</name>
                <value>uid=admin,ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.systemPassword</name>
                <value>admin-password</value>
            </param>
            <param>
                <name>main.ldapRealm.groupSearchBase</name>
                <value>ou=groups,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.groupObjectClass</name>
                <value>groupofnames</value>
            </param>
            <param>
                <name>main.ldapRealm.groupIdAttribute</name>
                <value>cn</value>
            </param>
            <param>
                <name>main.ldapRealm.memberAttribute</name>
                <value>member</value>
            </param>
            <param>
                <name>main.ldapRealm.memberAttributeValueTemplate</name>
                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
```

### Identity assertion provider config

```xml
     <provider>
            <role>identity-assertion</role>
            <name>Default</name>
            <enabled>true</enabled>
           <!-- existing principal to principal mapping already supported by CommonIdentityAssertionFilter -->
            <param>
                <name>principal.mapping</name>
                <value>tom=mapped-tom;</value>
            </param>
           <!-- existing principal to group mapping already supported by CommonIdentityAssertionFilter -->     
            <param>
                <name>group.principal.mapping</name>
                <value>mapped-tom=lg1;sam=lg2,lg3</value>
            </param>
            <!-- newly added syntax for virtual group -->
            <param>
                <name>virtual.group.mapping.sam-or-admin</name>
                <value>(or (username 'sam') (username 'admin'))</value>
            </param>
            <param>
                <name>virtual.group.mapping.tom-or-admin</name>
                <value>(or (username 'mapped-tom') (username 'admin'))</value>
            </param>
            <param>
                <name>virtual.group.mapping.regexp-group</name>
                <value>(and (match username 'mapped-tom|sam') (match groups 'analyst|scientist'))</value>
            </param>
            <param>
                <name>virtual.group.mapping.group-same-as-user</name>
                <value>(member username)</value>
            </param>
            <param>
                <name>virtual.group.mapping.at-least-one-group</name>
                <value>(!= 0 (size groups))</value>
            </param>
            <param>
                <name>virtual.group.mapping.everybody</name>
                <value>true</value>
            </param>
            <param>
                <name>virtual.group.mapping.both-analyst-and-scientist</name>
                <value>(and (member 'analyst') (member 'scientist'))</value>
            </param>
        </provider>
```