### PR TITLE
KNOX-2810 - Login on Knox UI doesn't work when the password contains special character

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
@@ -46,7 +46,7 @@ function redirect(redirectUrl) {
 // btoa skips some of the special characters such as ë
 // https://developer.mozilla.org/en-US/docs/Web/API/btoa
 function unicodeBase64Encode(str) {
-    return window.btoa(unescape(encodeURIComponent(str)));
+    return btoa(unescape(encodeURIComponent(str)));
 }
 
 var keypressed = function(event) {

--- a/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
@@ -43,6 +43,12 @@ function redirect(redirectUrl) {
 	}
 }
 
+// btoa skips some of the special characters such as ë
+// https://developer.mozilla.org/en-US/docs/Web/API/btoa
+function unicodeBase64Encode(str) {
+    return window.btoa(unescape(encodeURIComponent(str)));
+}
+
 var keypressed = function(event) {
 	if (event.keyCode == 13) {
 		login();
@@ -63,7 +69,7 @@ var login = function() {
 		//Instantiate HTTP Request
 		var request = ((window.XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject("Microsoft.XMLHTTP"));
 		request.open("POST", idpUrl, true);
-		request.setRequestHeader("Authorization", "Basic " + btoa(username + ":" + password));
+		request.setRequestHeader("Authorization", "Basic " + unicodeBase64Encode(username + ":" + password));
 		request.send(null);
 
 		//Process Response


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `btoa` (third party) javascript functions can't base64 encode some of the special characters such as the letter `ë`. 
We use this function to create the basic authorization header. If user's password contains an unsupported character the login will fail.


## How was this patch tested?

I tested the new function manually:

```
unicodeBase64Encode('árvíztűrő tükörfúrógép ë !#$%^&*()_!#@V')
'w6FydsOtenTFsXLFkSB0w7xrw7ZyZsO6csOzZ8OpcCDDqyAhIyQlXiYqKClfISNAVg=='

unicodeBase64Encode('阪熊奈岡鹿梨阜埼茨栃')
'6Ziq54aK5aWI5bKh6bm/5qKo6Zic5Z+86Iyo5qCD'
阪熊奈岡鹿梨阜埼茨栃
```
The I decoded the result and I got back the original string.

The I changed sam's password in users.ldif:

```
# entry for sample user sam
dn: uid=sam,ou=people,dc=hadoop,dc=apache,dc=org
objectclass:top
objectclass:person
objectclass:organizationalPerson
objectclass:inetOrgPerson
cn: sam
sn: sam
uid: sam
userPassword: 阪熊奈岡鹿梨阜埼茨栃 árvíztűrő tükörfúrógép ë !#$%^&*()_!#@V
```

Unfortunately the demo ldap server could not parse this password because it calls `Strings.toLowerCaseAscii(line)` on each line of the ldif file. After I temporary removed the toLowerCase I was able to start the demo ldap with this config.

I checked the login on the knox ui using the knoxsso topology and I was able to successfully login.
