### PR TITLE
KNOX-2801 Error Message should come in virtual group mapping provider if there are multiple occurrence's of a virtual group.

### DIFF
--- a/gateway-release/home/conf/topologies/homepage.xml
+++ b/gateway-release/home/conf/topologies/homepage.xml
@@ -47,10 +47,6 @@
             <value>false</value>
          </param>
          <param>
-            <name>xframe.options.enabled</name>
-            <value>true</value>
-         </param>
-         <param>
             <name>xframe.options</name>
             <value>SAMEORIGIN</value>
          </param>

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -79,4 +79,6 @@ public interface GatewaySpiMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to load truststore due to {0}")
   void failedToLoadTruststore(String message, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.WARN, text = "Duplicated filter param key: {0}")
+  void duplicatedFilterParamKey(String name);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Provider.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Provider.java
@@ -19,6 +19,8 @@ package org.apache.knox.gateway.topology;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Provider {
+  private static final GatewaySpiMessages LOG = MessagesFactory.get(GatewaySpiMessages.class);
 
   private String role;
   private String name;
@@ -60,6 +63,9 @@ public class Provider {
   }
 
   public void addParam(Param param) {
+    if (params.containsKey(param.getName())) {
+      LOG.duplicatedFilterParamKey(param.getName());
+    }
     params.put(param.getName(), param.getValue());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

It turned out to be a general problem that effects other filters as well. I added a warning message if there are filter config params with the same name.

## How was this patch tested?

Tested with the following config:

```xml
        <provider>
            <role>identity-assertion</role>
            <name>HadoopGroupProvider</name>
            <enabled>true</enabled>
           <param>
                <name>group.mapping.abhi</name>
                <value>true</value>
            </param>
           <param>
                <name>group.mapping.abhi</name>
                <value>false</value>
            </param>
        </provider>
```

```bash
$ grep WARN logs/gateway.log 
2022-09-06 18:52:46,777  WARN  knox.gateway (Provider.java:addParam(67)) - Duplicated filter param key: group.mapping.abhi
```

