### PR TITLE
KNOX-2789 - Changed configuration names, removed the option to config…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -17,18 +17,18 @@
  */
 package org.apache.knox.gateway;
 
+import java.io.File;
+import java.net.URI;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.cli.ParseException;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
 import org.apache.knox.gateway.i18n.messages.StackTrace;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
-
-import java.io.File;
-import java.net.URI;
-import java.util.Date;
-import java.util.Map;
-import java.util.Set;
 
 @Messages(logger="org.apache.knox.gateway")
 public interface GatewayMessages {
@@ -721,4 +721,7 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR, text = "ConcurrentSessionVerifier got blank username for verification.")
   void errorVerifyingUserBlankUsername();
+
+  @Message(level = MessageLevel.WARN, text = "InMemoryConcurrentSessionVerifier is used and privileged user group is not configured! Non-privileged limit applies to all users (except the unlimited group).")
+  void privilegedUserGroupIsNotConfigured();
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -295,16 +295,16 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String GATEWAY_DATABASE_TRUSTSTORE_FILE =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.truststore.file";
 
   // Concurrent session properties
-  private static final String PRIVILEGED_USERS = "privileged.users";
-  private static final String NON_PRIVILEGED_USERS = "non." + PRIVILEGED_USERS;
-  private static final String GATEWAY_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT = GATEWAY_CONFIG_FILE_PREFIX + "." + PRIVILEGED_USERS + ".concurrent.session.limit";
-  private static final String GATEWAY_NON_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT = GATEWAY_CONFIG_FILE_PREFIX + "." + NON_PRIVILEGED_USERS + ".concurrent.session.limit";
-  private static final int GATEWAY_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT_DEFAULT = 3;
-  private static final int GATEWAY_NON_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT_DEFAULT = 2;
-  private static final String GATEWAY_PRIVILEGED_USERS = GATEWAY_CONFIG_FILE_PREFIX + "." + PRIVILEGED_USERS;
-  private static final String GATEWAY_NON_PRIVILEGED_USERS = GATEWAY_CONFIG_FILE_PREFIX + "." + NON_PRIVILEGED_USERS;
-  private static final String GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".session.verification.expired.tokens.cleaning.period";
+  private static final String GATEWAY_SESSION_VERIFICATION_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".session.verification";
+  private static final String GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USER_LIMIT = GATEWAY_SESSION_VERIFICATION_PREFIX + ".privileged.user.limit";
+  private static final String GATEWAY_SESSION_VERIFICATION_NON_PRIVILEGED_USER_LIMIT = GATEWAY_SESSION_VERIFICATION_PREFIX + ".non.privileged.user.limit";
+  private static final int GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USER_LIMIT_DEFAULT = 3;
+  private static final int GATEWAY_SESSION_VERIFICATION_NON_PRIVILEGED_USER_LIMIT_DEFAULT = 2;
+  private static final String GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USERS = GATEWAY_SESSION_VERIFICATION_PREFIX + ".privileged.users";
+  private static final String GATEWAY_SESSION_VERIFICATION_UNLIMITED_USERS = GATEWAY_SESSION_VERIFICATION_PREFIX + ".unlimited.users";
+  private static final String GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD = GATEWAY_SESSION_VERIFICATION_PREFIX + ".expired.tokens.cleaning.period";
   private static final long GATEWAY_SESSION_VERIFICATION_EXPIRED_TOKENS_CLEANING_PERIOD_DEFAULT = TimeUnit.MINUTES.toSeconds(30);
+
 
   public GatewayConfigImpl() {
     init();
@@ -1365,25 +1365,26 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public int getPrivilegedUsersConcurrentSessionLimit() {
-    return getInt(GATEWAY_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT, GATEWAY_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT_DEFAULT);
+    return getInt(GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USER_LIMIT, GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USER_LIMIT_DEFAULT);
   }
 
   @Override
   public int getNonPrivilegedUsersConcurrentSessionLimit() {
-    return getInt(GATEWAY_NON_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT, GATEWAY_NON_PRIVILEGED_USERS_CONCURRENT_SESSION_LIMIT_DEFAULT);
+    return getInt(GATEWAY_SESSION_VERIFICATION_NON_PRIVILEGED_USER_LIMIT, GATEWAY_SESSION_VERIFICATION_NON_PRIVILEGED_USER_LIMIT_DEFAULT);
   }
 
   @Override
   public Set<String> getPrivilegedUsers() {
-    final Collection<String> privilegedUsers = getTrimmedStringCollection(GATEWAY_PRIVILEGED_USERS);
+    final Collection<String> privilegedUsers = getTrimmedStringCollection(GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USERS);
     return privilegedUsers == null ? Collections.emptySet() : new HashSet<>(privilegedUsers);
   }
 
   @Override
-  public Set<String> getNonPrivilegedUsers() {
-    final Collection<String> nonPrivilegedUsers = getTrimmedStringCollection(GATEWAY_NON_PRIVILEGED_USERS);
+  public Set<String> getUnlimitedUsers() {
+    final Collection<String> nonPrivilegedUsers = getTrimmedStringCollection(GATEWAY_SESSION_VERIFICATION_UNLIMITED_USERS);
     return nonPrivilegedUsers == null ? Collections.emptySet() : new HashSet<>(nonPrivilegedUsers);
   }
+
 
   @Override
   public long getConcurrentSessionVerifierExpiredTokensCleaningPeriod() {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -1374,13 +1374,13 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public Set<String> getPrivilegedUsers() {
+  public Set<String> getSessionVerificationPrivilegedUsers() {
     final Collection<String> privilegedUsers = getTrimmedStringCollection(GATEWAY_SESSION_VERIFICATION_PRIVILEGED_USERS);
     return privilegedUsers == null ? Collections.emptySet() : new HashSet<>(privilegedUsers);
   }
 
   @Override
-  public Set<String> getUnlimitedUsers() {
+  public Set<String> getSessionVerificationUnlimitedUsers() {
     final Collection<String> nonPrivilegedUsers = getTrimmedStringCollection(GATEWAY_SESSION_VERIFICATION_UNLIMITED_USERS);
     return nonPrivilegedUsers == null ? Collections.emptySet() : new HashSet<>(nonPrivilegedUsers);
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
@@ -44,7 +44,7 @@ public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
         service = new EmptyConcurrentSessionVerifier();
       } else if (matchesImplementation(implementation, InMemoryConcurrentSessionVerifier.class)) {
         service = new InMemoryConcurrentSessionVerifier();
-        if (gatewayConfig.getPrivilegedUsers().isEmpty()) {
+        if (gatewayConfig.getSessionVerificationPrivilegedUsers().isEmpty()) {
           LOG.privilegedUserGroupIsNotConfigured();
         }
       }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactory.java
@@ -23,7 +23,9 @@ import static java.util.Collections.unmodifiableList;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -32,6 +34,8 @@ import org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier;
 
 public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
+  private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+
   @Override
   protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options, String implementation) throws ServiceLifecycleException {
     Service service = null;
@@ -39,10 +43,9 @@ public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
       if (matchesImplementation(implementation, EmptyConcurrentSessionVerifier.class, true)) {
         service = new EmptyConcurrentSessionVerifier();
       } else if (matchesImplementation(implementation, InMemoryConcurrentSessionVerifier.class)) {
-        if (isThereGroupConfigured(gatewayConfig)) {
-          service = new InMemoryConcurrentSessionVerifier();
-        } else {
-          throw new ServiceLifecycleException("Error creating InMemoryConcurrentSessionVerifier, at least one user should be added in either the privileged group or the non-privileged group!");
+        service = new InMemoryConcurrentSessionVerifier();
+        if (gatewayConfig.getPrivilegedUsers().isEmpty()) {
+          LOG.privilegedUserGroupIsNotConfigured();
         }
       }
       logServiceUsage(implementation, serviceType);
@@ -58,9 +61,5 @@ public class ConcurrentSessionVerifierFactory extends AbstractServiceFactory {
   @Override
   protected Collection<String> getKnownImplementations() {
     return unmodifiableList(asList(InMemoryConcurrentSessionVerifier.class.getName(), EmptyConcurrentSessionVerifier.class.getName()));
-  }
-
-  private boolean isThereGroupConfigured(GatewayConfig gatewayConfig) {
-    return !gatewayConfig.getNonPrivilegedUsers().isEmpty() || !gatewayConfig.getPrivilegedUsers().isEmpty();
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
@@ -142,7 +142,7 @@ public class InMemoryConcurrentSessionVerifier implements ConcurrentSessionVerif
     expiredTokenRemover.shutdown();
   }
 
-  private void removeExpiredTokens() {
+  void removeExpiredTokens() {
     sessionCountModifyLock.lock();
     try {
       Iterator<Map.Entry<String, Set<SessionJWT>>> concurrentSessionCounterIterator = concurrentSessionCounter.entrySet().iterator();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifier.java
@@ -124,8 +124,8 @@ public class InMemoryConcurrentSessionVerifier implements ConcurrentSessionVerif
 
   @Override
   public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
-    this.privilegedUsers = config.getPrivilegedUsers();
-    this.unlimitedUsers = config.getUnlimitedUsers();
+    this.privilegedUsers = config.getSessionVerificationPrivilegedUsers();
+    this.unlimitedUsers = config.getSessionVerificationUnlimitedUsers();
     this.privilegedUserConcurrentSessionLimit = config.getPrivilegedUsersConcurrentSessionLimit();
     this.nonPrivilegedUserConcurrentSessionLimit = config.getNonPrivilegedUsersConcurrentSessionLimit();
     this.cleaningPeriod = config.getConcurrentSessionVerifierExpiredTokensCleaningPeriod();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -16,21 +16,6 @@
  */
 package org.apache.knox.gateway.config.impl;
 
-import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
-import org.apache.knox.test.TestUtils;
-import org.hamcrest.CoreMatchers;
-import org.junit.Test;
-
-import java.nio.file.Paths;
-import java.security.KeyStore;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
 import static org.apache.knox.gateway.services.security.impl.RemoteAliasService.REMOTE_ALIAS_SERVICE_TYPE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -42,7 +27,22 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-  import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
+import org.apache.knox.test.TestUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
 
 public class GatewayConfigImplTest {
 
@@ -446,43 +446,43 @@ public class GatewayConfigImplTest {
     assertThat(config.getPrivilegedUsersConcurrentSessionLimit(), is(3));
     assertThat(config.getNonPrivilegedUsersConcurrentSessionLimit(), is(2));
     assertThat(config.getPrivilegedUsers(), is(new HashSet<>()));
-    assertThat(config.getNonPrivilegedUsers(), is(new HashSet<>()));
+    assertThat(config.getUnlimitedUsers(), is(new HashSet<>()));
   }
 
   @Test
   public void testNormalConcurrentSessionLimitParameters() {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
-    config.set("gateway.privileged.users.concurrent.session.limit", "5");
+    config.set("gateway.session.verification.privileged.user.limit", "5");
     assertThat(config.getPrivilegedUsersConcurrentSessionLimit(), is(5));
-    config.set("gateway.non.privileged.users.concurrent.session.limit", "6");
+    config.set("gateway.session.verification.non.privileged.user.limit", "6");
     assertThat(config.getNonPrivilegedUsersConcurrentSessionLimit(), is(6));
-    config.set("gateway.privileged.users", "admin,jeff");
+    config.set("gateway.session.verification.privileged.users", "admin,jeff");
     assertThat(config.getPrivilegedUsers(), is(new HashSet<>(Arrays.asList("admin", "jeff"))));
-    config.set("gateway.non.privileged.users", "tom,sam");
-    assertThat(config.getNonPrivilegedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
+    config.set("gateway.session.verification.unlimited.users", "tom,sam");
+    assertThat(config.getUnlimitedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
   }
 
   @Test
   public void testAbnormalConcurrentSessionLimitParameters() {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
-    config.set("gateway.privileged.users", "");
+    config.set("gateway.session.verification.privileged.users", "");
     assertThat(config.getPrivilegedUsers(), is(new HashSet<>()));
-    config.set("gateway.non.privileged.users", "");
-    config.set("gateway.privileged.users", "   ");
+    config.set("gateway.session.verification.unlimited.users", "");
+    assertThat(config.getUnlimitedUsers(), is(new HashSet<>()));
+    config.set("gateway.session.verification.privileged.users", "   ");
     assertThat(config.getPrivilegedUsers(), is(new HashSet<>()));
-    config.set("gateway.non.privileged.users", "   ");
-    assertThat(config.getNonPrivilegedUsers(), is(new HashSet<>()));
-
-    config.set("gateway.privileged.users", " admin , jeff ");
+    config.set("gateway.session.verification.unlimited.users", "   ");
+    assertThat(config.getUnlimitedUsers(), is(new HashSet<>()));
+    config.set("gateway.session.verification.privileged.users", " admin , jeff ");
     assertThat(config.getPrivilegedUsers(), is(new HashSet<>(Arrays.asList("admin", "jeff"))));
-    config.set("gateway.non.privileged.users", " tom , sam ");
-    assertThat(config.getNonPrivilegedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
-    config.set("gateway.privileged.users", "  guest  ");
+    config.set("gateway.session.verification.unlimited.users", " tom , sam ");
+    assertThat(config.getUnlimitedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
+    config.set("gateway.session.verification.privileged.users", "  guest  ");
     assertThat(config.getPrivilegedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
-    config.set("gateway.non.privileged.users", "  guest  ");
-    assertThat(config.getNonPrivilegedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
+    config.set("gateway.session.verification.unlimited.users", "  guest  ");
+    assertThat(config.getUnlimitedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
   }
 
   // KNOX-2779

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -445,8 +445,8 @@ public class GatewayConfigImplTest {
 
     assertThat(config.getPrivilegedUsersConcurrentSessionLimit(), is(3));
     assertThat(config.getNonPrivilegedUsersConcurrentSessionLimit(), is(2));
-    assertThat(config.getPrivilegedUsers(), is(new HashSet<>()));
-    assertThat(config.getUnlimitedUsers(), is(new HashSet<>()));
+    assertThat(config.getSessionVerificationPrivilegedUsers(), is(new HashSet<>()));
+    assertThat(config.getSessionVerificationUnlimitedUsers(), is(new HashSet<>()));
   }
 
   @Test
@@ -458,9 +458,9 @@ public class GatewayConfigImplTest {
     config.set("gateway.session.verification.non.privileged.user.limit", "6");
     assertThat(config.getNonPrivilegedUsersConcurrentSessionLimit(), is(6));
     config.set("gateway.session.verification.privileged.users", "admin,jeff");
-    assertThat(config.getPrivilegedUsers(), is(new HashSet<>(Arrays.asList("admin", "jeff"))));
+    assertThat(config.getSessionVerificationPrivilegedUsers(), is(new HashSet<>(Arrays.asList("admin", "jeff"))));
     config.set("gateway.session.verification.unlimited.users", "tom,sam");
-    assertThat(config.getUnlimitedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
+    assertThat(config.getSessionVerificationUnlimitedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
   }
 
   @Test
@@ -468,21 +468,21 @@ public class GatewayConfigImplTest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     config.set("gateway.session.verification.privileged.users", "");
-    assertThat(config.getPrivilegedUsers(), is(new HashSet<>()));
+    assertThat(config.getSessionVerificationPrivilegedUsers(), is(new HashSet<>()));
     config.set("gateway.session.verification.unlimited.users", "");
-    assertThat(config.getUnlimitedUsers(), is(new HashSet<>()));
+    assertThat(config.getSessionVerificationUnlimitedUsers(), is(new HashSet<>()));
     config.set("gateway.session.verification.privileged.users", "   ");
-    assertThat(config.getPrivilegedUsers(), is(new HashSet<>()));
+    assertThat(config.getSessionVerificationPrivilegedUsers(), is(new HashSet<>()));
     config.set("gateway.session.verification.unlimited.users", "   ");
-    assertThat(config.getUnlimitedUsers(), is(new HashSet<>()));
+    assertThat(config.getSessionVerificationUnlimitedUsers(), is(new HashSet<>()));
     config.set("gateway.session.verification.privileged.users", " admin , jeff ");
-    assertThat(config.getPrivilegedUsers(), is(new HashSet<>(Arrays.asList("admin", "jeff"))));
+    assertThat(config.getSessionVerificationPrivilegedUsers(), is(new HashSet<>(Arrays.asList("admin", "jeff"))));
     config.set("gateway.session.verification.unlimited.users", " tom , sam ");
-    assertThat(config.getUnlimitedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
+    assertThat(config.getSessionVerificationUnlimitedUsers(), is(new HashSet<>(Arrays.asList("tom", "sam"))));
     config.set("gateway.session.verification.privileged.users", "  guest  ");
-    assertThat(config.getPrivilegedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
+    assertThat(config.getSessionVerificationPrivilegedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
     config.set("gateway.session.verification.unlimited.users", "  guest  ");
-    assertThat(config.getUnlimitedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
+    assertThat(config.getSessionVerificationUnlimitedUsers(), is(new HashSet<>(Arrays.asList("guest"))));
   }
 
   // KNOX-2779

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
@@ -19,10 +19,14 @@ package org.apache.knox.gateway.services.factory;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
+
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.session.control.ConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier;
+import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,7 +53,11 @@ public class ConcurrentSessionVerifierFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void testShouldReturnInMemoryConcurrentSessionVerifier() throws Exception {
-    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, gatewayConfig, null, InMemoryConcurrentSessionVerifier.class.getName());
+    GatewayConfig configForInMemoryVerifier = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(configForInMemoryVerifier.getPrivilegedUsers()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.replay(configForInMemoryVerifier);
+
+    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForInMemoryVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
     assertTrue(concurrentSessionVerifier instanceof InMemoryConcurrentSessionVerifier);
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
@@ -17,21 +17,12 @@
  */
 package org.apache.knox.gateway.services.factory;
 
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.session.control.ConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier;
 import org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,42 +41,16 @@ public class ConcurrentSessionVerifierFactoryTest extends ServiceFactoryTest {
 
   @Test
   public void testShouldReturnEmptyConcurrentSessionVerifier() throws Exception {
-    GatewayConfig configForVerifier = mockConfig(Collections.emptySet(), Collections.emptySet());
-
-    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, "");
+    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, gatewayConfig, null, "");
     assertTrue(concurrentSessionVerifier instanceof EmptyConcurrentSessionVerifier);
-    concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, EmptyConcurrentSessionVerifier.class.getName());
+    concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, gatewayConfig, null, EmptyConcurrentSessionVerifier.class.getName());
     assertTrue(concurrentSessionVerifier instanceof EmptyConcurrentSessionVerifier);
   }
 
   @Test
   public void testShouldReturnInMemoryConcurrentSessionVerifier() throws Exception {
-    GatewayConfig configForVerifier = mockConfig(new HashSet<>(Arrays.asList("admin")), Collections.emptySet());
-
-    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
+    ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, gatewayConfig, null, InMemoryConcurrentSessionVerifier.class.getName());
     assertTrue(concurrentSessionVerifier instanceof InMemoryConcurrentSessionVerifier);
-
-    configForVerifier = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("tom")));
-
-    concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
-    assertTrue(concurrentSessionVerifier instanceof InMemoryConcurrentSessionVerifier);
-  }
-
-  @Test
-  public void testShouldThrowException() {
-    GatewayConfig configForVerifier = mockConfig(Collections.emptySet(), Collections.emptySet());
-
-    assertThrows(ServiceLifecycleException.class, () -> {
-      serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());
-    });
-  }
-
-  private GatewayConfig mockConfig(Set<String> privilegedUsers, Set<String> nonPrivilegedUsers) {
-    GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
-    EasyMock.expect(config.getPrivilegedUsers()).andReturn(privilegedUsers).anyTimes();
-    EasyMock.expect(config.getNonPrivilegedUsers()).andReturn(nonPrivilegedUsers).anyTimes();
-    EasyMock.replay(config);
-    return config;
   }
 
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ConcurrentSessionVerifierFactoryTest.java
@@ -54,7 +54,7 @@ public class ConcurrentSessionVerifierFactoryTest extends ServiceFactoryTest {
   @Test
   public void testShouldReturnInMemoryConcurrentSessionVerifier() throws Exception {
     GatewayConfig configForInMemoryVerifier = EasyMock.createNiceMock(GatewayConfig.class);
-    EasyMock.expect(configForInMemoryVerifier.getPrivilegedUsers()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(configForInMemoryVerifier.getSessionVerificationPrivilegedUsers()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.replay(configForInMemoryVerifier);
 
     ConcurrentSessionVerifier concurrentSessionVerifier = (ConcurrentSessionVerifier) serviceFactory.create(gatewayServices, ServiceType.CONCURRENT_SESSION_VERIFIER, configForInMemoryVerifier, null, InMemoryConcurrentSessionVerifier.class.getName());

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -17,10 +17,6 @@
  */
 package org.apache.knox.gateway;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.knox.gateway.config.GatewayConfig;
-
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.nio.file.FileSystems;
@@ -36,6 +32,10 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.knox.gateway.config.GatewayConfig;
 
 public class GatewayTestConfig extends Configuration implements GatewayConfig {
 
@@ -970,7 +970,7 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public Set<String> getNonPrivilegedUsers() {
+  public Set<String> getUnlimitedUsers() {
     return null;
   }
 

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -965,12 +965,12 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public Set<String> getPrivilegedUsers() {
+  public Set<String> getSessionVerificationPrivilegedUsers() {
     return null;
   }
 
   @Override
-  public Set<String> getUnlimitedUsers() {
+  public Set<String> getSessionVerificationUnlimitedUsers() {
     return null;
   }
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -822,7 +822,7 @@ public interface GatewayConfig {
 
   Set<String> getPrivilegedUsers();
 
-  Set<String> getNonPrivilegedUsers();
+  Set<String> getUnlimitedUsers();
 
   long getConcurrentSessionVerifierExpiredTokensCleaningPeriod();
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -820,9 +820,9 @@ public interface GatewayConfig {
 
   int getNonPrivilegedUsersConcurrentSessionLimit();
 
-  Set<String> getPrivilegedUsers();
+  Set<String> getSessionVerificationPrivilegedUsers();
 
-  Set<String> getUnlimitedUsers();
+  Set<String> getSessionVerificationUnlimitedUsers();
 
   long getConcurrentSessionVerifierExpiredTokensCleaningPeriod();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduced new group called `gateway.session.verification.unlimited.users` and  changed the behaviour of the groups and the tests that check these behaviours. `gateway.non.privileged.users` group is now not configurable.
Also changed configuration names:
```
gateway.privileged.users -> gateway.session.verification.privileged.users
gateway.non.privileged.users.concurrent.session.limit -> gateway.session.verification.non.privileged.user.limit
gateway.privileged.users.concurrent.session.limit -> gateway.session.verification.privileged.user.limit
```

Previous behaviour:
If someone is configured privileged -> privileged limit applies
If someone is configured non-privileged -> non-privileged limit applies
If someone is not configured in either of the groups -> no limit applies

New behaviour:
If someone is configured privileged -> privileged limit applies
If someone is configured unlimited -> no limit applies
If someone is not configured in either of the groups -> non-privileged limit applies

## How was this patch tested?

I changed the existing unit tests to test the new behaviours.
I also tested the new behaviours manually with the following configurataions:
1. Nothing
2. Empty string for implementation configuration
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value></value>
</property>
```
3. Blank string for implementation
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>      </value>
</property>
```
4. Not valid implementation
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.NotExistingConcurrentSessionVerifier</value>
</property>
```
5. Empty implementation configured
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.EmptyConcurrentSessionVerifier</value>
</property>
```
6. InMemory implementation configured
```
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```
7. Fully configured
```
<property>
        <name>gateway.session.verification.unlimited.users</name>
        <value>admin</value>
</property>
<property>
        <name>gateway.session.verification.privileged.users</name>
        <value>tom</value>
</property>
<property>
        <name>gateway.session.verification.privileged.user.limit</name>
        <value>2</value>
</property>
<property>
        <name>gateway.session.verification.non.privileged.user.limit</name>
        <value>1</value>
</property>
<property>
        <name>gateway.session.verification.expired.tokens.cleaning.period</name>
        <value>80</value>
</property>
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```


