### PR TITLE
KNOX-2861 upgrade CM API version

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -48,6 +48,7 @@ import org.apache.knox.gateway.topology.simple.SimpleDescriptorFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -462,7 +463,8 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
     try {
       // giving 'null' as maximum result size results in fetching all events from CM within the given time interval
-      ApiEventQueryResult eventsResult = (new EventsResourceApi(client)).readEvents(null, queryString, 0);
+      ApiEventQueryResult eventsResult = (new EventsResourceApi(client)).readEvents(null, queryString,
+          BigDecimal.valueOf(0));
       events.addAll(eventsResult.getItems());
     } catch (ApiException e) {
       log.clouderaManagerEventsAPIError(e);

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <cglib.version>3.3.0</cglib.version>
         <checkstyle.version>8.38</checkstyle.version>
-        <cloudera-manager.version>7.0.3</cloudera-manager.version>
+        <cloudera-manager.version>7.8.1</cloudera-manager.version>
         <cloudera-manager-api-swagger.version>${cloudera-manager.version}</cloudera-manager-api-swagger.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade CM API version

## Testing
Tested on a local cluster 
```
2023-01-06 11:46:58,551  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(259)) - Performing cluster discovery for "Cluster 1"
2023-01-06 11:46:58,551  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(280)) - Skipping service discovery: OZONE-1 (OZONE)
2023-01-06 11:46:58,551  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(283)) - Discovering service: SOLR-1 (SOLR) ...
2023-01-06 11:46:58,552  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: SOLR-1-SOLR_SERVER-c0f21f059915235fddf68e4bd6267b28 (SOLR_SERVER) ...
2023-01-06 11:46:58,552  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: SOLR-1-SOLR_SERVER-c0f21f059915235fddf68e4bd6267b28 (SOLR_SERVER)
2023-01-06 11:46:58,552  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(318)) - Discovered service: SOLR-1 (SOLR)
2023-01-06 11:46:58,552  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(280)) - Skipping service discovery: KUDU-1 (KUDU)
2023-01-06 11:46:58,552  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(283)) - Discovering service: LIVY-1 (LIVY) ...
2023-01-06 11:46:58,552  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: LIVY-LIVY_SERVER-1 (LIVY_SERVER) ...
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: LIVY-LIVY_SERVER-1 (LIVY_SERVER)
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: LIVY-GATEWAY-3 (GATEWAY) ...
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: LIVY-GATEWAY-3 (GATEWAY)
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: LIVY-GATEWAY-1 (GATEWAY) ...
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: LIVY-GATEWAY-1 (GATEWAY)
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: LIVY-GATEWAY-2 (GATEWAY) ...
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: LIVY-GATEWAY-2 (GATEWAY)
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(318)) - Discovered service: LIVY-1 (LIVY)
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(283)) - Discovering service: HIVE-1 (HIVE) ...
2023-01-06 11:46:58,553  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: HIVE-1-GATEWAY-d0c0400625ae47e6e63a71b8b81a0afb (GATEWAY) ...
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: HIVE-1-GATEWAY-d0c0400625ae47e6e63a71b8b81a0afb (GATEWAY)
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: HIVE-1-GATEWAY-abe4cfb49ee7bdec3e25b3b2aac9d57e (GATEWAY) ...
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: HIVE-1-GATEWAY-abe4cfb49ee7bdec3e25b3b2aac9d57e (GATEWAY)
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: HIVE-1-GATEWAY-c0f21f059915235fddf68e4bd6267b28 (GATEWAY) ...
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: HIVE-1-GATEWAY-c0f21f059915235fddf68e4bd6267b28 (GATEWAY)
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: HIVE-1-HIVEMETASTORE-c0f21f059915235fddf68e4bd6267b28 (HIVEMETASTORE) ...
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: HIVE-1-HIVEMETASTORE-c0f21f059915235fddf68e4bd6267b28 (HIVEMETASTORE)
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(318)) - Discovered service: HIVE-1 (HIVE)
2023-01-06 11:46:58,554  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(280)) - Skipping service discovery: HUE-1 (HUE)
2023-01-06 11:46:58,555  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(283)) - Discovering service: KAFKA-1 (KAFKA) ...
2023-01-06 11:46:58,555  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-KAFKA_BROKER-3 (KAFKA_BROKER) ...
2023-01-06 11:46:58,555  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-KAFKA_BROKER-3 (KAFKA_BROKER)
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-KAFKA_BROKER-2 (KAFKA_BROKER) ...
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-KAFKA_BROKER-2 (KAFKA_BROKER)
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-KAFKA_CONNECT-2 (KAFKA_CONNECT) ...
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-KAFKA_CONNECT-2 (KAFKA_CONNECT)
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-KAFKA_CONNECT-1 (KAFKA_CONNECT) ...
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-KAFKA_CONNECT-1 (KAFKA_CONNECT)
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-GATEWAY-1 (GATEWAY) ...
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-GATEWAY-1 (GATEWAY)
2023-01-06 11:46:58,556  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-KAFKA_CONNECT-3 (KAFKA_CONNECT) ...
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-KAFKA_CONNECT-3 (KAFKA_CONNECT)
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: KAFKA-KAFKA_BROKER-1 (KAFKA_BROKER) ...
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: KAFKA-KAFKA_BROKER-1 (KAFKA_BROKER)
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(318)) - Discovered service: KAFKA-1 (KAFKA)
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(283)) - Discovering service: RANGER-1 (RANGER) ...
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: RANGER-RANGER_USERSYNC-1 (RANGER_USERSYNC) ...
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: RANGER-RANGER_USERSYNC-1 (RANGER_USERSYNC)
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: RANGER-RANGER_TAGSYNC-1 (RANGER_TAGSYNC) ...
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: RANGER-RANGER_TAGSYNC-1 (RANGER_TAGSYNC)
2023-01-06 11:46:58,557  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(293)) - Discovering service role: RANGER-RANGER_ADMIN-1 (RANGER_ADMIN) ...
2023-01-06 11:46:58,558  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(314)) - Discovered service role: RANGER-RANGER_ADMIN-1 (RANGER_ADMIN)
2023-01-06 11:46:58,558  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(318)) - Discovered service: RANGER-1 (RANGER)
2023-01-06 11:46:58,558  INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:discoverCluster(280)) - Skipping service discovery: ZEPPELIN-1 (ZEPPELIN)
```