### PR TITLE
KNOX-2748 - Fixed HashiCorp alias service getPasswordFromAliasForCluster

### DIFF
--- a/gateway-service-hashicorp-vault/src/main/java/org/apache/knox/gateway/backend/hashicorp/vault/HashicorpVaultAliasService.java
+++ b/gateway-service-hashicorp-vault/src/main/java/org/apache/knox/gateway/backend/hashicorp/vault/HashicorpVaultAliasService.java
@@ -153,8 +153,8 @@ public class HashicorpVaultAliasService extends AbstractAliasService {
 
   @Override
   public char[] getPasswordFromAliasForCluster(String clusterName, String alias, boolean generate) throws AliasServiceException {
-    char [] password = getPasswordFromAliasForCluster(clusterName, alias);
-    if(password == null && generate) {
+    char[] password = getPasswordFromAliasForCluster(clusterName, alias);
+    if (password == null && generate) {
       generateAliasForCluster(clusterName, alias);
       password = getPasswordFromAliasForCluster(clusterName, alias);
     }

--- a/gateway-service-hashicorp-vault/src/main/java/org/apache/knox/gateway/backend/hashicorp/vault/HashicorpVaultAliasService.java
+++ b/gateway-service-hashicorp-vault/src/main/java/org/apache/knox/gateway/backend/hashicorp/vault/HashicorpVaultAliasService.java
@@ -153,10 +153,12 @@ public class HashicorpVaultAliasService extends AbstractAliasService {
 
   @Override
   public char[] getPasswordFromAliasForCluster(String clusterName, String alias, boolean generate) throws AliasServiceException {
-    if(generate) {
-      getPasswordFromAliasForCluster(clusterName, alias);
+    char [] password = getPasswordFromAliasForCluster(clusterName, alias);
+    if(password == null && generate) {
+      generateAliasForCluster(clusterName, alias);
+      password = getPasswordFromAliasForCluster(clusterName, alias);
     }
-    return getPasswordFromAliasForCluster(clusterName, alias);
+    return password;
   }
 
   @Override

--- a/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
+++ b/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.knox.gateway.backend.hashicorp.vault.HashicorpVaultAliasService.VAULT_SEPARATOR;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -185,7 +186,7 @@ public class TestHashicorpVaultAliasService {
     assertEquals(0, aliasService.getAliasesForCluster(clusterName).size());
 
     char[] generatedPassword = aliasService.getPasswordFromAliasForCluster(clusterName, alias, true);
-    assertTrue(generatedPassword != null);
+    assertNotNull(generatedPassword != null);
 
     aliasService.stop();
   }

--- a/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
+++ b/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
@@ -184,6 +184,9 @@ public class TestHashicorpVaultAliasService {
     assertNull(aliasService.getPasswordFromAliasForCluster(clusterName, alias));
     assertEquals(0, aliasService.getAliasesForCluster(clusterName).size());
 
+    char[] generatedPassword = aliasService.getPasswordFromAliasForCluster(clusterName, alias, true);
+    assertTrue(generatedPassword != null);
+
     aliasService.stop();
   }
 

--- a/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
+++ b/gateway-service-hashicorp-vault/src/test/java/org/apache/knox/gateway/backend/hashicorp/vault/TestHashicorpVaultAliasService.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.knox.gateway.backend.hashicorp.vault.HashicorpVaultAliasService.VAULT_SEPARATOR;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -187,6 +188,7 @@ public class TestHashicorpVaultAliasService {
 
     char[] generatedPassword = aliasService.getPasswordFromAliasForCluster(clusterName, alias, true);
     assertNotNull(generatedPassword != null);
+    assertNotEquals(generatedPassword, aliasPassword.toCharArray());
 
     aliasService.stop();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the HashiCorpVaultAliasService `getPasswordFromAliasForCluster` function, because it worked incorrectly when the generate flag was set to `true`.

## How was this patch tested?

I extended the existing unit tests.
