### PR TITLE
KNOX-2804 - Escaping values in generated XML before trying to parse that XML using SAX

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.topology.simple;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.topology.validation.TopologyValidator;
 import org.apache.knox.gateway.util.XmlUtils;
 import org.easymock.EasyMock;
@@ -851,6 +852,25 @@ public class SimpleDescriptorHandlerTest {
         assertThat(topologyXml, hasXPath("/topology/service/role", is(equalTo("KNOX"))));
       } finally {
         providerConfig.delete();
+        if (topologyFile != null) {
+          topologyFile.delete();
+        }
+      }
+    }
+
+    @Test
+    public void testJsonHandler() throws Exception {
+      File topologyFile = null;
+      try {
+        final File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
+        final File descriptorFile = new File(SimpleDescriptorHandlerTest.class.getResource("/conf-full/conf/descriptors/test-topology.json").getFile());
+        final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
+        final Map<String, File> handleResult = SimpleDescriptorHandler.handle(null, descriptorFile, destDir, gatewayServices);
+        topologyFile = handleResult.get(SimpleDescriptorHandler.RESULT_TOPOLOGY);
+        final Document topologyXml = XmlUtils.readXml(topologyFile);
+        assertThat(topologyXml, hasXPath("/topology/service/role", is(equalTo("KNOX"))));
+        assertThat(topologyXml, hasXPath("/topology/gateway/provider/name", is(equalTo("ShiroProvider"))));
+      } finally {
         if (topologyFile != null) {
           topologyFile.delete();
         }

--- a/gateway-server/src/test/resources/conf-full/conf/descriptors/test-topology.json
+++ b/gateway-server/src/test/resources/conf-full/conf/descriptors/test-topology.json
@@ -1,0 +1,8 @@
+{
+   "provider-config-ref": "test-providers",
+   "services": [
+      {
+        "name": "KNOX"
+      }
+   ]
+}

--- a/gateway-server/src/test/resources/conf-full/conf/shared-providers/test-providers.json
+++ b/gateway-server/src/test/resources/conf-full/conf/shared-providers/test-providers.json
@@ -1,0 +1,22 @@
+{
+  "providers" : [ {
+    "role" : "authentication",
+    "name" : "ShiroProvider",
+    "enabled" : true,
+    "params" : {
+      "main.ldapContextFactory" : "org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory",
+      "main.ldapRealm" : "org.apache.knox.gateway.shirorealm.KnoxLdapRealm",
+      "main.ldapRealm.authenticationCachingEnabled" : "false",
+      "main.ldapRealm.contextFactory" : "$ldapContextFactory",
+      "main.ldapRealm.contextFactory.authenticationMechanism" : "simple",
+      "main.ldapRealm.contextFactory.url" : "ldap://localhost:33389",
+      "main.ldapRealm.userDnTemplate" : "uid=0ou=people,dc=hadoop,dc=apache,dc=org",
+      "main.ldapRealm.userSearchFilter" : "(&(&(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)(memberOf=CN=SecXX-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)))",
+      "redirectToUrl" : "/${GATEWAY_PATH}/knoxsso/knoxauth/login.html",
+      "restrictedCookies" : "rememberme,WWW-Authenticate",
+      "sessionTimeout" : "30",
+      "urls./**" : "authcBasic"
+    }
+  } ],
+  "readOnly" : true
+}

--- a/gateway-topology-simple/pom.xml
+++ b/gateway-topology-simple/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
         </dependency>

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.simple;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ServiceType;
@@ -465,7 +466,7 @@ public class SimpleDescriptorHandler {
                 for (Map.Entry<String, String> param : provider.getParams().entrySet()) {
                     sw.write("            <param>\n");
                     sw.write("                <name>" + param.getKey() + "</name>\n");
-                    sw.write("                <value>" + param.getValue() + "</value>\n");
+                    sw.write("                <value>" + StringEscapeUtils.escapeXml11(param.getValue()) + "</value>\n");
                     sw.write("            </param>\n");
                 }
 
@@ -559,7 +560,7 @@ public class SimpleDescriptorHandler {
                         if (!(svcParam.getKey().toLowerCase(Locale.ROOT)).startsWith(SimpleDescriptor.DISCOVERY_PARAM_PREFIX)) {
                             sw.write("        <param>\n");
                             sw.write("            <name>" + svcParam.getKey() + "</name>\n");
-                            sw.write("            <value>" + svcParam.getValue() + "</value>\n");
+                            sw.write("            <value>" + StringEscapeUtils.escapeXml11(svcParam.getValue()) + "</value>\n");
                             sw.write("        </param>\n");
                         }
                     }
@@ -589,7 +590,7 @@ public class SimpleDescriptorHandler {
                         for (Entry<String, String> entry : appParams.entrySet()) {
                             sw.write("        <param>\n");
                             sw.write("            <name>" + entry.getKey() + "</name>\n");
-                            sw.write("            <value>" + entry.getValue() + "</value>\n");
+                            sw.write("            <value>" + StringEscapeUtils.escapeXml11(entry.getValue()) + "</value>\n");
                             sw.write("        </param>\n");
                         }
                     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before writing a parameter (at provider, application, or service level) from a provider/descriptor pair into a topology, the parameter value has to be XML escaped so that it won't make the generated XML fail when Knox parses it.

## How was this patch tested?

Added new unit test case and resource (contains a simple `&` character in the provider resource) to the existing `SimpleDescriptorHandlerTest` suite that handles JSON type provider/descriptor pairs.

Additionally, I used this JSON in my local Knox Gateway deployment as a shared-provider config and confirmed that after my fix were applied the topology generation went well.

Shared-provider config JSON I used for testing (`shared-providers/smolnar.json`):
```
{
  "providers" : [ {
    "role" : "webappsec",
    "name" : "WebAppSec",
    "enabled" : true,
    "params" : {
      "xframe.options.enabled" : "true"
    }
  }, {
    "role" : "authentication",
    "name" : "ShiroProvider",
    "enabled" : true,
    "params" : {
      "main.ldapContextFactory" : "org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory",
      "main.ldapRealm" : "org.apache.knox.gateway.shirorealm.KnoxLdapRealm",
      "main.ldapRealm.authenticationCachingEnabled" : "false",
      "main.ldapRealm.contextFactory" : "$ldapContextFactory",
      "main.ldapRealm.contextFactory.authenticationMechanism" : "simple",
      "main.ldapRealm.contextFactory.url" : "ldap://localhost:33389",
      "main.ldapRealm.userDnTemplate" : "uid=0ou=people,dc=hadoop,dc=apache,dc=org",
      "main.ldapRealm.userSearchFilter" : "(&(&(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)(memberOf=CN=SecXX-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)))",
      "redirectToUrl" : "/${GATEWAY_PATH}/knoxsso/knoxauth/login.html",
      "restrictedCookies" : "rememberme,WWW-Authenticate",
      "sessionTimeout" : "30",
      "urls./**" : "authcBasic"
    }
  }, {
    "role" : "identity-assertion",
    "name" : "Default",
    "enabled" : true,
    "params" : { }
  } ],
  "readOnly" : true
}
```

Descriptor JSON I used for testing (`descriptors/smolnar.json`):
```
{
   "provider-config-ref": "smolnar",
   "services": [
      {
        "name": "KNOXSSO",
        "params": {
            "knoxsso.token.ttl": "86400000",
            "knoxsso.token.sigalg": "",
            "knoxsso.redirect.whitelist.regex": "^https?:\\/\\/(.*smolnar\\.root\\.xyz\\.com)(?::[0-9]+)?(?:\\/.*)?$"
         }
      }
   ],
   "applications": [
     {
       "name": "knoxauth"
     }
   ]
}

```
Generated topology XML:
```
<?xml version="1.0" encoding="utf-8"?>
<!--==============================================-->
<!-- DO NOT EDIT. This is an auto-generated file. -->
<!--==============================================-->
<topology>
    <generated>true</generated>
    <gateway>
        <provider>
            <role>webappsec</role>
            <name>WebAppSec</name>
            <enabled>true</enabled>
            <param>
                <name>xframe.options.enabled</name>
                <value>true</value>
            </param>
        </provider>
        <provider>
            <role>authentication</role>
            <name>ShiroProvider</name>
            <enabled>true</enabled>
            <param>
                <name>main.ldapContextFactory</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
            </param>
            <param>
                <name>main.ldapRealm.authenticationCachingEnabled</name>
                <value>false</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory</name>
                <value>$ldapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
                <value>simple</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.url</name>
                <value>ldap://localhost:33389</value>
            </param>
            <param>
                <name>main.ldapRealm.userDnTemplate</name>
                <value>uid=0ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.userSearchFilter</name>
                <value>(&amp;(&amp;(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-ali-bda-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=dm,DC=dm,DC=int)(memberOf=CN=SecXX-ali-bda-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=dm,DC=dm,DC=int)))</value>
            </param>
            <param>
                <name>redirectToUrl</name>
                <value>/${GATEWAY_PATH}/knoxsso/knoxauth/login.html</value>
            </param>
            <param>
                <name>restrictedCookies</name>
                <value>rememberme,WWW-Authenticate</value>
            </param>
            <param>
                <name>sessionTimeout</name>
                <value>30</value>
            </param>
            <param>
                <name>urls./**</name>
                <value>authcBasic</value>
            </param>
        </provider>
        <provider>
            <role>identity-assertion</role>
            <name>Default</name>
            <enabled>true</enabled>
        </provider>
    </gateway>

    <service>
        <role>KNOXSSO</role>
        <param>
            <name>knoxsso.token.ttl</name>
            <value>86400000</value>
        </param>
        <param>
            <name>knoxsso.token.sigalg</name>
            <value></value>
        </param>
        <param>
            <name>knoxsso.redirect.whitelist.regex</name>
            <value>^https?:\/\/(.*smolnar\.root\.xyz\.com)(?::[0-9]+)?(?:\/.*)?$</value>
        </param>
    </service>
    <application>
        <name>knoxauth</name>
    </application>
</topology>

```