### PR TITLE
KNOX-2733 - Support configurable value for saml.keyStoreType property in pac4j

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/Pac4jMessages.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/Pac4jMessages.java
@@ -51,4 +51,14 @@ public interface Pac4jMessages {
   @Message( level = MessageLevel.ERROR, text =
       "No keystore password alias found. Defaulting to master secret. Exception encountered: {0}")
   void noKeystorePasswordProvisioned(Exception e);
+
+  @Message( level = MessageLevel.ERROR, text =
+      "There was an error fetching keystore type. Exception encountered: {0}")
+  void errorFetchingKeystoreType(Exception e);
+
+  @Message( level = MessageLevel.DEBUG, text = "Pac4j keystore path used : {0}")
+  void pac4jSamlKeystorePath(String path);
+
+  @Message( level = MessageLevel.DEBUG, text = "Pac4j keystore type : {0}")
+  void pac4jSamlKeystoreType(String type);
 }

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/config/SAML2ClientConfigurationDecorator.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/config/SAML2ClientConfigurationDecorator.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.pac4j.Pac4jMessages;
+import org.pac4j.config.client.PropertiesConstants;
 import org.pac4j.core.client.Client;
 import org.pac4j.saml.client.SAML2Client;
 
@@ -31,6 +34,8 @@ public class SAML2ClientConfigurationDecorator implements ClientConfigurationDec
   private static final String CONFIG_NAME_USE_FORCE_AUTH = "forceAuth";
   private static final String CONFIG_NAME_USE_PASSIVE = "passive";
   private static final String CONFIG_NAME_NAMEID_POLICY_FORMAT = "nameIdPolicyFormat";
+  private static Pac4jMessages log = MessagesFactory.get(Pac4jMessages.class);
+  public static final String KEYSTORE_TYPE = "saml.keyStoreType";
 
   @Override
   public void decorateClients(List<Client> clients, Map<String, String> properties) {
@@ -41,6 +46,8 @@ public class SAML2ClientConfigurationDecorator implements ClientConfigurationDec
         setForceAuthFlag(properties, saml2Client);
         setPassiveFlag(properties, saml2Client);
         setNameIdPolicyFormat(properties, saml2Client);
+        setKeyStoreType(properties, saml2Client);
+        setKeyStorePath(properties, saml2Client);
       }
     }
   }
@@ -70,6 +77,22 @@ public class SAML2ClientConfigurationDecorator implements ClientConfigurationDec
     final String nameIdPolicyFormat = properties.get(CONFIG_NAME_NAMEID_POLICY_FORMAT);
     if (StringUtils.isNotBlank(nameIdPolicyFormat)) {
       saml2Client.getConfiguration().setNameIdPolicyFormat(nameIdPolicyFormat);
+    }
+  }
+
+  private void setKeyStoreType(Map<String, String> properties, final SAML2Client saml2Client) {
+    final String keyStoreType = properties.get(KEYSTORE_TYPE);
+    if (StringUtils.isNotBlank(keyStoreType)) {
+      saml2Client.getConfiguration().setKeystoreType(keyStoreType);
+      log.pac4jSamlKeystoreType(keyStoreType);
+    }
+  }
+
+  private void setKeyStorePath(Map<String, String> properties, final SAML2Client saml2Client) {
+    final String keyStorePath = properties.get(PropertiesConstants.SAML_KEYSTORE_PATH);
+    if (StringUtils.isNotBlank(keyStorePath)) {
+      saml2Client.getConfiguration().setKeystorePath(keyStorePath);
+      log.pac4jSamlKeystorePath(keyStorePath);
     }
   }
 }

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.pac4j.Pac4jMessages;
 import org.apache.knox.gateway.pac4j.config.ClientConfigurationDecorator;
 import org.apache.knox.gateway.pac4j.config.Pac4jClientConfigurationDecorator;
+import org.apache.knox.gateway.pac4j.config.SAML2ClientConfigurationDecorator;
 import org.apache.knox.gateway.pac4j.session.KnoxSessionStore;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
@@ -29,6 +30,7 @@ import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.CryptoService;
 import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.security.MasterService;
 import org.pac4j.config.client.PropertiesConfigFactory;
 import org.pac4j.config.client.PropertiesConstants;
@@ -268,6 +270,13 @@ public class Pac4jDispatcherFilter implements Filter {
     if (clientNameParameter.contains(SAML2Client.class.getSimpleName())) {
       properties.put(PropertiesConstants.SAML_KEYSTORE_PATH,
           keystoreService.getKeystorePath());
+
+      try {
+        properties.put(SAML2ClientConfigurationDecorator.KEYSTORE_TYPE,
+            keystoreService.getKeystoreForGateway().getType());
+      } catch (final KeystoreServiceException e) {
+        log.errorFetchingKeystoreType(e);
+      }
 
       // check for provisioned alias for keystore password
       char[] giksp = null;

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/config/SAML2ClientConfigurationDecoratorTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/config/SAML2ClientConfigurationDecoratorTest.java
@@ -39,6 +39,7 @@ public class SAML2ClientConfigurationDecoratorTest {
     properties.put("forceAuth", "true");
     properties.put("passive", "true");
     properties.put("nameIdPolicyFormat", "testPolicyFormat");
+    properties.put("saml.keyStoreType", "JKS");
 
     final SAML2ClientConfigurationDecorator saml2ConfigurationDecorator = new SAML2ClientConfigurationDecorator();
     saml2ConfigurationDecorator.decorateClients(Collections.singletonList(client), properties);
@@ -46,6 +47,7 @@ public class SAML2ClientConfigurationDecoratorTest {
     assertTrue(saml2Configuration.isForceAuth());
     assertTrue(saml2Configuration.isPassive());
     assertEquals("testPolicyFormat", saml2Configuration.getNameIdPolicyFormat());
+    assertEquals("JKS", saml2Configuration.getKeyStoreType());
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the ability to specify Keystore type and Keystore location used by Pac4j. 
Previously, default keystore type was always assumed to be JKS. With this PR we use the keystore type that is used by Knox.

## How was this patch tested?

This patch was tested on a local Knox instance with Okta SSO.