### PR TITLE
KNOX-2840 - SecureKnoxShellTest broken

### DIFF
--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -285,6 +285,13 @@
         </dependency>
 
         <dependency>
+             <groupId>org.mockito</groupId>
+             <artifactId>mockito-core</artifactId>
+             <version>${mockito.version}</version>
+             <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-release</artifactId>
             <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <hsql.db.version>2.4.0</hsql.db.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
         <dom4j.version>2.1.3</dom4j.version>
-        <easymock.version>4.2</easymock.version>
+        <easymock.version>4.3</easymock.version>
         <eclipselink.version>2.7.8</eclipselink.version>
         <ehcache.version>2.6.11</ehcache.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
@@ -248,6 +248,7 @@
         <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
         <metrics.version>4.1.16</metrics.version>
         <mina.version>2.0.22</mina.version>
+        <mockito.version>4.8.1</mockito.version>
         <netty.version>4.1.77.Final</netty.version>
         <nimbus-jose-jwt.version>8.14.1</nimbus-jose-jwt.version>
         <nodejs.version>v12.20.2</nodejs.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

SecureKnoxShellTest was broken due to a NoClassDefFound error. It seems miniDFS now requires mockito, which needed to be added to Knox test dependencies.

## How was this patch tested?

mvn -Ppackage,release clean verify

