### PR TITLE
KNOX-2790 - Added a new funtion to verifier, this way the session lim…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -722,6 +722,9 @@ public interface GatewayMessages {
   @Message(level = MessageLevel.ERROR, text = "ConcurrentSessionVerifier got blank username for verification.")
   void errorVerifyingUserBlankUsername();
 
+  @Message(level = MessageLevel.ERROR, text = "ConcurrentSessionVerifier got blank username for token registration.")
+  void errorRegisteringTokenForBlankUsername();
+
   @Message(level = MessageLevel.WARN, text = "InMemoryConcurrentSessionVerifier is used and privileged user group is not configured! Non-privileged limit applies to all users (except the unlimited group).")
   void privilegedUserGroupIsNotConfigured();
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/session/control/EmptyConcurrentSessionVerifier.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/session/control/EmptyConcurrentSessionVerifier.java
@@ -40,7 +40,12 @@ public class EmptyConcurrentSessionVerifier implements ConcurrentSessionVerifier
   }
 
   @Override
-  public boolean verifySessionForUser(String username, JWT JWToken) {
+  public boolean verifySessionForUser(String username) {
+    return true;
+  }
+
+  @Override
+  public boolean registerToken(String username, JWT jwtToken) {
     return true;
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -164,10 +164,14 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(new HashSet<>(Arrays.asList("admin")), Collections.emptySet(), 3, 2);
     verifier.init(config, options);
 
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken1));
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken2));
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken3));
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken4));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken1));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken2));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken3));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken4));
   }
 
   @Test
@@ -175,13 +179,19 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("admin")), 3, 2);
     verifier.init(config, options);
 
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken1));
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken2));
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken3));
-    Assert.assertFalse(verifier.verifySessionForUser("admin", adminToken4));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken1));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken2));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken3));
+    Assert.assertFalse(verifier.verifySessionForUser("admin"));
+    Assert.assertFalse(verifier.registerToken("admin", adminToken4));
     verifier.sessionEndedForUser("admin", adminToken1.toString());
-    Assert.assertTrue(verifier.verifySessionForUser("admin", adminToken5));
-    Assert.assertFalse(verifier.verifySessionForUser("admin", adminToken6));
+    Assert.assertTrue(verifier.verifySessionForUser("admin"));
+    Assert.assertTrue(verifier.registerToken("admin", adminToken5));
+    Assert.assertFalse(verifier.verifySessionForUser("admin"));
+    Assert.assertFalse(verifier.registerToken("admin", adminToken5));
   }
 
   @Test
@@ -189,21 +199,26 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(Collections.emptySet(), Collections.emptySet(), 3, 2);
     verifier.init(config, options);
 
-    Assert.assertTrue(verifier.verifySessionForUser("tom", tomToken1));
-    Assert.assertTrue(verifier.verifySessionForUser("tom", tomToken2));
-    Assert.assertFalse(verifier.verifySessionForUser("tom", tomToken3));
-    Assert.assertFalse(verifier.verifySessionForUser("tom", tomToken4));
+    Assert.assertTrue(verifier.verifySessionForUser("tom"));
+    Assert.assertTrue(verifier.registerToken("tom", tomToken1));
+    Assert.assertTrue(verifier.verifySessionForUser("tom"));
+    Assert.assertTrue(verifier.registerToken("tom", tomToken2));
+    Assert.assertFalse(verifier.verifySessionForUser("tom"));
+    Assert.assertFalse(verifier.registerToken("tom", tomToken3));
     verifier.sessionEndedForUser("tom", tomToken1.toString());
-    Assert.assertTrue(verifier.verifySessionForUser("tom", tomToken5));
-    Assert.assertFalse(verifier.verifySessionForUser("tom", tomToken6));
+    Assert.assertTrue(verifier.verifySessionForUser("tom"));
+    Assert.assertTrue(verifier.registerToken("tom", tomToken4));
+    Assert.assertFalse(verifier.verifySessionForUser("tom"));
+    Assert.assertFalse(verifier.registerToken("tom", tomToken5));
   }
 
   @Test
   public void testPrivilegedLimitIsZero() throws ServiceLifecycleException {
-    GatewayConfig config = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("tom")), 0, 2);
+    GatewayConfig config = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("admin")), 0, 2);
     verifier.init(config, options);
 
-    Assert.assertFalse(verifier.verifySessionForUser("tom", tomToken1));
+    Assert.assertFalse(verifier.verifySessionForUser("admin"));
+    Assert.assertFalse(verifier.registerToken("admin", adminToken1));
   }
 
   @Test
@@ -211,7 +226,8 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(Collections.emptySet(), Collections.emptySet(), 3, 0);
     verifier.init(config, options);
 
-    Assert.assertFalse(verifier.verifySessionForUser("tom", tomToken1));
+    Assert.assertFalse(verifier.verifySessionForUser("tom"));
+    Assert.assertFalse(verifier.registerToken("tom", tomToken1));
   }
 
   @Test
@@ -220,23 +236,23 @@ public class InMemoryConcurrentSessionVerifierTest {
     verifier.init(config, options);
 
     Assert.assertEquals(0, verifier.countValidTokensForUser("admin"));
-    verifier.verifySessionForUser("admin", adminToken1);
+    verifier.registerToken("admin", adminToken1);
     Assert.assertEquals(1, verifier.countValidTokensForUser("admin"));
     verifier.sessionEndedForUser("admin", adminToken1.toString());
     Assert.assertEquals(0, verifier.countValidTokensForUser("admin"));
     verifier.sessionEndedForUser("admin", adminToken1.toString());
     Assert.assertEquals(0, verifier.countValidTokensForUser("admin"));
-    verifier.verifySessionForUser("admin", adminToken2);
+    verifier.registerToken("admin", adminToken2);
     Assert.assertEquals(1, verifier.countValidTokensForUser("admin"));
 
     Assert.assertEquals(0, verifier.countValidTokensForUser("tom"));
-    verifier.verifySessionForUser("tom", tomToken1);
+    verifier.registerToken("tom", tomToken1);
     Assert.assertEquals(1, verifier.countValidTokensForUser("tom"));
     verifier.sessionEndedForUser("tom", tomToken1.toString());
     Assert.assertEquals(0, verifier.countValidTokensForUser("tom"));
     verifier.sessionEndedForUser("tom", tomToken1.toString());
     Assert.assertEquals(0, verifier.countValidTokensForUser("tom"));
-    verifier.verifySessionForUser("tom", tomToken2);
+    verifier.registerToken("tom", tomToken2);
     Assert.assertEquals(1, verifier.countValidTokensForUser("tom"));
   }
 
@@ -248,9 +264,11 @@ public class InMemoryConcurrentSessionVerifierTest {
     for (int i = 0; i < 10; i++) {
       try {
         JWT token = tokenAuthority.issueToken(jwtAttributesForAdmin);
-        Assert.assertTrue(verifier.verifySessionForUser("admin", token));
+        Assert.assertTrue(verifier.verifySessionForUser("admin"));
+        Assert.assertTrue(verifier.registerToken("admin", token));
         token = tokenAuthority.issueToken(jwtAttributesForTom);
-        Assert.assertTrue(verifier.verifySessionForUser("tom", token));
+        Assert.assertTrue(verifier.verifySessionForUser("tom"));
+        Assert.assertTrue(verifier.registerToken("tom", token));
       } catch (TokenServiceException ignored) {
       }
     }
@@ -261,22 +279,22 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("admin")), 3, 3);
     verifier.init(config, options);
 
-    verifier.verifySessionForUser("tom", tomToken1);
+    verifier.registerToken("tom", tomToken1);
     Assert.assertEquals(1, verifier.countValidTokensForUser("tom"));
     JWT expiredTomToken = tokenAuthority.issueToken(expiredJwtAttributesForTom);
-    verifier.verifySessionForUser("tom", expiredTomToken);
+    verifier.registerToken("tom", expiredTomToken);
     Assert.assertEquals(1, verifier.countValidTokensForUser("tom"));
     expiredTomToken = tokenAuthority.issueToken(expiredJwtAttributesForTom);
-    verifier.verifySessionForUser("tom", expiredTomToken);
+    verifier.registerToken("tom", expiredTomToken);
     Assert.assertEquals(1, verifier.countValidTokensForUser("tom"));
 
-    verifier.verifySessionForUser("admin", adminToken1);
+    verifier.registerToken("admin", adminToken1);
     Assert.assertEquals(1, verifier.countValidTokensForUser("admin"));
     JWT expiredAdminToken = tokenAuthority.issueToken(expiredJwtAttributesForAdmin);
-    verifier.verifySessionForUser("admin", expiredAdminToken);
+    verifier.registerToken("admin", expiredAdminToken);
     Assert.assertEquals(1, verifier.countValidTokensForUser("admin"));
     expiredAdminToken = tokenAuthority.issueToken(expiredJwtAttributesForAdmin);
-    verifier.verifySessionForUser("admin", expiredAdminToken);
+    verifier.registerToken("admin", expiredAdminToken);
     Assert.assertEquals(1, verifier.countValidTokensForUser("admin"));
   }
 
@@ -285,18 +303,18 @@ public class InMemoryConcurrentSessionVerifierTest {
     GatewayConfig config = mockConfig(Collections.emptySet(), new HashSet<>(Arrays.asList("admin")), 3, 3);
     verifier.init(config, options);
 
-    verifier.verifySessionForUser("admin", adminToken1);
-    verifier.verifySessionForUser("admin", adminToken2);
+    verifier.registerToken("admin", adminToken1);
+    verifier.registerToken("admin", adminToken2);
     JWT expiredAdminToken = tokenAuthority.issueToken(expiredJwtAttributesForAdmin);
-    verifier.verifySessionForUser("admin", expiredAdminToken);
+    verifier.registerToken("admin", expiredAdminToken);
     Assert.assertEquals(3, verifier.getTokenCountForUser("admin").intValue());
     verifier.removeExpiredTokens();
     Assert.assertEquals(2, verifier.getTokenCountForUser("admin").intValue());
 
-    verifier.verifySessionForUser("tom", tomToken1);
-    verifier.verifySessionForUser("tom", tomToken2);
+    verifier.registerToken("tom", tomToken1);
+    verifier.registerToken("tom", tomToken2);
     JWT expiredTomToken = tokenAuthority.issueToken(expiredJwtAttributesForTom);
-    verifier.verifySessionForUser("tom", expiredTomToken);
+    verifier.registerToken("tom", expiredTomToken);
     Assert.assertEquals(3, verifier.getTokenCountForUser("tom").intValue());
     verifier.removeExpiredTokens();
     Assert.assertEquals(2, verifier.getTokenCountForUser("tom").intValue());
@@ -321,7 +339,9 @@ public class InMemoryConcurrentSessionVerifierTest {
       } catch (InterruptedException | BrokenBarrierException | TokenServiceException e) {
         throw new RuntimeException(e);
       }
-      verifier.verifySessionForUser("admin", token);
+      if (verifier.verifySessionForUser("admin")) {
+        verifier.registerToken("admin", token);
+      }
     };
 
     for (int i = 0; i < 128; i++) {
@@ -386,7 +406,9 @@ public class InMemoryConcurrentSessionVerifierTest {
       } catch (InterruptedException | BrokenBarrierException | TokenServiceException e) {
         throw new RuntimeException(e);
       }
-      verifier.verifySessionForUser("tom", token);
+      if (verifier.verifySessionForUser("tom")) {
+        verifier.registerToken("tom", token);
+      }
     };
 
     for (int i = 0; i < 128; i++) {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -62,13 +62,11 @@ public class InMemoryConcurrentSessionVerifierTest {
   private JWT adminToken3;
   private JWT adminToken4;
   private JWT adminToken5;
-  private JWT adminToken6;
   private JWT tomToken1;
   private JWT tomToken2;
   private JWT tomToken3;
   private JWT tomToken4;
   private JWT tomToken5;
-  private JWT tomToken6;
 
   @Before
   public void setUp() throws AliasServiceException, IOException, ServiceLifecycleException {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/session/control/InMemoryConcurrentSessionVerifierTest.java
@@ -118,13 +118,11 @@ public class InMemoryConcurrentSessionVerifierTest {
       adminToken3 = tokenAuthority.issueToken(jwtAttributesForAdmin);
       adminToken4 = tokenAuthority.issueToken(jwtAttributesForAdmin);
       adminToken5 = tokenAuthority.issueToken(jwtAttributesForAdmin);
-      adminToken6 = tokenAuthority.issueToken(jwtAttributesForAdmin);
       tomToken1 = tokenAuthority.issueToken(jwtAttributesForTom);
       tomToken2 = tokenAuthority.issueToken(jwtAttributesForTom);
       tomToken3 = tokenAuthority.issueToken(jwtAttributesForTom);
       tomToken4 = tokenAuthority.issueToken(jwtAttributesForTom);
       tomToken5 = tokenAuthority.issueToken(jwtAttributesForTom);
-      tomToken6 = tokenAuthority.issueToken(jwtAttributesForTom);
     } catch (TokenServiceException ignored) {
     }
   }

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -185,7 +185,8 @@ public class WebSSOResourceTest {
     responseWrapper = new CookieResponseWrapper(response, outputStream);
 
     verifier = EasyMock.createNiceMock(ConcurrentSessionVerifier.class);
-    EasyMock.expect(verifier.verifySessionForUser(anyString(), anyObject())).andReturn(concurrentSessionVerifyResult).anyTimes();
+    EasyMock.expect(verifier.verifySessionForUser(anyString())).andReturn(concurrentSessionVerifyResult).anyTimes();
+    EasyMock.expect(verifier.registerToken(anyString(), anyObject())).andReturn(concurrentSessionVerifyResult).anyTimes();
     EasyMock.expect(services.getService(ServiceType.CONCURRENT_SESSION_VERIFIER)).andReturn(verifier).anyTimes();
 
     EasyMock.replay(principal, services, context, request, verifier);
@@ -555,7 +556,8 @@ public class WebSSOResourceTest {
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(TokenUtils.SIGNING_HMAC_SECRET_ALIAS)).andReturn(null).anyTimes();
 
     ConcurrentSessionVerifier concurrentSessionVerifier = EasyMock.createNiceMock(ConcurrentSessionVerifier.class);
-    EasyMock.expect(concurrentSessionVerifier.verifySessionForUser(anyString(), anyObject())).andReturn(true).anyTimes();
+    EasyMock.expect(concurrentSessionVerifier.verifySessionForUser(anyString())).andReturn(true).anyTimes();
+    EasyMock.expect(concurrentSessionVerifier.registerToken(anyString(), anyObject())).andReturn(true).anyTimes();
     EasyMock.expect(services.getService(ServiceType.CONCURRENT_SESSION_VERIFIER)).andReturn(concurrentSessionVerifier).anyTimes();
 
     JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
@@ -673,7 +675,8 @@ public class WebSSOResourceTest {
     EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
 
     ConcurrentSessionVerifier concurrentSessionVerifier = EasyMock.createNiceMock(ConcurrentSessionVerifier.class);
-    EasyMock.expect(concurrentSessionVerifier.verifySessionForUser(anyString(), anyObject())).andReturn(true).anyTimes();
+    EasyMock.expect(concurrentSessionVerifier.verifySessionForUser(anyString())).andReturn(true).anyTimes();
+    EasyMock.expect(concurrentSessionVerifier.registerToken(anyString(), anyObject())).andReturn(true).anyTimes();
     EasyMock.expect(services.getService(ServiceType.CONCURRENT_SESSION_VERIFIER)).andReturn(concurrentSessionVerifier).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/session/control/ConcurrentSessionVerifier.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/session/control/ConcurrentSessionVerifier.java
@@ -23,12 +23,23 @@ import org.apache.knox.gateway.services.security.token.impl.JWT;
 public interface ConcurrentSessionVerifier extends Service {
   /**
    * Verifies whether the given user is permitted to have a[nother] session or not.
+   * Similar to the registerToken function, but we need this in WebSSOResource to verify the before the token generation,
+   * so in case of an attack we are not wasting resources on token generation and storing.
    *
    * @param username the user who needs verification
-   * @param JWToken  the token which the user will use in the session
    * @return true if the user is allowed to have a[nother] session, false if the user is not allowed to have a[nother] session
    */
-  boolean verifySessionForUser(String username, JWT JWToken);
+  boolean verifySessionForUser(String username);
+
+  /**
+   * Verifies whether the given user is permitted to have a[nother] session or not.
+   * Also stores the token which the user is using for the session.
+   *
+   * @param jwtToken token which needs to be stored
+   * @param username the user who needs verification
+   * @return true if the user is allowed to have a[nother] session, false if the user is not allowed to have a[nother] session
+   */
+  boolean registerToken(String username, JWT jwtToken);
 
   void sessionEndedForUser(String username, String token);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the verifier, introduced a new function called `registerToken`, this function is checking the session limits for the given user and stores the  given token. Changed `verifySessionForUser` function, now this function only checks the limit but do not store token. These changes were needed, because previously in case of an attack we would generate tokens needlessly before verifying the session and checking the limit. Now we check the limit without a token before token generation, so in case of an attack we do not waste resources. And we add the token after token generation and also check the limit because thread safety requires it.

## How was this patch tested?

I have changed the unit tests in `InMemoryConcurrentSessionVerifierTest` and `WebSSOResourceTest` to test the new usage of the verifier.
I also tested it manually with this configuration:
```
<property>
        <name>gateway.session.verification.unlimited.users</name>
        <value>admin</value>
</property>
<property>
        <name>gateway.session.verification.privileged.users</name>
        <value>tom</value>
</property>
<property>
        <name>gateway.session.verification.privileged.user.limit</name>
        <value>2</value>
</property>
<property>
        <name>gateway.session.verification.non.privileged.user.limit</name>
        <value>1</value>
</property>
<property>
        <name>gateway.session.verification.expired.tokens.cleaning.period</name>
        <value>80</value>
</property>
<property>
        <name>gateway.service.concurrentsessionverifier.impl</name>
        <value>org.apache.knox.gateway.session.control.InMemoryConcurrentSessionVerifier</value>
</property>
```
