### PR TITLE
KNOX-2766 - Make sure disableLoadBalancingForUserAgents is picked up from HA configs

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -105,8 +105,11 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
         stickySessionCookieName = serviceConfig.getStickySessionCookieName();
       }
 
-      disableLoadBalancingForUserAgents = serviceConfig.getStickySessionDisabledUserAgents();
-
+      if(StringUtils.isNotBlank(serviceConfig.getStickySessionDisabledUserAgents())) {
+        disableLoadBalancingForUserAgents = Arrays.asList(serviceConfig.getStickySessionDisabledUserAgents()
+            .trim()
+            .split("\\s*,\\s*"));
+      }
       setupUrlHashLookup();
     }
 

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServiceConfig.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServiceConfig.java
@@ -17,7 +17,6 @@
  */
 package org.apache.knox.gateway.ha.provider;
 
-import java.util.List;
 
 public interface HaServiceConfig {
   void setServiceName(String name);
@@ -60,7 +59,7 @@ public interface HaServiceConfig {
 
   void setNoFallbackEnabled(boolean noFallbackEnabled);
 
-  void setDisableStickySessionForUserAgents(List<String> disableStickySessionForUserAgents);
+  void setDisableStickySessionForUserAgents(String disableStickySessionForUserAgents);
 
-  List<String> getStickySessionDisabledUserAgents();
+  String getStickySessionDisabledUserAgents();
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/DefaultHaServiceConfig.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/DefaultHaServiceConfig.java
@@ -17,8 +17,6 @@
  */
 package org.apache.knox.gateway.ha.provider.impl;
 
-import java.util.List;
-
 import org.apache.knox.gateway.ha.provider.HaServiceConfig;
 
 public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigConstants {
@@ -43,7 +41,7 @@ public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigC
 
   private String zookeeperNamespace;
 
-  private List<String> disableStickySessionForUserAgents;
+  private String disableStickySessionForUserAgents;
 
   public DefaultHaServiceConfig(String name) {
     this.name = name;
@@ -150,12 +148,12 @@ public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigC
   }
 
   @Override
-  public void setDisableStickySessionForUserAgents(List<String> disableStickySessionForUserAgents) {
+  public void setDisableStickySessionForUserAgents(String disableStickySessionForUserAgents) {
     this.disableStickySessionForUserAgents = disableStickySessionForUserAgents;
   }
 
   @Override
-  public List<String> getStickySessionDisabledUserAgents() {
+  public String getStickySessionDisabledUserAgents() {
     return disableStickySessionForUserAgents;
   }
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorConstants.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorConstants.java
@@ -51,4 +51,6 @@ public interface HaDescriptorConstants {
    String ENABLE_NO_FALLBACK = "noFallback";
 
    String STICKY_SESSION_COOKIE_NAME = "stickySessionCookieName";
+
+   String DISABLE_LB_USER_AGENTS = "disableLoadBalancingForUserAgents";
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactory.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactory.java
@@ -20,10 +20,7 @@ package org.apache.knox.gateway.ha.provider.impl;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.ha.provider.HaDescriptor;
 import org.apache.knox.gateway.ha.provider.HaServiceConfig;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
@@ -47,15 +44,8 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
     final String stickySessionCookieName = configMap.getOrDefault(STICKY_SESSION_COOKIE_NAME, DEFAULT_STICKY_SESSION_COOKIE_NAME);
 
     final String disableLoadBalancingForUserAgentsConfig = configMap.getOrDefault(DISABLE_LB_USER_AGENTS, DEFAULT_DISABLE_LB_USER_AGENTS);
-    /* configured user agents are comma separate list which *can* contain whitespaces */
-    List<String> disableLoadBalancingForUserAgents = Collections.EMPTY_LIST;
-    if(StringUtils.isNotBlank(disableLoadBalancingForUserAgentsConfig)) {
-      disableLoadBalancingForUserAgents = Arrays.asList(disableLoadBalancingForUserAgentsConfig
-              .trim()
-              .split("\\s*,\\s*"));
-    }
     return createServiceConfig(serviceName, enabled, maxFailoverAttempts, failoverSleep, zookeeperEnsemble, zookeeperNamespace, stickySessionsEnabled, loadBalancingEnabled,
-            stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgents);
+            stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgentsConfig);
   }
 
   /**
@@ -78,8 +68,8 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
                                                      String maxFailoverAttemptsValue, String failoverSleepValue,
                                                      String zookeeperEnsemble, String zookeeperNamespace,
                                                      String loadBalancingEnabledValue, String stickySessionsEnabledValue,
-                                                     String stickySessionCookieNameValue,
-                                                     String noFallbackEnabledValue) {
+                                                     String stickySessionCookieNameValue, String noFallbackEnabledValue,
+                                                     String disableLoadBalancingForUserAgentsValue) {
       boolean enabled = DEFAULT_ENABLED;
       int maxFailoverAttempts = DEFAULT_MAX_FAILOVER_ATTEMPTS;
       int failoverSleep = DEFAULT_FAILOVER_SLEEP;
@@ -87,6 +77,7 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
       boolean loadBalancingEnabled = DEFAULT_LOAD_BALANCING_ENABLED;
       boolean noFallbackEnabled = DEFAULT_NO_FALLBACK_ENABLED;
       String stickySessionCookieName = DEFAULT_STICKY_SESSION_COOKIE_NAME;
+      String disableLoadBalancingForUserAgentsConfig = DEFAULT_DISABLE_LB_USER_AGENTS;
       if (enabledValue != null && !enabledValue.trim().isEmpty()) {
          enabled = Boolean.parseBoolean(enabledValue);
       }
@@ -108,9 +99,12 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
       if (noFallbackEnabledValue != null && !noFallbackEnabledValue.trim().isEmpty()) {
          noFallbackEnabled = Boolean.parseBoolean(noFallbackEnabledValue);
       }
+      if(StringUtils.isNotBlank(disableLoadBalancingForUserAgentsValue)) {
+        disableLoadBalancingForUserAgentsConfig = disableLoadBalancingForUserAgentsValue;
+      }
 
      return createServiceConfig(serviceName, enabled, maxFailoverAttempts, failoverSleep, zookeeperEnsemble, zookeeperNamespace, stickySessionsEnabled, loadBalancingEnabled,
-             stickySessionCookieName, noFallbackEnabled, Arrays.asList(DEFAULT_DISABLE_LB_USER_AGENTS));
+             stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgentsConfig);
    }
 
   private static DefaultHaServiceConfig createServiceConfig(final String serviceName, final boolean enabled,
@@ -118,7 +112,7 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
           final String zookeeperEnsemble, final String zookeeperNamespace,
           final boolean stickySessionsEnabled, final boolean loadBalancingEnabled,
           final String stickySessionCookieName,
-          final boolean noFallbackEnabled, final List<String> disableStickySessionForUserAgents) {
+          final boolean noFallbackEnabled, final String disableStickySessionForUserAgents) {
     DefaultHaServiceConfig serviceConfig = new DefaultHaServiceConfig(serviceName);
     serviceConfig.setEnabled(enabled);
     serviceConfig.setMaxFailoverAttempts(maxFailoverAttempts);

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManager.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManager.java
@@ -66,6 +66,9 @@ public class HaDescriptorManager implements HaDescriptorConstants {
                if (config.getStickySessionCookieName() != null) {
                  serviceElement.setAttribute(STICKY_SESSION_COOKIE_NAME, config.getStickySessionCookieName());
                }
+               if(config.getStickySessionDisabledUserAgents() != null && !config.getStickySessionDisabledUserAgents().isEmpty()) {
+                  serviceElement.setAttribute(DISABLE_LB_USER_AGENTS, config.getStickySessionDisabledUserAgents());
+               }
                root.appendChild(serviceElement);
             }
          }
@@ -95,7 +98,8 @@ public class HaDescriptorManager implements HaDescriptorConstants {
                      element.getAttribute(ENABLE_LOAD_BALANCING),
                      element.getAttribute(ENABLE_STICKY_SESSIONS),
                      element.getAttribute(STICKY_SESSION_COOKIE_NAME),
-                     element.getAttribute(ENABLE_NO_FALLBACK));
+                     element.getAttribute(ENABLE_NO_FALLBACK),
+                     element.getAttribute(DISABLE_LB_USER_AGENTS));
                descriptor.addServiceConfig(config);
             }
          }

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatchTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatchTest.java
@@ -69,7 +69,7 @@ public class ConfigurableHADispatchTest {
   public void testHADispatchURL() throws Exception {
     String serviceName = "HIVE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null, null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI("http://host1.valid");
     URI uri2 = new URI("http://host2.valid");
@@ -105,7 +105,7 @@ public class ConfigurableHADispatchTest {
   public void testSetCookieHeader() throws Exception {
     String serviceName = "HIVE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
@@ -66,7 +66,7 @@ public class DefaultHaDispatchTest {
   public void testConnectivityFailover() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null, null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://unreachable-host.invalid" );
     URI uri2 = new URI( "http://reachable-host.invalid" );
@@ -134,7 +134,7 @@ public class DefaultHaDispatchTest {
   public void testNoLoadbalancingStickyFailoverNoFallback() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, "true", null, "true"));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, "true", null, "true", null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://unreachable-host.invalid" );
     URI uri2 = new URI( "http://reachable-host.invalid" );
@@ -200,7 +200,7 @@ public class DefaultHaDispatchTest {
   public void testNoFallbackWhenStickyDisabled() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, "true"));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, "true", null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://unreachable-host.invalid" );
     URI uri2 = new URI( "http://reachable-host.invalid" );
@@ -269,7 +269,7 @@ public class DefaultHaDispatchTest {
   public void testLoadbalancingOffStickyOn() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );
@@ -364,7 +364,7 @@ public class DefaultHaDispatchTest {
   public void testLoadbalancingOn() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", null, null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", null, null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );
@@ -460,7 +460,7 @@ public class DefaultHaDispatchTest {
   public void testLoadbalancingOnStickyOn() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );
@@ -592,7 +592,8 @@ public class DefaultHaDispatchTest {
                                                                         enableLoadBalancing,
                                                                         enableStickySession,
                                                                         null,
-                                                                        noFallback));
+                                                                        noFallback,
+                                                                        null));
     final HaProvider provider = new DefaultHaProvider(descriptor);
     final URI uri1 = new URI( "http://host1.valid" );
     final URI uri2 = new URI( "http://host2.valid" );
@@ -717,7 +718,7 @@ public class DefaultHaDispatchTest {
   public void testStickyOn() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );
@@ -816,7 +817,7 @@ public class DefaultHaDispatchTest {
     String userAgent = "ClouderaODBCDriverforApacheHive/2.6.11.1011 Thrift/0.9.0 (C++/THttpClient)[\\r][\\n]";
     String serviceName = "HIVE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );
@@ -970,7 +971,7 @@ public class DefaultHaDispatchTest {
     String userAgent = "JDBCDriverforApacheHive/2.6.11.1011 [\\r][\\n]";
     String serviceName = "HIVE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, "true", "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://host1.valid" );
     URI uri2 = new URI( "http://host2.valid" );
@@ -1162,7 +1163,7 @@ public class DefaultHaDispatchTest {
   public void testConnectivityActive() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, "true", null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, "true", null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://unreachable-host" );
     URI uri2 = new URI( "http://reachable-host" );
@@ -1219,7 +1220,7 @@ public class DefaultHaDispatchTest {
   public void testMarkedFailedWithoutRetry() throws Exception {
     String serviceName = "OOZIE";
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "0", "1000", null, null, null, null, null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "0", "1000", null, null, null, null, null, null,null));
     HaProvider provider = new DefaultHaProvider(descriptor);
     URI uri1 = new URI( "http://unreachable-host.invalid" );
     URI uri2 = new URI( "http://reachable-host.invalid" );

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactoryTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactoryTest.java
@@ -41,7 +41,7 @@ public class HaDescriptorFactoryTest {
       assertEquals(42, serviceConfig.getMaxFailoverAttempts());
       assertEquals(50, serviceConfig.getFailoverSleep());
 
-      serviceConfig = HaDescriptorFactory.createServiceConfig("bar", "false", "3", "1000", null, null, null, null, null, null);
+      serviceConfig = HaDescriptorFactory.createServiceConfig("bar", "false", "3", "1000", null, null, null, null, null, null,null);
       assertNotNull(serviceConfig);
       assertFalse(serviceConfig.isEnabled());
       assertEquals("bar", serviceConfig.getServiceName());
@@ -69,7 +69,7 @@ public class HaDescriptorFactoryTest {
     assertTrue(serviceConfig.isStickySessionEnabled());
     assertEquals("abc", serviceConfig.getStickySessionCookieName());
 
-    serviceConfig = HaDescriptorFactory.createServiceConfig( "bar", "false", "3", "1000", null, null, null, "true", null, null);
+    serviceConfig = HaDescriptorFactory.createServiceConfig( "bar", "false", "3", "1000", null, null, null, "true", null, null,null);
     assertNotNull(serviceConfig);
     assertFalse(serviceConfig.isEnabled());
     assertEquals("bar", serviceConfig.getServiceName());
@@ -78,7 +78,7 @@ public class HaDescriptorFactoryTest {
     assertTrue(serviceConfig.isStickySessionEnabled());
     assertEquals(HaServiceConfigConstants.DEFAULT_STICKY_SESSION_COOKIE_NAME, serviceConfig.getStickySessionCookieName());
 
-    serviceConfig = HaDescriptorFactory.createServiceConfig( "knox", "false", "4", "3000", null, null, null, null, null, null);
+    serviceConfig = HaDescriptorFactory.createServiceConfig( "knox", "false", "4", "3000", null, null, null, null, null, null,null);
     assertNotNull(serviceConfig);
     assertFalse(serviceConfig.isEnabled());
     assertEquals("knox", serviceConfig.getServiceName());
@@ -87,7 +87,7 @@ public class HaDescriptorFactoryTest {
     assertFalse(serviceConfig.isStickySessionEnabled());
     assertEquals(HaServiceConfigConstants.DEFAULT_STICKY_SESSION_COOKIE_NAME, serviceConfig.getStickySessionCookieName());
 
-    serviceConfig = HaDescriptorFactory.createServiceConfig( "bar", "false", "3", "1000", null, null, null, "true", "abc", null);
+    serviceConfig = HaDescriptorFactory.createServiceConfig( "bar", "false", "3", "1000", null, null, null, "true", "abc", null,null);
     assertNotNull(serviceConfig);
     assertFalse(serviceConfig.isEnabled());
     assertEquals("bar", serviceConfig.getServiceName());
@@ -96,7 +96,7 @@ public class HaDescriptorFactoryTest {
     assertTrue(serviceConfig.isStickySessionEnabled());
     assertEquals("abc", serviceConfig.getStickySessionCookieName());
 
-    serviceConfig = HaDescriptorFactory.createServiceConfig( "bar", "false", "3", "1000", null, null, "true", null, "abc", "true");
+    serviceConfig = HaDescriptorFactory.createServiceConfig( "bar", "false", "3", "1000", null, null, "true", null, "abc", "true",null);
     assertNotNull(serviceConfig);
     assertFalse(serviceConfig.isEnabled());
     assertEquals("bar", serviceConfig.getServiceName());

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManagerTest.java
@@ -76,8 +76,8 @@ public class HaDescriptorManagerTest {
    @Test
    public void testDescriptorStoring() throws IOException {
       HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-      descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", null, null, null, null));
-      descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, null, null, null, null));
+      descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", null, null, null, null,null));
+      descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, null, null, null, null,null));
       StringWriter writer = new StringWriter();
       HaDescriptorManager.store(descriptor, writer);
       String xml = writer.toString();
@@ -88,10 +88,10 @@ public class HaDescriptorManagerTest {
   @Test
   public void testDescriptorStoringStickySessionCookie() throws IOException {
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", null, "true", null, null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, null, "true", null, null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("abc", "true", "3", "5000", null, null, null, "true", "abc", null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("xyz", "true", "3", "5000", null, null, null, "true", "xyz", "true"));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", null, "true", null, null,null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, null, "true", null, null,null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("abc", "true", "3", "5000", null, null, null, "true", "abc", null,null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("xyz", "true", "3", "5000", null, null, null, "true", "xyz", "true",null));
 
     StringWriter writer = new StringWriter();
     HaDescriptorManager.store(descriptor, writer);
@@ -105,9 +105,9 @@ public class HaDescriptorManagerTest {
   @Test
   public void testDescriptorStoringLoadBalancerConfig() throws IOException {
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", "true", "false", null, null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, "true", null, null, null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("abc", "true", "3", "5000", null, null, null, "true", "abc", null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", "true", "false", null, null,null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, "true", null, null, null,null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("abc", "true", "3", "5000", null, null, null, "true", "abc", null,null));
     StringWriter writer = new StringWriter();
     HaDescriptorManager.store(descriptor, writer);
     String xml = writer.toString();

--- a/gateway-service-rm/src/test/java/org/apache/knox/gateway/rm/dispatch/RMHaDispatchTest.java
+++ b/gateway-service-rm/src/test/java/org/apache/knox/gateway/rm/dispatch/RMHaDispatchTest.java
@@ -58,7 +58,7 @@ public class RMHaDispatchTest {
     public void testConnectivityFailure() throws Exception {
         String serviceName = "RESOURCEMANAGER";
         HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-        descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null));
+        descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null,null));
         HaProvider provider = new DefaultHaProvider(descriptor);
         URI uri1 = new URI("http://unreachable-host.invalid");
         URI uri2 = new URI("http://reachable-host.invalid");
@@ -129,7 +129,7 @@ public class RMHaDispatchTest {
     public void testConnectivityFailover() throws Exception {
         String serviceName = "RESOURCEMANAGER";
         HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-        descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null));
+        descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null,null));
         HaProvider provider = new DefaultHaProvider(descriptor);
         URI uri1 = new URI("http://passive-host.invalid");
         URI uri2 = new URI("http://other-host.invalid");

--- a/gateway-service-webhdfs/src/test/java/org/apache/knox/gateway/hdfs/dispatch/WebHdfsHaDispatchTest.java
+++ b/gateway-service-webhdfs/src/test/java/org/apache/knox/gateway/hdfs/dispatch/WebHdfsHaDispatchTest.java
@@ -48,7 +48,7 @@ public class WebHdfsHaDispatchTest {
    public void testConnectivityFailover() throws Exception {
       String serviceName = "WEBHDFS";
       HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-      descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null));
+      descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null,null));
       HaProvider provider = new DefaultHaProvider(descriptor);
       URI uri1 = new URI( "http://unreachable-host.invalid" );
       URI uri2 = new URI( "http://reachable-host.invalid" );


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix case where `disableLoadBalancingForUserAgents` property defined in HA provider in a topology was not getting picked up.

## How was this patch tested?

This patch was tested locally.
