### PR TITLE
KNOX-2862 - Setup idle timeout for SSO cookie to 15 minutes

### DIFF
--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -95,7 +95,7 @@ public class WebSSOResource {
   private static final String ORIGINAL_URL_COOKIE_NAME = "original-url";
   private static final String DEFAULT_SSO_COOKIE_NAME = "hadoop-jwt";
   private static final String SSO_COOKIE_SAMESITE_DEFAULT = "Strict";
-  private static final long TOKEN_TTL_DEFAULT = 15000 * 60;
+  public static final long TOKEN_TTL_DEFAULT = 15000 * 60;
   static final String RESOURCE_PATH = "/api/v1/websso";
   private String cookieName;
   private boolean secureOnly = true;

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -95,7 +95,7 @@ public class WebSSOResource {
   private static final String ORIGINAL_URL_COOKIE_NAME = "original-url";
   private static final String DEFAULT_SSO_COOKIE_NAME = "hadoop-jwt";
   private static final String SSO_COOKIE_SAMESITE_DEFAULT = "Strict";
-  private static final long TOKEN_TTL_DEFAULT = 30000L;
+  private static final long TOKEN_TTL_DEFAULT = 15000 * 60;
   static final String RESOURCE_PATH = "/api/v1/websso";
   private String cookieName;
   private boolean secureOnly = true;

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.service.knoxsso;
 
+import static org.apache.knox.gateway.service.knoxsso.WebSSOResource.TOKEN_TTL_DEFAULT;
 import static org.apache.knox.gateway.services.GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
@@ -326,7 +327,7 @@ public class WebSSOResourceTest {
     Date expiresDate = parsedToken.getExpiresDate();
     Date now = new Date();
     assertTrue(expiresDate.after(now));
-    assertTrue((expiresDate.getTime() - now.getTime()) < 30000L);
+    assertTrue((expiresDate.getTime() - now.getTime()) < TOKEN_TTL_DEFAULT);
   }
 
   @Test
@@ -381,7 +382,7 @@ public class WebSSOResourceTest {
     Date expiresDate = parsedToken.getExpiresDate();
     Date now = new Date();
     assertTrue(expiresDate.after(now));
-    assertTrue((expiresDate.getTime() - now.getTime()) < 30000L);
+    assertTrue((expiresDate.getTime() - now.getTime()) < TOKEN_TTL_DEFAULT);
   }
 
   @Test
@@ -463,7 +464,7 @@ public class WebSSOResourceTest {
     Date expiresDate = parsedToken.getExpiresDate();
     Date now = new Date();
     assertTrue(expiresDate.after(now));
-    assertTrue((expiresDate.getTime() - now.getTime()) < 30000L);
+    assertTrue((expiresDate.getTime() - now.getTime()) < TOKEN_TTL_DEFAULT);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fedramp mandates this to be 15 minutes.

## How was this patch tested?

* Removed `knoxsso.token.ttl` from `knoxsso.xml`
* Logged in at knox ui
* Extracted and checked the "exp" field from the hadoop-jwt cookie

