### PR TITLE
KNOX-2738 On Fresh install JDBCTokenStateService initiation failed

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -449,6 +449,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>provided</scope>
+            <version>2.4.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
             <scope>test</scope>

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -452,7 +452,6 @@
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
             <scope>provided</scope>
-            <version>2.4.0</version>
         </dependency>
 
         <dependency>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/JDBCUtils.java
@@ -23,6 +23,7 @@ import org.apache.derby.jdbc.ClientDataSource;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.hsqldb.jdbc.JDBCDataSource;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.postgresql.jdbc.SslMode;
 import org.postgresql.ssl.NonValidatingFactory;
@@ -34,6 +35,7 @@ public class JDBCUtils {
   public static final String POSTGRESQL_DB_TYPE = "postgresql";
   public static final String MYSQL_DB_TYPE = "mysql";
   public static final String DERBY_DB_TYPE = "derbydb";
+  public static final String HSQL = "hsql";
   public static final String DATABASE_USER_ALIAS_NAME = "gateway_database_user";
   public static final String DATABASE_PASSWORD_ALIAS_NAME = "gateway_database_password";
   public static final String DATABASE_TRUSTSTORE_PASSWORD_ALIAS_NAME = "gateway_database_ssl_truststore_password";
@@ -43,6 +45,8 @@ public class JDBCUtils {
       return createPostgresDataSource(gatewayConfig, aliasService);
     } else if (DERBY_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
       return createDerbyDatasource(gatewayConfig, aliasService);
+    } else if (HSQL.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
+      return createHsqlDatasource(gatewayConfig, aliasService);
     } else if (MYSQL_DB_TYPE.equalsIgnoreCase(gatewayConfig.getDatabaseType())) {
       return createMySqlDataSource(gatewayConfig, aliasService);
     }
@@ -85,6 +89,15 @@ public class JDBCUtils {
     derbyDatasource.setUser(getDatabaseUser(aliasService));
     derbyDatasource.setPassword(getDatabasePassword(aliasService));
     return derbyDatasource;
+  }
+
+
+  private static DataSource createHsqlDatasource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
+    JDBCDataSource hsqlDatasource = new JDBCDataSource();
+    hsqlDatasource.setUrl(gatewayConfig.getDatabaseConnectionUrl());
+    hsqlDatasource.setUser(getDatabaseUser(aliasService));
+    hsqlDatasource.setPassword(getDatabasePassword(aliasService));
+    return hsqlDatasource;
   }
 
   private static DataSource createMySqlDataSource(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException, SQLException {

--- a/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
@@ -13,7 +13,7 @@
 --  License for the specific language governing permissions and limitations under
 --  the License.
 
-CREATE TABLE KNOX_TOKENS (
+CREATE TABLE IF NOT EXISTS KNOX_TOKENS (
    token_id varchar(128) NOT NULL,
    issue_time bigint NOT NULL,
    expiration bigint NOT NULL,

--- a/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenDatabaseTable.sql
@@ -13,7 +13,7 @@
 --  License for the specific language governing permissions and limitations under
 --  the License.
 
-CREATE TABLE IF NOT EXISTS KNOX_TOKENS (
+CREATE TABLE IF NOT EXISTS KNOX_TOKENS ( -- IF NOT EXISTS syntax is not supported by Derby
    token_id varchar(128) NOT NULL,
    issue_time bigint NOT NULL,
    expiration bigint NOT NULL,

--- a/gateway-server/src/main/resources/createKnoxTokenMetadataDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenMetadataDatabaseTable.sql
@@ -13,7 +13,7 @@
 --  License for the specific language governing permissions and limitations under
 --  the License.
 
-CREATE TABLE IF NOT EXISTS KNOX_TOKEN_METADATA (
+CREATE TABLE IF NOT EXISTS KNOX_TOKEN_METADATA ( -- IF NOT EXISTS syntax is not supported by Derby
    token_id varchar(128) NOT NULL,
    md_name varchar(32) NOT NULL,
    md_value varchar(256) NOT NULL,

--- a/gateway-server/src/main/resources/createKnoxTokenMetadataDatabaseTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenMetadataDatabaseTable.sql
@@ -13,7 +13,7 @@
 --  License for the specific language governing permissions and limitations under
 --  the License.
 
-CREATE TABLE KNOX_TOKEN_METADATA (
+CREATE TABLE IF NOT EXISTS KNOX_TOKEN_METADATA (
    token_id varchar(128) NOT NULL,
    md_name varchar(32) NOT NULL,
    md_value varchar(256) NOT NULL,

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.services.token.impl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.knox.gateway.util.JDBCUtils.HSQL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -63,6 +64,7 @@ public class JDBCTokenStateServiceTest {
   @ClassRule
   public static final TemporaryFolder testFolder = new TemporaryFolder();
   public static final String CONNECTION_URL = "jdbc:hsqldb:mem:knox;ifexists=false";
+  public static final String DB_NAME = "knox";
   private static JDBCTokenStateService jdbcTokenStateService;
   private static TokenMAC tokenMAC;
 
@@ -70,9 +72,9 @@ public class JDBCTokenStateServiceTest {
   @BeforeClass
   public static void setUp() throws Exception {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
-    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn("hsql").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(HSQL).anyTimes();
     EasyMock.expect(gatewayConfig.getDatabaseConnectionUrl()).andReturn(CONNECTION_URL).anyTimes();
-    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("knox").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn(DB_NAME).anyTimes();
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn(USERNAME.toCharArray()).anyTimes();
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn(PASSWORD.toCharArray()).anyTimes();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
@@ -22,9 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -36,23 +35,18 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.derby.drda.NetworkServerControl;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.token.KnoxToken;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
 import org.apache.knox.gateway.services.security.token.impl.TokenMAC;
-import org.apache.knox.gateway.shell.jdbc.Database;
-import org.apache.knox.gateway.shell.jdbc.derby.DerbyDatabase;
 import org.apache.knox.gateway.util.JDBCUtils;
 import org.easymock.EasyMock;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -60,65 +54,33 @@ import org.junit.rules.TemporaryFolder;
 
 public class JDBCTokenStateServiceTest {
 
+  public static final String USERNAME = "SA";
+  public static final String PASSWORD = "";
   private static final String GET_TOKENS_COUNT_SQL = "SELECT count(*) FROM " + TokenStateDatabase.TOKENS_TABLE_NAME;
   private static final String TRUNCATE_KNOX_TOKENS_SQL = "DELETE FROM " + TokenStateDatabase.TOKENS_TABLE_NAME;
   private static final String TRUNCATE_KNOX_TOKEN_METADATA_SQL = "DELETE FROM " + TokenStateDatabase.TOKEN_METADATA_TABLE_NAME;
 
   @ClassRule
   public static final TemporaryFolder testFolder = new TemporaryFolder();
-
-  private static final String SYSTEM_PROPERTY_DERBY_STREAM_ERROR_FILE = "derby.stream.error.file";
-  private static final String SAMPLE_DERBY_DATABASE_NAME = "sampleDerbyDatabase";
-  private static NetworkServerControl derbyNetworkServerControl;
-  private static Database derbyDatabase;
+  public static final String CONNECTION_URL = "jdbc:hsqldb:mem:knox;ifexists=false";
   private static JDBCTokenStateService jdbcTokenStateService;
   private static TokenMAC tokenMAC;
 
   @SuppressWarnings("PMD.JUnit4TestShouldUseBeforeAnnotation")
   @BeforeClass
   public static void setUp() throws Exception {
-    final String username = "app";
-    final String password = "P4ssW0rd!";
-    System.setProperty(SYSTEM_PROPERTY_DERBY_STREAM_ERROR_FILE, "/dev/null");
-    derbyNetworkServerControl = new NetworkServerControl(username, password);
-    derbyNetworkServerControl.start(null);
-    TimeUnit.SECONDS.sleep(1); // give a bit of time for the server to start
-    final Path derbyDatabaseFolder = Paths.get(testFolder.newFolder().toPath().toString(), SAMPLE_DERBY_DATABASE_NAME);
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
-    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();
-    EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
-    EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(NetworkServerControl.DEFAULT_PORTNUMBER).anyTimes();
-    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn(derbyDatabaseFolder.toString()).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn("hsql").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseConnectionUrl()).andReturn(CONNECTION_URL).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("knox").anyTimes();
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
-    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn(username.toCharArray()).anyTimes();
-    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn(password.toCharArray()).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn(USERNAME.toCharArray()).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn(PASSWORD.toCharArray()).anyTimes();
     EasyMock.replay(gatewayConfig, aliasService);
-
-    derbyDatabase = prepareDerbyDatabase(derbyDatabaseFolder);
-
     jdbcTokenStateService = new JDBCTokenStateService();
     jdbcTokenStateService.setAliasService(aliasService);
     jdbcTokenStateService.init(gatewayConfig, null);
-
-    assertTrue(derbyDatabase.hasTable(TokenStateDatabase.TOKENS_TABLE_NAME));
-
     tokenMAC = new TokenMAC(HmacAlgorithms.HMAC_SHA_256.getName(), "sPj8FCgQhCEi6G18kBfpswxYSki33plbelGLs0hMSbk".toCharArray());
-  }
-
-  private static Database prepareDerbyDatabase(Path derbyDatabaseFolder) throws SQLException {
-    final Database derbyDatabase = new DerbyDatabase(derbyDatabaseFolder.toString(), true);
-    derbyDatabase.create();
-    return derbyDatabase;
-  }
-
-  @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
-  @AfterClass
-  public static void tearDown() throws Exception {
-    if (derbyDatabase != null) {
-      derbyDatabase.shutdown();
-    }
-    derbyNetworkServerControl.shutdown();
-    System.clearProperty(SYSTEM_PROPERTY_DERBY_STREAM_ERROR_FILE);
   }
 
   @Test
@@ -266,7 +228,7 @@ public class JDBCTokenStateServiceTest {
   }
 
   private long getLongTokenAttributeFromDatabase(String tokenId, String sql) throws SQLException {
-    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+    try (Connection conn = getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
       if (tokenId != null) {
         stmt.setString(1, tokenId);
       }
@@ -277,7 +239,7 @@ public class JDBCTokenStateServiceTest {
   }
 
   private String getStringTokenAttributeFromDatabase(String tokenId, String sql) throws SQLException {
-    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+    try (Connection conn = getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
       stmt.setString(1, tokenId);
       try (ResultSet rs = stmt.executeQuery()) {
         return rs.next() ? rs.getString(1) : null;
@@ -286,13 +248,17 @@ public class JDBCTokenStateServiceTest {
   }
 
   private void truncateDatabase() throws SQLException {
-    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(TRUNCATE_KNOX_TOKEN_METADATA_SQL)) {
+    try (Connection conn = getConnection(); PreparedStatement stmt = conn.prepareStatement(TRUNCATE_KNOX_TOKEN_METADATA_SQL)) {
       stmt.executeUpdate();
     }
 
-    try (Connection conn = derbyDatabase.getConnection(); PreparedStatement stmt = conn.prepareStatement(TRUNCATE_KNOX_TOKENS_SQL)) {
+    try (Connection conn = getConnection(); PreparedStatement stmt = conn.prepareStatement(TRUNCATE_KNOX_TOKENS_SQL)) {
       stmt.executeUpdate();
     }
+  }
+
+  private Connection getConnection() throws SQLException {
+    return DriverManager.getConnection(CONNECTION_URL, USERNAME, PASSWORD);
   }
 
   private String getSelectMetadataSql(String metadataName) {

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
         <curator.version>4.3.0</curator.version>
         <dependency-check-maven.version>6.0.3</dependency-check-maven.version>
         <derby.db.version>10.14.2.0</derby.db.version> <!-- 10.15.1.3 requires Java 9 -->
+        <hsql.db.version>2.4.0</hsql.db.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
         <dom4j.version>2.1.3</dom4j.version>
         <easymock.version>4.2</easymock.version>
@@ -2481,6 +2482,11 @@
                 <artifactId>vault</artifactId>
                 <version>${testcontainers.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hsqldb</groupId>
+                <artifactId>hsqldb</artifactId>
+                <version>${hsql.db.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Starting multiple knox instances can cause token state service initialization failures when they try to create the same database tables.

```
ERROR knox.gateway (TokenStateServiceFactory.java:createService(63)) - Error while initiatalizing org.apache.knox.gateway.services.token.impl.JDBCTokenStateService: Error while initiating JDBCTokenStateService: org.postgresql.util.PSQLException: ERROR: relation "knox_tokens" already exists
```

To fix this issue I added a `IF NOT EXISTS` clause to the create table statement. This is unfortunately not supported by Derby (which is only used for unit testing), so I replaced derby with hsql.

## How was this patch tested?

I tested manually with both mysql and postgres.

Postgres gateway-site config:

```xml

    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.JDBCTokenStateService</value>
    </property>
     <property>
        <name>gateway.database.type</name>
        <value>postgresql</value>
    </property>
    <property>
        <name>gateway.database.connection.url</name>
        <value>jdbc:postgresql://localhost:5432/postgres?user=postgres</value>
    </property>
```

```bash
$ docker run --name posttest -d -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:alpine
```

```bash
   $ docker exec -it posttest psql -U postgres


   postgres=# select * from knox_tokens;
               token_id               |  issue_time   |  expiration   | max_lifetime  
--------------------------------------+---------------+---------------+---------------
 ad4953c9-38dd-4214-8ce1-e3b873a81f13 | 1650961012152 | 1650964612097 | 1651565812152
 d37f744c-ef5b-4086-a9b7-6c1c0640e596 | 1650961013088 | 1650964613065 | 1651565813088
 058b4e5c-642c-42fc-9e5a-9d23a56256d5 | 1650961026745 | 1650964626709 | 1651565826745
(3 rows)
```

MySql gateway-site config:

```xml
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.JDBCTokenStateService</value>
    </property>
     <property>
        <name>gateway.database.type</name>
        <value>mysql</value>
    </property>
     <property>
        <name>gateway.database.name</name>
        <value>mysql</value>
    </property>
     <property>
        <name>gateway.database.host</name>
        <value>localhost</value>
    </property>
     <property>
        <name>gateway.database.port</name>
        <value>3306</value>
    </property>
```

```bash
./bin/knoxcli.sh create-alias gateway_database_user --value root
./bin/knoxcli.sh create-alias gateway_database_password  --value password

$ docker exec -it mysql1 mysql -u root -p
```

