### PR TITLE
KNOX-2795 Handling missing OIDC client name parameter

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/Pac4jMessages.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/Pac4jMessages.java
@@ -32,9 +32,6 @@ public interface Pac4jMessages {
   @Message( level = MessageLevel.ERROR, text = "pac4j callback URL required")
   void ssoAuthenticationProviderUrlRequired();
 
-  @Message( level = MessageLevel.ERROR, text = "pac4j clientName parameter required")
-  void clientNameParameterRequired();
-
   @Message( level = MessageLevel.ERROR, text = "At least one pac4j client must be defined")
   void atLeastOnePac4jClientMustBeDefined();
 

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -161,10 +161,6 @@ public class Pac4jDispatcherFilter implements Filter {
 
     // client name from servlet parameter (mandatory)
     final String clientNameParameter = filterConfig.getInitParameter(PAC4J_CLIENT_NAME_PARAM);
-    if (clientNameParameter == null) {
-      log.clientNameParameterRequired();
-      throw new ServletException("Required pac4j clientName parameter is missing.");
-    }
 
     final String oidcType = filterConfig.getInitParameter(PAC4J_OIDC_TYPE);
     /*
@@ -266,7 +262,7 @@ public class Pac4jDispatcherFilter implements Filter {
 
   private void addDefaultConfig(String clientNameParameter, Map<String, String> properties) {
     // add default saml params
-    if (clientNameParameter.contains(SAML2Client.class.getSimpleName())) {
+    if (clientNameParameter != null && clientNameParameter.contains(SAML2Client.class.getSimpleName())) {
       properties.put(PropertiesConstants.SAML_KEYSTORE_PATH,
           keystoreService.getKeystorePath());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The client name config parameter was handled in an inconsistent manner.

 * When it was null we threw an exception saying that this parameter is mandatory
 * However when it was an empty string, we did fallback using the default client name coming from the provider

I removed the null check so that we use the default in that case too.

## How was this patch tested?

Manually tested with a topology like this:

```xml
      <provider>
          <role>federation</role>
          <name>pac4j</name>
          <enabled>true</enabled>
          <param>
            <name>pac4j.callbackUrl</name>
            <value>https://localhost:8443/gateway/knoxsso/api/v1/websso</value>
          </param>
<!-- client name is commented out
          <param>
            <name>clientName</name>
            <value>OidcClient</value>
          </param>
-->
          <param>
            <name>oidc.id</name>
            <value>....</value>
          </param>
          <param>
            <name>oidc.secret</name>
            <value>SECRET</value>
          </param>
          <param>
            <name>oidc.discoveryUri</name>
            <value>...</value>
          </param>
          <param>
            <name>oidc.preferredJwsAlgorithm</name>
            <value>RS256</value>
          </param>
      </provider>
```