### PR TITLE
KNOX-2725 - Add HiveServer2 webui support in service definition.

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hiveserver2ui/3.1.2/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hiveserver2ui/3.1.2/rewrite.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="HIVESERVER2UI/hiveserver2/inbound/root" pattern="*://*:*/**/hiveserver2/">
+        <rewrite template="{$serviceUrl[HIVESERVER2UI]}/"/>
+    </rule>
+    <rule dir="IN" name="HIVESERVER2UI/hiveserver2/inbound/path" pattern="*://*:*/**/hiveserver2/{**}">
+        <rewrite template="{$serviceUrl[HIVESERVER2UI]}/{**}"/>
+    </rule>
+    <rule dir="IN" name="HIVESERVER2UI/hiveserver2/inbound/query" pattern="*://*:*/**/hiveserver2/{**}?{**}">
+        <rewrite template="{$serviceUrl[HIVESERVER2UI]}/{**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="HIVESERVER2UI/hiveserver2/inbound/logs" pattern="*://*:*/**/hiveserver2/logs/">
+        <rewrite template="{$serviceUrl[HIVESERVER2UI]}/logs/"/>
+    </rule>
+
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/static" pattern="/static/{**}">
+        <rewrite template="{$frontend[url]}/hiveserver2/static/{**}"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/query_page" pattern="/query_page?{**}">
+        <rewrite template="{$frontend[url]}/hiveserver2/query_page?{**}"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/logs" pattern="/logs/">
+        <rewrite template="{$frontend[url]}/hiveserver2/logs/"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/jmx" pattern="/jmx">
+        <rewrite template="{$frontend[url]}/hiveserver2/jmx"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/conf" pattern="/conf/">
+        <rewrite template="{$frontend[url]}/hiveserver2/conf"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/stacks" pattern="/stacks">
+        <rewrite template="{$frontend[url]}/hiveserver2/stacks"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/llap.html" pattern="/llap.html">
+        <rewrite template="{$frontend[url]}/hiveserver2/llap.html"/>
+    </rule>
+    <rule dir="OUT" name="HIVESERVER2UI/hiveserver2/outbound/home" pattern="/">
+        <rewrite template="{$frontend[url]}/hiveserver2/"/>
+    </rule>
+    <filter name="HIVESERVER2UI/hiveserver2/outbound/body">
+        <content type="*/*" asType="text/html">
+        </content>
+    </filter>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/hiveserver2ui/3.1.2/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hiveserver2ui/3.1.2/service.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="HIVESERVER2UI" name="hiveserver2" version="2.3.0">
+    <metadata>
+        <type>UI</type>
+        <context>/hiveserver2</context>
+        <shortDesc>HiveServer2 Web UI</shortDesc>
+        <description>HiveServer2 is a service that enables clients to execute queries against Hive. It supports multi-client concurrency and authentication.</description>
+    </metadata>
+    <routes>
+        <route path="/hiveserver2/"/>
+        <route path="/hiveserver2/**"/>
+        <route path="/hiveserver2/query_page?**">
+            <rewrite apply="HIVESERVER2UI/hiveserver2/outbound/body" to="response.body"/>
+        </route>
+    </routes>
+    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch" ha-classname="org.apache.knox.gateway.ha.dispatch.ConfigurableHADispatch"/>
+</service>


### PR DESCRIPTION
## What changes were proposed in this pull request?
[HiveServer2](https://cwiki.apache.org/confluence/display/hive/hiveserver2+overview) is a service that enables clients to execute queries against Hive. It supports multi-client concurrency and authentication. We can support it in knox service definition, so that knox can proivide proxying service for it.

## How was this patch tested?
Deploy knox in a cluster with HiveServer2, we can access HiveServer2 web ui with knox server port 8443.
![image](https://user-images.githubusercontent.com/26102745/161515378-dcb8c7af-99b9-4f8e-bf5e-718603f3cf6d.png)
