### PR TITLE
KNOX-2745 VirtualGroupMapper doesn't use groups from HadoopGroupProviderFilter

### DIFF
--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
@@ -152,7 +152,7 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
     mappedPrincipalName = mapUserPrincipal(mappedPrincipalName);
     String[] mappedGroups = mapGroupPrincipalsBase(mappedPrincipalName, subject);
     String[] groups = mapGroupPrincipals(mappedPrincipalName, subject);
-    String[] virtualGroups = virtualGroupMapper.mapGroups(mappedPrincipalName, groups(subject), request).toArray(new String[0]);
+    String[] virtualGroups = virtualGroupMapper.mapGroups(mappedPrincipalName, combine(subject, groups), request).toArray(new String[0]);
     groups = combineGroupMappings(mappedGroups, groups);
     groups = combineGroupMappings(virtualGroups, groups);
 
@@ -160,6 +160,14 @@ public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilt
         request, mappedPrincipalName);
 
     continueChainAsPrincipal(wrapper, response, chain, mappedPrincipalName, unique(groups));
+  }
+
+  private Set<String> combine(Subject subject, String[] groups) {
+    Set<String> result = groups(subject);
+    if (groups != null) {
+      result.addAll(Arrays.asList(groups));
+    }
+    return result;
   }
 
   private static String[] unique(String[] groups) {

--- a/gateway-provider-identity-assertion-hadoop-groups/src/main/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilter.java
+++ b/gateway-provider-identity-assertion-hadoop-groups/src/main/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilter.java
@@ -96,8 +96,7 @@ public class HadoopGroupProviderFilter extends CommonIdentityAssertionFilter {
     /* return the groups as seen by Hadoop */
     String[] groups;
     try {
-      final List<String> groupList = hadoopGroups
-          .getGroups(mappedPrincipalName);
+      final List<String> groupList = hadoopGroups(mappedPrincipalName);
       LOG.groupsFound(mappedPrincipalName, groupList.toString());
       groups = groupList.toArray(new String[0]);
 
@@ -112,6 +111,10 @@ public class HadoopGroupProviderFilter extends CommonIdentityAssertionFilter {
       groups = new String[0];
     }
     return groups;
+  }
+
+  protected List<String> hadoopGroups(String mappedPrincipalName) throws IOException {
+    return hadoopGroups.getGroups(mappedPrincipalName);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Virtual group mapping didn't use the group information from HadoopGroupProviderFilter. 
HadoopGroupProviderFilter extends from CommonIdentityAssertionFilter so they share the doFilter method. But the hadoop groups were not passed to the virtual group mapper.

## How was this patch tested?

Using the following topology:

```xml
<topology>
    <gateway>
    <provider>
            <role>authentication</role>
            <name>ShiroProvider</name>
            <enabled>true</enabled>
            <param>
                <name>sessionTimeout</name>
                <value>30</value>
            </param>
            <param>
                <name>main.ldapRealm</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
            </param>
            <param>
                <name>main.ldapContextFactory</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory</name>
                <value>$ldapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm.userDnTemplate</name>
                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.url</name>
                <value>ldap://localhost:33389</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
                <value>simple</value>
            </param>
            <param>
                <name>urls./**</name>
                <value>authcBasic</value>
            </param>
            <!-- needed to get the groups from ldap -->
            <param>
                <name>main.ldapRealm.authorizationEnabled</name>
                <value>true</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.systemUsername</name>
                <value>uid=admin,ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.systemPassword</name>
                <value>admin-password</value>
            </param>
            <param>
                <name>main.ldapRealm.groupSearchBase</name>
                <value>ou=groups,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.groupObjectClass</name>
                <value>groupofnames</value>
            </param>
            <param>
                <name>main.ldapRealm.groupIdAttribute</name>
                <value>cn</value>
            </param>
            <param>
                <name>main.ldapRealm.memberAttribute</name>
                <value>member</value>
            </param>
            <param>
                <name>main.ldapRealm.memberAttributeValueTemplate</name>
                <value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
        </provider>
        <provider>
            <role>identity-assertion</role>
            <name>HadoopGroupProvider</name>
            <enabled>true</enabled>
            <param>
                <name>hadoop.security.group.mapping</name>
                <value>org.apache.hadoop.security.ShellBasedUnixGroupsMapping</value>
            </param>
             <param>
                <name>group.mapping.virtual1</name>
                <value>(and (member 'staff') (member 'everyone'))</value>
            </param>
        </provider>

        <provider>
            <role>hostmap</role>
            <name>static</name>
            <enabled>true</enabled>
            <param>
                <name>localhost</name>
                <value>sandbox,sandbox.hortonworks.com</value>
            </param>
        </provider>

    </gateway>

    <service>
        <role>NAMENODE</role>
        <url>hdfs://localhost:8020</url>
    </service>

    <service>
        <role>JOBTRACKER</role>
        <url>rpc://localhost:8050</url>
    </service>

    <service>
        <role>WEBHDFS</role>
        <url>http://localhost:50070/webhdfs</url>
    </service>

    <service>
        <role>WEBHCAT</role>
        <url>http://localhost:50111/templeton</url>
    </service>

    <service>
        <role>OOZIE</role>
        <url>http://localhost:11000/oozie</url>
        <param>
            <name>replayBufferSize</name>
            <value>8</value>
        </param>
    </service>

    <service>
        <role>WEBHBASE</role>
        <url>http://localhost:60080</url>
        <param>
            <name>replayBufferSize</name>
            <value>8</value>
        </param>
    </service>

    <service>
        <role>HIVE</role>
        <url>http://google.com</url>
        <param>
            <name>replayBufferSize</name>
            <value>8</value>
        </param>
    </service>

    <service>
        <role>RESOURCEMANAGER</role>
        <url>http://localhost:8088/ws</url>
    </service>

    <service>
        <role>DRUID-COORDINATOR-UI</role>
        <url>http://localhost:8081</url>
    </service>

    <service>
        <role>DRUID-COORDINATOR</role>
        <url>http://localhost:8081</url>
    </service>

    <service>
        <role>DRUID-BROKER</role>
        <url>http://localhost:8082</url>
    </service>

    <service>
        <role>DRUID-ROUTER</role>
        <url>http://localhost:8082</url>
    </service>
    
    <service>
        <role>DRUID-OVERLORD</role>
        <url>http://localhost:8090</url>
    </service>

    <service>
        <role>DRUID-OVERLORD-UI</role>
        <url>http://localhost:8090</url>
    </service>

    <service>
        <role>HUE</role>
        <url>http://localhost:8889</url>
    </service>
</topology>
```

```bash
amagyar-MBP16:test attilamagyar$ id sam
uid=504(sam) gid=20(staff) groups=20(staff),12(everyone),61(localaccounts),702(com.apple.sharepoint.group.2),100(_lpoperator),701(com.apple.sharepoint.group.1)
```

```bash
curl -u sam:sam-password -k "https://localhost:8443/gateway/sandbox/hive"
```

Result:

```
22/05/11 13:08:43 ||512b4daf-111e-43a6-8c58-c7e62dc98f9c|audit|[0:0:0:0:0:0:0:1]|HIVE|sam|||identity-mapping|principal|sam|success|Groups: [_lpoperator, everyone, staff, com.apple.sharepoint.group.2, com.apple.sharepoint.group.1, virtual1, localaccounts]
```