### PR TITLE
KNOX-2762 Bug fixes for spaces around delimiters with reviewed commen…

### DIFF
--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Arrays;
 
 public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContributorBase {
   @Override
@@ -57,22 +58,23 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
     Map<String, String> providerParams = provider.getParams();
     String providerNames = providerParams.get("composite.provider.names");
     if (!providerNames.isEmpty()) {
-    String[] names = parseProviderNames(providerNames);
-    for (String name : names) {
-      getProviderSpecificParams(resource, params, providerParams, name);
-      DeploymentFactory.getProviderContributor("authorization", name)
-              .contributeFilter(context, provider, service, resource, params);
-      params.clear();
-    }
+      List<String> names = parseProviderNames(providerNames);
+      for (String name : names) {
+        getProviderSpecificParams(resource, params, providerParams, name);
+        DeploymentFactory.getProviderContributor("authorization", name)
+                .contributeFilter(context, provider, service, resource, params);
+        params.clear();
+      }
     }
   }
 
-  String[] parseProviderNames(String providerNames) {
-    String[] b = providerNames.split("\\s*,\\s*");
-    for (int i = 0; i < b.length; i++) {
-      b[i] = b[i].trim();
+  List parseProviderNames(String providerNames) {
+    String[] providerNamesList = providerNames.split("\\s*,\\s*");
+    for (int i = 0; i < providerNamesList.length; i++) {
+      providerNamesList[i] = providerNamesList[i].trim();
     }
-    return b;
+    List<String> providerNamesCollection = Arrays.asList(providerNamesList);
+    return providerNamesCollection;
   }
 
   void getProviderSpecificParams(ResourceDescriptor resource, List<FilterParamDescriptor> params,

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -58,22 +58,24 @@ public class CompositeAuthzProviderTest {
   public void testParsingProviderNames() throws Exception {
     String names = "AclsAuthz,   SomeOther,TheOtherOne";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
-    String[] providerNames = c.parseProviderNames(names);
-    assertEquals(providerNames.length, 3);
-    assertEquals(providerNames[0], "AclsAuthz");
-    assertEquals(providerNames[1], "SomeOther");
-    assertEquals(providerNames[2], "TheOtherOne");
+    List providerNames = c.parseProviderNames(names);
+    assertEquals(providerNames.size(), 3);
+    assertEquals(providerNames.get(0), "AclsAuthz");
+    assertEquals(providerNames.get(1), "SomeOther");
+    assertEquals(providerNames.get(2), "TheOtherOne");
   }
 
   @Test
   public void testingParsingProviderNames() throws Exception {
-    String testnames = "   AclsAuthz  ,   SomeOther   ,   TheOtherOne   ,";
+    String testnames = " SpaceBefore,SpaceAfter , SpaceBeforeandAfter ,NoSpaces,   MoreSpaces   ";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
-    String[] providerNames = c.parseProviderNames(testnames);
-    assertEquals(providerNames.length, 3);
-    assertEquals(providerNames[0], "AclsAuthz");
-    assertEquals(providerNames[1], "SomeOther");
-    assertEquals(providerNames[2], "TheOtherOne");
+    List providerNames = c.parseProviderNames(testnames);
+    assertEquals(providerNames.size(), 5);
+    assertEquals(providerNames.get(0), "SpaceBefore");
+    assertEquals(providerNames.get(1), "SpaceAfter");
+    assertEquals(providerNames.get(2), "SpaceBeforeandAfter");
+    assertEquals(providerNames.get(3), "NoSpaces");
+    assertEquals(providerNames.get(4), "MoreSpaces");
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Issue arising from NPE due to whitespaces around delimiters in Composite Authz names fixed with review comments addressed.

## How was this patch tested?

Specific unit/integration tests covering most possible test cases conducted. Manual tests also conducted to ensure no build failures.

[Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) reviewed.