### PR TITLE
KNOX-2746 - Add presto/presto ui support in service definition

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/presto/0.261/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/presto/0.261/rewrite.xml
@@ -1,0 +1,36 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="PRESTO/presto/inbound" pattern="*://*:*/**/presto/{path=**}?{**}">
+      <rewrite template="{$serviceUrl[PRESTO]}/{path=**}?{**}"/>
+  </rule>
+  <rule dir="OUT" name="PRESTO/presto/uri/outbound">
+        <match pattern="*://*:*/{**}?{**}"/>
+        <rewrite template="{$frontend[url]}/presto/{**}?{**}"/>
+   </rule>
+   <filter name="PRESTO/presto/api/inbound">
+         <content type="*/*" asType="text/plain"/>
+    </filter>
+
+    <filter name="PRESTO/presto/api/outbound">
+        <content type="application/json">
+             <apply path="$.**.infoUri" rule="PRESTO/presto/uri/outbound"/>
+            <apply path="$.**.nextUri" rule="PRESTO/presto/uri/outbound"/>
+            <apply path="$.**.partialCancelUri" rule="PRESTO/presto/uri/outbound"/>
+        </content>
+    </filter>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/presto/0.261/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/presto/0.261/service.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="PRESTO" name="presto" version="0.261">
+    <metadata>
+        <type>API</type>
+        <context>/presto/</context>
+        <shortDesc>Presto REST API</shortDesc>
+        <description>Presto is a distributed SQL query engine designed to query large data sets distributed over one or more heterogeneous data sources</description>
+    </metadata>
+    <routes>
+        <route path="/presto/**">
+            <rewrite apply="PRESTO/presto/api/inbound" to="request.body"/>
+            <rewrite apply="PRESTO/presto/api/outbound" to="response.body"/>
+        </route>
+    </routes>
+</service>

--- a/gateway-service-definitions/src/main/resources/services/prestoui/0.261/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/prestoui/0.261/rewrite.xml
@@ -1,0 +1,45 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="PRESTOUI/prestoui/inbound" pattern="*://*:*/**/prestoui/">
+        <rewrite template="{$serviceUrl[PRESTOUI]}/ui/"/>
+    </rule>
+    <rule dir="IN" name="PRESTOUI/prestoui/inbound" pattern="*://*:*/**/prestoui/{**}">
+        <rewrite template="{$serviceUrl[PRESTOUI]}/ui/{**}"/>
+    </rule>
+        <rule dir="IN" name="PRESTOUI/prestoui/inbound/presto/vendor" pattern="*://*:*/**/prestoui/vendor/{**}?{**}">
+        <rewrite template="{$serviceUrl[PRESTOUI]}/ui/vendor/{**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="PRESTOUI/prestoui/inbound/presto/assets" pattern="*://*:*/**/prestoui/assets/{**}?{**}">
+        <rewrite template="{$serviceUrl[PRESTOUI]}/ui/assets/{**}?{**}"/>
+    </rule>
+
+    <rule dir="IN" name="PRESTOUI/prestoui/inbound/presto/dist" pattern="*://*:*/**/prestoui/dist/{**}?{**}">
+        <rewrite template="{$serviceUrl[PRESTOUI]}/ui/dist/{**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="PRESTOUI/prestoui/inbound/presto/api" pattern="*://*:*/**/prestoui/v1/{**}?{**}">
+        <rewrite template="{$serviceUrl[PRESTOUI]}/v1/{**}?{**}"/>
+    </rule>
+        <rule dir="OUT" name="PRESTOUI/prestoui/outbound/api" pattern="/v1/{**}">
+         <rewrite template="{$frontend[url]}/prestoui/v1/{**}"/>
+    </rule>
+        <filter name="PRESTOUI/prestoui/outbound/body">
+        <content type="application/javascript">
+        <apply path="/v1/[\w]+" rule="PRESTOUI/prestoui/outbound/api"/>
+        </content>
+    </filter>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/prestoui/0.261/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/prestoui/0.261/service.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="PRESTOUI" name="prestoui" version="0.261">
+    <metadata>
+        <type>UI</type>
+        <context>/presto/</context>
+        <shortDesc>Presto Web UI</shortDesc>
+        <description>Presto is a distributed SQL query engine designed to query large data sets distributed over one or more heterogeneous data sources. It provides a web UI for monitoring a Presto cluster and managing queries.</description>
+    </metadata>
+    <routes>
+        <route path="/prestoui/"/>
+        <route path="/prestoui/**">
+            <rewrite apply="PRESTOUI/prestoui/outbound/body"  to="response.body"/>
+        </route>
+        <route path="/prestoui/**?**"/>
+    </routes>
+</service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

 [Presto](https://prestodb.io/docs/current/) is a distributed SQL query engine designed to query large data sets distributed over one or more heterogeneous data sources. Add support for in knox service definition, so that knox can provide proxying service for presto.

## How was this patch tested?
Deployed knox in a cluster with presto, and checked access presto ui with knox server port 8442. Also checked presto apis with knox server as proxy

<img width="1762" alt="Screenshot 2022-05-17 at 4 58 23 PM" src="https://user-images.githubusercontent.com/92242165/168801653-1afbf65b-ee66-4570-95be-602af065db3e.png">
<img width="1762" alt="Screenshot 2022-05-17 at 4 58 49 PM" src="https://user-images.githubusercontent.com/92242165/168801685-a041b25a-7ad5-45d6-830b-4fbf8bb22959.png">

API testing: 

`curl --insecure -X POST -d 'show catalogs' -H "X-Presto-User: user" -H "Content-Type: application/json" https://localhost:8442/gateway/default/presto/v1/statement`

{"id":"20220517_112614_00000_muw7k","infoUri":"https://localhost:8442/gateway/default/presto/ui/query.html?20220517_112614_00000_muw7k","nextUri":"https://localhost:8442/gateway/default/presto/v1/statement/queued/20220517_112614_00000_muw7k/1?slug=x31aa07b4664b44de90fe15c2e2a758cc","stats":{"state":"WAITING_FOR_PREREQUISITES","waitingForPrerequisites":true,"queued":false,"scheduled":false,"nodes":0,"totalSplits":0,"queuedSplits":0,"runningSplits":0,"completedSplits":0,"cpuTimeMillis":0,"wallTimeMillis":0,"waitingForPrerequisitesTimeMillis":0,"queuedTimeMillis":0,"elapsedTimeMillis":0,"processedRows":0,"processedBytes":0,"peakMemoryBytes":0,"peakTotalMemoryBytes":0,"peakTaskTotalMemoryBytes":0,"spilledBytes":0},"warnings":[]}

`curl --insecure https://localhost:8442/gateway/default/presto/v1/statement/queued/20220517_112614_00000_muw7k/1?slug=x31aa07b4664b44de90fe15c2e2a758cc`

{"id":"20220517_112614_00000_muw7k","infoUri":"https://localhost:8442/gateway/default/presto/ui/query.html?20220517_112614_00000_muw7k","nextUri":"https://localhost:8442/gateway/default/presto/v1/statement/queued/20220517_112614_00000_muw7k/2?slug=x31aa07b4664b44de90fe15c2e2a758cc","stats":{"state":"WAITING_FOR_PREREQUISITES","waitingForPrerequisites":true,"queued":false,"scheduled":false,"nodes":0,"totalSplits":0,"queuedSplits":0,"runningSplits":0,"completedSplits":0,"cpuTimeMillis":0,"wallTimeMillis":0,"waitingForPrerequisitesTimeMillis":6,"queuedTimeMillis":0,"elapsedTimeMillis":6,"processedRows":0,"processedBytes":0,"peakMemoryBytes":0,"peakTotalMemoryBytes":0,"peakTaskTotalMemoryBytes":0,"spilledBytes":0},"warnings":[]}

`curl --insecure https://localhost:8442/gateway/default/presto/v1/statement/queued/20220517_112614_00000_muw7k/2?slug=x31aa07b4664b44de90fe15c2e2a758cc`

{"id":"20220517_112614_00000_muw7k","infoUri":"https://localhost:8442/gateway/default/presto/ui/query.html?20220517_112614_00000_muw7k","partialCancelUri":"https://localhost:8442/gateway/default/presto/v1/stage/20220517_112614_00000_muw7k.0","nextUri":"https://localhost:8442/gateway/default/presto/v1/statement/executing/20220517_112614_00000_muw7k/1?slug=x31aa07b4664b44de90fe15c2e2a758cc","columns":[{"name":"Catalog","type":"varchar(14)","typeSignature":{"rawType":"varchar","typeArguments":[],"literalArguments":[],"arguments":[{"kind":"LONG_LITERAL","value":14}]}}],"data":[["awsdatacatalog"],["hive"],["system"]],"stats":{"state":"RUNNING","waitingForPrerequisites":false,"queued":false,"scheduled":true,"nodes":1,"totalSplits":19,"queuedSplits":0,"runningSplits":0,"completedSplits":19,"cpuTimeMillis":14,"wallTimeMillis":141,"waitingForPrerequisitesTimeMillis":15,"queuedTimeMillis":0,"elapsedTimeMillis":12522,"processedRows":0,"processedBytes":0,"peakMemoryBytes":0,"peakTotalMemoryBytes":171,"peakTaskTotalMemoryBytes":171,"spilledBytes":0,"rootStage":{"stageId":"0","state":"RUNNING","done":false,"nodes":1,"totalSplits":1,"queuedSplits":0,"runningSplits":0,"completedSplits":1,"cpuTimeMillis":1,"wallTimeMillis":3,"processedRows":3,"processedBytes":67,"subStages":[{"stageId":"1","state":"FINISHED","done":true,"nodes":1,"totalSplits":17,"queuedSplits":0,"runningSplits":0,"completedSplits":17,"cpuTimeMillis":13,"wallTimeMillis":138,"processedRows":3,"processedBytes":67,"subStages":[{"stageId":"2","state":"FINISHED","done":true,"nodes":1,"totalSplits":1,"queuedSplits":0,"runningSplits":0,"completedSplits":1,"cpuTimeMillis":0,"wallTimeMillis":0,"processedRows":3,"processedBytes":0,"subStages":[]}]}]},"runtimeStats":{"S1-driverCountPerTask":{"name":"S1-driverCountPerTask","sum":17,"count":1,"max":17,"min":17},"S2-driverCountPerTask":{"name":"S2-driverCountPerTask","sum":1,"count":1,"max":1,"min":1},"S1-taskElapsedTimeNanos":{"name":"S1-taskElapsedTimeNanos","sum":142799852,"count":1,"max":142799852,"min":142799852},"S2-taskElapsedTimeNanos":{"name":"S2-taskElapsedTimeNanos","sum":106038415,"count":1,"max":106038415,"min":106038415},"S0-driverCountPerTask":{"name":"S0-driverCountPerTask","sum":1,"count":1,"max":1,"min":1},"S0-taskElapsedTimeNanos":{"name":"S0-taskElapsedTimeNanos","sum":0,"count":1,"max":0,"min":0}},"progressPercentage":100.0},"warnings":[]}
