### PR TITLE
KNOX-2730 - Fix missing Correlation id in audit logs

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayFilterTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayFilterTest.java
@@ -229,6 +229,8 @@ public class GatewayFilterTest {
 
     EasyMock.replay(response,request,requestNoID,context,gatewayConfig);
 
+    FilterChain chain = EasyMock.createNiceMock( FilterChain.class );
+    EasyMock.replay( chain );
 
     TestCorrelationFilter filter = new TestCorrelationFilter();
 
@@ -236,12 +238,12 @@ public class GatewayFilterTest {
     GatewayFilter gateway = new GatewayFilter();
     gateway.addFilter( "test-path/**", "test-filter", filter, null, "test-role" );
     gateway.init( config );
-    gateway.doFilter( request, response );
+    gateway.doFilter( request, response, chain );
     assertThat(filter.request_id, is( TEST_REQ_ID ) );
     assertThat(filter.correlation_id, is( TEST_REQ_ID ) );
 
     /* test the case where request id for request coming to knox is absent */
-    gateway.doFilter( requestNoID, response );
+    gateway.doFilter( requestNoID, response, chain );
     assertThat(filter.request_id, nullValue() );
     assertThat(filter.correlation_id, notNullValue() );
     assertThat(filter.correlation_id, not( TEST_REQ_ID ) );


### PR DESCRIPTION
## What changes were proposed in this pull request?
There was a change a while ago due to which correlation id in audit logs was missing in the last audit message for a request. This PR fixes that issue.

## How was this patch tested?
This patch was tested locally on local Knox instance. 

**Before Patch**
```
22/04/14 02:17:24 ||6bb6e07e-1540-47e9-9e07-7798563fe125|audit|[0:0:0:0:0:0:0:1]|WEATHER||||access|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|unavailable|Request method: GET
22/04/14 02:17:24 ||6bb6e07e-1540-47e9-9e07-7798563fe125|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||authentication|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|success|
22/04/14 02:17:24 ||6bb6e07e-1540-47e9-9e07-7798563fe125|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||authentication|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|success|Groups: []
22/04/14 02:17:24 ||6bb6e07e-1540-47e9-9e07-7798563fe125|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||identity-mapping|principal|guest|success|Groups: []
22/04/14 02:17:24 ||6bb6e07e-1540-47e9-9e07-7798563fe125|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||dispatch|uri|http://api.openweathermap.org:80/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&user.name=guest|unavailable|Request method: GET
22/04/14 02:17:25 ||6bb6e07e-1540-47e9-9e07-7798563fe125|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||dispatch|uri|http://api.openweathermap.org:80/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&user.name=guest|success|Response status: 200
22/04/14 02:17:25 |||audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||access|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|success|Response status: 200
```

**After Patch**
```
22/04/15 00:31:58 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER||||access|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|unavailable|Request method: GET
22/04/15 00:31:58 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||authentication|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|success|
22/04/15 00:31:58 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||authentication|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|success|Groups: []
22/04/15 00:31:58 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||identity-mapping|principal|guest|success|Groups: []
22/04/15 00:31:59 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||dispatch|uri|http://api.openweathermap.org:80/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&user.name=guest|unavailable|Request method: GET
22/04/15 00:32:00 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||dispatch|uri|http://api.openweathermap.org:80/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&user.name=guest|success|Response status: 200
22/04/15 00:32:00 ||3a931834-3751-40f9-a4d7-aa6232e8bde4|audit|[0:0:0:0:0:0:0:1]|WEATHER|guest|||access|uri|/gateway/sandbox/weather/data/2.5/forecast?id=524901&APPID=54557732afcfe106bfc955b9da04fb14|success|Response status: 200
```