### PR TITLE
KNOX-2809 - Fix dispatch ha-class for HDFSUI high available.

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/service.xml
@@ -57,5 +57,5 @@
             <rewrite apply="DATANODE/outbound/datanode/static" to="response.body"/>
         </route>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.hdfs.dispatch.HdfsUIHaDispatch"/>
 </service>

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsUIHaDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsUIHaDispatch.java
@@ -17,13 +17,21 @@
  */
 package org.apache.knox.gateway.hdfs.dispatch;
 
+import org.apache.knox.gateway.util.URLUtils;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
 
 public class HdfsUIHaDispatch extends AbstractHdfsHaDispatch {
   public static final String RESOURCE_ROLE = "HDFSUI";
 
   public HdfsUIHaDispatch() throws ServletException {
     super();
+  }
+
+  @Override
+  public URI getDispatchUrl(final HttpServletRequest request) {
+    return URLUtils.getDecodeUri(request.getRequestURL().toString(), request.getQueryString());
   }
 
   @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/URLDecodingDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/URLDecodingDispatch.java
@@ -17,10 +17,9 @@
  */
 package org.apache.knox.gateway.dispatch;
 
+import org.apache.knox.gateway.util.URLUtils;
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Dispatch which decodes the outgoing URLs (to services).
@@ -37,21 +36,6 @@ public class URLDecodingDispatch extends ConfigurableDispatch {
 
   @Override
   public URI getDispatchUrl(final HttpServletRequest request) {
-    String decoded;
-
-    try {
-      decoded = URLDecoder.decode(request.getRequestURL().toString(), StandardCharsets.UTF_8.name() );
-    } catch (final Exception e) {
-      /* fall back in case of exception */
-      decoded = request.getRequestURL().toString();
-    }
-
-    final StringBuilder str = new StringBuilder(decoded);
-    final String query = request.getQueryString();
-    if ( query != null ) {
-      str.append('?');
-      str.append(query);
-    }
-    return URI.create(str.toString());
+    return URLUtils.getDecodeUri(request.getRequestURL().toString(), request.getQueryString());
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/URLUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/URLUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class URLUtils {
+
+  /**
+   * A method that decode url and concat query params, return result as URI.
+   *
+   * @param encoded encoded url
+   * @param queryStr query params
+   * @return decoded URI
+   */
+  public static URI getDecodeUri(String encoded, String queryStr) {
+    String decoded;
+    try {
+      decoded = URLDecoder.decode(encoded, StandardCharsets.UTF_8.name());
+    } catch (final Exception e) {
+      /* fall back in case of exception */
+      decoded = encoded;
+    }
+
+    final StringBuilder str = new StringBuilder(decoded);
+    if (queryStr != null) {
+      str.append('?');
+      str.append(queryStr);
+    }
+    return URI.create(str.toString());
+  }
+}

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/util/URLUtilsTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/util/URLUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+public class URLUtilsTest {
+  @Test
+  public void testGetDecodeUri() {
+    String urlStr = "http%3A%2F%2Flocal.home.test.com";
+    String queryStr = "user.name=knox&service=hdfs";
+    URI uri = URLUtils.getDecodeUri(urlStr, queryStr);
+    assertEquals("http://local.home.test.com?user.name=knox&service=hdfs", uri.toString());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
@risdenk use `org.apache.knox.gateway.dispatch.URLDecodingDispatch` for HDFSUI dispatch ha-class  in https://github.com/apache/knox/pull/103. But `URLDecodingDispatch` didn't do failover request when request failed. 

I recommend using `org.apache.knox.gateway.hdfs.dispatch.HdfsUIHaDispatch` for this, but it  it lack URL decoding what  `URLDecodingDispatch` do. So I override `getDispatchUrl` method in `HdfsUIHaDispatch`, decode url just like `URLDecodingDispatch`.

## How was this patch tested?

- mvn clean verify -Ppackage,release
- Checked that HDFSUI service definition works with HaProvider on cluster

![image](https://user-images.githubusercontent.com/26102745/192078471-4927720c-42e0-45e2-96d1-cb36f0ef7d8a.png)

