### PR TITLE
KNOX-2863 - Fix an issue where session cookie order in LB feature breaks

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -289,8 +289,8 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
     if (inboundRequest.getCookies() != null) {
         sessionCookie =
                 Arrays.stream(inboundRequest.getCookies())
-                      .findFirst()
-                      .filter(cookie -> stickySessionCookieName.equals(cookie.getName()));
+                      .filter(cookie -> stickySessionCookieName.equals(cookie.getName()))
+                      .findFirst();
     }
 
     // Check for a case where no fallback is configured


### PR DESCRIPTION

## What changes were proposed in this pull request?

Fix a bug which causes LB to break when sticky session cookie is not the first one.

## How was this patch tested?

Unit tests.