### PR TITLE
KNOX-2741 - Upgraded Velocity and Pac4j versions

### DIFF
--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -112,7 +112,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gateway-provider-rewrite-func-hostmap-static/pom.xml
+++ b/gateway-provider-rewrite-func-hostmap-static/pom.xml
@@ -85,7 +85,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gateway-provider-rewrite-func-service-registry/pom.xml
+++ b/gateway-provider-rewrite-func-service-registry/pom.xml
@@ -97,7 +97,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/gateway-provider-rewrite-step-encrypt-uri/pom.xml
+++ b/gateway-provider-rewrite-step-encrypt-uri/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gateway-provider-rewrite/pom.xml
+++ b/gateway-provider-rewrite/pom.xml
@@ -187,7 +187,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gateway-provider-security-pac4j/pom.xml
+++ b/gateway-provider-security-pac4j/pom.xml
@@ -137,6 +137,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.velocity</groupId>
+                    <artifactId>velocity</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -456,7 +456,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -191,7 +191,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gateway-test-utils/pom.xml
+++ b/gateway-test-utils/pom.xml
@@ -119,7 +119,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -187,7 +187,7 @@
 
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/AmbariServiceDefinitionTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/AmbariServiceDefinitionTest.java
@@ -155,7 +155,7 @@ public class AmbariServiceDefinitionTest {
     params.put( "AMBARI_URL", "http://localhost:" + mockAmbari.getPort() );
 
     velocity = new VelocityEngine();
-    velocity.setProperty( RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, "org.apache.velocity.runtime.log.NullLogSystem" );
+    velocity.setProperty( "runtime.log.logsystem.class", "org.apache.velocity.runtime.log.NullLogSystem" );
     velocity.setProperty( RuntimeConstants.RESOURCE_LOADER, "classpath" );
     velocity.setProperty( "classpath.resource.loader.class", ClasspathResourceLoader.class.getName() );
     velocity.init();

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayBasicFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayBasicFuncTest.java
@@ -1000,7 +1000,7 @@ public class GatewayBasicFuncTest {
     createFile( user, pass, group, root+"/input/changes.txt", "666", "text/plain", "changes.txt", 307, 201, 200 );
 
     VelocityEngine velocity = new VelocityEngine();
-    velocity.setProperty( RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, "org.apache.velocity.runtime.log.NullLogSystem" );
+    velocity.setProperty( "runtime.log.logsystem.class", "org.apache.velocity.runtime.log.NullLogSystem" );
     velocity.setProperty( RuntimeConstants.RESOURCE_LOADER, "classpath" );
     velocity.setProperty( "classpath.resource.loader.class", ClasspathResourceLoader.class.getName() );
     velocity.init();
@@ -2410,7 +2410,7 @@ public class GatewayBasicFuncTest {
     String gatewayAddrName = InetAddress.getByName( gatewayHostName ).getHostAddress();
 
     VelocityEngine velocity = new VelocityEngine();
-    velocity.setProperty( RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, "org.apache.velocity.runtime.log.NullLogSystem" );
+    velocity.setProperty( "runtime.log.logsystem.class", "org.apache.velocity.runtime.log.NullLogSystem" );
     velocity.setProperty( RuntimeConstants.RESOURCE_LOADER, "classpath" );
     velocity.setProperty( "classpath.resource.loader.class", ClasspathResourceLoader.class.getName() );
     velocity.init();
@@ -2663,7 +2663,7 @@ public class GatewayBasicFuncTest {
     Map<String, Matcher<?>> matchers = new HashMap<>();
 
     VelocityEngine velocity = new VelocityEngine();
-    velocity.setProperty( RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, "org.apache.velocity.runtime.log.NullLogSystem" );
+    velocity.setProperty( "runtime.log.logsystem.class", "org.apache.velocity.runtime.log.NullLogSystem" );
     velocity.setProperty( RuntimeConstants.RESOURCE_LOADER, "classpath" );
     velocity.setProperty( "classpath.resource.loader.class", ClasspathResourceLoader.class.getName() );
     velocity.init();

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <nodejs.version>v12.18.2</nodejs.version>
         <okhttp.version>2.7.5</okhttp.version>
         <opensaml.version>3.4.5</opensaml.version>
-        <pac4j.version>4.3.0</pac4j.version>
+        <pac4j.version>4.5.2</pac4j.version>
         <postgresql.version>42.2.19</postgresql.version>
         <mysql.version>8.0.25</mysql.version>
         <protobuf.version>3.14.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <taglibs-standard.version>1.2.5</taglibs-standard.version>
         <testcontainers.version>1.15.1</testcontainers.version>
         <txw2.version>2.4.0-b180830.0438</txw2.version>
-        <velocity.version>1.7</velocity.version>
+        <velocity.version>2.3</velocity.version>
         <woodstox-core.version>6.1.1</woodstox-core.version>
         <xmlsec.version>2.1.5</xmlsec.version>
         <xmltool.version>3.3</xmltool.version>
@@ -2433,7 +2433,7 @@
 
             <dependency>
                 <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
+                <artifactId>velocity-engine-core</artifactId>
                 <version>${velocity.version}</version>
                 <!--scope>test</scope-->
             </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgraded Velocity and Pac4j versions to address CVE issues in Velocity (Pac4j upgrade was a required upgrade to be compatible with the new Velocity version).
Usually upgrading a 3rd party version is happening on the scope of its own JIRAs, but in this case the Velocity upgrade w/o the Pac4j modification would lead to errors.

## How was this patch tested?

Built and started the Knox Gateway with the new dependencies. I also modified the `knoxsso` topology to have the Pac4j federation provider instead of Shiro authentication and confirmed that I could successfully log in to our environment.