### PR TITLE
KNOX-2844 - Remote config monitor should not automatically delete local files if they're missing from the DB

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -767,4 +767,12 @@ public interface GatewayMessages {
   @Message(level = MessageLevel.DEBUG,
           text = "Creating local {0} with name {1}")
   void creatingLocalDescriptorProvider(String type, String name);
+
+  @Message(level = MessageLevel.DEBUG,
+          text = "Cleaning remote configuration db. Deleting logically deleted rows which are older than {0} seconds.")
+  void cleaningRemoteConfigTables(int cleanUpPeriodSeconds);
+
+  @Message(level = MessageLevel.INFO,
+          text = "Initializing remote configuration db. Sync interval={0} seconds. Clean up interval={1} seconds.")
+  void initDbRemoteConfigMonitor(long syncIntervalSeconds, int cleanUpPeriodSeconds);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -245,8 +245,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.poll.interval.seconds";
   private static final long REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS_DEFAULT = 30;
 
-  private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_HOURS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.cleanup.period.hours";
-  private static final int REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_DEFAULT = 2;
+  private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_SECONDS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.cleanup.period.hours";
+  private static final int REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_DEFAULT = 3 * 60 * 60;
 
   /* @since 1.1.0 Default discovery configuration */
   static final String DEFAULT_DISCOVERY_ADDRESS = GATEWAY_CONFIG_FILE_PREFIX + ".discovery.default.address";
@@ -1438,8 +1438,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public int getDbRemoteConfigMonitorCleanUpPeriod() {
-    return getInt(REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_HOURS, REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_DEFAULT);
+  public int getDbRemoteConfigMonitorCleanUpInterval() {
+    return getInt(REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_SECONDS, REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_DEFAULT);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -245,7 +245,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.poll.interval.seconds";
   private static final long REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS_DEFAULT = 30;
 
-  private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_SECONDS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.cleanup.period.hours";
+  private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_SECONDS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.cleanup.interval.seconds";
   private static final int REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_INTERVAL_DEFAULT = 3 * 60 * 60;
 
   /* @since 1.1.0 Default discovery configuration */

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -243,7 +243,10 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
                                                   REMOTE_CONFIG_MONITOR_CLIENT_NAME + ".allowUnauthenticatedReadAccess";
 
   private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.poll.interval.seconds";
-  private static final long REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS_DEFAULT = 15;
+  private static final long REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS_DEFAULT = 30;
+
+  private static final String REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_HOURS = GATEWAY_CONFIG_FILE_PREFIX + ".remote.config.monitor.db.cleanup.period.hours";
+  private static final int REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_DEFAULT = 2;
 
   /* @since 1.1.0 Default discovery configuration */
   static final String DEFAULT_DISCOVERY_ADDRESS = GATEWAY_CONFIG_FILE_PREFIX + ".discovery.default.address";
@@ -1432,6 +1435,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public long getDbRemoteConfigMonitorPollingInterval() {
     return getLong(REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS, REMOTE_CONFIG_MONITOR_DB_POLLING_INTERVAL_SECONDS_DEFAULT);
+  }
+
+  @Override
+  public int getDbRemoteConfigMonitorCleanUpPeriod() {
+    return getInt(REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_HOURS, REMOTE_CONFIG_MONITOR_DB_POLLING_CLEANUP_PERIOD_DEFAULT);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -503,14 +503,14 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
   public boolean deleteDescriptor(String name) {
     boolean result;
 
-    if (remoteMonitor != null) {
-      // If the remote config monitor is configured, delete the descriptor from the remote registry
-      remoteMonitor.deleteDescriptor(name);
-    }
-
     // Whether the remote configuration registry is being employed or not, delete the local file
     File descriptor = getExistingFile(descriptorsDirectory, name);
     result = (descriptor == null) || descriptor.delete();
+
+    if (remoteMonitor != null && descriptor != null) {
+      // If the remote config monitor is configured, delete the descriptor from the remote registry
+      remoteMonitor.deleteDescriptor(descriptor.getName());
+    }
 
     return result;
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -654,8 +654,10 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
       log.configuredMonitoringProviderConfigChangesInDirectory(sharedProvidersDirectory.getAbsolutePath());
 
       // Initialize the remote configuration monitor, if it has been configured
-      RemoteConfigurationMonitorServiceFactory provider = new RemoteConfigurationMonitorServiceFactory();
-      remoteMonitor = (RemoteConfigurationMonitor) provider.create(gwServices, ServiceType.REMOTE_CONFIGURATION_MONITOR, config, Collections.emptyMap());
+      if (gwServices != null) { // if it was called from knoxcli, we don't have gwServices
+        RemoteConfigurationMonitorServiceFactory provider = new RemoteConfigurationMonitorServiceFactory();
+        remoteMonitor = (RemoteConfigurationMonitor) provider.create(gwServices, ServiceType.REMOTE_CONFIGURATION_MONITOR, config, Collections.emptyMap());
+      }
 
     } catch (Exception e) {
       throw new ServiceLifecycleException(e.getMessage(), e);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorServiceFactory.java
@@ -57,7 +57,12 @@ public class RemoteConfigurationMonitorServiceFactory extends AbstractServiceFac
             LocalDirectory descriptorDir = new LocalDirectory(new File(config.getGatewayDescriptorsDir()));
             LocalDirectory providerDir = new LocalDirectory(new File(config.getGatewayProvidersConfigDir()));
             return new DbRemoteConfigurationMonitorService(
-                    db, providerDir, descriptorDir, config.getDbRemoteConfigMonitorPollingInterval());
+                    db,
+                    providerDir,
+                    descriptorDir,
+                    config.getDbRemoteConfigMonitorPollingInterval(),
+                    config.getDbRemoteConfigMonitorCleanUpPeriod()
+            );
         } catch (SQLException | AliasServiceException e) {
             throw new ServiceLifecycleException("Cannot create DbRemoteConfigurationMonitor", e);
         }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorServiceFactory.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -36,6 +37,8 @@ import org.apache.knox.gateway.util.JDBCUtils;
 
 
 public class RemoteConfigurationMonitorServiceFactory extends AbstractServiceFactory {
+    private static final String DEFAULT_IMPLEMENTATION = ZkRemoteConfigurationMonitorService.class.getName();
+
     @Override
     protected RemoteConfigurationMonitor createService(GatewayServices gatewayServices,
                                     ServiceType serviceType,
@@ -43,6 +46,9 @@ public class RemoteConfigurationMonitorServiceFactory extends AbstractServiceFac
                                     Map<String, String> options,
                                     String implementation) throws ServiceLifecycleException {
         RemoteConfigurationMonitor service = null;
+        if (StringUtils.isBlank(implementation) && gatewayConfig.getRemoteConfigurationMonitorClientName() != null) {
+            implementation = DEFAULT_IMPLEMENTATION; // for backward compatibility
+        }
         if (matchesImplementation(implementation, ZkRemoteConfigurationMonitorService.class)) {
             service = new ZkRemoteConfigurationMonitorService(gatewayConfig, gatewayServices.getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE));
         } else if (matchesImplementation(implementation, DbRemoteConfigurationMonitorService.class)) {
@@ -75,6 +81,6 @@ public class RemoteConfigurationMonitorServiceFactory extends AbstractServiceFac
 
     @Override
     protected Collection<String> getKnownImplementations() {
-        return Arrays.asList(ZkRemoteConfigurationMonitorService.class.getName(), DbRemoteConfigurationMonitorService.class.getName());
+        return Arrays.asList(DEFAULT_IMPLEMENTATION, DbRemoteConfigurationMonitorService.class.getName());
     }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/RemoteConfigurationMonitorServiceFactory.java
@@ -61,7 +61,7 @@ public class RemoteConfigurationMonitorServiceFactory extends AbstractServiceFac
                     providerDir,
                     descriptorDir,
                     config.getDbRemoteConfigMonitorPollingInterval(),
-                    config.getDbRemoteConfigMonitorCleanUpPeriod()
+                    config.getDbRemoteConfigMonitorCleanUpInterval()
             );
         } catch (SQLException | AliasServiceException e) {
             throw new ServiceLifecycleException("Cannot create DbRemoteConfigurationMonitor", e);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/ZkRemoteConfigurationMonitorService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/ZkRemoteConfigurationMonitorService.java
@@ -238,7 +238,7 @@ class ZkRemoteConfigurationMonitorService implements RemoteConfigurationMonitor 
         boolean result = false;
         List<String> existingProviderConfigs = client.listChildEntries(entryParent);
         for (String entryName : existingProviderConfigs) {
-            if (FilenameUtils.getBaseName(entryName).equals(name)) {
+            if (FilenameUtils.getName(entryName).equals(name)) {
                 String entryPath = entryParent + "/" + entryName;
                 client.deleteEntry(entryPath);
                 result = !client.entryExists(entryPath);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/RemoteConfig.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/RemoteConfig.java
@@ -22,11 +22,17 @@ public class RemoteConfig {
   private final String name;
   private final String content;
   private final Instant lastModified;
+  private final boolean deleted;
 
   public RemoteConfig(String name, String content, Instant lastModified) {
+    this(name, content, lastModified, false);
+  }
+
+  public RemoteConfig(String name, String content, Instant lastModified, boolean deleted) {
     this.name = name;
     this.content = content;
     this.lastModified = lastModified;
+    this.deleted = deleted;
   }
 
   public String getName() {
@@ -39,5 +45,9 @@ public class RemoteConfig {
 
   public Instant getLastModified() {
     return lastModified;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/RemoteConfigDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/RemoteConfigDatabase.java
@@ -159,17 +159,18 @@ public class RemoteConfigDatabase {
   private boolean deleteLogical(String name, String tableName) {
     try (Connection connection = dataSource.getConnection();
          PreparedStatement statement = connection.prepareStatement(
-                 "UPDATE " + tableName + " SET deleted = ? WHERE name = ?")) {
+                 "UPDATE " + tableName + " SET deleted = ?, last_modified_time = ? WHERE name = ?")) {
       statement.setBoolean(1, true);
-      statement.setString(2, name);
+      statement.setTimestamp(2, Timestamp.from(Instant.now()));
+      statement.setString(3, name);
       return statement.executeUpdate() == 1;
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public int cleanTables(int olderThanHours) {
-    Instant instant = Instant.now().minusSeconds(olderThanHours * 60 * 60);
+  public int cleanTables(int olderThanSeconds) {
+    Instant instant = Instant.now().minusSeconds(olderThanSeconds);
     return cleanTable(KNOX_PROVIDERS_TABLE_NAME, instant)
             + cleanTable(KNOX_DESCRIPTORS_TABLE_NAME, instant);
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/RemoteConfigDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/RemoteConfigDatabase.java
@@ -55,10 +55,16 @@ public class RemoteConfigDatabase {
     }
   }
 
+  /**
+   * @return all remote providers, including the deleted ones
+   */
   public List<RemoteConfig> selectProviders() {
     return selectFrom(KNOX_PROVIDERS_TABLE_NAME);
   }
 
+  /**
+   * @return all remote descriptors, including the deleted one
+   */
   public List<RemoteConfig> selectDescriptors() {
     return selectFrom(KNOX_DESCRIPTORS_TABLE_NAME);
   }
@@ -66,10 +72,16 @@ public class RemoteConfigDatabase {
   private List<RemoteConfig> selectFrom(String tableName) {
     List<RemoteConfig> result = new ArrayList<>();
     try (Connection connection = dataSource.getConnection();
-         PreparedStatement statement = connection.prepareStatement("SELECT name, content, last_modified_time FROM " + tableName)) {
+         PreparedStatement statement = connection.prepareStatement(
+                 "SELECT name, content, last_modified_time, deleted FROM " + tableName)) {
       try (ResultSet rs = statement.executeQuery()) {
         while(rs.next()) {
-          result.add(new RemoteConfig(rs.getString(1), rs.getString(2), rs.getTimestamp(3).toInstant()));
+          result.add(new RemoteConfig(
+                  rs.getString(1),
+                  rs.getString(2),
+                  rs.getTimestamp(3).toInstant(),
+                  rs.getBoolean(4)
+          ));
         }
       }
     } catch (SQLException e) {
@@ -97,10 +109,11 @@ public class RemoteConfigDatabase {
       if (exists(name, tableName)) {
         try (Connection connection = dataSource.getConnection();
              PreparedStatement statement = connection.prepareStatement(
-                     "UPDATE " + tableName + " SET content = ?, last_modified_time = ? WHERE name = ?")) {
+                     "UPDATE " + tableName + " SET content = ?, last_modified_time = ?, deleted = ? WHERE name = ?")) {
           statement.setString(1, content);
           statement.setTimestamp(2, Timestamp.from(Instant.now()));
-          statement.setString(3, name);
+          statement.setBoolean(3, false);
+          statement.setString(4, name);
           return statement.executeUpdate() == 1;
         }
       } else {
@@ -129,20 +142,45 @@ public class RemoteConfigDatabase {
     }
   }
 
+  /**
+   * Logically delete a provider
+   */
   public boolean deleteProvider(String name) {
-    return delete(name, KNOX_PROVIDERS_TABLE_NAME);
+    return deleteLogical(name, KNOX_PROVIDERS_TABLE_NAME);
   }
 
+  /**
+   * Logically delete a descriptor
+   */
   public boolean deleteDescriptor(String name) {
-    return delete(name, KNOX_DESCRIPTORS_TABLE_NAME);
+    return deleteLogical(name, KNOX_DESCRIPTORS_TABLE_NAME);
   }
 
-  private boolean delete(String name, String tableName) {
+  private boolean deleteLogical(String name, String tableName) {
     try (Connection connection = dataSource.getConnection();
          PreparedStatement statement = connection.prepareStatement(
-                 "DELETE FROM " + tableName + " WHERE name = ?")) {
-      statement.setString(1, name);
+                 "UPDATE " + tableName + " SET deleted = ? WHERE name = ?")) {
+      statement.setBoolean(1, true);
+      statement.setString(2, name);
       return statement.executeUpdate() == 1;
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public int cleanTables(int olderThanHours) {
+    Instant instant = Instant.now().minusSeconds(olderThanHours * 60 * 60);
+    return cleanTable(KNOX_PROVIDERS_TABLE_NAME, instant)
+            + cleanTable(KNOX_DESCRIPTORS_TABLE_NAME, instant);
+  }
+
+  private int cleanTable(String tableName, Instant instant) {
+    try (Connection connection = dataSource.getConnection();
+         PreparedStatement statement = connection.prepareStatement(
+                 "DELETE FROM " + tableName + " WHERE deleted = ? AND last_modified_time <= ?")) {
+      statement.setBoolean(1, true);
+      statement.setTimestamp(2, Timestamp.from(instant));
+      return statement.executeUpdate();
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }

--- a/gateway-server/src/main/resources/createKnoxProvidersTable.sql
+++ b/gateway-server/src/main/resources/createKnoxProvidersTable.sql
@@ -17,5 +17,6 @@ CREATE TABLE IF NOT EXISTS KNOX_PROVIDERS ( -- IF NOT EXISTS syntax is not suppo
    name varchar(256) NOT NULL,
    content TEXT NOT NULL,
    last_modified_time TIMESTAMP NOT NULL,
+   deleted boolean DEFAULT false NOT NULL,
    PRIMARY KEY (name)
 )

--- a/gateway-server/src/main/resources/createKnoxTokenDescriptorsTable.sql
+++ b/gateway-server/src/main/resources/createKnoxTokenDescriptorsTable.sql
@@ -17,5 +17,6 @@ CREATE TABLE IF NOT EXISTS KNOX_DESCRIPTORS ( -- IF NOT EXISTS syntax is not sup
    name varchar(256) NOT NULL,
    content TEXT NOT NULL,
    last_modified_time TIMESTAMP NOT NULL,
+   deleted boolean DEFAULT false NOT NULL,
    PRIMARY KEY (name)
 )

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/monitor/db/DbRemoteConfigurationMonitorServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/monitor/db/DbRemoteConfigurationMonitorServiceTest.java
@@ -41,7 +41,7 @@ public class DbRemoteConfigurationMonitorServiceTest {
     db = EasyMock.createMock(RemoteConfigDatabase.class);
     providersDir = EasyMock.createMock(LocalDirectory.class);
     descriptorsDir = EasyMock.createMock(LocalDirectory.class);
-    monitor = new DbRemoteConfigurationMonitorService(db, providersDir, descriptorsDir, 60, 1);
+    monitor = new DbRemoteConfigurationMonitorService(db, providersDir, descriptorsDir, 60, 3600);
     monitor.start();
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/monitor/db/DbRemoteConfigurationMonitorServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/monitor/db/DbRemoteConfigurationMonitorServiceTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashSet;
 
 import org.easymock.EasyMock;
@@ -40,7 +41,7 @@ public class DbRemoteConfigurationMonitorServiceTest {
     db = EasyMock.createMock(RemoteConfigDatabase.class);
     providersDir = EasyMock.createMock(LocalDirectory.class);
     descriptorsDir = EasyMock.createMock(LocalDirectory.class);
-    monitor = new DbRemoteConfigurationMonitorService(db, providersDir, descriptorsDir, 60);
+    monitor = new DbRemoteConfigurationMonitorService(db, providersDir, descriptorsDir, 60, 1);
     monitor.start();
   }
 
@@ -75,13 +76,15 @@ public class DbRemoteConfigurationMonitorServiceTest {
 
   @Test
   public void testDeletesProviderFromFileSystem() throws Exception {
-    EasyMock.expect(providersDir.list()).andReturn(new HashSet<>(asList("local"))).anyTimes();
+    EasyMock.expect(providersDir.list()).andReturn(new HashSet<>(asList("to-be-deleted"))).anyTimes();
     EasyMock.expect(descriptorsDir.list()).andReturn(emptySet()).anyTimes();
 
+    EasyMock.expect(db.selectProviders()).andReturn(Arrays.asList(
+            new RemoteConfig("to-be-deleted", "any", NOW, true)
+    )).anyTimes();
     EasyMock.expect(db.selectDescriptors()).andReturn(emptyList()).anyTimes();
-    EasyMock.expect(db.selectProviders()).andReturn(emptyList()).anyTimes();
 
-    EasyMock.expect(providersDir.deleteFile("local")).andReturn(true).once();
+    EasyMock.expect(providersDir.deleteFile("to-be-deleted")).andReturn(true).once();
 
     EasyMock.replay(providersDir, descriptorsDir, db);
     monitor.sync();
@@ -109,7 +112,8 @@ public class DbRemoteConfigurationMonitorServiceTest {
     EasyMock.expect(providersDir.list()).andReturn(emptySet()).anyTimes();
     EasyMock.expect(descriptorsDir.list()).andReturn(new HashSet<>(asList("local"))).anyTimes();
 
-    EasyMock.expect(db.selectDescriptors()).andReturn(emptyList()).anyTimes();
+    EasyMock.expect(db.selectDescriptors()).andReturn(Arrays.asList(
+            new RemoteConfig("local", "any", NOW, true))).anyTimes();
     EasyMock.expect(db.selectProviders()).andReturn(emptyList()).anyTimes();
 
     EasyMock.expect(descriptorsDir.deleteFile("local")).andReturn(true).once();
@@ -136,7 +140,8 @@ public class DbRemoteConfigurationMonitorServiceTest {
 
     EasyMock.expect(db.selectDescriptors()).andReturn(asList(
             new RemoteConfig("desc1", "desc1-same-content", NOW),
-            new RemoteConfig("desc2", "desc2-remote-content", NOW)
+            new RemoteConfig("desc2", "desc2-remote-content", NOW),
+            new RemoteConfig("desc3-to-be-deleted", "any", NOW, true)
     )).anyTimes();
 
     // Expectations

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1016,6 +1016,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public int getDbRemoteConfigMonitorCleanUpPeriod() {
+    return 1;
+  }
+
+  @Override
   public long getConcurrentSessionVerifierExpiredTokensCleaningPeriod() {
     return 0;
   }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1016,7 +1016,7 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public int getDbRemoteConfigMonitorCleanUpPeriod() {
+  public int getDbRemoteConfigMonitorCleanUpInterval() {
     return 1;
   }
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -862,7 +862,7 @@ public interface GatewayConfig {
 
   long getDbRemoteConfigMonitorPollingInterval();
 
-  int getDbRemoteConfigMonitorCleanUpPeriod();
+  int getDbRemoteConfigMonitorCleanUpInterval();
 
   long getConcurrentSessionVerifierExpiredTokensCleaningPeriod();
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -862,6 +862,8 @@ public interface GatewayConfig {
 
   long getDbRemoteConfigMonitorPollingInterval();
 
+  int getDbRemoteConfigMonitorCleanUpPeriod();
+
   long getConcurrentSessionVerifierExpiredTokensCleaningPeriod();
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

[KNOX-2835](https://issues.apache.org/jira/browse/KNOX-2835) introduced an unwanted side effect after enabling the SQL based topology monitor.

The intent of  synchronization which was added in KNOX-2835 is:
 * If a descriptor/provider was deleted from the DB the monitor should delete the descriptor/provider from the local file system
 
But what really happens, implementation wise is that:

* If a descriptor/provider exists on the file system but doesn't exist in the DB the topology monitor is going to delete it.

These two are not exactly the same. If a user creates a descriptor/provider on the file system, it will be deleted by the topology monitor even though it never existed in the DB. The Zookeeper implementation uses onDeleteEvents which are only triggered when something was previously added but later it was deleted. But the SQL based topology uses polling.

So if one enable this feature with an empty DB, all of the descriptors/providers are going to be deleted.

To address this issue, this patch introduces logical deletes. Deleting a descriptor/provider only sets the delete=true column in the DB. The monitor only deletes a local file if a corresponding record exists in the DB and the delete column is set to true. If something never existed in the DB it'll never be deleted.

The logically deleted records are eventually cleared up to.

## How was this patch tested?

```xml
<property>
    <name>gateway.service.remoteconfigurationmonitor.impl</name>
    <value>org.apache.knox.gateway.topology.monitor.db.DbRemoteConfigurationMonitorService</value>
</property>
<property>
    <name>gateway.database.type</name>
    <value>mysql</value>
</property>
<property>
    <name>gateway.database.connection.url</name>
    <value>jdbc:mysql://root:root@localhost:3306/knox</value>
</property>
```

Tested manually with 3 instances of knox. I created a custom descriptor + provider via the admin UI and checked the file content on each host. I deleted a descriptor/provider and checked if the file disappeared from the hosts. I checked the DB content to see the delete=true flag. I waited until the record was physically deleted. 
I checked that existing topologies were not effected by the deletes.

