### PR TITLE
KNOX-2761 - Knox Token renew/revoke operations are now PUT/DELETE HTTP methods in KnoxShell too

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/HttpDelete.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/HttpDelete.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shell;
+
+import java.net.URI;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+/**
+ * An alternative to {@link org.apache.http.client.methods.HttpDelete} that
+ * extends {@link org.apache.http.client.methods.HttpEntityEnclosingRequestBase}
+ * rather than {@link org.apache.http.client.methods.HttpRequestBase} and hence
+ * allows HTTP delete with a request body. For use with the RestTemplate
+ * exchange methods which allow the combination of HTTP DELETE with an entity.
+ */
+public class HttpDelete extends HttpEntityEnclosingRequestBase {
+
+  public HttpDelete(URI uri) {
+    super();
+    setURI(uri);
+  }
+
+  @Override
+  public String getMethod() {
+    return org.apache.http.client.methods.HttpDelete.METHOD_NAME;
+  }
+}

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/AbstractTokenLifecycleRequest.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/AbstractTokenLifecycleRequest.java
@@ -16,9 +16,8 @@
  */
 package org.apache.knox.gateway.shell.knox.token;
 
-import org.apache.http.client.methods.HttpPost;
+import org.apache.http.HttpRequest;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.entity.StringEntity;
 import org.apache.knox.gateway.shell.AbstractRequest;
 import org.apache.knox.gateway.shell.ErrorResponse;
 import org.apache.knox.gateway.shell.KnoxSession;
@@ -29,6 +28,9 @@ import java.net.URISyntaxException;
 import java.util.concurrent.Callable;
 
 public abstract class AbstractTokenLifecycleRequest extends AbstractRequest<TokenLifecycleResponse> {
+
+  private final URI requestURI;
+  private final String token;
 
   AbstractTokenLifecycleRequest(final KnoxSession session, final String token) {
     this(session, token, null);
@@ -47,18 +49,10 @@ public abstract class AbstractTokenLifecycleRequest extends AbstractRequest<Toke
 
   protected abstract String getOperation();
 
-  private URI requestURI;
-
-  private HttpPost httpPostRequest;
-
-  private String token;
+  protected abstract HttpRequest getRequest();
 
   public URI getRequestURI() {
     return requestURI;
-  }
-
-  public HttpPost getRequest() {
-    return httpPostRequest;
   }
 
   public String getToken() {
@@ -68,10 +62,8 @@ public abstract class AbstractTokenLifecycleRequest extends AbstractRequest<Toke
   @Override
   protected Callable<TokenLifecycleResponse> callable() {
     return () -> {
-      httpPostRequest = new HttpPost(requestURI);
-      httpPostRequest.setEntity(new StringEntity(token));
       try {
-        return new TokenLifecycleResponse(execute(httpPostRequest));
+        return new TokenLifecycleResponse(execute(getRequest()));
       } catch (ErrorResponse e) {
         return new TokenLifecycleResponse(e.getResponse());
       }

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Renew.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Renew.java
@@ -16,6 +16,11 @@
  */
 package org.apache.knox.gateway.shell.knox.token;
 
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
 import org.apache.knox.gateway.shell.KnoxSession;
 
 public class Renew {
@@ -23,18 +28,30 @@ public class Renew {
   public static class Request extends AbstractTokenLifecycleRequest {
 
     public static final String OPERATION = "renew";
+    private HttpPut putRequest;
 
     Request(final KnoxSession session, final String token) {
-      super(session, token);
+      this(session, token, null);
     }
 
     Request(final KnoxSession session, final String token, final String doAsUser) {
       super(session, token, doAsUser);
+      initPutRequest(token);
+    }
+
+    private void initPutRequest(String token) {
+      this.putRequest = new HttpPut(getRequestURI());
+      this.putRequest.setEntity(new StringEntity(token, StandardCharsets.UTF_8));
     }
 
     @Override
     protected String getOperation() {
       return OPERATION;
+    }
+
+    @Override
+    public HttpRequest getRequest() {
+      return this.putRequest;
     }
   }
 

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Revoke.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/knox/token/Revoke.java
@@ -16,6 +16,11 @@
  */
 package org.apache.knox.gateway.shell.knox.token;
 
+import java.nio.charset.StandardCharsets;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.entity.StringEntity;
+import org.apache.knox.gateway.shell.HttpDelete;
 import org.apache.knox.gateway.shell.KnoxSession;
 
 public class Revoke {
@@ -23,18 +28,30 @@ public class Revoke {
   public static class Request extends AbstractTokenLifecycleRequest {
 
     public static final String OPERATION = "revoke";
+    private HttpDelete deleteRequest;
 
     Request(final KnoxSession session, final String token) {
-      super(session, token);
+      this(session, token, null);
     }
 
     Request(final KnoxSession session, final String token, final String doAsUser) {
       super(session, token, doAsUser);
+      initDeleteRequest(token);
+    }
+
+    private void initDeleteRequest(String token) {
+      this.deleteRequest = new HttpDelete(getRequestURI());
+      this.deleteRequest.setEntity(new StringEntity(token, StandardCharsets.UTF_8));
     }
 
     @Override
     protected String getOperation() {
       return OPERATION;
+    }
+
+    @Override
+    protected HttpRequest getRequest() {
+      return this.deleteRequest;
     }
   }
 

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/knox/token/TokenTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/knox/token/TokenTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.util.EntityUtils;
 import org.apache.knox.gateway.shell.KnoxSession;
 import org.junit.Test;
@@ -209,8 +210,8 @@ public class TokenTest {
       // expected
     }
 
-    HttpEntity entity = request.getRequest().getEntity();
-    assertNotNull("Missing expected POST data.", entity);
+    HttpEntity entity = ((HttpEntityEnclosingRequestBase)request.getRequest()).getEntity();
+    assertNotNull("Missing expected PUT/DELETE data.", entity);
     String postData = null;
     try {
       postData = EntityUtils.toString(entity);

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,7 @@
                         <exclude>**/.project/**</exclude>
                         <exclude>**/.settings/**</exclude>
                         <exclude>**/.classpath/**</exclude>
+                        <exclude>**/.checkstyle/**</exclude>
                         <exclude>src/stage.txt</exclude>
                         <exclude>src/vote.txt</exclude>
                         <exclude>**/*.iml</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

As the corresponding JIRA states, #494 changed some of the HTTP methods in `TokenResource` that the KnoxShell classes were missing to implement.

## How was this patch tested?

Executed the existing unit tests (no new tests were added in this case; it wasn't needed) and ran manual tests using Knox's [performance test tool](https://cwiki.apache.org/confluence/display/KNOX/KNOX-2402+-+Develop+a+performance-test+framework+to+test+token+state+service).

In addition to this, I also tested these changes together with the newly added retry functionality in KnoxShell (thanks, @zeroflag for the detailed test steps in #568):
Mini HTTP server with the following Pharo image
```
| c  | 
c := 0.
Teapot on
  GET: '/knoxtoken/api/v1/token' -> [ 
    c := c + 1.
    Transcript
       cr;
       show: 'Incoming request c=', c asString.

    c < 3 
      ifTrue:[ TeaResponse code: 503 ] 
      ifFalse: [ 'OK' ] 
  ];
  PUT: '/knoxtoken/api/v1/token/renew' -> [ 
	:request |
	c := c + 1.
	Transcript 
	  cr;
	  show: 'Req # ', c asString, ' Token = ', request entity string .
    c < 3 
      ifTrue:[ TeaResponse code: 503 ] 
      ifFalse: [ 'OK' ] 
  ];
  start. 
```

Test code:
```
package org.apache.knox.gateway.shell.knox.token;

import org.apache.knox.gateway.shell.ClientContext;
import org.apache.knox.gateway.shell.KnoxSession;

public class KnoxTokenTest {

  public static void main(String[] args) throws Exception {
    ClientContext context = ClientContext.with("http://localhost:1701");
    context.connection().retryCount(2);
    KnoxSession session = KnoxSession.login(context);
    System.out.println( Token.renew(session, "token 1").now().getString() );
  }
}
```

Running it worked as expected; the output in Pharo was the following:
```
Req # 1 Token = token 1
Req # 2 Token = token 1
Req # 3 Token = token 1
```