### PR TITLE
KNOX-2762 Bug fixes for spaces around delimiters with all reviewed comments addressed

### DIFF
--- a/gateway-provider-security-authz-composite/pom.xml
+++ b/gateway-provider-security-authz-composite/pom.xml
@@ -36,5 +36,9 @@
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-spi</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Collections;
 import java.util.Arrays;
 
 public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContributorBase {
@@ -69,12 +70,12 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
   }
 
   List parseProviderNames(String providerNames) {
-    String[] providerNamesList = providerNames.split("\\s*,\\s*");
-    for (int i = 0; i < providerNamesList.length; i++) {
-      providerNamesList[i] = providerNamesList[i].trim();
+    if (providerNames==null){
+      return Collections.singletonList("");
     }
-    List<String> providerNamesCollection = Arrays.asList(providerNamesList);
-    return providerNamesCollection;
+    List<String> providerNamesList = Arrays.asList(providerNames.split("\\s*,\\s*"));
+    providerNamesList.replaceAll(String::trim);
+    return providerNamesList;
   }
 
   void getProviderSpecificParams(ResourceDescriptor resource, List<FilterParamDescriptor> params,

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -71,7 +71,7 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
   }
 
   List parseProviderNames(String providerNames) {
-    if (providerNames==null || StringUtils.isBlank(providerNames)){
+    if (StringUtils.isBlank(providerNames)){
       return Collections.emptyList();
     }
     List<String> providerNamesList = Arrays.asList(providerNames.split("\\s*,\\s*"));

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -59,16 +59,14 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
 
     Map<String, String> providerParams = provider.getParams();
     String providerNames = providerParams.get("composite.provider.names");
-    if (!StringUtils.isEmpty(providerNames)) {
-      List<String> names = parseProviderNames(providerNames);
-      for (String name : names) {
-        getProviderSpecificParams(resource, params, providerParams, name);
-        DeploymentFactory.getProviderContributor("authorization", name)
-                .contributeFilter(context, provider, service, resource, params);
-        params.clear();
+    List<String> names = parseProviderNames(providerNames);
+    for (String name : names) {
+      getProviderSpecificParams(resource, params, providerParams, name);
+      DeploymentFactory.getProviderContributor("authorization", name)
+              .contributeFilter(context, provider, service, resource, params);
+      params.clear();
       }
     }
-  }
 
    List<String> parseProviderNames(String providerNames) {
     if (StringUtils.isBlank(providerNames)){

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -70,7 +70,7 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
     }
   }
 
-  List parseProviderNames(String providerNames) {
+   List<String> parseProviderNames(String providerNames) {
     if (StringUtils.isBlank(providerNames)){
       return Collections.emptyList();
     }

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Arrays;
 
 public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContributorBase {
   @Override
@@ -57,22 +58,23 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
     Map<String, String> providerParams = provider.getParams();
     String providerNames = providerParams.get("composite.provider.names");
     if (!providerNames.isEmpty()) {
-    String[] names = parseProviderNames(providerNames);
-    for (String name : names) {
-      getProviderSpecificParams(resource, params, providerParams, name);
-      DeploymentFactory.getProviderContributor("authorization", name)
-              .contributeFilter(context, provider, service, resource, params);
-      params.clear();
-    }
+      List<String> names = parseProviderNames(providerNames);
+      for (String name : names) {
+        getProviderSpecificParams(resource, params, providerParams, name);
+        DeploymentFactory.getProviderContributor("authorization", name)
+                .contributeFilter(context, provider, service, resource, params);
+        params.clear();
+      }
     }
   }
 
-  String[] parseProviderNames(String providerNames) {
-    String[] b = providerNames.split("\\s*,\\s*");
-    for (int i = 0; i < b.length; i++) {
-      b[i] = b[i].trim();
+  List parseProviderNames(String providerNames) {
+    String[] providerNamesList = providerNames.split("\\s*,\\s*");
+    for (int i = 0; i < providerNamesList.length; i++) {
+      providerNamesList[i] = providerNamesList[i].trim();
     }
-    return b;
+    List<String> providerNamesCollection = Arrays.asList(providerNamesList);
+    return providerNamesCollection;
   }
 
   void getProviderSpecificParams(ResourceDescriptor resource, List<FilterParamDescriptor> params,

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -71,7 +71,7 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
   }
 
   List parseProviderNames(String providerNames) {
-    if (providerNames==null || StringUtils.isEmpty(providerNames) || StringUtils.isBlank(providerNames)){
+    if (providerNames==null || StringUtils.isBlank(providerNames)){
       return Collections.emptyList();
     }
     List<String> providerNamesList = Arrays.asList(providerNames.split("\\s*,\\s*"));

--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.deploy.impl;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
 import org.apache.knox.gateway.deploy.ProviderDeploymentContributorBase;
@@ -58,7 +59,7 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
 
     Map<String, String> providerParams = provider.getParams();
     String providerNames = providerParams.get("composite.provider.names");
-    if (!providerNames.isEmpty()) {
+    if (!StringUtils.isEmpty(providerNames)) {
       List<String> names = parseProviderNames(providerNames);
       for (String name : names) {
         getProviderSpecificParams(resource, params, providerParams, name);
@@ -70,8 +71,8 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
   }
 
   List parseProviderNames(String providerNames) {
-    if (providerNames==null){
-      return Collections.singletonList("");
+    if (providerNames==null || StringUtils.isEmpty(providerNames) || StringUtils.isBlank(providerNames)){
+      return Collections.emptyList();
     }
     List<String> providerNamesList = Arrays.asList(providerNames.split("\\s*,\\s*"));
     providerNamesList.replaceAll(String::trim);

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -96,8 +96,6 @@ public class CompositeAuthzProviderTest {
     providerNames = c.parseProviderNames(testnames);
     assertEquals(0,providerNames.size());
     assertEquals(Collections.emptyList(), providerNames);
-
-
   }
 }
 

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
 
 public class CompositeAuthzProviderTest {
@@ -61,10 +60,10 @@ public class CompositeAuthzProviderTest {
     String names = "AclsAuthz,   SomeOther,TheOtherOne";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
     List providerNames = c.parseProviderNames(names);
-    assertEquals(providerNames.size(), 3);
-    assertEquals(providerNames.get(0), "AclsAuthz");
-    assertEquals(providerNames.get(1), "SomeOther");
-    assertEquals(providerNames.get(2), "TheOtherOne");
+    assertEquals(3, providerNames.size());
+    assertEquals("AclsAuthz", providerNames.get(0));
+    assertEquals("SomeOther", providerNames.get(1));
+    assertEquals("TheOtherOne", providerNames.get(2));
   }
 
   @Test
@@ -72,12 +71,12 @@ public class CompositeAuthzProviderTest {
     String testnames = " SpaceBefore,SpaceAfter , SpaceBeforeandAfter ,NoSpaces,   MoreSpaces   ";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
     List providerNames = c.parseProviderNames(testnames);
-    assertEquals(providerNames.size(), 5);
-    assertEquals(providerNames.get(0), "SpaceBefore");
-    assertEquals(providerNames.get(1), "SpaceAfter");
-    assertEquals(providerNames.get(2), "SpaceBeforeandAfter");
-    assertEquals(providerNames.get(3), "NoSpaces");
-    assertEquals(providerNames.get(4), "MoreSpaces");
+    assertEquals(5, providerNames.size());
+    assertEquals("SpaceBefore", providerNames.get(0));
+    assertEquals("SpaceAfter", providerNames.get(1));
+    assertEquals("SpaceBeforeandAfter", providerNames.get(2));
+    assertEquals("NoSpaces", providerNames.get(3));
+    assertEquals("MoreSpaces", providerNames.get(4));
   }
   @Test
 
@@ -85,18 +84,18 @@ public class CompositeAuthzProviderTest {
     String testnames = "";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
     List providerNames = c.parseProviderNames(testnames);
-    assertSame(providerNames.size(),0);
-    assertSame(providerNames,Collections.emptyList());
+    assertEquals(0,providerNames.size());
+    assertEquals(Collections.emptyList(), providerNames);
 
     testnames = "  ";
     providerNames = c.parseProviderNames(testnames);
-    assertSame(providerNames.size(),0);
-    assertSame(providerNames,Collections.emptyList());
+    assertEquals(0, providerNames.size());
+    assertEquals(Collections.emptyList(), providerNames);
 
     testnames = null;
     providerNames = c.parseProviderNames(testnames);
-    assertSame(providerNames.size(),0);
-    assertSame(providerNames,Collections.emptyList());
+    assertEquals(0,providerNames.size());
+    assertEquals(Collections.emptyList(), providerNames);
 
 
   }

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -77,5 +77,20 @@ public class CompositeAuthzProviderTest {
     assertEquals(providerNames.get(3), "NoSpaces");
     assertEquals(providerNames.get(4), "MoreSpaces");
   }
+  @Test
+
+  public void testingNullandEmptyProviderNames() throws Exception {
+    String testnames = "";
+    CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
+    List providerNames = c.parseProviderNames(testnames);
+    assertEquals(providerNames.size(), 1);
+    assertEquals(providerNames.get(0), "");
+
+    testnames = null;
+    providerNames = c.parseProviderNames(testnames);
+    assertEquals(providerNames.size(), 1);
+    assertEquals(providerNames.get(0), "");
+
+  }
 }
 

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -58,22 +58,24 @@ public class CompositeAuthzProviderTest {
   public void testParsingProviderNames() throws Exception {
     String names = "AclsAuthz,   SomeOther,TheOtherOne";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
-    String[] providerNames = c.parseProviderNames(names);
-    assertEquals(providerNames.length, 3);
-    assertEquals(providerNames[0], "AclsAuthz");
-    assertEquals(providerNames[1], "SomeOther");
-    assertEquals(providerNames[2], "TheOtherOne");
+    List providerNames = c.parseProviderNames(names);
+    assertEquals(providerNames.size(), 3);
+    assertEquals(providerNames.get(0), "AclsAuthz");
+    assertEquals(providerNames.get(1), "SomeOther");
+    assertEquals(providerNames.get(2), "TheOtherOne");
   }
 
   @Test
   public void testingParsingProviderNames() throws Exception {
-    String testnames = "   AclsAuthz  ,   SomeOther   ,   TheOtherOne   ,";
+    String testnames = " SpaceBefore,SpaceAfter , SpaceBeforeandAfter ,NoSpaces,   MoreSpaces   ";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
-    String[] providerNames = c.parseProviderNames(testnames);
-    assertEquals(providerNames.length, 3);
-    assertEquals(providerNames[0], "AclsAuthz");
-    assertEquals(providerNames[1], "SomeOther");
-    assertEquals(providerNames[2], "TheOtherOne");
+    List providerNames = c.parseProviderNames(testnames);
+    assertEquals(providerNames.size(), 5);
+    assertEquals(providerNames.get(0), "SpaceBefore");
+    assertEquals(providerNames.get(1), "SpaceAfter");
+    assertEquals(providerNames.get(2), "SpaceBeforeandAfter");
+    assertEquals(providerNames.get(3), "NoSpaces");
+    assertEquals(providerNames.get(4), "MoreSpaces");
   }
 }
 

--- a/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
+++ b/gateway-provider-security-authz-composite/src/test/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzProviderTest.java
@@ -21,16 +21,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
+
 
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 
 public class CompositeAuthzProviderTest {
   @Test
@@ -83,13 +85,19 @@ public class CompositeAuthzProviderTest {
     String testnames = "";
     CompositeAuthzDeploymentContributor c = new CompositeAuthzDeploymentContributor();
     List providerNames = c.parseProviderNames(testnames);
-    assertEquals(providerNames.size(), 1);
-    assertEquals(providerNames.get(0), "");
+    assertSame(providerNames.size(),0);
+    assertSame(providerNames,Collections.emptyList());
+
+    testnames = "  ";
+    providerNames = c.parseProviderNames(testnames);
+    assertSame(providerNames.size(),0);
+    assertSame(providerNames,Collections.emptyList());
 
     testnames = null;
     providerNames = c.parseProviderNames(testnames);
-    assertEquals(providerNames.size(), 1);
-    assertEquals(providerNames.get(0), "");
+    assertSame(providerNames.size(),0);
+    assertSame(providerNames,Collections.emptyList());
+
 
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix for NullPointer Exception arising due to whitespaces around delimiters in Composite Auth Provider Names. All review comments addressed.
## How was this patch tested?

Comprehensive Unit tests used to cover most possible test cases. Also manually tested.

[Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) reviewed.