### PR TITLE
KNOX-2814 - Run shellcheck for GitHub Actions too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,4 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: 'Build and Test'
-        run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V
-# This is failing due to not finding files? - See KNOX-2347
-#      - name: shellcheck
-#        uses: reviewdog/action-shellcheck@v1
-#        with:
-#          pattern: "*release*/home/bin/*.sh"
-
+        run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Dshellcheck=true -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V

--- a/gateway-release-common/pom.xml
+++ b/gateway-release-common/pom.xml
@@ -32,7 +32,6 @@
   
   <profiles>
         <profile>
-           <!-- Running this profile require you to have the 'shellcheck' tool installed on your DEV environment. Check out https://github.com/koalaman/shellcheck#installing for more information -->
            <activation>
                <property>
                    <name>shellcheck</name>

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -169,7 +169,6 @@
             </build>
         </profile>
         <profile>
-           <!-- Running this profile require you to have the 'shellcheck' tool installed on your DEV environment. Check out https://github.com/koalaman/shellcheck#installing for more information -->
            <activation>
                <property>
                    <name>shellcheck</name>

--- a/gateway-shell-release/pom.xml
+++ b/gateway-shell-release/pom.xml
@@ -169,7 +169,6 @@
             </build>
         </profile>
         <profile>
-           <!-- Running this profile require you to have the 'shellcheck' tool installed on your DEV environment. Check out https://github.com/koalaman/shellcheck#installing for more information -->
            <activation>
                <property>
                    <name>shellcheck</name>


### PR DESCRIPTION
## What changes were proposed in this pull request?

I'd like to make sure that Knox's GH actions flow includes the previously added/configured `shellcheck` plugin.

## How was this patch tested?

After creating this PR I'm going to check if the `shellcheck` plugin was enabled and executed in the affected Maven sub-modules.
