### PR TITLE
KNOX-2756 - Fixing NPE caused by null GatewayConfig

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -111,9 +111,8 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
 
     if (gatewayConfig != null) {
       repository.setCacheEntryTTL(gatewayConfig.getClouderaManagerServiceDiscoveryRepositoryEntryTTL());
+      configureRetryParams(gatewayConfig);
     }
-
-    configureRetryParams(gatewayConfig);
   }
 
   private void configureRetryParams(GatewayConfig gatewayConfig) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Configuring the CM retry params only, of `gatewayConfig` is not `null`.

## How was this patch tested?

Manual testing:
```
$ curl -iku admin:admin-password https://localhost:8443/gateway/admin/api/v1/servicediscoveries
HTTP/1.1 200 OK
Date: Fri, 03 Jun 2022 05:11:31 GMT
Set-Cookie: KNOXSESSIONID=node01x6ieg9i4zz6x1nd5qa5u0q9ys0.node0; Path=/gateway/admin; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/admin; Max-Age=0; Expires=Thu, 02-Jun-2022 05:11:31 GMT; SameSite=lax
Content-Type: application/xml
Content-Length: 486

<?xml version="1.0" encoding="UTF-8"?>
<knoxServiceDiscoveries>
   <knoxServiceDiscovery>
      <type>Ambari</type>
      <implementation>org.apache.knox.gateway.topology.discovery.ambari.AmbariServiceDiscovery</implementation>
   </knoxServiceDiscovery>
   <knoxServiceDiscovery>
      <type>ClouderaManager</type>
      <implementation>org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery</implementation>
   </knoxServiceDiscovery>
</knoxServiceDiscoveries>

```
