### PR TITLE
KNOX-2841 Oozie "root" rewrite rule's pattern is too open

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/oozie/5.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/oozie/5.0.0/rewrite.xml
@@ -16,7 +16,7 @@
 -->
 <rules>
 
-    <rule dir="IN" name="OOZIE/oozie/root" pattern="*://*:*/**/oozie/{**}?{**}">
+    <rule dir="IN" name="OOZIE/oozie/root" pattern="http*://*:*/**/oozie/{**}?{**}">
         <rewrite template="{$serviceUrl[OOZIE]}/{**}?{**}"/>
     </rule>
 


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Oozie's "root" rewrite rule must be more strict making it not to match to HDFS paths like "hdfs://namespace/oozie/libraries"

## How was this patch tested?

I did manual test steps in my environment:
 * I run an Oozie job using Hue having a workflow property: prop1=hdfs://namespace/oozie/libraries
 * checked the value is broken
 * then I edited /var/lib/knox/gateway/data/services/oozie/5.0.0/rewrite.xml to apply the change
 * then restarted Knox
 * then waited two minutes
 * then started the same Oozie workflow via Hue
then I experienced on the issue is gone. I did revert the change, tun the whole again then the issue came again. Then repeated the whole with the fix and the issue has gone again.
