### PR TITLE
KNOX-2744 Upgrade protobuf-java to 3.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <pac4j.version>4.3.0</pac4j.version>
         <postgresql.version>42.2.19</postgresql.version>
         <mysql.version>8.0.25</mysql.version>
-        <protobuf.version>3.14.0</protobuf.version>
+        <protobuf.version>3.16.1</protobuf.version>
         <rest-assured.version>4.3.3</rest-assured.version>
         <shiro.version>1.8.0</shiro.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump protobuf version to 3.16.1

## How was this patch tested?

```bash
amagyar-MBP16:knox attilamagyar$ mvn dependency:tree | grep protobuf-java
[INFO] |  \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:test
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:test
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:test
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:test
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |  |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.16.1:provided
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
[INFO] |     \- com.google.protobuf:protobuf-java:jar:3.16.1:test
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.16.1:provided
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.16.1:provided
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.16.1:provided
[INFO] |  |     \- com.google.protobuf:protobuf-java:jar:3.16.1:compile
```