### PR TITLE
KNOX-2825 - Webshell - Only add Default provider iff it is found in the provider contributor map

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/deploy/DeploymentFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/deploy/DeploymentFactory.java
@@ -260,7 +260,13 @@ public abstract class DeploymentFactory {
     // for some tests the number of providers are limited to the classpath of the module
     // and exceptions will be thrown as topologies are deployed even though they will
     // work fine at actual server runtime.
-    if (PROVIDER_CONTRIBUTOR_MAP.get("identity-assertion") != null) {
+
+    // SRM: Only add "Default" provider iff it is found in the provider contributor map
+    // There could be cases where service loader might find other
+    // identity-assertion providers e.g. JWTAuthCodeAsserter
+    if (PROVIDER_CONTRIBUTOR_MAP.get("identity-assertion") != null &&
+        PROVIDER_CONTRIBUTOR_MAP.get("identity-assertion").keySet() != null &&
+        PROVIDER_CONTRIBUTOR_MAP.get("identity-assertion").keySet().contains("Default")) {
       // check for required providers and add the defaults if missing
       if (!providerMap.containsKey("identity-assertion")) {
         Provider idassertion = new Provider();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Only add "Default" provider iff it is found in the provider contributor map. There could be cases where service loader might find other identity-assertion providers e.g. JWTAuthCodeAsserter

## How was this patch tested?
Tested locally