### PR TITLE
KNOX-2848: Prevent overwriting generated descriptors/providers

### DIFF
--- a/gateway-admin-ui/admin-ui/app/new-desc-wizard/new-desc-wizard.component.html
+++ b/gateway-admin-ui/admin-ui/app/new-desc-wizard/new-desc-wizard.component.html
@@ -1,4 +1,4 @@
-<bs-modal (onClose)="onClose()" #newDescriptorModal xmlns="http://www.w3.org/1999/html">
+<bs-modal #newDescriptorModal xmlns="http://www.w3.org/1999/html">
     <bs-modal-header [showDismiss]="true">
         <label class="modal-title">Create a New Descriptor</label>
     </bs-modal-header>
@@ -12,6 +12,8 @@
                 <span *ngIf="isMissingDescriptorName()" style="color: red">required</span>
                 <span *ngIf="!isMissingDescriptorName() && !isValidDescriptorName()"
                       style="color: red">invalid</span>
+                <span *ngIf="isExistingReadOnlyTopology()"
+                      style="color: red">Cannot overwrite existing read-only topology</span>
             </div> <!-- Descriptor Name -->
 
             <br>
@@ -141,7 +143,7 @@
         <button type="button"
                 class="btn btn-primary btn-sm"
                 [disabled]="!validate()"
-                (click)="newDescriptorModal.close()">Ok
+                (click)="save()">Ok
         </button>
     </bs-modal-footer>
 </bs-modal>

--- a/gateway-admin-ui/admin-ui/app/new-desc-wizard/new-desc-wizard.component.ts
+++ b/gateway-admin-ui/admin-ui/app/new-desc-wizard/new-desc-wizard.component.ts
@@ -23,6 +23,7 @@ import {ResourceService} from '../resource/resource.service';
 import {Resource} from '../resource/resource';
 import {ResourceTypesService} from '../resourcetypes/resourcetypes.service';
 import {ValidationUtils} from '../utils/validation-utils';
+import {HttpErrorResponse} from '@angular/common/http';
 
 @Component({
     selector: 'app-new-desc-wizard',
@@ -92,6 +93,8 @@ export class NewDescWizardComponent implements OnInit {
 
     editModePC: boolean;
 
+    existingReadOnlyTopology = false;
+
     constructor(private resourceTypesService: ResourceTypesService, private resourceService: ResourceService) {
     }
 
@@ -110,6 +113,7 @@ export class NewDescWizardComponent implements OnInit {
         this.resource = new Resource();
         this.descriptor = new Descriptor();
         this.descriptorName = '';
+        this.existingReadOnlyTopology = false;
 
         // Reset any previously-selected services
         for (let serviceName of NewDescWizardComponent.supportedServices) {
@@ -120,7 +124,7 @@ export class NewDescWizardComponent implements OnInit {
         }
     }
 
-    onClose() {
+    save() {
         // Set the service declarations on the descriptor
         for (let serviceName of NewDescWizardComponent.supportedServices) {
             if (this.isSelected(serviceName)) {
@@ -153,7 +157,15 @@ export class NewDescWizardComponent implements OnInit {
                         }
                     }
                 });
+                this.childModal.close(); // close the dialog if there was no error
+            }).catch((err: HttpErrorResponse) => {
+                this.existingReadOnlyTopology = (err.status === 409);
+                console.error('Error creating ' + this.descriptorName + ' : ' + err.message);
             });
+    }
+
+    isExistingReadOnlyTopology(): boolean {
+        return this.existingReadOnlyTopology;
     }
 
     getServiceDisplayColumns() {

--- a/gateway-admin-ui/admin-ui/app/provider-config-wizard/provider-config-wizard.component.html
+++ b/gateway-admin-ui/admin-ui/app/provider-config-wizard/provider-config-wizard.component.html
@@ -1,4 +1,4 @@
-<bs-modal (onClose)="onClose()" #newProviderConfigModal xmlns="http://www.w3.org/1999/html">
+<bs-modal #newProviderConfigModal xmlns="http://www.w3.org/1999/html">
     <bs-modal-header [showDismiss]="true">
         <label class="modal-title">Create a New Provider Configuration</label>
     </bs-modal-header>
@@ -19,6 +19,8 @@
                             <span *ngIf="field.errors?.required" style="color: red">
                 &nbsp;required
               </span>
+                            <span *ngIf="isExistingReadOnlyProvider()"
+                                  style="color: red">Cannot overwrite existing read-only topology</span>
                             <span *ngIf="!field.errors?.required && !isValidProviderConfigName()"
                                   style="color: red">
                 &nbsp;invalid
@@ -120,7 +122,7 @@
                 *ngIf="isRootStep() || !hasMoreSteps()"
                 class="btn btn-primary btn-sm"
                 [disabled]="(isRootStep() && !name)"
-                (click)="isRootStep() ? newProviderConfigModal.close() : onFinishAdd()">Ok
+                (click)="isRootStep() ? save() : onFinishAdd()">Ok
         </button>
         <button type="button"
                 *ngIf="!isRootStep() && hasMoreSteps()"

--- a/gateway-admin-ui/admin-ui/app/provider-config-wizard/provider-config-wizard.component.ts
+++ b/gateway-admin-ui/admin-ui/app/provider-config-wizard/provider-config-wizard.component.ts
@@ -32,6 +32,7 @@ import {HostMapProviderWizard} from './hostmap-provider-wizard';
 import {ProviderContributorWizard} from './provider-contributor-wizard';
 import {WebAppSecurityWizard} from './webappsec-wizard';
 import {ValidationUtils} from '../utils/validation-utils';
+import {HttpErrorResponse} from '@angular/common/http';
 
 @Component({
     selector: 'app-provider-config-wizard',
@@ -79,6 +80,8 @@ export class ProviderConfigWizardComponent implements OnInit {
 
     selectedCategory: string;
 
+    existingReadOnlyProvider = false;
+
     static isProviderConfigValid(pc: ProviderConfig): boolean {
         let isValid = true;
         if (pc instanceof DisplayBindingProviderConfig) {
@@ -113,6 +116,7 @@ export class ProviderConfigWizardComponent implements OnInit {
         this.name = '';
         this.providers = [];
         this.selectedCategory = ProviderConfigWizardComponent.CATEGORY_AUTHENTICATION;
+        this.existingReadOnlyProvider = false;
     }
 
     onFinishAdd() {
@@ -189,7 +193,7 @@ export class ProviderConfigWizardComponent implements OnInit {
         }
     }
 
-    onClose() {
+    save() {
         // Identify the new resource
         let newResource = new Resource();
         newResource.name = this.name + '.json';
@@ -222,7 +226,11 @@ export class ProviderConfigWizardComponent implements OnInit {
                         }
                     }
                 });
-            });
+                this.childModal.close(); // close the dialog if there was no error
+            }).catch((err: HttpErrorResponse) => {
+                this.existingReadOnlyProvider = (err.status === 409);
+                console.error('Error creating ' + newResource + ' : ' + err.message);
+          });
     }
 
     onNextStep() {
@@ -392,4 +400,7 @@ export class ProviderConfigWizardComponent implements OnInit {
         return this['show' + propertName];
     }
 
+    isExistingReadOnlyProvider(): boolean {
+        return this.existingReadOnlyProvider;
+    }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -205,6 +205,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String READ_ONLY_OVERRIDE_TOPOLOGIES =
                                                     GATEWAY_CONFIG_FILE_PREFIX + ".read.only.override.topologies";
 
+  public static final String READ_ONLY_OVERRIDE_PROVIDERS =
+                                                    GATEWAY_CONFIG_FILE_PREFIX + ".read.only.override.providers";
+
   /* Websocket defaults */
   public static final boolean DEFAULT_WEBSOCKET_FEATURE_ENABLED = false;
   public static final int DEFAULT_WEBSOCKET_MAX_TEXT_MESSAGE_SIZE = Integer.MAX_VALUE;
@@ -1153,6 +1156,18 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     List<String> topologyNames = new ArrayList<>();
 
     String value = get(READ_ONLY_OVERRIDE_TOPOLOGIES);
+    if (value != null && !value.isEmpty()) {
+      topologyNames.addAll(Arrays.asList(value.trim().split("\\s*,\\s*")));
+    }
+
+    return topologyNames;
+  }
+
+  @Override
+  public List<String> getReadOnlyOverrideProviderNames() {
+    List<String> topologyNames = new ArrayList<>();
+
+    String value = get(READ_ONLY_OVERRIDE_PROVIDERS);
     if (value != null && !value.isEmpty()) {
       topologyNames.addAll(Arrays.asList(value.trim().split("\\s*,\\s*")));
     }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -782,6 +782,18 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public List<String> getReadOnlyOverrideProviderNames() {
+    List<String> readOnly = new ArrayList<>();
+
+    String value = get("gateway.read.only.override.providers");
+    if (value != null && !value.isEmpty()) {
+      readOnly.addAll(Arrays.asList(value.trim().split("\\s*,\\s*")));
+    }
+
+    return readOnly;
+  }
+
+  @Override
   public String getKnoxAdminGroups() {
     return null;
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -627,6 +627,11 @@ public interface GatewayConfig {
   List<String> getReadOnlyOverrideTopologyNames();
 
   /**
+   * Get the list of those topology names which should be treated as read-only.
+   */
+  List<String> getReadOnlyOverrideProviderNames();
+
+  /**
    * Get the comma separated list of group names that represent Knox Admin users
    * @return comma separate list of admin group names
    */

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -76,6 +76,12 @@ public interface GatewaySpiMessages {
   @Message( level = MessageLevel.ERROR, text = "Topology {0} cannot be manually overwritten because it was generated from a simple descriptor." )
   void disallowedOverwritingGeneratedTopology(String topologyName);
 
+  @Message( level = MessageLevel.INFO, text = "Read-only descriptor {0} cannot be overwritten." )
+  void disallowedOverwritingGeneratedDescriptor(String name);
+
+  @Message( level = MessageLevel.INFO, text = "Read-only provider {0} cannot be overwritten." )
+  void disallowedOverwritingGeneratedProvider(String providerName);
+
   @Message(level = MessageLevel.ERROR, text = "Failed to load truststore due to {0}")
   void failedToLoadTruststore(String message, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
@@ -1926,7 +1926,7 @@ public class GatewayAdminTopologyFuncTest {
               .header("Content-type", MediaType.APPLICATION_JSON)
               .body("new content")
               .then()
-              .statusCode(HttpStatus.SC_BAD_REQUEST)
+              .statusCode(HttpStatus.SC_CONFLICT)
               .when().put((clusterUrl + "/api/v1/descriptors/" + topologyName));
     } finally {
       // Restart the gateway with old settings.

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
@@ -1913,6 +1913,31 @@ public class GatewayAdminTopologyFuncTest {
   }
 
   @Test( timeout = TestUtils.LONG_TIMEOUT )
+  public void testPutExistingGeneratedDescriptorFails() throws Exception {
+    LOG_ENTER();
+    try {
+      gateway.stop();
+      GatewayTestConfig conf = new GatewayTestConfig();
+      String topologyName = "admin";
+      conf.set(GatewayConfigImpl.READ_ONLY_OVERRIDE_TOPOLOGIES, topologyName);
+      setupGateway(conf);
+      given()
+              .auth().preemptive().basic("admin", "admin-password")
+              .header("Content-type", MediaType.APPLICATION_JSON)
+              .body("new content")
+              .then()
+              .statusCode(HttpStatus.SC_BAD_REQUEST)
+              .when().put((clusterUrl + "/api/v1/descriptors/" + topologyName));
+    } finally {
+      // Restart the gateway with old settings.
+      gateway.stop();
+      setupGateway(new GatewayTestConfig());
+    }
+
+    LOG_EXIT();
+  }
+
+  @Test( timeout = TestUtils.LONG_TIMEOUT )
   public void testPutDescriptorWithInvalidNameEncodedElement() throws Exception {
     LOG_ENTER();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When creating a new descriptor or provider config, knox should check if there is an existing read-only descriptor/provider with the same name.

## How was this patch tested?

Using this config:

```xml
<property>
        <name>gateway.read.only.override.topologies</name>
        <value>admin,manager,xxx</value>    
    </property>
   <property>
	<name>gateway.read.only.override.providers</name>
	<value>prov1,prov2</value>
   </property>
```

Checking descriptor creation (negative case):

<img width="918" alt="Screenshot 2022-12-02 at 14 41 56" src="https://user-images.githubusercontent.com/641365/205306762-d2909420-cff1-42e1-8e1f-ba07fd220bf2.png">

Plus positive case.