### PR TITLE
KNOX-2798 - Add a trim method to KnoxShellTable to trim all values in…

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/table/KnoxShellTable.java
@@ -289,6 +289,32 @@ public class KnoxShellTable {
     return this;
   }
 
+  /**
+   * Trims the String value of whitespace for each of the values in a column
+   * given the column name.
+   * @param colIndex
+   * @return table
+   */
+  public KnoxShellTable trim(String colName) {
+    int colIndex = headers.indexOf(colName);
+    return trim(colIndex);
+  }
+
+  /**
+   * Trims the String value of whitespace for each of the values in a column
+   * given the column index.
+   * @param colIndex
+   * @return table
+   */
+  public KnoxShellTable trim(int colIndex) {
+    List<Comparable<? extends Object>> col = values(colIndex);
+    for (int i = 0; i < col.size(); i++) {
+      String v = (String) col.get(i);
+      rows.get(i).set(colIndex, v.trim());
+    }
+    return this;
+  }
+
   public List<String> getHeaders() {
     return headers == null || headers.isEmpty() ? null : headers;
   }

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/table/KnoxShellTableTest.java
@@ -296,6 +296,24 @@ public class KnoxShellTableTest {
   }
 
   @Test
+  public void testTrim() throws IOException {
+    KnoxShellTable table = new KnoxShellTable();
+
+    table.header("Column A").header("Column B").header("Column C");
+
+    table.row().value(" 789").value("012").value("844444444");
+    table.row().value(" 123").value("456").value("344444444");
+
+    KnoxShellTable table2 = table.trim("Column A");
+    assertEquals(table2.getRows().get(0).get(0), "789");
+    assertEquals(table2.getRows().get(1).get(0), "123");
+
+    KnoxShellTable table3 = table.trim(0);
+    assertEquals(table3.getRows().get(0).get(0), "789");
+    assertEquals(table3.getRows().get(1).get(0), "123");
+  }
+
+  @Test
   public void testSortStringValuesNumerically() throws IOException {
     KnoxShellTable table = new KnoxShellTable();
 


### PR DESCRIPTION
… a Column

## What changes were proposed in this pull request?
We need a method to call to trim whitespace from all values in a column of a KnoxShellTable. This is useful for values that are numbers that are padded with spaces in order to enable numeric operations.

## How was this patch tested?

Added unit tests and manual testing from within KnoxShell

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
