### PR TITLE
KNOX-2742 - Retrying CM service discovery in case of ConnectExceptions

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -81,6 +81,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
            text = "Encountered an error during cluster ({0}) discovery: {1}")
   void clusterDiscoveryError(String clusterName, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.INFO, text = "Sleeping {0} second(s) before retrying Cloudera Manager service discovery for the {1}. time")
+  void retryDiscovery(long retrySleep, int retryAttempt);
+
   @Message(level = MessageLevel.ERROR,
            text = "Failed to access the service configurations for cluster ({0}) discovery: {1}")
   void failedToAccessServiceConfigs(String clusterName, @StackTrace(level = MessageLevel.DEBUG) Exception e);
@@ -250,4 +253,6 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.DEBUG, text = "Clearing service discovery repository...")
   void clearServiceDiscoveryRepository();
 
+  @Message(level = MessageLevel.WARN, text = "The configured maximum retry attempts of {0} may overlap with the configured polling interval settings; using {1} retry attempts")
+  void updateMaxRetryAttempts(int configured, int actual);
 }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.client.ApiResponse;
 import com.cloudera.api.swagger.model.ApiClusterRef;
@@ -55,25 +58,31 @@ import org.apache.knox.gateway.topology.discovery.cm.model.solr.SolrServiceModel
 import org.apache.knox.gateway.topology.discovery.cm.model.spark.Spark3HistoryUIServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.spark.SparkHistoryUIServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.zeppelin.ZeppelinServiceModelGenerator;
+import org.apache.knox.gateway.topology.discovery.cm.monitor.ClouderaManagerClusterConfigurationMonitor;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
-
 import java.lang.reflect.Type;
+import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class ClouderaManagerServiceDiscoveryTest {
 
   private static final String DISCOVERY_URL = "http://localhost:1234";
+  private static final String ATLAS_SERVICE_NAME = "ATLAS-1";
+
+  @Test
+  public void testServiceDiscoveryRetry() throws Exception {
+    //re-using an already existing test with 'true' retry flag
+    doTestAtlasDiscovery(true, true);
+  }
 
   @Test
   public void testJobTrackerServiceDiscovery() {
@@ -130,10 +139,14 @@ public class ClouderaManagerServiceDiscoveryTest {
   }
 
   private void doTestAtlasDiscovery(final boolean isSSL) {
+    doTestAtlasDiscovery(isSSL, false);
+  }
+
+  private void doTestAtlasDiscovery(final boolean isSSL, boolean testRetry) {
     final String hostName       = "atlas-host-1";
     final String port           = "21000";
     final String sslPort        = "21003";
-    ServiceDiscovery.Cluster cluster = doTestAtlasDiscovery(hostName, port, sslPort, isSSL);
+    ServiceDiscovery.Cluster cluster = doTestAtlasDiscovery(hostName, port, sslPort, isSSL, testRetry);
     List<String> atlastURLs = cluster.getServiceURLs(AtlasServiceModelGenerator.SERVICE);
     assertEquals(1, atlastURLs.size());
     assertEquals((isSSL ? "https" : "http") + "://" + hostName + ":" + (isSSL ? sslPort : port),
@@ -935,9 +948,17 @@ public class ClouderaManagerServiceDiscoveryTest {
   }
 
   private ServiceDiscovery.Cluster doTestAtlasDiscovery(final String  atlasHost,
+      final String  port,
+      final String  sslPort,
+      final boolean isSSL) {
+    return doTestAtlasDiscovery(atlasHost, port, sslPort, isSSL, false);
+  }
+
+  private ServiceDiscovery.Cluster doTestAtlasDiscovery(final String  atlasHost,
                                                         final String  port,
                                                         final String  sslPort,
-                                                        final boolean isSSL) {
+                                                        final boolean isSSL,
+                                                        final boolean testRetry) {
     // Configure the role
     Map<String, String> roleProperties = new HashMap<>();
     roleProperties.put("atlas_server_http_port", port);
@@ -945,12 +966,13 @@ public class ClouderaManagerServiceDiscoveryTest {
     roleProperties.put("ssl_enabled", String.valueOf(isSSL));
 
     return doTestDiscovery(atlasHost,
-                           "ATLAS-1",
+                           ATLAS_SERVICE_NAME,
                            AtlasServiceModelGenerator.SERVICE_TYPE,
                            "ATLAS-ATLAS_SERVER-1",
                            AtlasServiceModelGenerator.ROLE_TYPE,
                            Collections.emptyMap(),
-                           roleProperties);
+                           roleProperties,
+                           testRetry);
   }
 
 
@@ -1138,21 +1160,36 @@ public class ClouderaManagerServiceDiscoveryTest {
 
 
   private ServiceDiscovery.Cluster doTestDiscovery(final String hostName,
+      final String serviceName,
+      final String serviceType,
+      final String roleName,
+      final String roleType,
+      final Map<String, String> serviceProperties,
+      final Map<String, String> roleProperties) {
+    return doTestDiscovery(hostName, serviceName, serviceType, roleName, roleType, serviceProperties, roleProperties, false);
+  }
+
+  private ServiceDiscovery.Cluster doTestDiscovery(final String hostName,
                                                    final String serviceName,
                                                    final String serviceType,
                                                    final String roleName,
                                                    final String roleType,
                                                    final Map<String, String> serviceProperties,
-                                                   final Map<String, String> roleProperties) {
+                                                   final Map<String, String> roleProperties,
+                                                   boolean testRetry) {
     final String clusterName = "cluster-1";
 
     GatewayConfig gwConf = EasyMock.createNiceMock(GatewayConfig.class);
+    if (testRetry) {
+      EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryMaximumRetryAttempts()).andReturn(GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS).anyTimes();
+      EasyMock.expect(gwConf.getClusterMonitorPollingInterval(ClouderaManagerClusterConfigurationMonitor.getType())).andReturn(10).anyTimes();
+    }
     EasyMock.replay(gwConf);
 
     ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(clusterName);
 
     // Create the test client for providing test response content
-    TestDiscoveryApiClient mockClient = new TestDiscoveryApiClient(sdConfig, null, null);
+    TestDiscoveryApiClient mockClient = testRetry ? new TestFaultyDiscoveryApiClient(sdConfig, null, null) : new TestDiscoveryApiClient(sdConfig, null, null);
 
     // Prepare the service list response for the cluster
     ApiServiceList serviceList = EasyMock.createNiceMock(ApiServiceList.class);
@@ -1185,6 +1222,9 @@ public class ClouderaManagerServiceDiscoveryTest {
     ServiceDiscovery.Cluster cluster = cmsd.discover(gwConf, sdConfig, clusterName, Collections.emptySet(), mockClient);
     assertNotNull(cluster);
     assertEquals(clusterName, cluster.getName());
+    if (serviceName.equals(ATLAS_SERVICE_NAME)) {
+      assertEquals(testRetry ? 9 : 4, mockClient.getExecuteCount());
+    }
     return cluster;
   }
 
@@ -1276,6 +1316,8 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     private Map<Type, ApiResponse<?>> responseMap = new HashMap<>();
 
+    protected AtomicInteger executeCount = new AtomicInteger(0);
+
     TestDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService,
                            KeystoreService keystoreService) {
       super(sdConfig, aliasService, keystoreService);
@@ -1292,7 +1334,28 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     @Override
     public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
+      executeCount.incrementAndGet();
       return (ApiResponse<T>) responseMap.get(returnType);
+    }
+
+    int getExecuteCount() {
+      return executeCount.get();
+    }
+  }
+
+  private static class TestFaultyDiscoveryApiClient extends TestDiscoveryApiClient {
+
+    TestFaultyDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService,
+                           KeystoreService keystoreService) {
+      super(sdConfig, aliasService, keystoreService);
+    }
+
+    @Override
+    public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
+      if (executeCount.getAndIncrement() < GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS - 2) {
+        throw new ApiException(new ConnectException("Failed to connect to CM HOST"));
+      }
+      return super.execute(call, returnType);
     }
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -261,6 +261,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_REPOSITORY_CACHE_ENTRY_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.repository.cache.entry.ttl";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPS = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.maximum.retry.attemps";
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
@@ -1175,6 +1176,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public long getClouderaManagerServiceDiscoveryRepositoryEntryTTL() {
     return getLong(CLOUDERA_MANAGER_SERVICE_DISCOVERY_REPOSITORY_CACHE_ENTRY_TTL, DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL);
+  }
+
+  @Override
+  public int getClouderaManagerServiceDiscoveryMaximumRetryAttempts() {
+    return getInt(CLOUDERA_MANAGER_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPS, DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS);
   }
 
   @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -111,6 +111,8 @@ public interface GatewayConfig {
 
   long DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL = 600; // 10 minutes
 
+  int DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS = 3;
+
   /**
    * The location of the gateway configuration.
    * Subdirectories will be: topologies
@@ -688,6 +690,16 @@ public interface GatewayConfig {
    * @return the entry TTL in seconds in CM service discovery repository cache where we store service/role configurations
    */
   long getClouderaManagerServiceDiscoveryRepositoryEntryTTL();
+
+  /**
+   * The maximum number of attempts to try connecting to a configured Cloudera
+   * Manager endpoint in case a communication related exception is caught when
+   * trying to discover the configured cluster.
+   * <p>
+   * Setting this configuration to <code>-1</code> indicates the user does not
+   * want to retry the failed service discovery.
+   */
+  int getClouderaManagerServiceDiscoveryMaximumRetryAttempts();
 
   /**
    * @return true, if state for tokens issued by the Knox Token service should be managed by Knox.

--- a/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-test-release-utils/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -797,6 +797,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public int getClouderaManagerServiceDiscoveryMaximumRetryAttempts() {
+    return -1;
+  }
+
+  @Override
   public boolean isServerManagedTokenStateEnabled() {
     return false;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case of `ConnectException`s coming from Cloudera Manager during service discovery, Knox may re-try connecting to CM every 3 seconds for the configured number of times in order to successfully discover the configured cluster for the configured descriptor.

## How was this patch tested?

In addition to adding new unit tests, I manually tested the solution:
- configured `gateway.cloudera.manager.service.discovery.maximum.retry.attemps` to 20 in `gateway-site.xml`
- declared a descriptor with valid CM service discovery params
- started Knox in a way such as it started 20-30 seconds earlier than the configured Cloudera Manager server. In the logs I saw the retry attempt, and, finally, the successful service discovery.
