### PR TITLE
KNOX-2829 - Impersonation is disabled if knox.token.impersonation.enabled is not added in the KNOXTOKEN service configuration

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -50,4 +50,8 @@ public interface HadoopAuthMessages {
 
   @Message(level=MessageLevel.WARN, text="{1} alias is NOT stored on neither topology ({0}) nor gateway levels.")
   void noAliasStored(String cluster, String alias);
+
+  @Message(level=MessageLevel.DEBUG, text="Refreshing proxyuser config in {0} topology with prefix {1} and config {2}")
+  void refreshProxyuserConfig(String topology, String prefix, String properties);
+
 }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -114,11 +114,13 @@ public class HadoopAuthFilter extends
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
+    final String topologyName = (String) filterConfig.getInitParameter("clusterName");
     // Return a {@link Configuration} instance with the proxy user
     // (<code>hadoop.proxyuser.*</code>) properties set using parameter information
     // from the filterConfig.
     final Configuration conf = AuthFilterUtils.getProxyUserConfiguration(filterConfig, PROXYUSER_PREFIX);
     ProxyUsers.refreshSuperUserGroupsConfiguration(conf, PROXYUSER_PREFIX);
+    LOG.refreshProxyuserConfig(topologyName, PROXYUSER_PREFIX, conf.getPropsWithPrefix(PROXYUSER_PREFIX).toString());
 
     Collection<String> ignoredServices = null;
 

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -138,6 +138,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     expect(filterConfig.getServletContext()).andReturn(servletContext).atLeastOnce();
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
     Properties configProperties = createMock(Properties.class);
     expect(configProperties.getProperty("signature.secret.file")).andReturn("signature.secret.file").atLeastOnce();
@@ -201,6 +202,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("config.prefix")).andReturn("some.prefix").atLeastOnce();
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
 
     EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -248,6 +250,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -306,6 +309,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -364,6 +368,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -422,6 +427,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -481,6 +487,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -554,6 +561,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("config.prefix")).andReturn("some.prefix").atLeastOnce();
     expect(filterConfig.getInitParameter("support.jwt")).andReturn(supportJwt).anyTimes();
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
     final boolean isJwtSupported = Boolean.parseBoolean(supportJwt);
     if (isJwtSupported) {
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_AUDIENCES)).andReturn(null).anyTimes();

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -274,7 +274,7 @@ public class TokenResource {
     // management status (i.e. even if token state management is enabled users
     // should be able to opt-out token impersonation
     final String impersonationEnabledValue = context.getInitParameter(IMPERSONATION_ENABLED_PARAM);
-    impersonationEnabled = impersonationEnabledValue == null ? Boolean.TRUE : Boolean.parseBoolean(impersonationEnabledValue);
+    impersonationEnabled = impersonationEnabledValue == null ? Boolean.FALSE : Boolean.parseBoolean(impersonationEnabledValue);
 
     // If server-managed token expiration is configured, set the token state service
     if (isServerManagedTokenStateEnabled()) {
@@ -327,6 +327,7 @@ public class TokenResource {
       if (impersonationEnabled) {
         final Configuration conf = AuthFilterUtils.getProxyUserConfiguration(context, PROXYUSER_PREFIX);
         ProxyUsers.refreshSuperUserGroupsConfiguration(conf, PROXYUSER_PREFIX);
+        log.refreshProxyuserConfig(topologyName, PROXYUSER_PREFIX, conf.getPropsWithPrefix(PROXYUSER_PREFIX).toString());
       }
     }
     setTokenStateServiceStatusMap();
@@ -730,7 +731,7 @@ public class TokenResource {
           AuthFilterUtils.authorizeImpersonationRequest(request, doAsUser);
           createdBy = userName;
           userName = doAsUser;
-          log.tokenImpersonationSuccess(userName, doAsUser);
+          log.tokenImpersonationSuccess(createdBy, doAsUser);
         } catch (AuthorizationException e) {
           log.tokenImpersonationFailed(e);
           return Response.status(Response.Status.FORBIDDEN).entity("{ \"" + e.getMessage() + "\" }").build();

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -95,4 +95,7 @@ public interface TokenServiceMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "Token impersonation failed: {0}" )
   void tokenImpersonationFailed(@StackTrace Throwable t);
+
+  @Message(level=MessageLevel.DEBUG, text="Refreshing proxyuser config in {0} topology with prefix {1} and config {2}")
+  void refreshProxyuserConfig(String topology, String prefix, String properties);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the default value of `knox.token.impersonation.enabled` and added some helpful DEBUG-level log messages.

## How was this patch tested?

Tested in a live cluster with more than one topology w/ the `KNOXTOKEN` service with different parameter list.
