### PR TITLE
KNOX-2713 - Allowing end-users to customize 'user limit exceeded' action when creating Knox tokens

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -86,4 +86,7 @@ public interface TokenServiceMessages {
 
   @Message( level = MessageLevel.ERROR, text = "Unable to get token for user {0}: token limit exceeded")
   void tokenLimitExceeded(String userName);
+
+  @Message( level = MessageLevel.INFO, text = "{0}")
+  void generalInfoMessage(String message);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changing Knox's default behavior when a user exceeds the configured token limit: if `REMOVE_OLDEST` is configured, Knox will remove the oldest token instead of returning an error.

## How was this patch tested?

Updated existing JUnit tests as well as added new ones:
```
$ mvn clean -Dshellcheck=true verify -Prelease,package -am -pl gateway-service-knoxtoken
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:56 min
[INFO] Finished at: 2022-03-04T15:23:36+01:00
[INFO] ------------------------------------------------------------------------
```
Manual testing:
- set `gateway.knox.token.limit.per.user = 1` in `gateway-site.xml`
- set `knox.token.user.limit.exceeded.action = REMOVE_OLDEST` in the `homepage` topology for the `KNOXTOKEN` service
- restarted Knox and created a token with comment `token 1` on the Token Generation page<img width="1780" alt="Screenshot 2022-03-04 at 15 16 14" src="https://user-images.githubusercontent.com/34065904/156782896-3a4122fb-7f78-4ee5-b4f4-08412a7cd21c.png">
- created another token with comment `token 2` successfully (and the previously created one got revoked):<img width="1782" alt="Screenshot 2022-03-04 at 15 16 30" src="https://user-images.githubusercontent.com/34065904/156783086-867177d5-cd3c-4f12-811c-680f9331bb80.png">

```
2022-03-04 15:30:48,390 3ee2f801-ed84-4cee-bf9d-8da686266eed ERROR service.knoxtoken (TokenResource.java:getAuthenticationToken(669)) - Unable to get token for user admin: token limit exceeded
2022-03-04 15:30:48,391 3ee2f801-ed84-4cee-bf9d-8da686266eed INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(675)) - Revoking admin's oldest token 066b2c...2bb6f5 ...
2022-03-04 15:30:48,407 3ee2f801-ed84-4cee-bf9d-8da686266eed INFO  service.knoxtoken (TokenResource.java:revoke(512)) - Knox Token service (homepage) revoked token 066b2c...2bb6f5 (066b2cc3...946c6e2bb6f5) (renewer=admin)
2022-03-04 15:30:48,413 3ee2f801-ed84-4cee-bf9d-8da686266eed INFO  service.knoxtoken (TokenResource.java:getAuthenticationToken(704)) - Knox Token service (homepage) issued token eyJqa3...k1ikvg (893cbbef...a754c8a4f5bb)
```