### PR TITLE
KNOX-2799 - When exporting certificate using Knox CLI, the certificate is coming with wrong name when type=PEM

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -723,8 +723,8 @@ public class KnoxCLI extends Configured implements Tool {
           }
 
           if ("PEM".equalsIgnoreCase(type) || type == null) {
-            X509CertificateUtil.writeCertificateToFile(cert, new File(keyStoreDir + "gateway-identity.pem"));
-            out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-identity.pem");
+            X509CertificateUtil.writeCertificateToFile(cert, new File(keyStoreDir + "gateway-client-trust.pem"));
+            out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-client-trust.pem");
           } else if ("JKS".equalsIgnoreCase(type)) {
             X509CertificateUtil.writeCertificateToJks(cert, new File(keyStoreDir + "gateway-client-trust.jks"));
             out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-client-trust.jks");

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -719,7 +719,7 @@ public class KnoxCLITest {
     rc = cli.run(gwCreateArgs2);
     assertEquals(0, rc);
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("Certificate gateway-identity has been successfully exported to"));
-    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("gateway-identity.pem"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("gateway-client-trust.pem"));
 
     // case insensitive
     outContent.reset();
@@ -727,14 +727,14 @@ public class KnoxCLITest {
     rc = cli.run(gwCreateArgs2_6);
     assertEquals(0, rc);
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("Certificate gateway-identity has been successfully exported to"));
-    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("gateway-identity.pem"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("gateway-client-trust.pem"));
 
     outContent.reset();
     String[] gwCreateArgs2_5 = {"export-cert"};
     rc = cli.run(gwCreateArgs2_5);
     assertEquals(0, rc);
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("Certificate gateway-identity has been successfully exported to"));
-    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("gateway-identity.pem"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("gateway-client-trust.pem"));
 
     outContent.reset();
     String[] gwCreateArgs3 = {"export-cert", "--type", "JKS"};


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is an inconsistency in naming of the output file of the export cert command. The doc says it should be `gateway-client-trust.<type>` but in case of pem it's `gateway-identity.pem`.

## How was this patch tested?

```bash
$ bin/knoxcli.sh export-cert --type pem
Certificate gateway-identity has been successfully exported to: /Users/attilamagyar/development/test/data/security/keystores/gateway-client-trust.pem
$  ls -al  /Users/attilamagyar/development/test/data/security/keystores/gateway-client-trust.pem
-rw-r--r--  1 attilamagyar  staff  1246 Sep  6 10:28 /Users/attilamagyar/development/test/data/security/keystores/gateway-client-trust.pem
````
