### PR TITLE
KNOX-2771 - Log HTTP client config parameters such as socket timeouts with info level

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -91,10 +91,10 @@ public interface SpiGatewayMessages {
             text = "The dispatch to {0} was disallowed because it fails the dispatch whitelist validation. See documentation for dispatch whitelisting." )
   void dispatchDisallowed(String uri);
 
-  @Message( level = MessageLevel.DEBUG, text = "HTTP client connection timeout is set to {0} for {1}" )
+  @Message( level = MessageLevel.INFO, text = "HTTP client connection timeout is set to {0} for {1}" )
   void setHttpClientConnectionTimeout(int connectionTimeout, String serviceRole);
 
-  @Message( level = MessageLevel.DEBUG, text = "HTTP client socket timeout is set to {0} for {1}" )
+  @Message( level = MessageLevel.INFO, text = "HTTP client socket timeout is set to {0} for {1}" )
   void setHttpClientSocketTimeout(int csocketTimeout, String serviceRole);
 
   @Message( level = MessageLevel.DEBUG, text = "replayBufferSize is set to {0} for {1}" )
@@ -108,4 +108,10 @@ public interface SpiGatewayMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "Skipped adding outbound header {0} and value {1}" )
   void skippedOutboundHeader(String header, String value);
+
+  @Message( level = MessageLevel.INFO, text = "HTTP client retry count is set to {0} for {1}" )
+  void setRetryCount(int retryCount, String serviceRole);
+
+  @Message( level = MessageLevel.INFO, text = "HTTP client retry non safe request is set to {0} for {1}" )
+  void setRetryNonIndependent(boolean retryNonIndependent, String serviceRole);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -91,11 +91,11 @@ public interface SpiGatewayMessages {
             text = "The dispatch to {0} was disallowed because it fails the dispatch whitelist validation. See documentation for dispatch whitelisting." )
   void dispatchDisallowed(String uri);
 
-  @Message( level = MessageLevel.INFO, text = "HTTP client connection timeout is set to {0} msec for {1}" )
+  @Message( level = MessageLevel.INFO, text = "HTTP client connection timeout is set to {0} ms for {1}" )
   void setHttpClientConnectionTimeout(int connectionTimeout, String serviceRole);
 
-  @Message( level = MessageLevel.INFO, text = "HTTP client socket timeout is set to {0} msec for {1}" )
-  void setHttpClientSocketTimeout(int csocketTimeout, String serviceRole);
+  @Message( level = MessageLevel.INFO, text = "HTTP client socket timeout is set to {0} ms for {1}" )
+  void setHttpClientSocketTimeout(int socketTimeout, String serviceRole);
 
   @Message( level = MessageLevel.DEBUG, text = "replayBufferSize is set to {0} for {1}" )
   void setReplayBufferSize(int replayBufferSize, String serviceRole);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -91,10 +91,10 @@ public interface SpiGatewayMessages {
             text = "The dispatch to {0} was disallowed because it fails the dispatch whitelist validation. See documentation for dispatch whitelisting." )
   void dispatchDisallowed(String uri);
 
-  @Message( level = MessageLevel.INFO, text = "HTTP client connection timeout is set to {0} for {1}" )
+  @Message( level = MessageLevel.INFO, text = "HTTP client connection timeout is set to {0} msec for {1}" )
   void setHttpClientConnectionTimeout(int connectionTimeout, String serviceRole);
 
-  @Message( level = MessageLevel.INFO, text = "HTTP client socket timeout is set to {0} for {1}" )
+  @Message( level = MessageLevel.INFO, text = "HTTP client socket timeout is set to {0} msec for {1}" )
   void setHttpClientSocketTimeout(int csocketTimeout, String serviceRole);
 
   @Message( level = MessageLevel.DEBUG, text = "replayBufferSize is set to {0} for {1}" )

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -128,12 +128,14 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
 
     if (doesRetryParamExist(filterConfig)) {
       int retryCount = Integer.parseInt(filterConfig.getInitParameter(PARAMETER_RETRY_COUNT));
+      LOG.setRetryCount(retryCount, serviceRole);
       /* do we want to retry non-idempotent requests? default no */
       boolean retryNonIdempotent = DEFAULT_PARAMETER_RETRY_NON_SAFE_REQUEST;
       if (filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST)
           != null) {
         retryNonIdempotent = Boolean.parseBoolean(
             filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST));
+        LOG.setRetryNonIndependent(retryNonIdempotent, serviceRole);
       }
       builder.setRetryHandler(new DefaultHttpRequestRetryHandler(retryCount,
           retryNonIdempotent));

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -135,8 +135,8 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
           != null) {
         retryNonIdempotent = Boolean.parseBoolean(
             filterConfig.getInitParameter(PARAMETER_RETRY_NON_SAFE_REQUEST));
-        LOG.setRetryNonIndependent(retryNonIdempotent, serviceRole);
       }
+      LOG.setRetryNonIndependent(retryNonIdempotent, serviceRole);
       builder.setRetryHandler(new DefaultHttpRequestRetryHandler(retryCount,
           retryNonIdempotent));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed log level of http connection timeout and socket timeout to from DEBUG to INFO and added INFO level log for retry count and retry non safe request parameters, because sometimes clients were confused why the timeout parameters haven't changed even though they changed it in gateway-site.xml, but service.xml override-s it. Now they can see in the log what is the value of these parameters, only after the first request after topology deployment.

## How was this patch tested?

I tested it manually, using ```curl -k -u tom:tom-password https://localhost:8443/gateway/sandbox/hive``` command from terminal.

1. Nothing is set:

<img width="1654" alt="semmiben" src="https://user-images.githubusercontent.com/77810082/177487369-f710d79c-b7a7-482d-8fc7-96f30c517873.png">

2. Timeout params set in gateway-site.xml and retry params set in sandbox.xml:

<img width="1655" alt="gatewayben" src="https://user-images.githubusercontent.com/77810082/177488015-15cadfe4-4a19-4426-91a1-83520d0ae119.png">
<img width="492" alt="globalbeallitas" src="https://user-images.githubusercontent.com/77810082/177487993-22eb1066-bb82-4348-8ead-91b42ea0a2ab.png">
<img width="494" alt="Screenshot 2022-07-06 at 8 56 18" src="https://user-images.githubusercontent.com/77810082/177488328-b48d9e69-7c0d-44b4-90bd-6405f10fea5e.png">

3. Timeout params set in gateway-site.xml and in service.xml, retry params set like 2.:

<img width="1653" alt="servicebenesgatewayben" src="https://user-images.githubusercontent.com/77810082/177489168-614d58fc-a22a-4387-bbff-949b70802725.png">
<img width="492" alt="globalbeallitas" src="https://user-images.githubusercontent.com/77810082/177489298-5a13d6c8-4c44-4e66-bcc6-04d932371632.png">
<img width="1359" alt="servicekod" src="https://user-images.githubusercontent.com/77810082/177489894-f509c7b4-76cf-409f-b46c-46445ee67c5a.png">

We can see that service.xml overrides gateway-site.xml settings.

The logs only appear after the first request after the topology is deployed.
After that it is not logged until the topology is deployed again.
<img width="1654" alt="masodszorra nem logol" src="https://user-images.githubusercontent.com/77810082/177491088-769f9fb3-d188-42e4-913e-53a1a91bddec.png">
