### PR TITLE
KNOX-2740 - Impersonation-related fields should be displayed only if that's enabled in the topology for the KnoxToken service

### DIFF
--- a/gateway-applications/src/main/resources/applications/tokengen/app/index.html
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/index.html
@@ -79,9 +79,11 @@
                             </table>
                             <label style="display: none; color: red;" id="invalidLifetimeText"><i class="icon-warning"></i>Invalid lifetime!</label>
                         </div>
-                        <label><i class="icon-user"></i> Generating token for (impersonation):</label>
-                        <input type="text" name="doas" id="doas" size="50" maxlength="255">
-                        <label style="display: none; color: red;" id="invalidDoasText"><i class="icon-warning"></i>Invalid doAs!</label>
+                        <div id="impersonationFields" style="display: none;">
+                            <label><i class="icon-user"></i> Generating token for (impersonation):</label>
+                            <input type="text" name="doas" id="doas" size="50" maxlength="255">
+                            <label style="display: none; color: red;" id="invalidDoasText"><i class="icon-warning"></i>Invalid doAs!</label>
+                        </div>
                     </div>
                     <span id="errorBox" class="help-inline" style="color:red;display:none;"><span class="errorMsg"></span>
                         <i class="icon-warning-sign" style="color:#ae2817;"></i>

--- a/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
+++ b/gateway-applications/src/main/resources/applications/tokengen/app/js/tokengen.js
@@ -112,6 +112,10 @@ function setTokenStateServiceStatus() {
                     $('#lifespanFields').show();
                     document.getElementById("lifespanInputEnabled").value = "true";
                 }
+
+                if (resp.impersonationEnabled === "true") {
+                    $('#impersonationFields').show();
+                }
             }
         }
     }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -145,6 +145,8 @@ public class TokenResource {
   private static final String TARGET_ENDPOINT_PULIC_CERT_PEM = TOKEN_PARAM_PREFIX + "target.endpoint.cert.pem";
   static final String QUERY_PARAMETER_DOAS = "doAs";
   static final String PROXYUSER_PREFIX = TOKEN_PARAM_PREFIX + "proxyuser";
+  private static final String IMPERSONATION_ENABLED_PARAM = TOKEN_PARAM_PREFIX + "impersonation.enabled";
+  private static final String IMPERSONATION_ENABLED_TEXT = "impersonationEnabled";
   public static final String KNOX_TOKEN_INCLUDE_GROUPS = TOKEN_PARAM_PREFIX + "include.groups";
 
   private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
@@ -361,6 +363,10 @@ public class TokenResource {
     final String lifespanInputEnabledValue = context.getInitParameter(LIFESPAN_INPUT_ENABLED_PARAM);
     final Boolean lifespanInputEnabled = lifespanInputEnabledValue == null ? Boolean.TRUE : Boolean.parseBoolean(lifespanInputEnabledValue);
     tokenStateServiceStatusMap.put(LIFESPAN_INPUT_ENABLED_TEXT, lifespanInputEnabled.toString());
+
+    final String impersonationEnabledValue = context.getInitParameter(IMPERSONATION_ENABLED_PARAM);
+    final Boolean impersonationEnabled = impersonationEnabledValue == null ? Boolean.TRUE : Boolean.parseBoolean(impersonationEnabledValue);
+    tokenStateServiceStatusMap.put(IMPERSONATION_ENABLED_TEXT, impersonationEnabled.toString());
   }
 
   private void populateAllowedTokenStateBackendForTokenGenApp(final String actualTokenServiceName) {

--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -66,7 +66,7 @@
 
     <!-- 'doAs' Knox Tokens (tokens created by the current user on behalf on another user -->
 
-    <div class="table-responsive" style="width:100%; overflow: auto; overflow-y: scroll; padding: 10px 0px 0px 0px;">
+    <div class="table-responsive" style="width:100%; overflow: auto; overflow-y: scroll; padding: 10px 0px 0px 0px;" *ngIf="isImpersonationEnabled()">
         <label>Impersonation Knox Tokens</label>
         <table class="table table-hover" [mfData]="doAsKnoxTokens" #doAsTokens="mfDataTable" [mfRowsOnPage]="10">
             <thead>

--- a/knox-token-management-ui/token-management/app/token.management.component.ts
+++ b/knox-token-management-ui/token-management/app/token.management.component.ts
@@ -31,6 +31,7 @@ export class TokenManagementComponent implements OnInit {
     userName: string;
     knoxTokens: KnoxToken[];
     doAsKnoxTokens: KnoxToken[];
+    impersonationEnabled: boolean;
 
     toggleBoolean(propertyName: string) {
         this[propertyName] = !this[propertyName];
@@ -46,6 +47,8 @@ export class TokenManagementComponent implements OnInit {
     ngOnInit(): void {
         console.debug('TokenManagementComponent --> ngOnInit()');
         this.tokenManagementService.getUserName().then(userName => this.setUserName(userName));
+        this.tokenManagementService.getImpersonationEnabled()
+            .then(impersonationEnabled => this.impersonationEnabled = impersonationEnabled === 'true');
     }
 
     setUserName(userName: string) {
@@ -85,6 +88,10 @@ export class TokenManagementComponent implements OnInit {
 
     isTokenExpired(expiration: number): boolean {
         return Date.now() > expiration;
+    }
+
+    isImpersonationEnabled(): boolean {
+        return this.impersonationEnabled;
     }
 
     getCustomMetadataArray(knoxToken: KnoxToken): [string, string][] {

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -31,6 +31,7 @@ export class TokenManagementService {
     enableKnoxTokenUrl = this.apiUrl + 'enable';
     disableKnoxTokenUrl = this.apiUrl + 'disable';
     revokeKnoxTokenUrl = this.apiUrl + 'revoke';
+    getTssStatusUrl = this.apiUrl + 'getTssStatus';
 
     constructor(private http: HttpClient) {}
 
@@ -94,6 +95,23 @@ export class TokenManagementService {
             .then(response => response['sessioninfo'].user as string)
             .catch((err: HttpErrorResponse) => {
                 console.debug('TokenManagementService --> getUserName() --> ' + this.sessionUrl + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    getImpersonationEnabled(): Promise<string> {
+        let headers = new HttpHeaders();
+        headers = this.addJsonHeaders(headers);
+        return this.http.get(this.getTssStatusUrl, { headers: headers})
+            .toPromise()
+            .then(response => response['impersonationEnabled'] as string)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('TokenManagementService --> getImpersonationEnabled() --> ' + this.getTssStatusUrl
+                              + '\n  error: ' + err.message);
                 if (err.status === 401) {
                     window.location.assign(document.location.pathname);
                 } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new KnonToken service level configuration to enable/disable token impersonation. It's called `knox.token.impersonation.enabled` and defaults to `true`. Using this boolean config we can show/hide impersonation-related fields in Knox UIs.

## How was this patch tested?

Manual testing:

1. `knox.token.impersonation.enabled=true` or w/o declaring this config

Token Management UI:
<img width="1781" alt="image" src="https://user-images.githubusercontent.com/34065904/166899212-fe849eb3-4c5d-4be6-9d03-f3f16fcb4115.png">

Token Generation UI:
<img width="1748" alt="image" src="https://user-images.githubusercontent.com/34065904/166899141-30c24349-e842-4296-be8e-82371528ce36.png">

2. `knox.token.impersonation.enabled=false`

Token Management UI:
<img width="1784" alt="image" src="https://user-images.githubusercontent.com/34065904/166899409-ea233c7a-2ca0-4cc1-a4d6-129243453246.png">

Token Generation UI:
<img width="1756" alt="image" src="https://user-images.githubusercontent.com/34065904/166899493-fb3cd817-a956-4579-b40a-939bc5dd8be3.png">
