### PR TITLE
KNOX-2762 

### DIFF
--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -69,7 +69,6 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
 
   String[] parseProviderNames(String providerNames) {
     String[] b = providerNames.split("\\s*,\\s*");
-
     for (int i = 0; i < b.length; i++) {
       b[i] = b[i].trim();
     }

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -56,17 +56,24 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
 
     Map<String, String> providerParams = provider.getParams();
     String providerNames = providerParams.get("composite.provider.names");
+    if (!providerNames.isEmpty()) {
     String[] names = parseProviderNames(providerNames);
     for (String name : names) {
       getProviderSpecificParams(resource, params, providerParams, name);
       DeploymentFactory.getProviderContributor("authorization", name)
-        .contributeFilter(context, provider, service, resource, params);
+              .contributeFilter(context, provider, service, resource, params);
       params.clear();
+    }
     }
   }
 
   String[] parseProviderNames(String providerNames) {
-    return providerNames.split(",\\s*");
+    String[] b = providerNames.split("\\s*,\\s*");
+
+    for (int i = 0; i < b.length; i++) {
+      b[i] = b[i].trim();
+    }
+    return b;
   }
 
   void getProviderSpecificParams(ResourceDescriptor resource, List<FilterParamDescriptor> params,

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -64,4 +64,16 @@ public class CompositeAuthzProviderTest {
     assertEquals(providerNames[1], "SomeOther");
     assertEquals(providerNames[2], "TheOtherOne");
   }
+
+  @Test
+  public void testingParsingProviderNames() throws Exception {
+    String testnames = "   AclsAuthz  ,   SomeOther   ,   TheOtherOne   ,";
+    CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
+    String[] providerNames = c.parseProviderNames(testnames);
+    assertEquals(providerNames.length, 3);
+    assertEquals(providerNames[0], "AclsAuthz");
+    assertEquals(providerNames[1], "SomeOther");
+    assertEquals(providerNames[2], "TheOtherOne");
+  }
 }
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

Whitespaces around delimiters were causing problems while specifying composite auth provider names. The parseProviderNames function has been modified to trim provider names before passing it to the Deployment Contributor function. 

## How was this patch tested?
Ran automated unit/integration tests to ensure provider names did not contain whitespaces. Also ran manual tests to ensure no malfunctions.

[Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) reviewed.