### PR TITLE
KNOX-2737 - Make maxFormContentSize and maxFormKeys configurable in Knox's embedded Jetty server

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -712,4 +712,10 @@ public interface GatewayMessages {
           text = "Unable to complete service discovery for cluster {0} topology = {1}.")
   void failedToDiscoverClusterServices(String clusterName, String topologyName,
                                        @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.DEBUG, text = "Jetty's maxFormContentSize is set to {0}")
+  void setMaxFormContentSize(int maxFormContentSize);
+
+  @Message(level = MessageLevel.DEBUG, text = "Jetty's maxFormKeys is set to {0}")
+  void setMaxFormKeys(int maxFormKeys);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -65,6 +65,7 @@ import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
@@ -598,6 +599,11 @@ public class GatewayServer {
     // Start Jetty.
     jetty = new Server( new QueuedThreadPool( config.getThreadPoolMax() ) );
 
+    jetty.setAttribute(ContextHandler.MAX_FORM_CONTENT_SIZE_KEY, config.getJettyMaxFormContentSize());
+    log.setMaxFormContentSize(config.getJettyMaxFormContentSize());
+    jetty.setAttribute(ContextHandler.MAX_FORM_KEYS_KEY, config.getJettyMaxFormKeys());
+    log.setMaxFormKeys(config.getJettyMaxFormKeys());
+
     /* topologyName is null because all topology listen on this port */
     jetty.addConnector( createConnector( jetty, config, config.getGatewayPort(), null) );
 
@@ -800,6 +806,10 @@ public class GatewayServer {
     context.setInitParameter("org.eclipse.jetty.servlet.Default.dirAllowed", "false");
     ClassLoader jspClassLoader = new URLClassLoader(new URL[0], this.getClass().getClassLoader());
     context.setClassLoader(jspClassLoader);
+    context.setMaxFormContentSize(config.getJettyMaxFormContentSize());
+    log.setMaxFormContentSize(config.getJettyMaxFormContentSize());
+    context.setMaxFormKeys(config.getJettyMaxFormKeys());
+    log.setMaxFormKeys(config.getJettyMaxFormKeys());
     return context;
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -49,6 +49,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.dto.HomePageProfile;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
@@ -142,6 +143,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String GRAPHITE_METRICS_REPORTING_FREQUENCY = GATEWAY_CONFIG_FILE_PREFIX + ".graphite.metrics.reporting.frequency";
   public static final String GATEWAY_IDLE_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".idle.timeout";
   public static final String REMOTE_IP_HEADER_NAME = GATEWAY_CONFIG_FILE_PREFIX + ".remote.ip.header.name";
+  private static final String JETTY_MAX_FORM_CONTENT_SIZE = GATEWAY_CONFIG_FILE_PREFIX + ".jetty.max.form.content.size";
+  private static final String JETTY_MAX_FORM_KEYS = GATEWAY_CONFIG_FILE_PREFIX + ".jetty.max.form.keys";
 
   /* @since 0.10 Websocket config variables */
   public static final String WEBSOCKET_FEATURE_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".websocket.feature.enabled";
@@ -1314,6 +1317,16 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getDatabaseSslTruststoreFileName() {
     return get(GATEWAY_DATABASE_TRUSTSTORE_FILE);
+  }
+
+  @Override
+  public int getJettyMaxFormContentSize() {
+    return getInt(JETTY_MAX_FORM_CONTENT_SIZE, ContextHandler.DEFAULT_MAX_FORM_CONTENT_SIZE);
+  }
+
+  @Override
+  public int getJettyMaxFormKeys() {
+    return getInt(JETTY_MAX_FORM_KEYS, ContextHandler.DEFAULT_MAX_FORM_KEYS);
   }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -798,4 +798,7 @@ public interface GatewayConfig {
 
   String getDatabaseSslTruststoreFileName();
 
+  int getJettyMaxFormContentSize();
+
+  int getJettyMaxFormKeys();
 }

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -922,4 +922,13 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return null;
   }
 
+  @Override
+  public int getJettyMaxFormContentSize() {
+    return 0;
+  }
+
+  @Override
+  public int getJettyMaxFormKeys() {
+    return 0;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Knox's embedded Jetty's maxFormContentSize and maxFormKeys configurations are now configurable in `gateway-site.xml`

## How was this patch tested?

Ran JUnit tests:
```
$  mvn clean -Dshellcheck=true verify -Prelease,package -am -pl gateway-server
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:59 min
[INFO] Finished at: 2022-04-22T15:54:23+02:00
[INFO] ------------------------------------------------------------------------
```
