### PR TITLE
KNOX-2855:Added Hbase UI proxying for prometheus end points

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/rewrite.xml
@@ -214,6 +214,14 @@
     <rewrite template="{$frontend[url]}/hbase/webui/jmx?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
   </rule>
 
+  <!-- Prometheus metrics -->
+  <rule dir="IN" name="HBASEUI/hbase/inbound/prometheus" pattern="*://*:*/**/hbase/webui/prometheus?{host}?{port}?{**}">
+    <rewrite template="{$serviceScheme[HBASEUI]}://{host}:{port}/prometheus?{**}"/>
+  </rule>
+  <rule dir="OUT" name="HBASEUI/hbase/outbound/prometheus" pattern="/prometheus?{**}">
+    <rewrite template="{$frontend[url]}/hbase/webui/prometheus?host={$inboundurl[host]}?port={$inboundurl[port]}?{**}"/>
+  </rule>
+
   <!-- Static file serving -->
   <rule dir="IN" name="HBASEUI/hbase/inbound/static" pattern="*://*:*/**/hbase/webui/static/{**}">
     <rewrite template="{$serviceUrl[HBASEUI]}/static/{**}"/>

--- a/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hbaseui/2.1.0/service.xml
@@ -63,6 +63,10 @@
           <rewrite apply="HBASEUI/hbase/inbound/jmx" to="request.url"/>
           <rewrite apply="HBASEUI/hbase/outbound/jmx" to="response.body"/>
         </route>
+        <route path="/hbase/webui/prometheus?{**}">
+            <rewrite apply="HBASEUI/hbase/inbound/prometheus" to="request.url"/>
+            <rewrite apply="HBASEUI/hbase/outbound/prometheus" to="response.body"/>
+        </route>
         <route path="/hbase/webui/prof?{**}">
           <rewrite apply="HBASEUI/hbase/inbound/profiler" to="request.url"/>
           <rewrite apply="HBASEUI/hbase/outbound/profiler" to="response.body"/>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?
In HBASE-20904 we added support for /prometheus endpoints under Hbase WebUI. 
So in this PR added configurations to make sure that /prometheus endpoints works fine through the proxy.

## How was this patch tested?
Copied the patched files "rewrite.xml" and "service.xml" into knox directory and restarted the knox. When opened the Hbase WebUI, the /prometheus endpoint started working as expected. Earlier it used to give 404 error without proxying configurations.

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
