### PR TITLE
KNOX-2342 - CommonIdentityAssertionFilter calling mapGroupPrincipals Twice

### DIFF
--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
@@ -20,8 +20,10 @@ package org.apache.knox.gateway.identityasserter.common.filter;
 import java.io.IOException;
 import java.security.AccessController;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -157,7 +159,11 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
     HttpServletRequestWrapper wrapper = wrapHttpServletRequest(
         request, mappedPrincipalName);
 
-    continueChainAsPrincipal(wrapper, response, chain, mappedPrincipalName, groups);
+    continueChainAsPrincipal(wrapper, response, chain, mappedPrincipalName, unique(groups));
+  }
+
+  private static String[] unique(String[] groups) {
+    return new HashSet<>(Arrays.asList(groups)).toArray(new String[0]);
   }
 
   protected String[] combineGroupMappings(String[] mappedGroups, String[] groups) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

CommonIdentityAssertionFilter puts the same group multiple times as shown in the audit log:

```
22/02/17 17:40:38 ||b28adfe1-90ea-4fb5-9ad7-9d444edd3d26|audit|[0:0:0:0:0:0:0:1]|HIVE|tom|mapped-tom||identity-mapping|principal|mapped-tom|success|Groups: [lg1, lg1]
```

## How was this patch tested?

manually + unittest
