### PR TITLE
KNOX-2726 - Impersonation Params should be configurable

### DIFF
--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -88,12 +88,10 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-            <scope>compile</scope>
         </dependency>
 
 

--- a/gateway-provider-identity-assertion-common/pom.xml
+++ b/gateway-provider-identity-assertion-common/pom.xml
@@ -85,8 +85,23 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-api-javaee</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
 
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-server</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
@@ -47,4 +47,7 @@ public interface IdentityAsserterMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "User {0} (with group(s) {1}) added to group(s) {2}")
   void virtualGroups(String userName, Set<String> userGroups, Set<String> virtualGroups);
+
+  @Message( level = MessageLevel.INFO, text = "Using configured impersonation parameters: {0}")
+  void impersonationConfig(String config);
 }

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAsserterDeploymentContributor.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAsserterDeploymentContributor.java
@@ -33,6 +33,9 @@ import java.util.Map.Entry;
 public abstract class AbstractIdentityAsserterDeploymentContributor extends
     ProviderDeploymentContributorBase {
 
+  /* Service specific impersonation params that needs to be scrubbed */
+  public static final String IMPERSONATION_PARAMS = "impersonation.params";
+
   @Override
   public String getRole() {
     return "identity-assertion";
@@ -42,7 +45,28 @@ public abstract class AbstractIdentityAsserterDeploymentContributor extends
   public void contributeFilter( DeploymentContext context, Provider provider, Service service,
       ResourceDescriptor resource, List<FilterParamDescriptor> params ) {
     params = buildFilterInitParms(provider, resource, params);
+    /* extract params from service definition */
+    params = buildServiceParams(service, resource, params);
     resource.addFilter().name(getName()).role(getRole()).impl(getFilterClassname()).params(params);
+  }
+
+  protected List<FilterParamDescriptor> buildServiceParams(Service service,
+      ResourceDescriptor resource, List<FilterParamDescriptor> params) {
+    // blindly add all the service params as filter init params
+    if (params == null) {
+      params = new ArrayList<>();
+    }
+    Map<String, String> serviceParams = service.getParams();
+    for(Entry<String, String> entry : serviceParams.entrySet()) {
+      FilterParamDescriptor f = resource
+          .createFilterParam()
+          .name(entry.getKey().toLowerCase(Locale.ROOT))
+          .value(entry.getValue());
+      if(!params.contains(f)) {
+        params.add(f);
+      }
+    }
+    return params;
   }
 
   public List<FilterParamDescriptor> buildFilterInitParms(Provider provider,
@@ -56,6 +80,13 @@ public abstract class AbstractIdentityAsserterDeploymentContributor extends
       params.add( resource.createFilterParam().name(entry.getKey().toLowerCase(Locale.ROOT)).value(entry.getValue()));
     }
     return params;
+  }
+
+  @Override
+  public void contributeProvider(final DeploymentContext context, final Provider provider ) {
+    super.contributeProvider(context, provider);
+    final String impersonationParams = provider.getParams().get(IMPERSONATION_PARAMS);
+    context.getWebAppDescriptor().createContextParam().paramName(IMPERSONATION_PARAMS).paramValue(impersonationParams);
   }
 
   protected abstract String getFilterClassname();

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/IdentityAsserterHttpServletRequestWrapper.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/IdentityAsserterHttpServletRequestWrapper.java
@@ -50,12 +50,18 @@ public class IdentityAsserterHttpServletRequestWrapper extends HttpServletReques
 
   private static final String PRINCIPAL_PARAM = "user.name";
   private static final String DOAS_PRINCIPAL_PARAM = "doAs";
+  private List<String> impersonationParamsList;
 
   private String username;
 
   public IdentityAsserterHttpServletRequestWrapper( HttpServletRequest request, String principal ) {
+    this(request, principal, Collections.EMPTY_LIST);
+  }
+
+  public IdentityAsserterHttpServletRequestWrapper( HttpServletRequest request, String principal, List impersonationParamsList ) {
     super(request);
     username = principal;
+    this.impersonationParamsList = impersonationParamsList;
   }
 
   @Override
@@ -182,14 +188,18 @@ public class IdentityAsserterHttpServletRequestWrapper extends HttpServletReques
   }
 
   protected List<String> getImpersonationParamNames() {
-    // TODO: let's have service definitions register their impersonation
-    // params in a future release and get this list from a central registry.
-    // This will provide better coverage of protection by removing any
-    // prepopulated impersonation params.
-    ArrayList<String> principalParamNames = new ArrayList<>();
-    principalParamNames.add(DOAS_PRINCIPAL_PARAM);
-    principalParamNames.add(PRINCIPAL_PARAM);
-    return principalParamNames;
+    /**
+     *  If for some reason impersonationParamsList is empty e.g. some component using
+     *  old api then return the default list. This is for backwards compatibility.
+     **/
+    if(impersonationParamsList == null || impersonationParamsList.isEmpty()) {
+      ArrayList<String> principalParamNames = new ArrayList<>();
+      principalParamNames.add(DOAS_PRINCIPAL_PARAM);
+      principalParamNames.add(PRINCIPAL_PARAM);
+      return principalParamNames;
+    } else {
+      return impersonationParamsList;
+    }
   }
 
   protected Map<String, List<String>> scrubOfExistingPrincipalParams(

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAsserterDeploymentContributorTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAsserterDeploymentContributorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.identityasserter.common.filter;
+
+import org.apache.knox.gateway.deploy.DeploymentContext;
+import org.apache.knox.gateway.descriptor.FilterDescriptor;
+import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
+import org.apache.knox.gateway.descriptor.GatewayDescriptor;
+import org.apache.knox.gateway.descriptor.ResourceDescriptor;
+import org.apache.knox.gateway.descriptor.impl.GatewayDescriptorImpl;
+import org.apache.knox.gateway.topology.Provider;
+import org.apache.knox.gateway.topology.Service;
+import org.apache.knox.gateway.topology.Topology;
+import org.easymock.EasyMock;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractIdentityAsserterDeploymentContributorTest {
+
+  @Test
+  public void testDeployment() {
+    WebArchive webArchive = ShrinkWrap.create( WebArchive.class, "test-archive" );
+    final String CUSTOM_IMPERSONATION_PARAM = "impersonationParam";
+
+    Provider provider = new Provider();
+    provider.setEnabled(true);
+    provider.setName(MockAbstractIdentityAsserterDeploymentContributor.NAME);
+
+    Service service = new Service();
+    Map<String, String> params = new HashMap<>();
+    params.put(CommonIdentityAssertionFilter.IMPERSONATION_PARAMS, CUSTOM_IMPERSONATION_PARAM);
+    service.setParams(params);
+
+    Topology topology = new Topology();
+    topology.setName( "Sample" );
+
+    GatewayDescriptor gatewayDescriptor = new GatewayDescriptorImpl();
+    ResourceDescriptor resource = gatewayDescriptor.createResource();
+
+    DeploymentContext context = EasyMock.createNiceMock( DeploymentContext.class );
+    EasyMock.expect( context.getWebArchive() ).andReturn( webArchive ).anyTimes();
+    EasyMock.expect( context.getTopology() ).andReturn( topology ).anyTimes();
+    EasyMock.expect(context.getGatewayDescriptor()).andReturn(gatewayDescriptor).anyTimes();
+    EasyMock.replay( context );
+
+    AbstractIdentityAsserterDeploymentContributor contributor = new MockAbstractIdentityAsserterDeploymentContributor();
+
+    contributor.initializeContribution( context );
+    contributor.contributeFilter(context, provider, service, resource, null);
+    contributor.finalizeContribution( context );
+
+    FilterDescriptor identityFilterDescriptor = resource.filters().get(0);
+    List<FilterParamDescriptor> filterParams = identityFilterDescriptor.params();
+    assertEquals(1, filterParams.size());
+
+    FilterParamDescriptor paramDescriptor = filterParams.get(0);
+    assertEquals(CommonIdentityAssertionFilter.IMPERSONATION_PARAMS, paramDescriptor.name());
+    assertEquals(CUSTOM_IMPERSONATION_PARAM, paramDescriptor.value());
+  }
+}
+
+@SuppressWarnings("PMD")
+class MockAbstractIdentityAsserterDeploymentContributor extends AbstractIdentityAsserterDeploymentContributor {
+
+  public static String NAME = "MOCK";
+  @Override
+  protected String getFilterClassname() {
+    return MockAbstractIdentityAsserterDeploymentContributor.class.getName();
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+}

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAsserterDeploymentContributorTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAsserterDeploymentContributorTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
 
 public class AbstractIdentityAsserterDeploymentContributorTest {
@@ -50,7 +51,7 @@ public class AbstractIdentityAsserterDeploymentContributorTest {
 
     Service service = new Service();
     Map<String, String> params = new HashMap<>();
-    params.put(CommonIdentityAssertionFilter.IMPERSONATION_PARAMS, CUSTOM_IMPERSONATION_PARAM);
+    params.put(IMPERSONATION_PARAMS, CUSTOM_IMPERSONATION_PARAM);
     service.setParams(params);
 
     Topology topology = new Topology();
@@ -76,7 +77,7 @@ public class AbstractIdentityAsserterDeploymentContributorTest {
     assertEquals(1, filterParams.size());
 
     FilterParamDescriptor paramDescriptor = filterParams.get(0);
-    assertEquals(CommonIdentityAssertionFilter.IMPERSONATION_PARAMS, paramDescriptor.name());
+    assertEquals(IMPERSONATION_PARAMS, paramDescriptor.name());
     assertEquals(CUSTOM_IMPERSONATION_PARAM, paramDescriptor.value());
   }
 }

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.identityasserter.filter;
 
 import static org.apache.knox.gateway.audit.log4j.audit.Log4jAuditService.MDC_AUDIT_CONTEXT_KEY;
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -102,7 +103,7 @@ public class CommonIdentityAssertionFilterTest {
                     CommonIdentityAssertionFilter.PRINCIPAL_MAPPING,
                     CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")))
             .anyTimes();
-    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.IMPERSONATION_PARAMS)).
+    EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS)).
         andReturn("doAs").anyTimes();
     EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")).
             andReturn("(and (username 'lmccay') (and (member 'users') (member 'admin')))").anyTimes();

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
@@ -102,6 +102,8 @@ public class CommonIdentityAssertionFilterTest {
                     CommonIdentityAssertionFilter.PRINCIPAL_MAPPING,
                     CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")))
             .anyTimes();
+    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.IMPERSONATION_PARAMS)).
+        andReturn("doAs").anyTimes();
     EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")).
             andReturn("(and (username 'lmccay') (and (member 'users') (member 'admin')))").anyTimes();
     EasyMock.replay( config );

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/IdentityAssertionHttpServletRequestWrapperTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/IdentityAssertionHttpServletRequestWrapperTest.java
@@ -118,6 +118,26 @@ public class IdentityAssertionHttpServletRequestWrapperTest {
   }
 
   @Test
+  public void testRemoveImpersonationParam() throws IOException {
+    String inputBody = "DelegationUID=drwho&user.name=input-user";
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setInputStream( new MockServletInputStream( new ByteArrayInputStream( inputBody.getBytes( StandardCharsets.UTF_8 ) ) ) );
+    request.setCharacterEncoding( StandardCharsets.UTF_8.name() );
+    request.setContentType( "application/x-www-form-urlencoded" );
+    request.setMethod("POST");
+
+    // Add DelegationUID to impersonation list
+    IdentityAsserterHttpServletRequestWrapper wrapper
+        = new IdentityAsserterHttpServletRequestWrapper( request, "output-user", Arrays.asList("DelegationUID"));
+
+    String output = wrapper.getQueryString();
+    assertThat( output, containsString( "user.name=output-user" ) );
+    assertThat( output, not( containsString( "input-user" ) ) );
+    assertThat( output, not( containsString( "drwho" ) ) );
+  }
+
+  @Test
   public void testIngoreNonFormBody() throws IOException {
     String inputBody = "user.name=input-user&jar=%2Ftmp%2FGatewayWebHdfsFuncTest%2FtestJavaMapReduceViaWebHCat%2Fhadoop-examples.jar&class=org.apache.org.apache.hadoop.examples.WordCount&arg=%2Ftmp%2FGatewayWebHdfsFuncTest%2FtestJavaMapReduceViaTempleton%2Finput&arg=%2Ftmp%2FGatewayWebHdfsFuncTest%2FtestJavaMapReduceViaTempleton%2Foutput";
 

--- a/gateway-provider-identity-assertion-no-doas/src/main/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationAsserterRequestWrapper.java
+++ b/gateway-provider-identity-assertion-no-doas/src/main/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationAsserterRequestWrapper.java
@@ -21,6 +21,7 @@ import org.apache.knox.gateway.identityasserter.common.filter.IdentityAsserterHt
 import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,8 +31,14 @@ public class NoImpersonationAsserterRequestWrapper extends
 
   public NoImpersonationAsserterRequestWrapper(
       HttpServletRequest request, String principal) {
-    super(request, principal);
+    this(request, principal, Collections.EMPTY_LIST);
   }
+
+  public NoImpersonationAsserterRequestWrapper(
+      HttpServletRequest request, String principal, List<String> impersonationParamsList) {
+    super(request, principal, impersonationParamsList);
+  }
+
 
   /**
    * Skip adding doAs as query param

--- a/gateway-provider-identity-assertion-no-doas/src/main/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationFilter.java
+++ b/gateway-provider-identity-assertion-no-doas/src/main/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationFilter.java
@@ -49,6 +49,7 @@ public class NoImpersonationFilter extends CommonIdentityAssertionFilter {
       ServletRequest request, String mappedPrincipalName) {
     return new NoImpersonationAsserterRequestWrapper(
         (HttpServletRequest) request,
-        mappedPrincipalName);
+        mappedPrincipalName,
+        impersonationParamsList);
   }
 }

--- a/gateway-provider-identity-assertion-no-doas/src/test/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationFilterTest.java
+++ b/gateway-provider-identity-assertion-no-doas/src/test/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationFilterTest.java
@@ -28,6 +28,7 @@ import javax.servlet.ServletContext;
 import java.security.Principal;
 import java.util.Arrays;
 
+import static org.apache.knox.gateway.identityasserter.common.filter.CommonIdentityAssertionFilter.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -61,6 +62,7 @@ public class NoImpersonationFilterTest {
     config = EasyMock.createNiceMock( FilterConfig.class );
     EasyMock.expect(config.getInitParameter("principal.mapping") ).andReturn( "lmccay,kminder=hdfs;newuser=mapred" ).anyTimes();
     EasyMock.expect(config.getInitParameter("group.principal.mapping") ).andReturn( "kminder=group1;lmccay=mrgroup,mrducks" ).anyTimes();
+    EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS) ).andReturn("doAs").anyTimes();
     context = EasyMock.createNiceMock(ServletContext.class);
     EasyMock.expect(config.getServletContext() ).andReturn( context ).anyTimes();
     EasyMock.replay( config );
@@ -81,6 +83,7 @@ public class NoImpersonationFilterTest {
     config = EasyMock.createNiceMock( FilterConfig.class );
     EasyMock.expect(config.getInitParameter("principal.mapping") ).andReturn( "lmccay,kminder=hdfs;newuser=mapred" ).anyTimes();
     EasyMock.expect(config.getInitParameter("group.principal.mapping") ).andReturn( "kminder=group1;lmccay=mrgroup,mrducks" ).anyTimes();
+    EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS) ).andReturn("doAs").anyTimes();
     context = EasyMock.createNiceMock(ServletContext.class);
     EasyMock.expect(config.getServletContext() ).andReturn( context ).anyTimes();
     EasyMock.replay( config );

--- a/gateway-provider-identity-assertion-no-doas/src/test/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationFilterTest.java
+++ b/gateway-provider-identity-assertion-no-doas/src/test/java/org/apache/knox/gateway/identityasserter/filter/NoImpersonationFilterTest.java
@@ -28,7 +28,7 @@ import javax.servlet.ServletContext;
 import java.security.Principal;
 import java.util.Arrays;
 
-import static org.apache.knox.gateway.identityasserter.common.filter.CommonIdentityAssertionFilter.IMPERSONATION_PARAMS;
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;

--- a/gateway-provider-identity-assertion-pseudo/src/test/java/org/apache/knox/gateway/identityasserter/filter/DefaultIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-pseudo/src/test/java/org/apache/knox/gateway/identityasserter/filter/DefaultIdentityAssertionFilterTest.java
@@ -28,7 +28,7 @@ import javax.servlet.ServletContext;
 import java.security.Principal;
 import java.util.Arrays;
 
-import static org.apache.knox.gateway.identityasserter.common.filter.CommonIdentityAssertionFilter.IMPERSONATION_PARAMS;
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;

--- a/gateway-provider-identity-assertion-pseudo/src/test/java/org/apache/knox/gateway/identityasserter/filter/DefaultIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-pseudo/src/test/java/org/apache/knox/gateway/identityasserter/filter/DefaultIdentityAssertionFilterTest.java
@@ -28,6 +28,7 @@ import javax.servlet.ServletContext;
 import java.security.Principal;
 import java.util.Arrays;
 
+import static org.apache.knox.gateway.identityasserter.common.filter.CommonIdentityAssertionFilter.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -61,6 +62,7 @@ public class DefaultIdentityAssertionFilterTest {
     config = EasyMock.createNiceMock( FilterConfig.class );
     EasyMock.expect(config.getInitParameter("principal.mapping") ).andReturn( "lmccay,kminder=hdfs;newuser=mapred" ).anyTimes();
     EasyMock.expect(config.getInitParameter("group.principal.mapping") ).andReturn( "kminder=group1;lmccay=mrgroup,mrducks" ).anyTimes();
+    EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS) ).andReturn("doAs").anyTimes();
     context = EasyMock.createNiceMock(ServletContext.class);
     EasyMock.expect(config.getServletContext() ).andReturn( context ).anyTimes();
     EasyMock.replay( config );
@@ -81,6 +83,7 @@ public class DefaultIdentityAssertionFilterTest {
     config = EasyMock.createNiceMock( FilterConfig.class );
     EasyMock.expect(config.getInitParameter("principal.mapping") ).andReturn( "lmccay,kminder=hdfs;newuser=mapred" ).anyTimes();
     EasyMock.expect(config.getInitParameter("group.principal.mapping") ).andReturn( "kminder=group1;lmccay=mrgroup,mrducks" ).anyTimes();
+    EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS) ).andReturn("doAs").anyTimes();
     context = EasyMock.createNiceMock(ServletContext.class);
     EasyMock.expect(config.getServletContext() ).andReturn( context ).anyTimes();
     EasyMock.replay( config );

--- a/gateway-service-definitions/src/main/java/org/apache/knox/gateway/service/definition/CustomDispatch.java
+++ b/gateway-service-definitions/src/main/java/org/apache/knox/gateway/service/definition/CustomDispatch.java
@@ -119,12 +119,12 @@ public class CustomDispatch {
   }
 
   @XmlAccessorType(XmlAccessType.NONE)
-  private static class XMLParam {
+  static class XMLParam {
     @XmlElement
-    private String name;
+    protected String name;
 
     @XmlElement
-    private String value;
+    protected String value;
 
     @SuppressWarnings("unused")
     XMLParam() {

--- a/gateway-service-definitions/src/main/java/org/apache/knox/gateway/service/definition/Policy.java
+++ b/gateway-service-definitions/src/main/java/org/apache/knox/gateway/service/definition/Policy.java
@@ -18,12 +18,20 @@
 package org.apache.knox.gateway.service.definition;
 
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class Policy {
 
   private String name;
 
   private String role;
+
+  @XmlElement(name = "param")
+  private List<CustomDispatch.XMLParam> params = new ArrayList<>();
 
   @XmlAttribute
   public String getName() {
@@ -41,5 +49,19 @@ public class Policy {
 
   public void setRole(String role) {
     this.role = role;
+  }
+
+  public void addParam( DispatchParam param ) {
+    params.add(new CustomDispatch.XMLParam(param.getName(), param.getValue()));
+  }
+
+  public Map<String, String> getParams() {
+    Map<String, String> result = new LinkedHashMap<>();
+    if( params != null ) {
+      for (CustomDispatch.XMLParam p : params) {
+        result.put(p.name, p.value);
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Impersonation Params should be configurable so that Knox can scrub these params before sending it out to the backend services. There could be cases where some services might use their own impersonation params (similar to doAs used by Knox). Including these parameters in request could have unknown side effects. In order to prevent these issue, Impersonation Params should be configurable. 

The PR proposes adding `impersonation.params` parameter to the `identity-assertion` provider. 
This can be added in `service.xml` file or in topology file.

e.g. `service.xml`

```
 <policies>
	  <policy role="authentication"/>
	  <policy role="rewrite"/>
      <policy role="identity-assertion" name="Default">
	      <param>
	           <name>impersonation.params</name>
	           <value>customID, customServiceID</value>
	       </param>
	  </policy>
  </policies>
```
**NOTE: `authentication` and `rewrite` policies are required for proper functioning.**

e.g. `topology.xml`
```
      <provider>
            <role>identity-assertion</role>
            <name>Default</name>
            <enabled>true</enabled>
			<param>
			        <name>impersonation.params</name>
			        <value>customID</value>
			    </param>
        </provider>
```

As a side effect of this, we now have ability to specify parameters for providers in `service.xml` file, providers as defined in policy. e.g.

```
 <policies>
	  <policy role="authentication"/>
	  <policy role="rewrite"/>
      <policy role="identity-assertion" name="Default">
	      <param>
	           <name>impersonation.params</name>
	           <value>customID, customServiceID</value>
	       </param>
	  </policy>
  </policies>
```

**NOTE: `authentication` and `rewrite` policies are required for proper functioning.**


Adding this parameter tells Knox to scrub this parameter from the dispatched request. 
e.g. 
```
2022-05-18 07:06:12,733 cde0df3d-5fc8-4b7a-8b96-0f828f4e524e WARN  knox.gateway (IdentityAsserterHttpServletRequestWrapper.java:scrubOfExistingPrincipalParams(212)) - Possible identity spoofing attempt - impersonation parameter removed: customID
```


## How was this patch tested?
This patch was tested locally

Logs without `impersonation.params` 

```
2022-05-18 07:11:02,332 aadcfc0f-5159-4c50-bacb-0308a496ad32 DEBUG knox.gateway (UrlRewriteProcessor.java:rewrite(162)) - Rewrote URL: https://localhost:8443/gateway/sandbox/weather/data/2.5/forecast/city?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&customID=somerandomestring, direction: IN via implicit rule: WEATHER/weather/inbound to URL: http://api.openweathermap.org:80/data/2.5/forecast/city?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&customID=somerandomestring
2022-05-18 07:11:02,333 aadcfc0f-5159-4c50-bacb-0308a496ad32 DEBUG knox.gateway (DefaultDispatch.java:executeOutboundRequest(157)) - Dispatch request: GET http://api.openweathermap.org:80/data/2.5/forecast/city?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&customID=somerandomestring&user.name=guest
```

Logs with `impersonation.params`

```
557732afcfe106bfc955b9da04fb14&customID=somerandomestring, direction: IN via implicit rule: WEATHER/weather/inbound to URL: http://api.openweathermap.org:80/data/2.5/forecast/city?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&customID=somerandomestring
2022-05-18 07:06:12,733 cde0df3d-5fc8-4b7a-8b96-0f828f4e524e WARN  knox.gateway (IdentityAsserterHttpServletRequestWrapper.java:scrubOfExistingPrincipalParams(212)) - Possible identity spoofing attempt - impersonation parameter removed: customID
2022-05-18 07:06:12,738 cde0df3d-5fc8-4b7a-8b96-0f828f4e524e DEBUG knox.gateway (DefaultDispatch.java:executeOutboundRequest(157)) - Dispatch request: GET http://api.openweathermap.org:80/data/2.5/forecast/city?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&user.name=guest
```