### PR TITLE
KNOX-2846 - Disabling org.apache.knox.gateway.websockets.GatewayWebsocketHandlerTest.testValidWebShellRequest()

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
@@ -33,6 +33,7 @@ import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -67,6 +68,7 @@ public class GatewayWebsocketHandlerTest {
     }
 
 
+    @Ignore("KNOX-2846 - Temporary ignoring until it's fixed in a way such as it passes GH runs too 100%")
     @Test
     public void testValidWebShellRequest() throws Exception{
         // mock GatewayConfig and GatewayServices


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disabled `GatewayWebsocketHandlerTest.testValidWebShellRequest()` temporarily. 

## How was this patch tested?

Let the build run here.
