### PR TITLE
fix validation errors of getPID: return 0 when the process started

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -232,12 +232,20 @@ function getPID {
       printf "Can't find PID dir.\n"
       exit 1
    fi
-   if [ ! -f "$APP_PID_FILE" ]; then
+
+   getPidByCommand
+
+   if [ ! -f "$APP_PID_FILE" ] && [ -z $APP_GATEWAY_PID ]; then
      APP_PID=0
      return 1
    fi
 
    APP_PID="$(<"$APP_PID_FILE")"
+
+   PID_EXIST=$(ps aux | awk '{print $2}'| grep -w $APP_PID)
+   if [ ! $PID_EXIST ];then
+	    APP_PID=$APP_GATEWAY_PID
+   fi
 
    ps -p "$APP_PID" > /dev/null
    # if the exit code was 1 then it isn't running
@@ -247,6 +255,14 @@ function getPID {
    fi
 
    return 0
+}
+
+function getPidByCommand {
+   APP_GATEWAY_PID=` ps ax | grep 'java.*'$APP_NAME'.jar' | grep -v grep | awk '{print $1}'`
+   if [ -z $APP_GATEWAY_PID ];then
+     return 0
+   fi
+   return 1
 }
 
 function appStart {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some cases  getPID will return 0 even if the process started. e.g. pid file is deleted or file is modified and we can not get 
correct pid from the file.  So I add a new function getPidByCommand. It will give the correct pid (APP_GATEWAY_PID ) if process is started. And we'll check the process whether it is started according to APP_PID obtained from pid file ,if it return false ,use APP_GATEWAY_PID  . set APP_PID=$APP_GATEWAY_PID.In this way,we can get correct messagge whether the gateway or ldap process is started

## How was this patch tested?
1.  start gateway or ldap process 
2.  delete pid file or modify the content in file
3.  execute gateway.sh status or ldap.sh status . It will return correct message 
 

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
