### PR TITLE
KNOX-2846 - Fix GatewayWebsocketHandlerTest.testValidWebShellRequest

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
@@ -48,7 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*", "org.w3c.*"})
 @PrepareForTest({JWTValidatorFactory.class, MessagesFactory.class, GatewayWebsocketHandler.class, AuditServiceFactory.class})
 public class GatewayWebsocketHandlerTest {
     @BeforeClass

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
@@ -33,7 +33,6 @@ import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,8 +68,6 @@ public class GatewayWebsocketHandlerTest {
         EasyMock.replay(auditService,auditor);
     }
 
-
-    @Ignore("KNOX-2846 - Temporary ignoring until it's fixed in a way such as it passes GH runs too 100%")
     @Test
     public void testValidWebShellRequest() throws Exception{
         // mock GatewayConfig and GatewayServices

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/GatewayWebsocketHandlerTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -47,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*"})
 @PrepareForTest({JWTValidatorFactory.class, MessagesFactory.class, GatewayWebsocketHandler.class, AuditServiceFactory.class})
 public class GatewayWebsocketHandlerTest {
     @BeforeClass


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let's see if it fixes this:

```
2022-11-28T05:34:23.3732998Z [ERROR] testValidWebShellRequest(org.apache.knox.gateway.websockets.GatewayWebsocketHandlerTest)  Time elapsed: 0.585 s  <<< ERROR!
2022-11-28T05:34:23.3733695Z java.lang.IllegalStateException: Unable to load cache item
2022-11-28T05:34:23.3734384Z 	at org.apache.knox.gateway.websockets.GatewayWebsocketHandlerTest.testValidWebShellRequest(GatewayWebsocketHandlerTest.java:88)
2022-11-28T05:34:23.3735487Z Caused by: java.lang.IllegalAccessError: class javax.xml.parsers.FactoryFinder (in unnamed module @0x38954d02) cannot access class jdk.xml.internal.SecuritySupport (in module java.xml) because module java.xml does not export jdk.xml.internal to unnamed module @0x38954d02
2022-11-28T05:34:23.3736670Z 	at org.apache.knox.gateway.websockets.GatewayWebsocketHandlerTest.testValidWebShellRequest(GatewayWebsocketHandlerTest.java:88)
```

## How was this patch tested?

