### PR TITLE
KNOX-2346 - Eliminated the accidentally re-introduced configs in one of the tests

### DIFF
--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactoryTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactoryTest.java
@@ -51,7 +51,7 @@ public class HaDescriptorFactoryTest {
 
   @Test
   public void testCreateServiceConfigActive() {
-    HaServiceConfig serviceConfig = HaDescriptorFactory.createServiceConfig("foo", "enableStickySession=true;enabled=true;maxFailoverAttempts=42;failoverSleep=50;maxRetryAttempts=1;retrySleep=1000");
+    HaServiceConfig serviceConfig = HaDescriptorFactory.createServiceConfig("foo", "enableStickySession=true;enabled=true;maxFailoverAttempts=42;failoverSleep=50");
     assertNotNull(serviceConfig);
     assertTrue(serviceConfig.isEnabled());
     assertEquals("foo", serviceConfig.getServiceName());
@@ -60,7 +60,7 @@ public class HaDescriptorFactoryTest {
     assertTrue(serviceConfig.isStickySessionEnabled());
     assertEquals(HaServiceConfigConstants.DEFAULT_STICKY_SESSION_COOKIE_NAME, serviceConfig.getStickySessionCookieName());
 
-    serviceConfig = HaDescriptorFactory.createServiceConfig("foo", "enableStickySession=true;enabled=true;maxFailoverAttempts=42;failoverSleep=50;maxRetryAttempts=1;retrySleep=1000;stickySessionCookieName=abc");
+    serviceConfig = HaDescriptorFactory.createServiceConfig("foo", "enableStickySession=true;enabled=true;maxFailoverAttempts=42;failoverSleep=50;stickySessionCookieName=abc");
     assertNotNull(serviceConfig);
     assertTrue(serviceConfig.isEnabled());
     assertEquals("foo", serviceConfig.getServiceName());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed the previously eliminated `maxRetryAttempts` and `retrySleep` HA configs from a test case which were accidentally re-introduced.

## How was this patch tested?

Unit testing.
