### PR TITLE
KNOX-2807 - Hive's SSL_ENABLED flag is processed on the service level with the correct service configuration name in CM

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -37,7 +37,7 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
   static final String TRANSPORT_MODE_ALL  = "all";
 
   static final String SAFETY_VALVE   = "hive_hs2_config_safety_valve";
-  static final String SSL_ENABLED    = "hive.server2.use.SSL";
+  public static final String SSL_ENABLED = "hiveserver2_enable_ssl";
   static final String TRANSPORT_MODE = "hive.server2.transport.mode";
   static final String HTTP_PORT      = "hive.server2.thrift.http.port";
   static final String HTTP_PATH      = "hive.server2.thrift.http.path";
@@ -90,7 +90,7 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
 
     ServiceModel model =
         createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/%s", scheme, hostname, port, httpPath));
-    model.addRoleProperty(getRoleType(), SSL_ENABLED, Boolean.toString(sslEnabled));
+    model.addServiceProperty(SSL_ENABLED, Boolean.toString(sslEnabled));
     model.addRoleProperty(getRoleType(), SAFETY_VALVE, getRoleConfigValue(roleConfig, SAFETY_VALVE));
 
     return model;

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -995,7 +995,7 @@ public class ClouderaManagerServiceDiscoveryTest {
     Map<String, String> roleProperties = new HashMap<>();
     roleProperties.put("hive_hs2_config_safety_valve", hs2SafetyValveValue);
 
-    final Map<String, String> serviceProperties = Collections.singletonMap("hive.server2.use.SSL", String.valueOf(enableSSL));
+    final Map<String, String> serviceProperties = Collections.singletonMap(HiveServiceModelGenerator.SSL_ENABLED, String.valueOf(enableSSL));
 
     return doTestDiscovery(hostName,
                            "HIVE-1",
@@ -1023,7 +1023,7 @@ public class ClouderaManagerServiceDiscoveryTest {
     roleProperties.put("hive_server2_transport_mode", "http");
     roleProperties.put("hive_hs2_config_safety_valve", hs2SafetyValveValue);
 
-    final Map<String, String> serviceProperties = Collections.singletonMap("hive.server2.use.SSL", String.valueOf(enableSSL));
+    final Map<String, String> serviceProperties = Collections.singletonMap(HiveServiceModelGenerator.SSL_ENABLED, String.valueOf(enableSSL));
 
     return doTestDiscovery(hostName,
                            "HIVE_ON_TEZ-1",

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGeneratorTest.java
@@ -55,10 +55,10 @@ public class HiveOnTezServiceModelGeneratorTest extends AbstractServiceModelGene
 
   @Test
   public void testServiceModelMetadata() {
-    final Map<String, String> serviceConfig = Collections.emptyMap();
+    final Map<String, String> serviceConfig = new HashMap<>();
+    serviceConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
 
     final Map<String, String> roleConfig = new HashMap<>();
-    roleConfig.put(HiveOnTezServiceModelGenerator.SSL_ENABLED, "false");
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_TRANSPORT_MODE,
                    HiveOnTezServiceModelGenerator.TRANSPORT_MODE_HTTP);
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_HTTP_PORT, "12345");
@@ -69,10 +69,10 @@ public class HiveOnTezServiceModelGeneratorTest extends AbstractServiceModelGene
 
   @Test
   public void testServiceModelMetadataTransportModeAll() {
-    final Map<String, String> serviceConfig = Collections.emptyMap();
+    final Map<String, String> serviceConfig = new HashMap<>();
+    serviceConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
 
     final Map<String, String> roleConfig = new HashMap<>();
-    roleConfig.put(HiveOnTezServiceModelGenerator.SSL_ENABLED, "false");
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_TRANSPORT_MODE,
                    HiveOnTezServiceModelGenerator.TRANSPORT_MODE_ALL);
     roleConfig.put(HiveOnTezServiceModelGenerator.HIVEONTEZ_HTTP_PORT, "12345");

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGeneratorTest.java
@@ -55,10 +55,10 @@ public class HiveServiceModelGeneratorTest extends AbstractServiceModelGenerator
 
   @Test
   public void testServiceModelMetadata() {
-    final Map<String, String> serviceConfig = Collections.emptyMap();
+    final Map<String, String> serviceConfig = new HashMap<>();
+    serviceConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
 
     final Map<String, String> roleConfig = new HashMap<>();
-    roleConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
     roleConfig.put(HiveServiceModelGenerator.SAFETY_VALVE,
                    getSafetyValveConfig(HiveServiceModelGenerator.TRANSPORT_MODE_HTTP));
 
@@ -67,10 +67,10 @@ public class HiveServiceModelGeneratorTest extends AbstractServiceModelGenerator
 
   @Test
   public void testServiceModelMetadataTransportModeAll() {
-    final Map<String, String> serviceConfig = Collections.emptyMap();
+    final Map<String, String> serviceConfig = new HashMap<>();
+    serviceConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
 
     final Map<String, String> roleConfig = new HashMap<>();
-    roleConfig.put(HiveServiceModelGenerator.SSL_ENABLED, "false");
     roleConfig.put(HiveServiceModelGenerator.SAFETY_VALVE,
                    getSafetyValveConfig(HiveServiceModelGenerator.TRANSPORT_MODE_ALL));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Knox's automated service discovery had a bug when it came to HIVE(_ON_TEZ) service discovery. These services have their SSL-enabled flag on the service level, but the generated service model (by Knox) stored that information in the HS2 role configs.
In addition to this, the CM configuration name referred to the so-called `related name` configuration field which Knox does not consider when comparing previous and current service/role configs.

## How was this patch tested?

Updated JUnit tests and executed manual testing in a cluster with KNOX, HIVE and HIVE_ON_TEZ.
