### PR TITLE
KNOX-2774 - "usage: sleep seconds" messages in terminal after starting knox

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -44,7 +44,7 @@ declare -a APP_JAVA_OPTS
 
 #status-based test related variables
 DEFAULT_APP_STATUS_TEST_RETRY_ATTEMPTS=5
-DEFAULT_APP_STATUS_TEST_RETRY_SLEEP=2s
+DEFAULT_APP_STATUS_TEST_RETRY_SLEEP=2
 
 ############################
 ##### common functions #####


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed  the value of DEFAULT_APP_STATUS_TEST_RETRY_SLEEP from `2s` to `2` in `knox-functions.sh`, because sleep command in BSD family of operating systems (such as FreeBSD) or macOS/mac OS X does NOT take any suffix arguments (m/h/d). It only takes arguments in seconds.

## How was this patch tested?

I tested it manually.
Before the change:
```
mbalazs-MBP15:test mbalazs$ bin/gateway.sh start
usage: sleep seconds
usage: sleep seconds
.
.
.
usage: sleep seconds
usage: sleep seconds
Starting Gateway succeeded with PID 55659.
```
After the change:
```
mbalazs-MBP15:test mbalazs$ bin/gateway.sh start
Starting Gateway succeeded with PID 55659.
```
I also tried a request using `curl -k -u tom:tom-password https://localhost:8443/gateway/sandbox/hive` and got 
```
2022-07-07 14:50:25,037 726f3103-8de2-4ff8-9bc8-f47f8929da49 INFO  knox.gateway (KnoxLdapRealm.java:getUserDn(688)) - Computed userDn: uid=tom,ou=people,dc=hadoop,dc=apache,dc=org using dnTemplate for principal: tom
```
