### PR TITLE
KNOX-2736 Knox clients should support retry/failover

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ClientContext.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ClientContext.java
@@ -195,6 +195,39 @@ public class ClientContext {
     public String endpointPublicCertPem() {
       return configuration.getString("endpointPublicCertPem");
     }
+
+    /**
+     * Number of retries, after a failure, before giving up.
+     */
+    public ConnectionContext retryCount(int retryCount) {
+      configuration.addProperty("retryCount", retryCount);
+      return this;
+    }
+
+    public int retryCount() {
+      return configuration.getInt("retryCount", 3);
+    }
+
+    /**
+     * true if it's OK to retry requests that have been sent
+     */
+    public ConnectionContext withRequestSentRetryEnabled(boolean retryNonIdempotent) {
+      configuration.addProperty("requestSentRetryEnabled", retryNonIdempotent);
+      return this;
+    }
+
+    public boolean requestSentRetryEnabled() {
+      return configuration.getBoolean("requestSentRetryEnabled", false);
+    }
+
+    public ConnectionContext withRetryIntervalMillis(int msec) {
+      configuration.addProperty("retryIntervalMillis", msec);
+      return this;
+    }
+
+    public int retryIntervalMillis() {
+      return configuration.getInt("retryIntervalMillis", 1000);
+    }
   }
 
   /**

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxClientRetryHandler.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/KnoxClientRetryHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell;
+
+import java.io.InterruptedIOException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.net.ssl.SSLException;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+
+/**
+ * This is the same as StandardHttpRequestRetryHandler, but ConnectException is not marked as non-retriable,
+ * so connection timeouts and connection refused are also retried
+ */
+public class KnoxClientRetryHandler extends DefaultHttpRequestRetryHandler {
+    private final Map<String, Boolean> idempotentMethods;
+
+    public KnoxClientRetryHandler(int retryCount, boolean requestSentRetryEnabled) {
+        super(retryCount, requestSentRetryEnabled, Arrays.asList(InterruptedIOException.class, UnknownHostException.class, SSLException.class));
+        this.idempotentMethods = new ConcurrentHashMap();
+        this.idempotentMethods.put("GET", Boolean.TRUE);
+        this.idempotentMethods.put("HEAD", Boolean.TRUE);
+        this.idempotentMethods.put("PUT", Boolean.TRUE);
+        this.idempotentMethods.put("DELETE", Boolean.TRUE);
+        this.idempotentMethods.put("OPTIONS", Boolean.TRUE);
+        this.idempotentMethods.put("TRACE", Boolean.TRUE);
+    }
+
+    @Override
+    protected boolean handleAsIdempotent(HttpRequest request) {
+        String method = request.getRequestLine().getMethod().toUpperCase(Locale.ROOT);
+        Boolean b = this.idempotentMethods.get(method);
+        return b != null && b;
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The apache http client has a default mechanism (StandardHttpRequestRetryHandler and DefaultServiceUnavailableRetryStrategy) to support retries.

* DefaultServiceUnavailableRetryStrategy only retries in case of a 503 - ServiceUnavailable.
* StandardHttpRequestRetryHandler retries when a non excluded exception occurs during the request.

The excluded exceptions are: InterruptedIOException, UnknownHostException, ConnectException, SSLException. In these cases no retry is going to happen.

However I think we should also retry in case of a ConnectException since ConnectionRefused and ConnectionTimeoouts are subclasses of ConnectException.

The following HTTP methods are considered idempotent so they can be retried: GET, HEAD, PUT, DELETE, OPTIONS, TRACE.

Note that if an endpoint is implemented as a non-idempotent way (for example a PUT) then this might have unwanted side-effects.

Other methods such as POST are only retried if the request has not yet written out to the output stream when the error happened. Or if requestSentRetryEnabled is enabled.

## How was this patch tested?

### Service Unavailable

I used this mini http server that simulates an 503, and only works at the 3rd try.

```smalltalk
| c | 
c := 0.
Teapot on
  GET: '/knoxtoken/api/v1/token' -> [ 
    c := c + 1. 
    Transcript
       cr;
       show: 'Incoming request. c=', c asString.
    c < 3 
      ifTrue:[ TeaResponse code: 503 ] 
      ifFalse: [ 'OK' ] 
  ];
  start. 
```

#### Retry count is 0 => Failed 


```java
    ClientContext context = ClientContext.with("http://localhost:1701");
    context.connection().retryCount(0);
    KnoxSession session = KnoxSession.login(context);
    System.out.println( Token.get(session).now().getString() );
```

```
Caused by: org.apache.knox.gateway.shell.ErrorResponse: http://localhost:1701/knoxtoken/api/v1/token: HTTP/1.1 503 Service Unavailable    
```

#### Retry count is 2 => OK

```java
    ClientContext context = ClientContext.with("http://localhost:1701");
    context.connection().retryCount(2);
    KnoxSession session = KnoxSession.login(context);
    System.out.println( Token.get(session).now().getString() );
```

```
OK
Process finished with exit code 0

2022-04-28 12:39:00 116 793648 Request Read a ZnRequest(GET /knoxtoken/api/v1/token) 0ms
Incoming request. c=1
2022-04-28 12:39:01 124 837271 Request Read a ZnRequest(GET /knoxtoken/api/v1/token) 0ms
Incoming request. c=2
2022-04-28 12:39:02 132 050616 Request Read a ZnRequest(GET /knoxtoken/api/v1/token) 0ms
Incoming request. c=3
```

I tested other errors such as ConnectionRefused separately.