### PR TITLE
KNOX-2735 Add support for group info inclusion in tokens to the KnoxShell client

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Get.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Get.java
@@ -20,8 +20,11 @@ package org.apache.knox.gateway.shell.knox.token;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.apache.http.NameValuePair;
 import org.apache.knox.gateway.shell.AbstractRequest;
 import org.apache.knox.gateway.shell.BasicResponse;
 import org.apache.knox.gateway.shell.KnoxSession;
@@ -37,13 +40,18 @@ import org.apache.knox.gateway.shell.KnoxShellException;
 public class Get {
   public static class Request extends AbstractRequest<Response> {
     Request(KnoxSession session) {
-      this(session, null);
+      this(session, null, Collections.emptyList());
     }
 
     Request(KnoxSession session, String doAsUser) {
+      this(session, doAsUser, Collections.emptyList());
+    }
+
+    Request(KnoxSession session, String doAsUser, List<NameValuePair> queryParameters) {
       super(session, doAsUser);
       try {
         URIBuilder uri = uri(Token.SERVICE_PATH);
+        uri.addParameters(queryParameters);
         requestURI = uri.build();
       } catch (URISyntaxException e) {
         throw new KnoxShellException(e);

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Token.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Token.java
@@ -17,10 +17,16 @@
  */
 package org.apache.knox.gateway.shell.knox.token;
 
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.knox.gateway.shell.KnoxSession;
 
-public class Token {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
+public class Token {
+  private static final String KNOX_TOKEN_INCLUDE_GROUPS = "knox.token.include.groups";
   static String SERVICE_PATH = "/knoxtoken/api/v1/token";
 
   public static Get.Request get(final KnoxSession session) {
@@ -28,7 +34,15 @@ public class Token {
   }
 
   public static Get.Request get(final KnoxSession session, final String doAsUser) {
-    return new Get.Request(session, doAsUser);
+    return new Get.Request(session, doAsUser, Collections.emptyList());
+  }
+
+  public static Get.Request get(final KnoxSession session, final String doAsUser, boolean includeGroupsInToken) {
+    List<NameValuePair> queryParamss = new ArrayList<>();
+    if (includeGroupsInToken) {
+      queryParamss.add(new BasicNameValuePair(KNOX_TOKEN_INCLUDE_GROUPS, "true"));
+    }
+    return new Get.Request(session, doAsUser, queryParamss);
   }
 
   public static Renew.Request renew(final KnoxSession session, final String token) {

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/knox/token/TokenTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/knox/token/TokenTest.java
@@ -111,7 +111,14 @@ public class TokenTest {
     expect(knoxSession.base()).andReturn("http://localhost/base").atLeastOnce();
     replay(knoxSession);
 
-    Get.Request request = Token.get(knoxSession, setDoAsUser ? doAsUser : null, includeGroupsInToken);
+    Get.Request request;
+    if (!includeGroupsInToken) {
+      request = (setDoAsUser)
+              ? Token.get(knoxSession, doAsUser)
+              : Token.get(knoxSession);
+    } else {
+      request = Token.get(knoxSession, setDoAsUser ? doAsUser : null, true);
+    }
 
     if (setDoAsUser) {
       assertEquals(doAsUser, request.getDoAsUser());

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/knox/token/TokenTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/knox/token/TokenTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
@@ -42,24 +43,28 @@ public class TokenTest {
 
   @Test
   public void testTokenWithNoDoAs() {
-    testToken(false, null);
+    testToken(false, null, false);
   }
 
   @Test
   public void testTokenWithNullDoAs() {
-    testToken(true, null);
+    testToken(true, null, false);
   }
 
   @Test
   public void testTokenWithEmptyDoAs() {
-    testToken(true, "");
+    testToken(true, "", false);
   }
 
   @Test
   public void testTokenWithDoAs() {
-    testToken(true, "userA");
+    testToken(true, "userA", false);
   }
 
+  @Test
+  public void testTokenWithDoAsAndIncludeGroups() {
+    testToken(true, "userA", true);
+  }
 
   @Test
   public void testTokenRenewalWithNoDoAs() throws Exception {
@@ -101,15 +106,12 @@ public class TokenTest {
     testRevokeToken(true, "userA");
   }
 
-
-  private void testToken(boolean setDoAsUser, String doAsUser) {
+  private void testToken(boolean setDoAsUser, String doAsUser, boolean includeGroupsInToken) {
     KnoxSession knoxSession = createMock(KnoxSession.class);
     expect(knoxSession.base()).andReturn("http://localhost/base").atLeastOnce();
     replay(knoxSession);
 
-    Get.Request request = (setDoAsUser)
-        ? Token.get(knoxSession, doAsUser)
-        : Token.get(knoxSession);
+    Get.Request request = Token.get(knoxSession, setDoAsUser ? doAsUser : null, includeGroupsInToken);
 
     if (setDoAsUser) {
       assertEquals(doAsUser, request.getDoAsUser());
@@ -117,11 +119,9 @@ public class TokenTest {
       assertNull(request.getDoAsUser());
     }
 
-    if (setDoAsUser && StringUtils.isNotEmpty(doAsUser)) {
-      assertEquals("http://localhost/base/knoxtoken/api/v1/token?doAs=" + doAsUser, request.getRequestURI().toString());
-    } else {
-      assertEquals("http://localhost/base/knoxtoken/api/v1/token", request.getRequestURI().toString());
-    }
+    assertTrue(request.getRequestURI().toString().startsWith("http://localhost/base/knoxtoken/api/v1/token"));
+    assertEquals(setDoAsUser && StringUtils.isNotEmpty(doAsUser), request.getRequestURI().toString().contains("doAs=" + doAsUser));
+    assertEquals(includeGroupsInToken, request.getRequestURI().toString().contains("knox.token.include.groups=true"));
 
     assertSame(knoxSession, request.getSession());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a flag to Knox shell Token.Get API to support tokens with group informations in them.


## How was this patch tested?

1.

Generated a token and checked the group information in the result:

```java
  public static void main(String[] args) throws Exception {
    ClientContext context = ClientContext.with("admin", "admin-password", "https://localhost:8443/gateway/homepage");
    KnoxSession knoxSession = new KnoxSession(context);
    System.out.println( Token.get(knoxSession, null, true).now().getString() );
  }
```

2.

Generated a token and verified that there was no group information in the result:

```java
  public static void main(String[] args) throws Exception {
    ClientContext context = ClientContext.with("admin", "admin-password", "https://localhost:8443/gateway/homepage");
    KnoxSession knoxSession = new KnoxSession(context);
    System.out.println( Token.get(knoxSession, null, false).now().getString() );
  }
```