### PR TITLE
KNOX-2831 - Make Hadoop impersonation work across topologies and roles with different proxyuser configs

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -51,7 +51,4 @@ public interface HadoopAuthMessages {
   @Message(level=MessageLevel.WARN, text="{1} alias is NOT stored on neither topology ({0}) nor gateway levels.")
   void noAliasStored(String cluster, String alias);
 
-  @Message(level=MessageLevel.DEBUG, text="Refreshing proxyuser config in {0} topology with prefix {1} and config {2}")
-  void refreshProxyuserConfig(String topology, String prefix, String properties);
-
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -61,13 +61,12 @@ import com.nimbusds.jose.crypto.MACSigner;
 import com.nimbusds.jose.util.ByteUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.authorize.AuthorizationException;
-import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.security.GroupPrincipal;
 import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.knox.gateway.service.knoxtoken.deploy.TokenServiceDeploymentContributor;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -325,9 +324,7 @@ public class TokenResource {
       // refreshing Hadoop ProxyUser groups config only makes sense if token state management is turned on
       // and impersonation is enabled
       if (impersonationEnabled) {
-        final Configuration conf = AuthFilterUtils.getProxyUserConfiguration(context, PROXYUSER_PREFIX);
-        ProxyUsers.refreshSuperUserGroupsConfiguration(conf, PROXYUSER_PREFIX);
-        log.refreshProxyuserConfig(topologyName, PROXYUSER_PREFIX, conf.getPropsWithPrefix(PROXYUSER_PREFIX).toString());
+        AuthFilterUtils.refreshSuperUserGroupsConfiguration(context, PROXYUSER_PREFIX, getTopologyName(), TokenServiceDeploymentContributor.ROLE);
       }
     }
     setTokenStateServiceStatusMap();
@@ -728,7 +725,7 @@ public class TokenResource {
       if (doAsUser != null && !doAsUser.equals(userName)) {
         try {
           //this call will authorize the doAs request
-          AuthFilterUtils.authorizeImpersonationRequest(request, doAsUser);
+          AuthFilterUtils.authorizeImpersonationRequest(request, doAsUser, getTopologyName(), TokenServiceDeploymentContributor.ROLE);
           createdBy = userName;
           userName = doAsUser;
           log.tokenImpersonationSuccess(createdBy, doAsUser);

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -96,6 +96,4 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.DEBUG, text = "Token impersonation failed: {0}" )
   void tokenImpersonationFailed(@StackTrace Throwable t);
 
-  @Message(level=MessageLevel.DEBUG, text="Refreshing proxyuser config in {0} topology with prefix {1} and config {2}")
-  void refreshProxyuserConfig(String topology, String prefix, String properties);
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/deploy/TokenServiceDeploymentContributor.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/deploy/TokenServiceDeploymentContributor.java
@@ -21,9 +21,11 @@ import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
 
 public class TokenServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
 
+  public static final String ROLE = "KNOXTOKEN";
+
   @Override
   public String getRole() {
-    return "KNOXTOKEN";
+    return ROLE;
   }
 
   @Override

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -155,6 +155,7 @@ public class TokenServiceResourceTest {
     context = EasyMock.createNiceMock(ServletContext.class);
     contextExpectations.forEach((key, value) -> EasyMock.expect(context.getInitParameter(key)).andReturn(value).anyTimes());
     EasyMock.expect(context.getInitParameterNames()).andReturn(Collections.enumeration(contextExpectations.keySet())).anyTimes();
+    EasyMock.expect(context.getAttribute("org.apache.knox.gateway.gateway.cluster")).andReturn("topology1").anyTimes();
     request = EasyMock.createNiceMock(HttpServletRequest.class);
     EasyMock.expect(request.getServletContext()).andReturn(context).anyTimes();
     Principal principal = EasyMock.createNiceMock(Principal.class);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -81,4 +81,7 @@ public interface GatewaySpiMessages {
 
   @Message(level = MessageLevel.WARN, text = "Duplicated filter param key: {0}")
   void duplicatedFilterParamKey(String name);
+
+  @Message(level=MessageLevel.DEBUG, text="Creating impersonation provider in {0} / {1} with prefix {2} and config {3}")
+  void createImpersonationProvider(String topology, String role, String prefix, String properties);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prior to my changes, both Knox's `HadoopAuthFilter` and `TokenResource` classes used Hadoop's `ProxyUsers` class that maintains a static `ImpersonationProvider` instance and invokes delegation methods on that. Subsequent `ProxyUsers.refreshSuperUserGroupsConfiguration` calls overwrite this impersonation provider. This causes a problem in the following cases:
- end-users have multiple Knox topologies where token impersonation enabled with different proxyuser configurations in the `KNOXTOKEN` service
- even in the same topology if the authentication method is Kerberos (thus we have the `HadoopAuth` filter enabled and configured) and the `KNOXTOKEN` service with impersonation enabled with another proxuyser configuration

The solution is to eliminate the need for this static `ProxyUsers` factory and have the `ImpersonationProvider` instances created and stored in a map on topology/role level.

## How was this patch tested?

After deploying Knox with y changes, I duplicated the the `homepage` topology and re-configured the proxyuser settings:
- homepage.xml - `admin` can impersonate anyone
```
      <param>
          <name>knox.token.impersonation.enabled</name>
          <value>true</value>
      </param>
      <param>
          <name>knox.token.proxyuser.admin.users</name>
          <value>*</value>
      </param>
      <param>
          <name>knox.token.proxyuser.admin.groups</name>
          <value>*</value>
      </param>
      <param>
          <name>knox.token.proxyuser.admin.hosts</name>
          <value>*</value>
      </param>
```
- homepage_2.xml - `guest` can impersonate anyone
```
      <param>
          <name>knox.token.impersonation.enabled</name>
          <value>true</value>
      </param>
      <param>
          <name>knox.token.proxyuser.guest.users</name>
          <value>*</value>
      </param>
      <param>
          <name>knox.token.proxyuser.guest.groups</name>
          <value>*</value>
      </param>
      <param>
          <name>knox.token.proxyuser.guest.hosts</name>
          <value>*</value>
      </param>
```
Then I generated impersonated tokens for`user1` and `user2` on behalf of the `admin` user using the `homepage` topology and on behalf of the `guest` user using the `homepage_2` topology. All tokens were generated successfully (as opposed to what I experienced before my changes; see the [KNOX-2831](https://issues.apache.org/jira/browse/KNOX-2831)):
```
postgres=> select * from knox_tokens kt, knox_token_metadata meta where kt.token_id = meta.token_id ORDER by kt.issue_time;
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               |  md_name  |                                           md_value                                           
--------------------------------------+---------------+---------------+---------------+--------------------------------------+-----------+----------------------------------------------------------------------------------------------
 2b107f91-6808-40c4-a21c-2f0cd7b0517a | 1666863575514 | 1666899575273 | 1667468375514 | 2b107f91-6808-40c4-a21c-2f0cd7b0517a | passcode  | 77+977+9aN+f3aHvv71oUkwO77+977+9WRvvv73vv73vv70A77+9Fe+/vS3vv70Q77+977+9UAx977+9
 2b107f91-6808-40c4-a21c-2f0cd7b0517a | 1666863575514 | 1666899575273 | 1667468375514 | 2b107f91-6808-40c4-a21c-2f0cd7b0517a | enabled   | true
 2b107f91-6808-40c4-a21c-2f0cd7b0517a | 1666863575514 | 1666899575273 | 1667468375514 | 2b107f91-6808-40c4-a21c-2f0cd7b0517a | createdBy | guest
 2b107f91-6808-40c4-a21c-2f0cd7b0517a | 1666863575514 | 1666899575273 | 1667468375514 | 2b107f91-6808-40c4-a21c-2f0cd7b0517a | userName  | user2
 2b107f91-6808-40c4-a21c-2f0cd7b0517a | 1666863575514 | 1666899575273 | 1667468375514 | 2b107f91-6808-40c4-a21c-2f0cd7b0517a | comment   | guest token for user2
 aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | 1666863636583 | 1666899636571 | 1667468436583 | aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | passcode  | au+/vdKt77+977+9Au+/ve+/ve+/ve+/vXrvv71Z77+9K++/vRPvv73vv73vv73vv73GnO+/vWTvv73vv70SLO+/vQ==
 aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | 1666863636583 | 1666899636571 | 1667468436583 | aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | enabled   | true
 aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | 1666863636583 | 1666899636571 | 1667468436583 | aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | createdBy | admin
 aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | 1666863636583 | 1666899636571 | 1667468436583 | aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | userName  | user1
 aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | 1666863636583 | 1666899636571 | 1667468436583 | aa8dc15e-3253-4b49-ac65-97d7db1af1c3 | comment   | admin token for user1
 e51e760f-1df7-4341-92aa-9a9b73a9cab5 | 1666863653051 | 1666899653040 | 1667468453051 | e51e760f-1df7-4341-92aa-9a9b73a9cab5 | passcode  | Mng777+977+9ZSBp77+9YRDvv718xLnvv70NTBlGbzDvv71w77+9O++/vcSB77+9UXg=
 e51e760f-1df7-4341-92aa-9a9b73a9cab5 | 1666863653051 | 1666899653040 | 1667468453051 | e51e760f-1df7-4341-92aa-9a9b73a9cab5 | enabled   | true
 e51e760f-1df7-4341-92aa-9a9b73a9cab5 | 1666863653051 | 1666899653040 | 1667468453051 | e51e760f-1df7-4341-92aa-9a9b73a9cab5 | createdBy | guest
 e51e760f-1df7-4341-92aa-9a9b73a9cab5 | 1666863653051 | 1666899653040 | 1667468453051 | e51e760f-1df7-4341-92aa-9a9b73a9cab5 | userName  | user2
 e51e760f-1df7-4341-92aa-9a9b73a9cab5 | 1666863653051 | 1666899653040 | 1667468453051 | e51e760f-1df7-4341-92aa-9a9b73a9cab5 | comment   | 2nd guest token for user2
 fe678d59-aaea-430e-8b2f-e3471cc65e29 | 1666863684763 | 1666899684752 | 1667468484763 | fe678d59-aaea-430e-8b2f-e3471cc65e29 | passcode  | aSdFBjfvv70abE8I77+9cGVx77+9Re+/ve+/vVIS77+93otX26nvv71NFB3vv70=
 fe678d59-aaea-430e-8b2f-e3471cc65e29 | 1666863684763 | 1666899684752 | 1667468484763 | fe678d59-aaea-430e-8b2f-e3471cc65e29 | enabled   | true
 fe678d59-aaea-430e-8b2f-e3471cc65e29 | 1666863684763 | 1666899684752 | 1667468484763 | fe678d59-aaea-430e-8b2f-e3471cc65e29 | createdBy | admin
 fe678d59-aaea-430e-8b2f-e3471cc65e29 | 1666863684763 | 1666899684752 | 1667468484763 | fe678d59-aaea-430e-8b2f-e3471cc65e29 | userName  | user1
 fe678d59-aaea-430e-8b2f-e3471cc65e29 | 1666863684763 | 1666899684752 | 1667468484763 | fe678d59-aaea-430e-8b2f-e3471cc65e29 | comment   | 2nd admin token for user1
 860bf063-8088-44b5-9b91-dc1ba098ede6 | 1666864008506 | 1666900008479 | 1667468808506 | 860bf063-8088-44b5-9b91-dc1ba098ede6 | passcode  | 77+977+9CBsreu+/vVotLwZ677+9D++/ve+/ve+/vXTvv71mHO+/vSLRjCA5U3/vv70=
 860bf063-8088-44b5-9b91-dc1ba098ede6 | 1666864008506 | 1666900008479 | 1667468808506 | 860bf063-8088-44b5-9b91-dc1ba098ede6 | enabled   | true
 860bf063-8088-44b5-9b91-dc1ba098ede6 | 1666864008506 | 1666900008479 | 1667468808506 | 860bf063-8088-44b5-9b91-dc1ba098ede6 | createdBy | guest
 860bf063-8088-44b5-9b91-dc1ba098ede6 | 1666864008506 | 1666900008479 | 1667468808506 | 860bf063-8088-44b5-9b91-dc1ba098ede6 | userName  | user2
 860bf063-8088-44b5-9b91-dc1ba098ede6 | 1666864008506 | 1666900008479 | 1667468808506 | 860bf063-8088-44b5-9b91-dc1ba098ede6 | comment   | 3rd guest token for user2
 c733ee76-622c-4a19-ad4e-fed262ef9d01 | 1666864017664 | 1666900017652 | 1667468817664 | c733ee76-622c-4a19-ad4e-fed262ef9d01 | passcode  | S9WyKmnvv73vv73vv73vv73vv70z77+977+977+9NlDvv73vv73vv73vv70N77+9SBTvv71077+9WSPvv73vv70=
 c733ee76-622c-4a19-ad4e-fed262ef9d01 | 1666864017664 | 1666900017652 | 1667468817664 | c733ee76-622c-4a19-ad4e-fed262ef9d01 | enabled   | true
 c733ee76-622c-4a19-ad4e-fed262ef9d01 | 1666864017664 | 1666900017652 | 1667468817664 | c733ee76-622c-4a19-ad4e-fed262ef9d01 | createdBy | guest
 c733ee76-622c-4a19-ad4e-fed262ef9d01 | 1666864017664 | 1666900017652 | 1667468817664 | c733ee76-622c-4a19-ad4e-fed262ef9d01 | userName  | user1
 c733ee76-622c-4a19-ad4e-fed262ef9d01 | 1666864017664 | 1666900017652 | 1667468817664 | c733ee76-622c-4a19-ad4e-fed262ef9d01 | comment   | guest token for user1
 392cabee-e9d3-491a-9edf-97974749ffad | 1666864038730 | 1666900038554 | 1667468838730 | 392cabee-e9d3-491a-9edf-97974749ffad | passcode  | Qe+/veePjUHvv73vv70077+9O0nvv73vv73ak3nvv73vv71K77+9au+/ve+/ve+/vUYfeBTvv73vv71T
 392cabee-e9d3-491a-9edf-97974749ffad | 1666864038730 | 1666900038554 | 1667468838730 | 392cabee-e9d3-491a-9edf-97974749ffad | enabled   | true
 392cabee-e9d3-491a-9edf-97974749ffad | 1666864038730 | 1666900038554 | 1667468838730 | 392cabee-e9d3-491a-9edf-97974749ffad | createdBy | admin
 392cabee-e9d3-491a-9edf-97974749ffad | 1666864038730 | 1666900038554 | 1667468838730 | 392cabee-e9d3-491a-9edf-97974749ffad | userName  | user1
 392cabee-e9d3-491a-9edf-97974749ffad | 1666864038730 | 1666900038554 | 1667468838730 | 392cabee-e9d3-491a-9edf-97974749ffad | comment   | 3rd test token for user1
 e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | 1666864047038 | 1666900047026 | 1667468847038 | e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | passcode  | Ie+/vSrvv73vv73vv71ARBrvv71E77+9au+/vTTvv73vv718Ve+/ve+/vVDvv73vv70iYwTvv71wIijvv70=
 e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | 1666864047038 | 1666900047026 | 1667468847038 | e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | enabled   | true
 e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | 1666864047038 | 1666900047026 | 1667468847038 | e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | createdBy | admin
 e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | 1666864047038 | 1666900047026 | 1667468847038 | e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | userName  | user2
 e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | 1666864047038 | 1666900047026 | 1667468847038 | e5b99abb-82ba-4b7f-982a-380fd1d4aa89 | comment   | admin token for user2
(40 rows)
```