### PR TITLE
KNOX-2792 - new REST API endpoint to set Authorization/Bearer header in the response using an environment variable

### DIFF
--- a/gateway-service-auth/pom.xml
+++ b/gateway-service-auth/pom.xml
@@ -55,6 +55,11 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AuthBearerResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AuthBearerResource.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.auth;
+
+import static javax.ws.rs.core.Response.ok;
+
+import java.util.Locale;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+/**
+ * The service populates HTTP "Authorization" header with the Bearer Token,
+ * obtained from an environment variable.
+ * <p>
+ * This implementation assumes that the token is not rotated as it never gets
+ * exposed to the end-user. Consider alternative ways of obtaining tokens(e.g.
+ * from files) and implement caching/refreshing mechanism if token rotation is
+ * required.
+ */
+@Path(AuthBearerResource.RESOURCE_PATH)
+public class AuthBearerResource {
+  static final String RESOURCE_PATH = "auth/api/v1/bearer";
+  static final String BEARER_AUTH_TOKEN_ENV_CONFIG = "auth.bearer.token.env";
+  static final String DEFAULT_BEARER_AUTH_TOKEN_ENV = "BEARER_AUTH_TOKEN";
+  static final String HEADER_FORMAT = "Bearer %s";
+
+  private String token;
+
+  @Context
+  HttpServletResponse response;
+
+  @Context
+  ServletContext context;
+
+  @PostConstruct
+  public void init() throws ServletException {
+    String bearerTokenEnvVariableName = context.getInitParameter(BEARER_AUTH_TOKEN_ENV_CONFIG);
+    if (bearerTokenEnvVariableName == null) {
+      bearerTokenEnvVariableName = DEFAULT_BEARER_AUTH_TOKEN_ENV;
+    }
+
+    token = System.getenv(bearerTokenEnvVariableName);
+    if (token == null) {
+      throw new ServletException(String.format(Locale.ROOT, "Token environment variable '%s' is not set", bearerTokenEnvVariableName));
+    }
+  }
+
+  @GET
+  public Response doGet() {
+    response.addHeader(HttpHeaders.AUTHORIZATION, String.format(Locale.ROOT, HEADER_FORMAT, token));
+    return ok().build();
+  }
+}

--- a/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/AuthBearerResourceTest.java
+++ b/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/AuthBearerResourceTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.auth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.easymock.EasyMock;
+import org.junit.Rule;
+import org.junit.Test;
+
+import uk.org.webcompere.systemstubs.rules.EnvironmentVariablesRule;
+
+public class AuthBearerResourceTest {
+
+  @Rule
+  public EnvironmentVariablesRule environmentVariablesRule = new EnvironmentVariablesRule();
+
+  private static final String CUSTOM_TOKEN_ENV_VARIABLE = "MY_BEARER_TOKEN_ENV";
+  private static final String TOKEN = "TestBearerToken";
+
+  private ServletContext context;
+  private HttpServletResponse response;
+
+  private void configureCommonExpectations(String bearerTokenEnvVariableName, boolean expectHeader) {
+    context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getInitParameter(AuthBearerResource.BEARER_AUTH_TOKEN_ENV_CONFIG)).andReturn(bearerTokenEnvVariableName).anyTimes();
+    response = EasyMock.createNiceMock(HttpServletResponse.class);
+    if (expectHeader) {
+      response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + TOKEN);
+      EasyMock.expectLastCall();
+    }
+    EasyMock.replay(context, response);
+  }
+
+  @Test
+  public void testBearerTokenWithDefaultEnvVariableName() throws Exception {
+    testAuthBearerResource(null, true);
+  }
+
+  @Test
+  public void testBearerTokenWithCustomEnvVariableName() throws Exception {
+    testAuthBearerResource(CUSTOM_TOKEN_ENV_VARIABLE, true);
+  }
+
+  @Test
+  public void testNoBearerTokenWithDefaultEnvVariableName() throws Exception {
+    testAuthBearerResource(null, false);
+  }
+
+  @Test
+  public void testNoBearerTokenWithCustomEnvVariableName() throws Exception {
+    testAuthBearerResource(CUSTOM_TOKEN_ENV_VARIABLE, false);
+  }
+
+  private void testAuthBearerResource(String envVariableName, boolean setEnv) {
+    final String expectedEnvVariableName = envVariableName == null ? AuthBearerResource.DEFAULT_BEARER_AUTH_TOKEN_ENV : envVariableName;
+    boolean exceptionThrown = false;
+    try {
+      if (setEnv) {
+        environmentVariablesRule.set(expectedEnvVariableName, TOKEN);
+      }
+      configureCommonExpectations(envVariableName, setEnv);
+      final AuthBearerResource authBearerResource = new AuthBearerResource();
+      authBearerResource.context = context;
+      authBearerResource.response = response;
+      authBearerResource.init();
+      authBearerResource.doGet();
+      EasyMock.verify(response);
+    } catch (ServletException e) {
+      exceptionThrown = true;
+      assertEquals("Token environment variable '" + expectedEnvVariableName + "' is not set", e.getMessage());
+    }
+    if (setEnv) {
+      assertFalse(exceptionThrown);
+    } else {
+      assertTrue(exceptionThrown);
+    }
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,7 @@
         <spring-vault.version>2.3.2</spring-vault.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>
+        <system-stubs-junit4.version>1.1.0</system-stubs-junit4.version>
         <swagger-annotations.version>1.6.2</swagger-annotations.version>
         <swagger-maven-plugin.version>3.1.7</swagger-maven-plugin.version>
         <taglibs-standard.version>1.2.5</taglibs-standard.version>
@@ -2520,6 +2521,12 @@
                 <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
                 <version>${hsql.db.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>uk.org.webcompere</groupId>
+                <artifactId>system-stubs-junit4</artifactId>
+                <version>${system-stubs-junit4.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

A new REST API endpoint is added in `KNOX-AUTH-SERVICE` with `auth/api/v1/bearer` path.

## How was this patch tested?

Implemented new unit test cases to cover this new functionality and executed manual testing:

1. Default environment variable name:
```
$ export BEARER_AUTH_TOKEN=MY_AUTH_BEARER_TOKEN
$ bin/gateway.sh start
$ curl -iku admin:admin-password -X GET https://localhost:8443/gateway/sandbox/auth/api/v1/bearer
HTTP/1.1 200 OK
Date: Fri, 26 Aug 2022 09:11:00 GMT
Set-Cookie: KNOXSESSIONID=node01u0cyzk36nibi18g2binv7e1290.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Thu, 25-Aug-2022 09:11:00 GMT; SameSite=lax
Authorization: Bearer MY_AUTH_BEARER_TOKEN
Content-Length: 0
```

2. Custom environment variable name:
```
$ bin/gateway.sh stop
$ export CUSTOM_AUTH_TOKEN_ENV=MY_CUSTOM_AUTH_BEARER_TOKEN
$ bin/gateway.sh start
updated sandbox.xml to

    <service>
         <role>KNOX-AUTH-SERVICE</role>
         <param>
             <name>auth.bearer.token.env</name>
             <value>CUSTOM_AUTH_TOKEN_ENV</value>
         </param>
    </service>

$ curl -iku admin:admin-password -X GET https://localhost:8443/gateway/sandbox/auth/api/v1/bearer
HTTP/1.1 200 OK
Date: Fri, 26 Aug 2022 09:14:01 GMT
Set-Cookie: KNOXSESSIONID=node0169z65o0ns1lphe6xi9b4cse80.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Thu, 25-Aug-2022 09:14:01 GMT; SameSite=lax
Authorization: Bearer MY_CUSTOM_AUTH_BEARER_TOKEN
Content-Length: 0

```
