### PR TITLE
KNOX-2788 - Implementing EmptyVerifier and Cleaning background thread

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -303,6 +303,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final int GATEWAY_NON_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT_DEFAULT = 2;
   private static final String GATEWAY_PRIVILEGED_USERS = GATEWAY_CONFIG_FILE_PREFIX + "." + PRIVILEGED_USERS;
   private static final String GATEWAY_NON_PRIVILEGED_USERS = GATEWAY_CONFIG_FILE_PREFIX + "." + NON_PRIVILEGED_USERS;
+  private static final String GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".session.verification.expired.tokens.cleaning.period";
+  private static final long GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD_DEFAULT = TimeUnit.MINUTES.toSeconds(30);
 
   public GatewayConfigImpl() {
     init();
@@ -1381,5 +1383,10 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public Set<String> getNonPrivilegedUsers() {
     final Collection<String> nonPrivilegedUsers = getTrimmedStringCollection(GATEWAY_NON_PRIVILEGED_USERS);
     return nonPrivilegedUsers == null ? Collections.emptySet() : new HashSet<>(nonPrivilegedUsers);
+  }
+
+  @Override
+  public long getConcurrentSessionVerifierExpiredTokensCleaningPeriod() {
+    return getLong(GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD, GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD_DEFAULT);
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
@@ -42,7 +42,7 @@ public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
         if (isThereGroupConfigured(gatewayConfig)) {
           service = new InMemoryConcurrentSessionVerifier();
         } else {
-          throw new ServiceLifecycleException("Error, neither privileged nor non-privileged groups are configured!");
+          throw new ServiceLifecycleException("Error creating InMemoryConcurrentSessionVerifier, at least one user should be added in either the privileged group or the non-privileged group!");
         }
       }
       logServiceUsage(implementation, serviceType);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
@@ -17,6 +17,12 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import java.util.Collection;
+import java.util.Map;
+
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
@@ -24,12 +30,6 @@ import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier;
-
-import java.util.Collection;
-import java.util.Map;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
 
 public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
@@ -22,16 +22,32 @@ import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
   @Override
   protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation) throws ServiceLifecycleException {
-    return shouldCreateService(implementation) ? new InMemoryConcurrentSessionVerifier() : null;
+    Service service = null;
+    if (shouldCreateService(implementation)) {
+      if (matchesImplementation(implementation, EmptyConcurrentSessionVerifier.class, true)) {
+        service = new EmptyConcurrentSessionVerifier();
+      } else if (matchesImplementation(implementation, InMemoryConcurrentSessionVerifier.class)) {
+        if (isThereGroupConfigured(gatewayConfig)) {
+          service = new InMemoryConcurrentSessionVerifier();
+        } else {
+          throw new ServiceLifecycleException("Error, neither privileged nor non-privileged groups are configured!");
+        }
+      }
+      logServiceUsage(implementation, serviceType);
+    }
+    return service;
   }
 
   @Override
@@ -41,6 +57,10 @@ public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
 
   @Override
   protected Collection<String> getKnownImplementations() {
-    return Collections.singleton(InMemoryConcurrentSessionVerifier.class.getName());
+    return unmodifiableList(asList(InMemoryConcurrentSessionVerifier.class.getName(), EmptyConcurrentSessionVerifier.class.getName()));
+  }
+
+  private boolean isThereGroupConfigured(GatewayConfig gatewayConfig) {
+    return !gatewayConfig.getNonPrivilegedUsers().isEmpty() || !gatewayConfig.getPrivilegedUsers().isEmpty();
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/EmptyConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/EmptyConcurrentSessionVerifier.java
@@ -17,11 +17,11 @@
  */
 package org.apache.knox.gateway.session.control;
 
+import java.util.Map;
+
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
-
-import java.util.Map;
 
 public class EmptyConcurrentSessionVerifier implements ConcurrentSessionVerifier {
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/EmptyConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/EmptyConcurrentSessionVerifier.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.session.control;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
+
+import java.util.Map;
+
+public class EmptyConcurrentSessionVerifier implements ConcurrentSessionVerifier {
+  @Override
+  public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+
+  }
+
+  @Override
+  public void start() throws ServiceLifecycleException {
+
+  }
+
+  @Override
+  public void stop() throws ServiceLifecycleException {
+
+  }
+
+  @Override
+  public boolean verifySessionForUser(String username, JWT JWToken) {
+    return true;
+  }
+
+  @Override
+  public void sessionEndedForUser(String username, String token) {
+
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
@@ -18,13 +18,6 @@
 package org.apache.knox.gateway.session.control;
 
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.knox.gateway.GatewayMessages;
-import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.services.ServiceLifecycleException;
-import org.apache.knox.gateway.services.security.token.impl.JWT;
-
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -39,6 +32,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
 
 public class InMemoryConcurrentSessionVerifier implements ConcurrentSessionVerifier {
   private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.GatewayMessages;
@@ -148,9 +147,9 @@ public class InMemoryConcurrentSessionVerifier implements ConcurrentSessionVerif
     try {
       Iterator<Map.Entry<String, Set<SessionJWT>>> concurrentSessionCounterIterator = concurrentSessionCounter.entrySet().iterator();
       while (concurrentSessionCounterIterator.hasNext()) {
-        Map.Entry<String, Set<SessionJWT>> concurrentSessionCounterMapEntry = concurrentSessionCounterIterator.next();
-        concurrentSessionCounterMapEntry.setValue(concurrentSessionCounterMapEntry.getValue().stream().filter(sessionJWT -> !sessionJWT.hasExpired()).collect(Collectors.toSet()));
-        if (concurrentSessionCounterMapEntry.getValue().isEmpty()) {
+        Set<SessionJWT> sessionJWTSet = concurrentSessionCounterIterator.next().getValue();
+        sessionJWTSet.removeIf(session -> session.hasExpired());
+        if (sessionJWTSet.isEmpty()) {
           concurrentSessionCounterIterator.remove();
         }
       }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -498,4 +498,20 @@ public class GatewayConfigImplTest {
     hosts.add("127.0.0.1");
     assertThat(config.getGatewayHost(), is(hosts));
   }
+
+  @Test
+  public void testDefaultConcurrentSessionVerifierExpiredTokensCleaningPeriodParameter() {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    assertThat(config.getConcurrentSessionVerifierExpiredTokensCleaningPeriod(), is(TimeUnit.MINUTES.toSeconds(30)));
+  }
+
+  @Test
+  public void testConcurrentSessionVerifierExpiredTokensCleaningPeriodParameter() {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    config.set("gateway.session.verification.expired.tokens.cleaning.period", "1000");
+    assertThat(config.getConcurrentSessionVerifierExpiredTokensCleaningPeriod(), is(1000L));
+  }
+
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
@@ -17,6 +17,14 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
@@ -26,14 +34,6 @@ import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 public class ConcurrentSessionVerifierFactoryTest extends ServiceFactoryTest {
   private final ConcurrentSessionVerifierFactory serviceFactory = new ConcurrentSessionVerifierFactory();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.session.control.ConcurrentSessionVerifier;
+import org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier;
+import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrentSessionVerifierFactoryTest extends ServiceFactoryTest {
+  private final ConcurrentSessionVerifierFactory serviceFactory = new ConcurrentSessionVerifierFactory();
+
+  @Before
+  public void setUp() throws Exception {
+    initConfig();
+  }
+
+  @Test
+  public void testBasics() throws Exception {
+    super.testBasics(serviceFactory, ServiceType.MASTER_SERVICE, ServiceType.CONCURRENT_SESSION_VERIFIER);
+  }
+
+  @Test
+  public void testShouldReturnEmptyConcurrentSessionVerifier() throws Exception {
+    GatewayConfig configForVerifier = mockConfig(Collections.emptySet(), Collections.emptySet());
+
+    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, "");
+    assertTrue(concurrentSessionVerifier instanceof EmptyConcurrentSessionVerifier);
+    concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, EmptyConcurrentSessionVerifier.class.getName());
+    assertTrue(concurrentSessionVerifier instanceof EmptyConcurrentSessionVerifier);
+  }
+
+  @Test
+  public void testShouldReturnInMemoryConcurrentSessionVerifier() throws Exception {
+    GatewayConfig configForVerifier = mockConfig(new HashSet<>(Arrays.asList("admin")), Collections.emptySet());
+
+    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
+    assertTrue(concurrentSessionVerifier instanceof InMemoryConcurrentSessionVerifier);
+
+    configForVerifier = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("tom")));
+
+    concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
+    assertTrue(concurrentSessionVerifier instanceof InMemoryConcurrentSessionVerifier);
+  }
+
+  @Test
+  public void testShouldThrowException() {
+    GatewayConfig configForVerifier = mockConfig(Collections.emptySet(), Collections.emptySet());
+
+    assertThrows(ServiceLifecycleException.class, () -> {
+      serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
+    });
+  }
+
+  private GatewayConfig mockConfig(Set<String> privilegedUsers, Set<String> nonPrivilegedUsers) {
+    GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(config.getPrivilegedUsers()).andReturn(privilegedUsers).anyTimes();
+    EasyMock.expect(config.getNonPrivilegedUsers()).andReturn(nonPrivilegedUsers).anyTimes();
+    EasyMock.replay(config);
+    return config;
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -42,8 +42,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class InMemoryConcurrentSessionVerifierTest {
+  private final long DEFAULT_TEST_EXPIRY_PERIOD = 1000;
   private InMemoryConcurrentSessionVerifier verifier;
   private Map<String, String> options;
   private DefaultTokenAuthorityService tokenAuthority;
@@ -101,26 +108,9 @@ public class InMemoryConcurrentSessionVerifierTest {
     tokenAuthority.init(config, new HashMap<>());
     tokenAuthority.start();
 
-    jwtAttributesForAdmin = new JWTokenAttributesBuilder()
-            .setIssuer("KNOXSSO")
-            .setUserName("admin")
-            .setAudiences(new ArrayList<>())
-            .setAlgorithm("RS256")
-            .setExpires(-1)
-            .setSigningKeystoreName(null)
-            .setSigningKeystoreAlias(null)
-            .setSigningKeystorePassphrase(null)
-            .build();
-    jwtAttributesForTom = new JWTokenAttributesBuilder()
-            .setIssuer("KNOXSSO")
-            .setUserName("tom")
-            .setAudiences(new ArrayList<>())
-            .setAlgorithm("RS256")
-            .setExpires(-1)
-            .setSigningKeystoreName(null)
-            .setSigningKeystoreAlias(null)
-            .setSigningKeystorePassphrase(null)
-            .build();
+    jwtAttributesForAdmin = makeJwtAttribute("admin", false);
+    jwtAttributesForTom = makeJwtAttribute("tom", false);
+
     try {
       adminToken1 = tokenAuthority.issueToken(jwtAttributesForAdmin);
       adminToken2 = tokenAuthority.issueToken(jwtAttributesForAdmin);
@@ -146,6 +136,20 @@ public class InMemoryConcurrentSessionVerifierTest {
     EasyMock.expect(config.getNonPrivilegedUsersConcurrentSessionLimit()).andReturn(nonPrivilegedUsersLimit);
     EasyMock.replay(config);
     return config;
+  }
+
+  private JWTokenAttributes makeJwtAttribute(String username, boolean expiring) {
+    long expiryTime = expiring ? System.currentTimeMillis() + DEFAULT_TEST_EXPIRY_PERIOD : -1;
+    return new JWTokenAttributesBuilder()
+            .setIssuer("KNOXSSO")
+            .setUserName(username)
+            .setAudiences(new ArrayList<>())
+            .setAlgorithm("RS256")
+            .setExpires(expiryTime)
+            .setSigningKeystoreName(null)
+            .setSigningKeystoreAlias(null)
+            .setSigningKeystorePassphrase(null)
+            .build();
   }
 
   /**
@@ -272,16 +276,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 3, 3);
     verifier.init(config, options);
 
-    JWTokenAttributes expiringJwtAttributesForTom = new JWTokenAttributesBuilder()
-            .setIssuer("KNOXSSO")
-            .setUserName("tom")
-            .setAudiences(new ArrayList<>())
-            .setAlgorithm("RS256")
-            .setExpires(System.currentTimeMillis() + 1000)
-            .setSigningKeystoreName(null)
-            .setSigningKeystoreAlias(null)
-            .setSigningKeystorePassphrase(null)
-            .build();
+    JWTokenAttributes expiringJwtAttributesForTom = makeJwtAttribute("tom", true);
 
     JWT tomToken = tokenAuthority.issueToken(jwtAttributesForTom);
     verifier.verifySessionForUser("tom", tomToken);
@@ -295,16 +290,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     Thread.sleep(1000L);
     Assert.assertEquals(1, verifier.countValidTokensForUser("tom"));
 
-    JWTokenAttributes expiringJwtAttributesForAdmin = new JWTokenAttributesBuilder()
-            .setIssuer("KNOXSSO")
-            .setUserName("admin")
-            .setAudiences(new ArrayList<>())
-            .setAlgorithm("RS256")
-            .setExpires(System.currentTimeMillis() + 1000)
-            .setSigningKeystoreName(null)
-            .setSigningKeystoreAlias(null)
-            .setSigningKeystorePassphrase(null)
-            .build();
+    JWTokenAttributes expiringJwtAttributesForAdmin = makeJwtAttribute("admin", true);
 
     JWT adminToken = tokenAuthority.issueToken(jwtAttributesForAdmin);
     verifier.verifySessionForUser("admin", adminToken);
@@ -317,6 +303,160 @@ public class InMemoryConcurrentSessionVerifierTest {
     Assert.assertEquals(3, verifier.countValidTokensForUser("admin"));
     Thread.sleep(1000L);
     Assert.assertEquals(1, verifier.countValidTokensForUser("admin"));
+  }
+
+  @Test
+  public void testBackgroundThreadRemoveExpiredTokens() throws ServiceLifecycleException, TokenServiceException, InterruptedException {
+    GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 3, 3);
+    verifier.init(config, options);
+
+    JWTokenAttributes expiringJwtAttributesForAdmin = makeJwtAttribute("admin", true);
+
+    verifier.verifySessionForUser("admin", adminToken1);
+    verifier.verifySessionForUser("admin", adminToken2);
+    JWT expiringAdminToken = tokenAuthority.issueToken(expiringJwtAttributesForAdmin);
+    verifier.verifySessionForUser("admin", expiringAdminToken);
+    Assert.assertEquals(3, verifier.countValidTokensForUser("admin"));
+    Thread.sleep(1100);
+    Assert.assertEquals(2, verifier.countValidTokensForUser("admin"));
+
+    JWTokenAttributes expiringJwtAttributesForTom = makeJwtAttribute("tom", true);
+
+    verifier.verifySessionForUser("tom", tomToken1);
+    verifier.verifySessionForUser("tom", tomToken2);
+    JWT expiringTomToken = tokenAuthority.issueToken(expiringJwtAttributesForTom);
+    verifier.verifySessionForUser("tom", expiringTomToken);
+    Assert.assertEquals(3, verifier.countValidTokensForUser("tom"));
+    Thread.sleep(1100);
+    Assert.assertEquals(2, verifier.countValidTokensForUser("tom"));
+  }
+
+  @Test
+  public void testPrivilegedLoginLogoutStress() throws ServiceLifecycleException, InterruptedException {
+    GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 256, 256);
+    verifier.init(config, options);
+
+    ExecutorService executor = Executors.newFixedThreadPool(128);
+    BlockingQueue<JWT> tokenStorage = new ArrayBlockingQueue<>(256);
+    CyclicBarrier barrier = new CyclicBarrier(128);
+
+    Runnable privilegedLogin = () -> {
+      JWT token;
+      try {
+        token = tokenAuthority.issueToken(jwtAttributesForAdmin);
+        tokenStorage.add(token);
+        barrier.await();
+      } catch (InterruptedException | BrokenBarrierException | TokenServiceException e) {
+        throw new RuntimeException(e);
+      }
+      verifier.verifySessionForUser("admin", token);
+    };
+
+    for (int i = 0; i < 128; i++) {
+      executor.submit(privilegedLogin);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(128, verifier.countValidTokensForUser("admin"));
+
+    Runnable privilegedLogout = () -> {
+      JWT token;
+      try {
+        token = tokenStorage.take();
+        barrier.await();
+      } catch (InterruptedException | BrokenBarrierException e) {
+        throw new RuntimeException(e);
+      }
+      verifier.sessionEndedForUser("admin", String.valueOf(token));
+    };
+
+    for (int i = 0; i < 64; i++) {
+      executor.submit(privilegedLogin);
+    }
+    for (int i = 0; i < 64; i++) {
+      executor.submit(privilegedLogout);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(128, verifier.countValidTokensForUser("admin"));
+
+    for (int i = 0; i < 128; i++) {
+      executor.submit(privilegedLogout);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(0, verifier.countValidTokensForUser("admin"));
+
+    config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 10, 10);
+    verifier.init(config, options);
+    tokenStorage.clear();
+
+    for (int i = 0; i < 128; i++) {
+      executor.submit(privilegedLogin);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(10, verifier.countValidTokensForUser("admin"));
+  }
+
+  @Test
+  public void testNonPrivilegedLoginLogoutStress() throws ServiceLifecycleException, InterruptedException {
+    GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 256, 256);
+    verifier.init(config, options);
+
+    ExecutorService executor = Executors.newFixedThreadPool(128);
+    BlockingQueue<JWT> tokenStorage = new ArrayBlockingQueue<>(256);
+    CyclicBarrier barrier = new CyclicBarrier(128);
+
+    Runnable nonPrivilegedLogin = () -> {
+      JWT token;
+      try {
+        token = tokenAuthority.issueToken(jwtAttributesForTom);
+        tokenStorage.add(token);
+        barrier.await();
+      } catch (InterruptedException | BrokenBarrierException | TokenServiceException e) {
+        throw new RuntimeException(e);
+      }
+      verifier.verifySessionForUser("tom", token);
+    };
+
+    for (int i = 0; i < 128; i++) {
+      executor.submit(nonPrivilegedLogin);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(128, verifier.countValidTokensForUser("tom"));
+
+    Runnable nonPrivilegedLogout = () -> {
+      JWT token;
+      try {
+        token = tokenStorage.take();
+        barrier.await();
+      } catch (InterruptedException | BrokenBarrierException e) {
+        throw new RuntimeException(e);
+      }
+      verifier.sessionEndedForUser("tom", String.valueOf(token));
+    };
+
+    for (int i = 0; i < 64; i++) {
+      executor.submit(nonPrivilegedLogin);
+    }
+    for (int i = 0; i < 64; i++) {
+      executor.submit(nonPrivilegedLogout);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(128, verifier.countValidTokensForUser("tom"));
+
+    for (int i = 0; i < 128; i++) {
+      executor.submit(nonPrivilegedLogout);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(0, verifier.countValidTokensForUser("tom"));
+
+    config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 10, 10);
+    verifier.init(config, options);
+    tokenStorage.clear();
+
+    for (int i = 0; i < 128; i++) {
+      executor.submit(nonPrivilegedLogin);
+    }
+    Thread.sleep(100L);
+    Assert.assertEquals(10, verifier.countValidTokensForUser("tom"));
   }
 }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -356,7 +356,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 128; i++) {
       executor.submit(privilegedLogin);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(128, verifier.countValidTokensForUser("admin"));
 
     Runnable privilegedLogout = () -> {
@@ -376,13 +376,13 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 64; i++) {
       executor.submit(privilegedLogout);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(128, verifier.countValidTokensForUser("admin"));
 
     for (int i = 0; i < 128; i++) {
       executor.submit(privilegedLogout);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(0, verifier.countValidTokensForUser("admin"));
 
     config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 10, 10);
@@ -392,7 +392,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 128; i++) {
       executor.submit(privilegedLogin);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(10, verifier.countValidTokensForUser("admin"));
   }
 
@@ -421,7 +421,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 128; i++) {
       executor.submit(nonPrivilegedLogin);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(128, verifier.countValidTokensForUser("tom"));
 
     Runnable nonPrivilegedLogout = () -> {
@@ -441,13 +441,13 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 64; i++) {
       executor.submit(nonPrivilegedLogout);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(128, verifier.countValidTokensForUser("tom"));
 
     for (int i = 0; i < 128; i++) {
       executor.submit(nonPrivilegedLogout);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(0, verifier.countValidTokensForUser("tom"));
 
     config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 10, 10);
@@ -457,7 +457,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 128; i++) {
       executor.submit(nonPrivilegedLogin);
     }
-    Thread.sleep(100L);
+    Thread.sleep(1000L);
     Assert.assertEquals(10, verifier.countValidTokensForUser("tom"));
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -331,6 +331,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     Assert.assertEquals(2, verifier.countValidTokensForUser("tom"));
   }
 
+  @SuppressWarnings("PMD.DoNotUseThreads")
   @Test
   public void testPrivilegedLoginLogoutStress() throws ServiceLifecycleException, InterruptedException {
     GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 256, 256);
@@ -395,6 +396,7 @@ public class InMemoryConcurrentSessionVerifierTest {
     Assert.assertEquals(10, verifier.countValidTokensForUser("admin"));
   }
 
+  @SuppressWarnings("PMD.DoNotUseThreads")
   @Test
   public void testNonPrivilegedLoginLogoutStress() throws ServiceLifecycleException, InterruptedException {
     GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), new HashSet<>(Arrays.asList("tom", "guest")), 256, 256);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -17,22 +17,6 @@
  */
 package org.apache.knox.gateway.session.control;
 
-import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.services.ServiceLifecycleException;
-import org.apache.knox.gateway.services.security.AliasService;
-import org.apache.knox.gateway.services.security.AliasServiceException;
-import org.apache.knox.gateway.services.security.MasterService;
-import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
-import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
-import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
-import org.apache.knox.gateway.services.security.token.TokenServiceException;
-import org.apache.knox.gateway.services.security.token.impl.JWT;
-import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
-import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +32,22 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.services.security.impl.DefaultKeystoreService;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
+import org.apache.knox.gateway.services.security.token.JWTokenAttributesBuilder;
+import org.apache.knox.gateway.services.security.token.TokenServiceException;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
+import org.apache.knox.gateway.services.token.impl.DefaultTokenAuthorityService;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 public class InMemoryConcurrentSessionVerifierTest {
   private final long DEFAULT_TEST_EXPIRY_PERIOD = 1000;

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -292,7 +292,7 @@ public class WebSSOResource {
       // Coverity CID 1327959
       if (token != null) {
         ConcurrentSessionVerifier verifier = services.getService(ServiceType.CONCURRENT_SESSION_VERIFIER);
-        if (verifier != null && !verifier.verifySessionForUser(p.getName(), token)) {
+        if (!verifier.verifySessionForUser(p.getName(), token)) {
           throw new WebApplicationException("Too many sessions for user: " + request.getUserPrincipal().getName(), Response.Status.FORBIDDEN);
         }
         addJWTHadoopCookie(original, token);

--- a/gateway-service-knoxssout/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOutResource.java
+++ b/gateway-service-knoxssout/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOutResource.java
@@ -117,9 +117,7 @@ public class WebSSOutResource {
               (GatewayServices) request.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
       if (gwServices != null) {
         ConcurrentSessionVerifier verifier = gwServices.getService(ServiceType.CONCURRENT_SESSION_VERIFIER);
-        if (verifier != null) {
-          verifier.sessionEndedForUser(request.getUserPrincipal().getName(), ssoCookie.get().getValue());
-        }
+        verifier.sessionEndedForUser(request.getUserPrincipal().getName(), ssoCookie.get().getValue());
       }
     } else {
       log.couldNotFindCookieWithTokenToRemove(cookieName, request.getUserPrincipal().getName());

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -973,4 +973,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public Set<String> getNonPrivilegedUsers() {
     return null;
   }
+
+  @Override
+  public long getConcurrentSessionVerifierExpiredTokensCleaningPeriod() {
+    return 0;
+  }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -823,4 +823,6 @@ public interface GatewayConfig {
   Set<String> getPrivilegedUsers();
 
   Set<String> getNonPrivilegedUsers();
+
+  long getConcurrentSessionVerifierExpiredTokensCleaningPeriod();
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/ServiceType.java
@@ -36,7 +36,7 @@ public enum ServiceType {
   TOKEN_SERVICE("TokenService"),
   TOKEN_STATE_SERVICE("TokenStateService"),
   TOPOLOGY_SERVICE("TopologyService"),
-  CONCURRENT_SESSION_VERIFIER("ConcurrentSessionCounter");
+  CONCURRENT_SESSION_VERIFIER("ConcurrentSessionVerifier");
 
   private final String serviceTypeName;
   private final String shortName;


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added an empty implementation of the `ConcurrentSessionVerifier` (`EmptyConcurrentSessionVerifier`), now it is the default so users do not waste resources when they forget to configure the verifier. If they need the `InMemoryConcurrentSessionVerifier` implementation they need to configure it and pay attention to configure at least one user in at least one of the groups.
For example:
```
<property>
        <name>gateway.privileged.users</name>
        <value>admin</value>
</property>
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```

I also added a background thread which cleans out the expired tokens from the `InMemoryConcurrentSessionVerifier` to save some resources. The default cleaning time is 30 minutes, but it can be configured by adding how many minutes we want the cleaning period to be:
```
<property>
        <name>gateway.session.verification.expired.tokens.cleaning.period</name>
        <value>80</value>
</property>
<property>
        <name>gateway.privileged.users</name>
        <value>admin</value>
</property>
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```

## How was this patch tested?

I have written unit tests for the `ConcurrentSessionVeriferFactory` to test that the factory gives back the right implementation for the right configuration.
I also added a unit test into `InMemoryConcurrentSessionVerifierTest` to test the background thread removing the expired tokens.
I also added stress tests to `InMemoryConcurrentSessionVerifierTest` to test whether the locking is working and the `InMemoryConcurrentSessionVerifier` is truly thread safe.

I also tested the behaviour with the following configurations:

1. Nothing
2. Empty String
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value></value>
</property>
```
3. Empty implementation
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier</value>
</property>
```
4. InMemory implementation without groups configured
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```
5. InMemory fully configured
```
<property>
        <name>gateway.non.privileged.users</name>
        <value>tom,guest</value>
</property>
<property>
        <name>gateway.privileged.users</name>
        <value>admin</value>
</property>
<property>
        <name>gateway.privileged.users.concurrent.session.limit</name>
        <value>2</value>
</property>
<property>
        <name>gateway.non.privileged.users.concurrent.session.limit</name>
        <value>1</value>
</property>
<property>
        <name>gateway.session.verification.expired.tokens.cleaning.period</name>
        <value>80</value>
</property>
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```


