### PR TITLE
KNOX-2864 - TLS cipher suites and protocols are configured for CM service discovery

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -27,11 +27,13 @@ import com.cloudera.api.swagger.model.ApiServiceConfig;
 import com.cloudera.api.swagger.model.ApiServiceList;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
@@ -39,6 +41,7 @@ import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.monitor.ClouderaManagerClusterConfigurationMonitor;
 
 import java.net.ConnectException;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -61,6 +64,8 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
 
   private static final ClouderaManagerServiceDiscoveryMessages log =
                                         MessagesFactory.get(ClouderaManagerServiceDiscoveryMessages.class);
+
+  private static final GatewaySpiMessages LOGGER = MessagesFactory.get(GatewaySpiMessages.class);
 
   static final String API_PATH = "api/v32";
 
@@ -86,7 +91,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
   private boolean debug;
 
   private AliasService aliasService;
-  private KeystoreService keystoreService;
+  private KeyStore truststore;
 
   private ClouderaManagerClusterConfigurationMonitor configChangeMonitor;
 
@@ -104,7 +109,14 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
     GatewayServices gwServices = GatewayServer.getGatewayServices();
     if (gwServices != null) {
       this.aliasService = gwServices.getService(ServiceType.ALIAS_SERVICE);
-      this.keystoreService = gwServices.getService(ServiceType.KEYSTORE_SERVICE);
+      KeystoreService keystoreService = gwServices.getService(ServiceType.KEYSTORE_SERVICE);
+      if (keystoreService != null) {
+        try {
+          truststore = keystoreService.getTruststoreForHttpClient();
+        } catch (KeystoreServiceException e) {
+          LOGGER.failedToLoadTruststore(e.getMessage(), e);
+        }
+      }
     }
     this.debug = debug;
     this.configChangeMonitor = getConfigurationChangeMonitor();
@@ -142,7 +154,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
       throw new IllegalArgumentException("Missing or invalid discovery address.");
     }
 
-    DiscoveryApiClient client = new DiscoveryApiClient(discoveryConfig, aliasService, keystoreService);
+    DiscoveryApiClient client = new DiscoveryApiClient(discoveryConfig, aliasService, truststore);
     client.setDebugging(debug);
     return client;
   }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -147,14 +147,14 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
     return TYPE;
   }
 
-  private DiscoveryApiClient getClient(ServiceDiscoveryConfig discoveryConfig) {
+  private DiscoveryApiClient getClient(GatewayConfig gatewayConfig, ServiceDiscoveryConfig discoveryConfig) {
     String discoveryAddress = discoveryConfig.getAddress();
     if (discoveryAddress == null || discoveryAddress.isEmpty()) {
       log.missingDiscoveryAddress();
       throw new IllegalArgumentException("Missing or invalid discovery address.");
     }
 
-    DiscoveryApiClient client = new DiscoveryApiClient(discoveryConfig, aliasService, truststore);
+    DiscoveryApiClient client = new DiscoveryApiClient(gatewayConfig, discoveryConfig, aliasService, truststore);
     client.setDebugging(debug);
     return client;
   }
@@ -195,7 +195,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
                                          ServiceDiscoveryConfig discoveryConfig,
                                          String                 clusterName,
                                          Collection<String>     includedServices) {
-    return discover(gatewayConfig, discoveryConfig, clusterName, includedServices, getClient(discoveryConfig));
+    return discover(gatewayConfig, discoveryConfig, clusterName, includedServices, getClient(gatewayConfig, discoveryConfig));
   }
 
   protected ClouderaManagerCluster discover(GatewayConfig          gatewayConfig,

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/DiscoveryApiClient.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/DiscoveryApiClient.java
@@ -16,28 +16,32 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm;
 
-import com.cloudera.api.swagger.client.ApiClient;
-import com.cloudera.api.swagger.client.Pair;
-import com.cloudera.api.swagger.client.auth.Authentication;
-import com.cloudera.api.swagger.client.auth.HttpBasicAuth;
+import static org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery.API_PATH;
+import static org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery.DEFAULT_PWD_ALIAS;
+import static org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery.DEFAULT_USER_ALIAS;
+
+import java.security.KeyStore;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.security.auth.Subject;
+
 import org.apache.knox.gateway.config.ConfigurationException;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
-import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.auth.AuthUtils;
 import org.apache.knox.gateway.topology.discovery.cm.auth.SpnegoAuthInterceptor;
 import org.apache.knox.gateway.util.TruststoreSSLContextUtils;
 
-import javax.net.ssl.SSLContext;
-import javax.security.auth.Subject;
-import java.util.List;
-
-import static org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery.API_PATH;
-import static org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery.DEFAULT_USER_ALIAS;
-import static org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery.DEFAULT_PWD_ALIAS;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.Pair;
+import com.cloudera.api.swagger.client.auth.Authentication;
+import com.cloudera.api.swagger.client.auth.HttpBasicAuth;
+import com.squareup.okhttp.ConnectionSpec;
 
 /**
  * Cloudera Manager ApiClient extension for service discovery.
@@ -52,9 +56,9 @@ public class DiscoveryApiClient extends ApiClient {
   private ServiceDiscoveryConfig config;
 
   public DiscoveryApiClient(ServiceDiscoveryConfig discoveryConfig, AliasService aliasService,
-                            KeystoreService keystoreService) {
+      KeyStore trustStore) {
     this.config = discoveryConfig;
-    configure(aliasService, keystoreService);
+    configure(aliasService, trustStore);
   }
 
   ServiceDiscoveryConfig getConfig() {
@@ -65,7 +69,7 @@ public class DiscoveryApiClient extends ApiClient {
     return isKerberos;
   }
 
-  private void configure(AliasService aliasService, KeystoreService keystoreService) {
+  private void configure(AliasService aliasService, KeyStore trustStore) {
     String apiAddress = config.getAddress();
     apiAddress += (apiAddress.endsWith("/") ? API_PATH : "/" + API_PATH);
 
@@ -130,7 +134,7 @@ public class DiscoveryApiClient extends ApiClient {
       }
     }
 
-    configureTruststore(keystoreService);
+    configureSsl(trustStore);
   }
 
   @Override
@@ -157,12 +161,18 @@ public class DiscoveryApiClient extends ApiClient {
     return username;
   }
 
-  private void configureTruststore(KeystoreService keystoreService) {
-    SSLContext truststoreSSLContext = TruststoreSSLContextUtils.getTruststoreSSLContext(keystoreService);
+  private void configureSsl(KeyStore trustStore) {
+    final SSLContext truststoreSSLContext = TruststoreSSLContextUtils.getTruststoreSSLContext(trustStore);
+
     if (truststoreSSLContext != null) {
+      final ConnectionSpec.Builder connectionSpecBuilder = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS);
+      connectionSpecBuilder.cipherSuites(truststoreSSLContext.getSupportedSSLParameters().getCipherSuites());
+      connectionSpecBuilder.tlsVersions(truststoreSSLContext.getSupportedSSLParameters().getProtocols());
+      getHttpClient().setConnectionSpecs(Arrays.asList(connectionSpecBuilder.build()));
       getHttpClient().setSslSocketFactory(truststoreSSLContext.getSocketFactory());
     } else {
       log.failedToConfigureTruststore();
     }
   }
+
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
@@ -87,7 +87,7 @@ public class ClouderaManagerClusterConfigurationMonitor implements ClusterConfig
     this.executorService = Executors.newSingleThreadExecutor(tf);
 
     // Initialize the internal monitor
-    internalMonitor = new PollingConfigurationAnalyzer(configCache, aliasService, keystoreService, this);
+    internalMonitor = new PollingConfigurationAnalyzer(config, configCache, aliasService, keystoreService, this);
 
     // Override the default polling interval if it has been configured
     // (org.apache.knox.gateway.topology.discovery.cm.monitor.interval)

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -33,6 +33,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.apache.knox.gateway.GatewayServer;
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.GatewaySpiMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
@@ -142,18 +143,23 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
   private boolean isActive;
 
-  PollingConfigurationAnalyzer(final ClusterConfigurationCache   configCache,
+  private final GatewayConfig gatewayConfig;
+
+  PollingConfigurationAnalyzer(final GatewayConfig gatewayConfig,
+                               final ClusterConfigurationCache   configCache,
                                final AliasService                aliasService,
                                final KeystoreService             keystoreService,
                                final ConfigurationChangeListener changeListener) {
-    this(configCache, aliasService, keystoreService, changeListener, DEFAULT_POLLING_INTERVAL);
+    this(gatewayConfig, configCache, aliasService, keystoreService, changeListener, DEFAULT_POLLING_INTERVAL);
   }
 
-  PollingConfigurationAnalyzer(final ClusterConfigurationCache   configCache,
+  PollingConfigurationAnalyzer(final GatewayConfig gatewayConfig,
+                               final ClusterConfigurationCache   configCache,
                                final AliasService                aliasService,
                                final KeystoreService             keystoreService,
                                final ConfigurationChangeListener changeListener,
                                int                               interval) {
+    this.gatewayConfig = gatewayConfig;
     this.configCache     = configCache;
     this.aliasService    = aliasService;
 
@@ -396,7 +402,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
    */
   private DiscoveryApiClient getApiClient(final ServiceDiscoveryConfig discoveryConfig) {
     return clients.computeIfAbsent(discoveryConfig.getAddress(),
-                                   c -> new DiscoveryApiClient(discoveryConfig, aliasService, truststore));
+                                   c -> new DiscoveryApiClient(gatewayConfig, discoveryConfig, aliasService, truststore));
   }
 
   /**

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -33,11 +33,13 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import org.apache.knox.gateway.GatewayServer;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.services.topology.TopologyService;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
@@ -49,6 +51,7 @@ import org.apache.knox.gateway.topology.simple.SimpleDescriptorFactory;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.security.KeyStore;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -105,6 +108,8 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
   private static final ClouderaManagerServiceDiscoveryMessages log = MessagesFactory.get(ClouderaManagerServiceDiscoveryMessages.class);
 
+  private static final GatewaySpiMessages LOGGER = MessagesFactory.get(GatewaySpiMessages.class);
+
   // Fully-qualified cluster name delimiter
   private static final String FQCN_DELIM = "::";
 
@@ -115,7 +120,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
   private AliasService aliasService;
 
-  private KeystoreService keystoreService;
+  private KeyStore truststore;
 
   private TopologyService topologyService;
 
@@ -151,7 +156,15 @@ public class PollingConfigurationAnalyzer implements Runnable {
                                int                               interval) {
     this.configCache     = configCache;
     this.aliasService    = aliasService;
-    this.keystoreService = keystoreService;
+
+    if (keystoreService != null) {
+      try {
+        truststore = keystoreService.getTruststoreForHttpClient();
+      } catch (KeystoreServiceException e) {
+        LOGGER.failedToLoadTruststore(e.getMessage(), e);
+      }
+    }
+
     this.changeListener  = changeListener;
     this.interval        = interval;
     this.processedEvents = Caffeine.newBuilder().expireAfterAccess(interval * 3, TimeUnit.SECONDS).maximumSize(1000).build();
@@ -383,7 +396,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
    */
   private DiscoveryApiClient getApiClient(final ServiceDiscoveryConfig discoveryConfig) {
     return clients.computeIfAbsent(discoveryConfig.getAddress(),
-                                   c -> new DiscoveryApiClient(discoveryConfig, aliasService, keystoreService));
+                                   c -> new DiscoveryApiClient(discoveryConfig, aliasService, truststore));
   }
 
   /**

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -33,7 +33,6 @@ import com.cloudera.api.swagger.model.ApiServiceList;
 import com.squareup.okhttp.Call;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
-import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.model.atlas.AtlasAPIServiceModelGenerator;
@@ -1189,7 +1188,7 @@ public class ClouderaManagerServiceDiscoveryTest {
     ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(clusterName);
 
     // Create the test client for providing test response content
-    TestDiscoveryApiClient mockClient = testRetry ? new TestFaultyDiscoveryApiClient(sdConfig, null, null) : new TestDiscoveryApiClient(sdConfig, null, null);
+    TestDiscoveryApiClient mockClient = testRetry ? new TestFaultyDiscoveryApiClient(sdConfig, null) : new TestDiscoveryApiClient(sdConfig, null);
 
     // Prepare the service list response for the cluster
     ApiServiceList serviceList = EasyMock.createNiceMock(ApiServiceList.class);
@@ -1318,9 +1317,8 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     protected AtomicInteger executeCount = new AtomicInteger(0);
 
-    TestDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService,
-                           KeystoreService keystoreService) {
-      super(sdConfig, aliasService, keystoreService);
+    TestDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
+      super(sdConfig, aliasService, null);
     }
 
     void addResponse(Type type, ApiResponse<?> response) {
@@ -1345,9 +1343,8 @@ public class ClouderaManagerServiceDiscoveryTest {
 
   private static class TestFaultyDiscoveryApiClient extends TestDiscoveryApiClient {
 
-    TestFaultyDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService,
-                           KeystoreService keystoreService) {
-      super(sdConfig, aliasService, keystoreService);
+    TestFaultyDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
+      super(sdConfig, aliasService);
     }
 
     @Override

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -1183,12 +1183,14 @@ public class ClouderaManagerServiceDiscoveryTest {
       EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryMaximumRetryAttempts()).andReturn(GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS).anyTimes();
       EasyMock.expect(gwConf.getClusterMonitorPollingInterval(ClouderaManagerClusterConfigurationMonitor.getType())).andReturn(10).anyTimes();
     }
+    EasyMock.expect(gwConf.getIncludedSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
+    EasyMock.expect(gwConf.getIncludedSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.replay(gwConf);
 
     ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(clusterName);
 
     // Create the test client for providing test response content
-    TestDiscoveryApiClient mockClient = testRetry ? new TestFaultyDiscoveryApiClient(sdConfig, null) : new TestDiscoveryApiClient(sdConfig, null);
+    TestDiscoveryApiClient mockClient = testRetry ? new TestFaultyDiscoveryApiClient(gwConf, sdConfig, null) : new TestDiscoveryApiClient(gwConf, sdConfig, null);
 
     // Prepare the service list response for the cluster
     ApiServiceList serviceList = EasyMock.createNiceMock(ApiServiceList.class);
@@ -1317,8 +1319,8 @@ public class ClouderaManagerServiceDiscoveryTest {
 
     protected AtomicInteger executeCount = new AtomicInteger(0);
 
-    TestDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
-      super(sdConfig, aliasService, null);
+    TestDiscoveryApiClient(GatewayConfig gatewayConfig, ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
+      super(gatewayConfig, sdConfig, aliasService, null);
     }
 
     void addResponse(Type type, ApiResponse<?> response) {
@@ -1343,8 +1345,8 @@ public class ClouderaManagerServiceDiscoveryTest {
 
   private static class TestFaultyDiscoveryApiClient extends TestDiscoveryApiClient {
 
-    TestFaultyDiscoveryApiClient(ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
-      super(sdConfig, aliasService);
+    TestFaultyDiscoveryApiClient(GatewayConfig gatewayConfig, ServiceDiscoveryConfig sdConfig, AliasService aliasService) {
+      super(gatewayConfig, sdConfig, aliasService);
     }
 
     @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -181,6 +181,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   // backward compatibility.
   // LET'S NOT CONTINUE THIS PATTERN BUT LEAVE THEM FOR NOW.
   private static final String SSL_ENABLED = "ssl.enabled";
+  private static final String SSL_INCLUDE_PROTOCOLS = "ssl.include.protocols";
   private static final String SSL_EXCLUDE_PROTOCOLS = "ssl.exclude.protocols";
   private static final String SSL_INCLUDE_CIPHERS = "ssl.include.ciphers";
   private static final String SSL_EXCLUDE_CIPHERS = "ssl.exclude.ciphers";
@@ -614,6 +615,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getFrontendUrl() {
     return get( FRONTEND_URL, null );
+  }
+
+  @Override
+  public Set<String> getIncludedSSLProtocols() {
+    final Collection<String> includedSslProtocols = getTrimmedStringCollection(SSL_INCLUDE_PROTOCOLS);
+    return includedSslProtocols == null ? Collections.emptySet() : new HashSet<>(includedSslProtocols);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
@@ -24,6 +24,8 @@ import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import javax.security.auth.x500.X500Principal;
 
 import org.apache.knox.gateway.GatewayMessages;
@@ -223,6 +225,11 @@ public class JettySSLService implements SSLService {
     List<String> sslExcludeProtocols = config.getExcludedSSLProtocols();
     if (sslExcludeProtocols != null && !sslExcludeProtocols.isEmpty()) {
       sslContextFactory.setExcludeProtocols( sslExcludeProtocols.toArray(new String[0]) );
+    }
+
+    final Set<String> sslIncludeProtocols = config.getIncludedSSLProtocols();
+    if (sslIncludeProtocols != null && sslIncludeProtocols.isEmpty()) {
+      sslContextFactory.setIncludeProtocols(sslIncludeProtocols.toArray(new String[0]));
     }
 
     sslContextFactory.setRenegotiationAllowed(config.isSSLRenegotiationAllowed());

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/JettySSLServiceTest.java
@@ -480,6 +480,7 @@ public class JettySSLServiceTest {
     expect(config.getTrustAllCerts()).andReturn(false).atLeastOnce();
     expect(config.getIncludedSSLCiphers()).andReturn(null).atLeastOnce();
     expect(config.getExcludedSSLCiphers()).andReturn(null).atLeastOnce();
+    expect(config.getIncludedSSLProtocols()).andReturn(null).atLeastOnce();
     expect(config.getExcludedSSLProtocols()).andReturn(null).atLeastOnce();
     expect(config.isSSLRenegotiationAllowed()).andReturn(true).atLeastOnce();
     return config;

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -304,6 +304,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public Set<String> getIncludedSSLProtocols() {
+    return Collections.singleton("TLSv1.2");
+  }
+
+  @Override
   public List<String> getExcludedSSLProtocols() {
     List<String> protocols = new ArrayList<>();
     protocols.add("SSLv3");

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -177,6 +177,8 @@ public interface GatewayConfig {
 
   boolean isSSLEnabled();
 
+  Set<String> getIncludedSSLProtocols();
+
   List<String> getExcludedSSLProtocols();
 
   List<String> getIncludedSSLCiphers();

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/TruststoreSSLContextUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/TruststoreSSLContextUtils.java
@@ -16,18 +16,17 @@
  */
 package org.apache.knox.gateway.util;
 
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.ssl.SSLContexts;
-import org.apache.knox.gateway.i18n.GatewaySpiMessages;
-import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.services.security.KeystoreService;
-import org.apache.knox.gateway.services.security.KeystoreServiceException;
-
-import javax.net.ssl.SSLContext;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
 public class TruststoreSSLContextUtils {
   private static final GatewaySpiMessages LOGGER = MessagesFactory.get(GatewaySpiMessages.class);
@@ -35,21 +34,18 @@ public class TruststoreSSLContextUtils {
   private TruststoreSSLContextUtils() {
   }
 
-  public static SSLContext getTruststoreSSLContext(KeystoreService keystoreService) {
+  public static SSLContext getTruststoreSSLContext(KeyStore truststore) {
     SSLContext sslContext = null;
     try {
-      if(keystoreService != null) {
-        KeyStore truststore = keystoreService.getTruststoreForHttpClient();
-        if (truststore != null) {
-          SSLContextBuilder sslContextBuilder = SSLContexts.custom();
-          sslContextBuilder.loadTrustMaterial(truststore, null);
-          sslContext = sslContextBuilder.build();
-        }
+      if (truststore != null) {
+        SSLContextBuilder sslContextBuilder = SSLContexts.custom();
+        sslContextBuilder.loadTrustMaterial(truststore, null);
+        sslContext = sslContextBuilder.build();
       }
-    } catch (KeystoreServiceException | NoSuchAlgorithmException | KeyStoreException
-                 | KeyManagementException e) {
+    } catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
       LOGGER.failedToLoadTruststore(e.getMessage(), e);
     }
     return sslContext;
   }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are 2 changes in this PR:
- TLS cipher suites and protocols are now customizable in CM service discovery:
  - end-users can define the TLS protocol(s) and cipher suite(s) to use while creating a secure connection to a CM instance
  - if none is defined, Knox will pick up the relevant supported values from Java's own `java.security` thru the acquired SSL context.
- Added a new method to indicate the TLS protocols to be included when creating SSL context in the embedded Jetty server. Prior to this change, end-users could only tell what to exclude.

## How was this patch tested?

Unit testing and running service discovery in a secure cluster with updated SSL configs.