### PR TITLE
KNOX-2783 - User can be mapped to an empty virtual group

### DIFF
--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/filter/CommonIdentityAssertionFilterTest.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.identityasserter.filter;
 import static org.apache.knox.gateway.audit.log4j.audit.Log4jAuditService.MDC_AUDIT_CONTEXT_KEY;
 import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -101,12 +102,15 @@ public class CommonIdentityAssertionFilterTest {
             andReturn(Collections.enumeration(Arrays.asList(
                     CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING,
                     CommonIdentityAssertionFilter.PRINCIPAL_MAPPING,
-                    CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")))
+                    CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group",
+                    CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX))) // invalid group with no name
             .anyTimes();
     EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS)).
         andReturn("doAs").anyTimes();
     EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")).
             andReturn("(and (username 'lmccay') (and (member 'users') (member 'admin')))").anyTimes();
+    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX)).
+            andReturn("true").anyTimes();
     EasyMock.replay( config );
 
     final HttpServletRequest request = EasyMock.createNiceMock( HttpServletRequest.class );
@@ -146,5 +150,6 @@ public class CommonIdentityAssertionFilterTest {
     assertEquals("LMCCAY", username);
     assertTrue("Should be greater than 2", calculatedGroups.size() > 2);
     assertTrue(calculatedGroups.containsAll(Arrays.asList("everyone", "USERS", "ADMIN", "test-virtual-group")));
+    assertFalse(calculatedGroups.contains(""));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If there is no group name after the `group.mapping.` then the user is mapped to an empty group ("").

## How was this patch tested?

Toplogy:

```xml
        <provider>
           <role>authentication</role>
           <name>ShiroProvider</name>
           <enabled>true</enabled>
           <param>
                <name>sessionTimeout</name>
                <value>30</value>
            </param>
            <param>
                <name>main.pamRealm</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxPamRealm</value>
            </param>
            <param>
               <name>main.pamRealm.service</name>
               <value>login</value>
            </param>
            <param>
               <name>urls./**</name>
               <value>authcBasic</value>
           </param>
        </provider>

        <provider>
            <role>identity-assertion</role>
            <name>HadoopGroupProvider</name>
            <enabled>true</enabled>
            <param>
                <name>hadoop.security.group.mapping</name>
                <value>org.apache.hadoop.security.ShellBasedUnixGroupsMapping</value>
            </param>
            <param>
                <name>group.mapping.</name>
                <value>true</value>
            </param>
            <param>
                <name>group.mapping. </name>
                <value>true</value>
            </param>
            <param>
                <name>group.mapping.valid-group-name</name>
                <value>true</value>
            </param>
        </provider>
```

```bash
curl -v -k -u sam:123456 https://localhost:8443/gateway/sandbox/hive
```

User was not added to "".
```
2022-07-20 10:29:30,034 abe3a1ca-aea1-4736-ae53-d2c8481a279a WARN  knox.gateway (CommonIdentityAssertionFilter.java:addGroup(147)) - Invalid mapping parameter name: Missing required group name.

22/07/20 10:29:30 ||abe3a1ca-aea1-4736-ae53-d2c8481a279a|audit|[0:0:0:0:0:0:0:1]|HIVE|sam|||identity-mapping|principal|sam|success|Groups: [_lpoperator, everyone, com.apple.sharepoint.group.3, staff, com.apple.sharepoint.group.2, com.apple.sharepoint.group.1, valid-group-name, localaccounts]
```