### PR TITLE
KNOX-2827 - isDispatchAllowed should cut off path segments from the URL

### DIFF
--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/GatewayDispatchFilterTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/GatewayDispatchFilterTest.java
@@ -229,6 +229,15 @@ public class GatewayDispatchFilterTest {
                                     true);
   }
 
+  @Test
+  public void testIgnorePathSegmentsAndQueryParams() throws Exception {
+    final String serviceRole = "TESTROLE";
+    doTestServiceDispatchWhitelist(Collections.singletonList(serviceRole),
+            "^https://localhost:[0-9]+/?$",
+            serviceRole,
+            "https://localhost:1234/any/path?any=query",
+            true);
+  }
 
   private void doTestServiceDispatchWhitelist(List<String> whitelistedServices,
                                               String       whitelist,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In isDispatchAllowed we check the full URL against the whitelist regexp (including /path, but not including query parameters). This makes complicated and error prone to configure the regular expression.

## How was this patch tested?

gateway-site.xml

```xml
<property>
      <name>gateway.dispatch.whitelist.services</name>
      <value>HBASEUI,DATANODE,HBASEUI,HDFSUI,JOBHISTORYUI,NODEUI,YARNUI,knoxauth</value>
      <description>The comma-delimited list of service roles for which the gateway.dispatch.whitelist should be applied.</description>
</property>
```

Tested manually.

