### PR TITLE
KNOX-2734 - Passcode token is optional in TokenResource's response

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -228,7 +228,12 @@ var gen = function() {
                     $('#accessToken').text(accessToken);
                     var decodedToken = b64DecodeUnicode(accessToken.split(".")[1]);
                     var jwtjson = JSON.parse(decodedToken);
-                    $('#accessPasscode').text(resp.passcode);
+                    if (resp.passcode && resp.passcode != "") {
+                        document.getElementById('jwtPasscodeTokenLabel').style.display = 'block';
+                        $('#accessPasscode').text(resp.passcode);
+                    } else {
+                        document.getElementById('jwtPasscodeTokenLabel').style.display = 'none';
+                    }
                     $('#expiry').text(new Date(resp.expires_in).toLocaleString());
                     $('#user').text(jwtjson.sub);
                     var homepageURL = resp.homepage_url;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AbstractPersistentTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AbstractPersistentTokenStateService.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import org.apache.knox.gateway.services.security.token.PersistentTokenStateService;
+
+public abstract class AbstractPersistentTokenStateService extends DefaultTokenStateService implements PersistentTokenStateService {
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -53,7 +53,7 @@ import org.apache.knox.gateway.util.Tokens;
 /**
  * A TokenStateService implementation based on the AliasService.
  */
-public class AliasBasedTokenStateService extends DefaultTokenStateService implements TokenStatePeristerMonitorListener {
+public class AliasBasedTokenStateService extends AbstractPersistentTokenStateService implements TokenStatePeristerMonitorListener {
 
   static final String TOKEN_ALIAS_SUFFIX_DELIM   = "--";
   static final String TOKEN_ISSUE_TIME_POSTFIX   = TOKEN_ALIAS_SUFFIX_DELIM + "iss";

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -39,7 +39,7 @@ import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.util.JDBCUtils;
 import org.apache.knox.gateway.util.Tokens;
 
-public class JDBCTokenStateService extends DefaultTokenStateService {
+public class JDBCTokenStateService extends AbstractPersistentTokenStateService {
   private AliasService aliasService; // connection username/pw and passcode HMAC secret are stored here
   private TokenStateDatabase tokenDatabase;
   private AtomicBoolean initialized = new AtomicBoolean(false);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateService.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class JournalBasedTokenStateService extends DefaultTokenStateService {
+public class JournalBasedTokenStateService extends AbstractPersistentTokenStateService {
 
     private TokenStateJournal journal;
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateServiceTest.java
@@ -318,13 +318,13 @@ public class JournalBasedTokenStateServiceTest extends DefaultTokenStateServiceT
     }
 
     private static Map<String, Long> getTokenExpirationsField(TokenStateService tss) throws Exception {
-        Field tokenExpirationsField = tss.getClass().getSuperclass().getDeclaredField("tokenExpirations");
+        Field tokenExpirationsField = tss.getClass().getSuperclass().getSuperclass().getDeclaredField("tokenExpirations");
         tokenExpirationsField.setAccessible(true);
         return (Map<String, Long>) tokenExpirationsField.get(tss);
     }
 
     private static Map<String, Long> getMaxTokenLifetimesField(TokenStateService tss) throws Exception {
-        Field maxTokenLifetimesField = tss.getClass().getSuperclass().getDeclaredField("maxTokenLifetimes");
+        Field maxTokenLifetimesField = tss.getClass().getSuperclass().getSuperclass().getDeclaredField("maxTokenLifetimes");
         maxTokenLifetimesField.setAccessible(true);
         return (Map<String, Long>) maxTokenLifetimesField.get(tss);
     }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -79,6 +79,7 @@ import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
 import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.KnoxToken;
+import org.apache.knox.gateway.services.security.token.PersistentTokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
@@ -103,7 +104,7 @@ public class TokenResource {
   private static final String TOKEN_TYPE = "token_type";
   private static final String ACCESS_TOKEN = "access_token";
   private static final String TOKEN_ID = "token_id";
-  private static final String PASSCODE = "passcode";
+  static final String PASSCODE = "passcode";
   private static final String MANAGED_TOKEN = "managed";
   private static final String TARGET_URL = "target_url";
   private static final String ENDPOINT_PUBLIC_CERT = "endpoint_public_cert";
@@ -804,8 +805,11 @@ public class TokenResource {
         if (endpointPublicCert != null) {
           map.put(ENDPOINT_PUBLIC_CERT, endpointPublicCert);
         }
+
         final String passcode = UUID.randomUUID().toString();
-        map.put(PASSCODE, generatePasscodeField(tokenId, passcode));
+        if (tokenStateService != null && tokenStateService instanceof PersistentTokenStateService) {
+          map.put(PASSCODE, generatePasscodeField(tokenId, passcode));
+        }
 
         String jsonResponse = JsonUtils.renderAsJsonString(map);
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/PersistentTokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/PersistentTokenStateService.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+/**
+ * A marker interface that indicates the tokens are stored in a persistent
+ * repository (FileSystem, Database, ZooKeeper, etc...)
+ */
+public interface PersistentTokenStateService extends TokenStateService {
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in [KNOX-2734](https://issues.apache.org/jira/browse/KNOX-2734), the passcode token should not be presented in the JSON response coming from TokenResource, when a Knox Token is generated, if:
- token state management is disabled
- the underlying token state backend stores the tokens in-memory only

The token generation UI got modified too: when there is no passcode tag in the JSON response there is no reason to show its label on the UI.

## How was this patch tested?

Added new JUnit tests to cover the new business logic.

Additionally, I did E2E testing:
- added KnoxToken service into the `sandbox` topology with `knox.token.exp.server-managed=false`
- configured the token state backend to `DefaultTokenStateService` in `gateway-site.xml`
- Left `knox.token.exp.server-managed=true` in the `homepage` topology
- Generated a token using the token generation page and confirmed the `Passcode Token` label was hidden
```
$ curl -iku admin:admin-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
HTTP/1.1 200 OK
...

{"access_token":"eyJqa3...W7S7rAVtg","token_id":"bc6ae4b8-3064-4835-8601-5cfffa0cbc51","managed":"false","target_url":"proxy-token/","homepage_url":"homepage/home?profile=token&topologies=sandbox","endpoint_public_cert":"MIIDeDCCAmCgAwIBAgIIfjC1dY...etfIPYZ5yWVL7Q==","token_type":"Bearer","expires_in":1660896802064}
```

- Changed `knox.token.exp.server-managed` to `true` in the `sandbox` topology (please note, the token state backend is still `DefaultTokenStateService`
```
$ curl -iku admin:admin-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
HTTP/1.1 200 OK
...

{"access_token":"eyJqa3UiOiJodH...Gfy157xezu3Q","token_id":"8fad76c1-147d-44f0-8d18-a067eea7d615","managed":"true","target_url":"proxy-token/","homepage_url":"homepage/home?profile=token&topologies=sandbox","endpoint_public_cert":"MIIDeDCCAmCgAwIBAgIIfj...aetfIPYZ5yWVL7Q==","token_type":"Bearer","expires_in":1660897040594}
```
- Set `gateway.service.tokenstate.impl` to `org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService` in `gateway-site.xml` and re-started Knox
```
{"access_token":"eyJqa3UiOiJodHRwczp...3zAiz5ygsEBuOVQ","token_id":"f5aaa081-5de2-40aa-8d6f-9961a93bf502","managed":"true","target_url":"proxy-token/","homepage_url":"homepage/home?profile=token&topologies=sandbox","endpoint_public_cert":"MIIDeDCCAmCg...kEFdn5aetfIPYZ5yWVL7Q==","token_type":"Bearer","expires_in":1660896828475,"passcode":"WmpWaFlXRXdPREV0TldSbE1pMDBNR0ZoTFRoa05tWXRPVGsyTVdFNU0ySm1OVEF5OjpZVFF6T1dRd05UVXROamcwWWkwME9HWTNMVGxqT1RBdE16WTBZMkUwTlRFMllXRTM="}
```
- Generated a token using the token generation page and confirmed the `Passcode Token` label was shown with the correct passcode
