### PR TITLE
KNOX-2773 - Log replay buffer size with info level

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -97,7 +97,7 @@ public interface SpiGatewayMessages {
   @Message( level = MessageLevel.DEBUG, text = "HTTP client socket timeout is set to {0} for {1}" )
   void setHttpClientSocketTimeout(int csocketTimeout, String serviceRole);
 
-  @Message( level = MessageLevel.DEBUG, text = "replayBufferSize is set to {0} for {1}" )
+  @Message( level = MessageLevel.INFO, text = "replayBufferSize is set to {0} for {1}" )
   void setReplayBufferSize(int replayBufferSize, String serviceRole);
 
   @Message( level = MessageLevel.DEBUG, text = "Using two way SSL in {0}" )


### PR DESCRIPTION
## What changes were proposed in this pull request?

The replayBufferSize log level was changed from debug to info, to prevent confusion on what value was used, since it can be configured in two places (topology file and service.xml). Now the client can see what value was configured as replayBufferSize in the log after the first request after deploying a topology.

## How was this patch tested?

I tested it manually, using the following curl command
`curl -k -u tom:tom-password https://localhost:8443/gateway/sandbox/hive`

1. No configuration in either file
The log output was:
```
2022-07-07 09:27:30,761 ff7f8623-703b-4118-9d83-7a73d5f37231 INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: tom
2022-07-07 09:27:34,515 ff7f8623-703b-4118-9d83-7a73d5f37231 INFO  knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(121)) - replayBufferSize is set to -1 for HIVE
```

2. Configured in service.xml
Configuration:
```
<param>
    <name>replayBufferSize</name>
    <value>11</value>
</param>
```
Log output:
```
022-07-07 09:29:46,028 d15fb564-9185-420c-91da-3c31734e1a9c INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: tom
2022-07-07 09:29:54,590 d15fb564-9185-420c-91da-3c31734e1a9c INFO  knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(121)) - replayBufferSize is set to 11,264 for HIVE
```

3. Configured in service.xml and in the topology file
Service.xml configuration:
```
<param>
    <name>replayBufferSize</name>
    <value>11</value>
</param>
```
Topology configuration:
```
<param>
    <name>replayBufferSize</name>
    <value>5</value>
</param>
```
Log output:
```
022-07-07 09:31:30,155 df38456e-3b9c-4f29-baca-768a323f4bbe INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: tom
2022-07-07 09:31:33,457 df38456e-3b9c-4f29-baca-768a323f4bbe INFO  knox.gateway (DefaultDispatch.java:setReplayBufferSizeInBytes(121)) - replayBufferSize is set to 5,120 for HIVE
```

We can see that the topology file overrides the service.xml if they are configured differently.