### PR TITLE
KNOX-2721: upgrade jetty to 9.4.45 due to cves

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <jee-pac4j.version>5.0.0</jee-pac4j.version>
         <jericho-html.version>3.4</jericho-html.version>
         <jersey.version>2.6</jersey.version>
-        <jetty.version>9.4.34.v20201102</jetty.version>
+        <jetty.version>9.4.45.v20220203</jetty.version>
         <jline.version>2.14.6</jline.version>
         <jna.version>5.6.0</jna.version>
         <joda-time.version>2.10.8</joda-time.version>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

[KNOX-2721](https://issues.apache.org/jira/browse/KNOX-2721): upgrade jetty to 9.4.45 due to cves

## How was this patch tested?

CI build

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
