### PR TITLE
KNOX-2732 Issuer claim in Knox JWTs should be configurable

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
@@ -31,6 +31,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.filter.security.AbstractIdentityAssertionFilter;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
@@ -71,9 +72,9 @@ public class JWTAccessTokenAssertionFilter extends AbstractIdentityAssertionFilt
     authority = services.getService(ServiceType.TOKEN_SERVICE);
     sr = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
 
-    this.tokenIssuer = filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER) != null
-            ? filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER)
-            : JWTokenAttributes.DEFAULT_ISSUER;
+    this.tokenIssuer = StringUtils.isEmpty(filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER))
+            ? JWTokenAttributes.DEFAULT_ISSUER
+            : filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER);
   }
 
   @Override

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAccessTokenAssertionFilter.java
@@ -72,7 +72,7 @@ public class JWTAccessTokenAssertionFilter extends AbstractIdentityAssertionFilt
     authority = services.getService(ServiceType.TOKEN_SERVICE);
     sr = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
 
-    this.tokenIssuer = StringUtils.isEmpty(filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER))
+    this.tokenIssuer = StringUtils.isBlank(filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER))
             ? JWTokenAttributes.DEFAULT_ISSUER
             : filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER);
   }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
@@ -28,6 +28,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.filter.security.AbstractIdentityAssertionFilter;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
@@ -58,9 +59,9 @@ public class JWTAuthCodeAssertionFilter extends AbstractIdentityAssertionFilter 
     authority = services.getService(ServiceType.TOKEN_SERVICE);
     sr = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
 
-    this.tokenIssuer = filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER) != null
-            ? filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER)
-            : JWTokenAttributes.DEFAULT_ISSUER;
+    this.tokenIssuer = StringUtils.isEmpty(filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER))
+            ? JWTokenAttributes.DEFAULT_ISSUER
+            : filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER);
   }
 
   @Override

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTAuthCodeAssertionFilter.java
@@ -59,7 +59,7 @@ public class JWTAuthCodeAssertionFilter extends AbstractIdentityAssertionFilter 
     authority = services.getService(ServiceType.TOKEN_SERVICE);
     sr = services.getService(ServiceType.SERVICE_REGISTRY_SERVICE);
 
-    this.tokenIssuer = StringUtils.isEmpty(filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER))
+    this.tokenIssuer = StringUtils.isBlank(filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER))
             ? JWTokenAttributes.DEFAULT_ISSUER
             : filterConfig.getInitParameter(JWTAccessTokenAssertionFilter.ISSUER);
   }

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -83,6 +83,7 @@ public class WebSSOResource {
   private static final String SSO_SIGNINGKEY_KEYSTORE_NAME = "knoxsso.signingkey.keystore.name";
   private static final String SSO_SIGNINGKEY_KEYSTORE_ALIAS = "knoxsso.signingkey.keystore.alias";
   private static final String SSO_SIGNINGKEY_KEYSTORE_PASSPHRASE_ALIAS = "knoxsso.signingkey.keystore.passphrase.alias";
+  private static final String SSO_TOKEN_ISSUER = "knoxsso.token.issuer";
 
   /* parameters expected by knoxsso */
   private static final String SSO_EXPECTED_PARAM = "knoxsso.expected.params";
@@ -104,6 +105,7 @@ public class WebSSOResource {
   private String signatureAlgorithm;
   private List<String> ssoExpectedparams = new ArrayList<>();
   private String clusterName;
+  private String tokenIssuer;
 
   @Context
   HttpServletRequest request;
@@ -122,6 +124,10 @@ public class WebSSOResource {
 
     String enableSessionStr = context.getInitParameter(SSO_ENABLE_SESSION_PARAM);
     this.enableSession = Boolean.parseBoolean(enableSessionStr);
+
+    this.tokenIssuer = context.getInitParameter(SSO_TOKEN_ISSUER) != null
+            ? context.getInitParameter(SSO_TOKEN_ISSUER)
+            : JWTokenAttributes.DEFAULT_ISSUER;
 
     setSignatureAlogrithm();
 
@@ -262,8 +268,16 @@ public class WebSSOResource {
         signingKeystorePassphrase = as.getPasswordFromAliasForCluster(clusterName, signingKeystorePassphraseAlias);
       }
 
-      final JWTokenAttributes jwtAttributes = new JWTokenAttributesBuilder().setUserName(p.getName()).setAudiences(targetAudiences).setAlgorithm(signatureAlgorithm).setExpires(getExpiry())
-          .setSigningKeystoreName(signingKeystoreName).setSigningKeystoreAlias(signingKeystoreAlias).setSigningKeystorePassphrase(signingKeystorePassphrase).build();
+      final JWTokenAttributes jwtAttributes = new JWTokenAttributesBuilder()
+              .setIssuer(tokenIssuer)
+              .setUserName(p.getName())
+              .setAudiences(targetAudiences)
+              .setAlgorithm(signatureAlgorithm)
+              .setExpires(getExpiry())
+              .setSigningKeystoreName(signingKeystoreName)
+              .setSigningKeystoreAlias(signingKeystoreAlias)
+              .setSigningKeystorePassphrase(signingKeystorePassphrase)
+              .build();
       JWT token = tokenAuthority.issueToken(jwtAttributes);
 
       // Coverity CID 1327959

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -125,7 +125,7 @@ public class WebSSOResource {
     String enableSessionStr = context.getInitParameter(SSO_ENABLE_SESSION_PARAM);
     this.enableSession = Boolean.parseBoolean(enableSessionStr);
 
-    this.tokenIssuer = StringUtils.isEmpty(context.getInitParameter(SSO_TOKEN_ISSUER))
+    this.tokenIssuer = StringUtils.isBlank(context.getInitParameter(SSO_TOKEN_ISSUER))
             ? JWTokenAttributes.DEFAULT_ISSUER
             : context.getInitParameter(SSO_TOKEN_ISSUER);
 

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -125,9 +125,9 @@ public class WebSSOResource {
     String enableSessionStr = context.getInitParameter(SSO_ENABLE_SESSION_PARAM);
     this.enableSession = Boolean.parseBoolean(enableSessionStr);
 
-    this.tokenIssuer = context.getInitParameter(SSO_TOKEN_ISSUER) != null
-            ? context.getInitParameter(SSO_TOKEN_ISSUER)
-            : JWTokenAttributes.DEFAULT_ISSUER;
+    this.tokenIssuer = StringUtils.isEmpty(context.getInitParameter(SSO_TOKEN_ISSUER))
+            ? JWTokenAttributes.DEFAULT_ISSUER
+            : context.getInitParameter(SSO_TOKEN_ISSUER);
 
     setSignatureAlogrithm();
 

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -243,9 +243,9 @@ public class TokenResource {
             ? true
             : Boolean.parseBoolean(includeGroupsInTokenAllowedParam);
 
-    this.tokenIssuer = context.getInitParameter(KNOX_TOKEN_ISSUER) != null
-            ? context.getInitParameter(KNOX_TOKEN_ISSUER)
-            : JWTokenAttributes.DEFAULT_ISSUER;
+    this.tokenIssuer = StringUtils.isEmpty(context.getInitParameter(KNOX_TOKEN_ISSUER))
+            ? JWTokenAttributes.DEFAULT_ISSUER
+            : context.getInitParameter(KNOX_TOKEN_ISSUER);
     this.tokenType = context.getInitParameter(TOKEN_TYPE_PARAM);
 
     tokenTTLAsText = getTokenTTLAsText();

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -243,7 +243,7 @@ public class TokenResource {
             ? true
             : Boolean.parseBoolean(includeGroupsInTokenAllowedParam);
 
-    this.tokenIssuer = StringUtils.isEmpty(context.getInitParameter(KNOX_TOKEN_ISSUER))
+    this.tokenIssuer = StringUtils.isBlank(context.getInitParameter(KNOX_TOKEN_ISSUER))
             ? JWTokenAttributes.DEFAULT_ISSUER
             : context.getInitParameter(KNOX_TOKEN_ISSUER);
     this.tokenType = context.getInitParameter(TOKEN_TYPE_PARAM);

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -145,7 +145,7 @@ public class TokenResource {
   static final String QUERY_PARAMETER_DOAS = "doAs";
   static final String PROXYUSER_PREFIX = TOKEN_PARAM_PREFIX + "proxyuser";
   public static final String KNOX_TOKEN_INCLUDE_GROUPS = TOKEN_PARAM_PREFIX + "include.groups";
-
+  public static final String KNOX_TOKEN_ISSUER = TOKEN_PARAM_PREFIX + "issuer";
   private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
   private long tokenTTL = TOKEN_TTL_DEFAULT;
   private String tokenType;
@@ -169,6 +169,7 @@ public class TokenResource {
 
   private int tokenLimitPerUser;
   private boolean includeGroupsInTokenAllowed;
+  private String tokenIssuer;
 
   enum UserLimitExceededAction {REMOVE_OLDEST, RETURN_ERROR};
   private UserLimitExceededAction userLimitExceededAction = UserLimitExceededAction.RETURN_ERROR;
@@ -242,6 +243,9 @@ public class TokenResource {
             ? true
             : Boolean.parseBoolean(includeGroupsInTokenAllowedParam);
 
+    this.tokenIssuer = context.getInitParameter(KNOX_TOKEN_ISSUER) != null
+            ? context.getInitParameter(KNOX_TOKEN_ISSUER)
+            : JWTokenAttributes.DEFAULT_ISSUER;
     this.tokenType = context.getInitParameter(TOKEN_TYPE_PARAM);
 
     tokenTTLAsText = getTokenTTLAsText();
@@ -761,6 +765,7 @@ public class TokenResource {
       JWTokenAttributes jwtAttributes;
       final JWTokenAttributesBuilder jwtAttributesBuilder = new JWTokenAttributesBuilder();
       jwtAttributesBuilder
+          .setIssuer(tokenIssuer)
           .setUserName(userName)
           .setAlgorithm(signatureAlgorithm)
           .setExpires(expires)

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -19,8 +19,10 @@ package org.apache.knox.gateway.service.knoxtoken;
 
 import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.KNOX_TOKEN_USER_LIMIT;
 import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.KNOX_TOKEN_USER_LIMIT_DEFAULT;
+import static org.apache.knox.gateway.service.knoxtoken.TokenResource.KNOX_TOKEN_ISSUER;
 import static org.apache.knox.gateway.service.knoxtoken.TokenResource.KNOX_TOKEN_USER_LIMIT_EXCEEDED_ACTION;
 import static org.apache.knox.gateway.service.knoxtoken.TokenResource.TOKEN_INCLUDE_GROUPS_IN_JWT_ALLOWED;
+import static org.apache.knox.gateway.services.security.token.JWTokenAttributes.DEFAULT_ISSUER;
 import static org.apache.knox.gateway.services.security.token.impl.JWTToken.KNOX_GROUPS_CLAIM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1119,6 +1121,43 @@ public class TokenServiceResourceTest {
     final Map<String, String> metadata = (Map<String, String>) knoxToken.get("metadata");
     assertEquals(metadata.get("createdBy"), USER_NAME);
     assertEquals(metadata.get("userName"), impersonatedUser);
+  }
+
+  @Test
+  public void testDefaultIssuer() throws Exception {
+    Map<String, String> contextExpectations = new HashMap<>();
+    configureCommonExpectations(contextExpectations, Boolean.TRUE);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response response = tr.doGet();
+    assertEquals(200, response.getStatus());
+
+    String accessToken = getTagValue(response.getEntity().toString(), "access_token");
+    Map<String, Object> payload = parseJSONResponse(JWTToken.parseToken(accessToken).getPayload());
+    assertEquals(DEFAULT_ISSUER, payload.get("iss"));
+  }
+
+  @Test
+  public void testConfiguredIssuer() throws Exception {
+    Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put(KNOX_TOKEN_ISSUER, "test issuer");
+    configureCommonExpectations(contextExpectations, Boolean.TRUE);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response response = tr.doGet();
+    assertEquals(200, response.getStatus());
+
+    String accessToken = getTagValue(response.getEntity().toString(), "access_token");
+    Map<String, Object> payload = parseJSONResponse(JWTToken.parseToken(accessToken).getPayload());
+    assertEquals("test issuer", payload.get("iss"));
   }
 
   @Test

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 public class JWTokenAttributes {
+  public static final String DEFAULT_ISSUER = "KNOXSSO";
   private final String userName;
   private final List<String> audiences;
   private final String algorithm;

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
@@ -36,7 +36,7 @@ public class JWTokenAttributesBuilder {
   private String type;
   private Set<String> groups;
   private String kid;
-  private String issuer = "KNOXSSO";
+  private String issuer = JWTokenAttributes.DEFAULT_ISSUER;
 
   public JWTokenAttributesBuilder setUserName(String userName) {
     this.userName = userName;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The issuer of the JWT tokens is now configurable.

## How was this patch tested?

1. Added `knox.token.issuer` to KNOXTOKEN service.

```
      <param>
          <name>knox.token.issuer</name>
          <value>test 1 2 3</value>
      </param>
````

2. Created a token on the UI and checked the issuer.
3. Removed the `knox.token.issuer` from the config and checked the issuer (default KNOXSSO) again 
