### PR TITLE
KNOX-2724 Add HBase UI proxying for Named Queue Logs

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/rewrite.xml
@@ -141,6 +141,9 @@
   <rule dir="OUT" name="HBASEUI/hbase/outbound/master/children" pattern="/hbck.jsp?{**}">
     <rewrite template="{$frontend[url]}/hbase/webui/master/hbck.jsp?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
   </rule>
+  <rule dir="OUT" name="HBASEUI/hbase/outbound/master/children" pattern="/namedQueueLog.jsp?{**}">
+    <rewrite template="{$frontend[url]}/hbase/webui/master/namedQueueLog.jsp?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
+  </rule>
 
   <!-- RegionServer UI proxying -->
   <rule dir="IN" name="HBASEUI/hbase/inbound/regionserver/root/qualified" pattern="*://*:*/**/hbase/webui/regionserver?{host}?port}">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add rewrite rule for Named Queue Logs on HBase Master UI.

## How was this patch tested?

Copied the rewrite.xml file to a cluster, restarted Knox, and verified the URL is redirecting correctly.
