### PR TITLE
KNOX-2782 - Enhanced Shiro config with the object class of invalidRequest

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
@@ -33,6 +33,7 @@ public class ShiroConfig {
     String sectionName;
     String value;
 
+    params.putIfAbsent("main.invalidRequest", "org.apache.shiro.web.filter.InvalidRequestFilter");
     params.putIfAbsent("main.invalidRequest.blockSemicolon", "false");
     params.putIfAbsent("main.invalidRequest.blockBackslash", "false");
     params.putIfAbsent("main.invalidRequest.blockNonAscii", "false");


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to make the `user-auth-test` KnoxCLI command work after the 1.6 Shiro upgrade, I'd to add the `invalidRequest` filter's object class (`org.apache.shiro.web.filter.InvalidRequestFilter`) into the `main` section in the generated shiro.ini. Without that change, an error was thrown (see the corresponding JIRA).

## How was this patch tested?

Ran the `GatewayShiroAuthTest` that covers use-cases for Shiro LDAP authentication including a valid service URL with a semicolon (`;jsessionid=OI24B9ASD7BSSD`).

<img width="1307" alt="Screenshot 2022-07-20 at 11 20 44" src="https://user-images.githubusercontent.com/34065904/179946658-8ea68ad7-2478-4a74-83c0-095654232b04.png">

Other than this I made sure the `user-auth-test` KnoxCLI command works:
```
$ bin/knoxcli.sh user-auth-test --cluster sandbox --u admin --p admin-password --d
LDAP authentication successful!
```
