### PR TITLE
KNOX-2865 -  Accessing parameters of a x-www-form-urlencoded request consumes the request body

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayFilter.java
@@ -184,7 +184,11 @@ public class GatewayFilter implements Filter {
       Chain chain = match.getValue();
       servletRequest.setAttribute( AbstractGatewayFilter.TARGET_SERVICE_ROLE, chain.getResourceRole() );
       try {
-        chain.doFilter( servletRequest, servletResponse );
+        chain.doFilter(
+                UrlEncodedFormRequest.isUrlEncodedForm(servletRequest)
+                  ? new UrlEncodedFormRequest((HttpServletRequest) servletRequest)
+                  : servletRequest,
+                servletResponse);
       } catch( IOException | RuntimeException | ThreadDeath | ServletException e ) {
         LOG.failedToExecuteFilter( e );
         auditor.audit( Action.ACCESS, contextWithPathAndQuery, ResourceType.URI, ActionOutcome.FAILURE );

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -775,4 +775,8 @@ public interface GatewayMessages {
   @Message(level = MessageLevel.INFO,
           text = "Initializing remote configuration db. Sync interval={0} seconds. Clean up interval={1} seconds.")
   void initDbRemoteConfigMonitor(long syncIntervalSeconds, int cleanUpPeriodSeconds);
+
+  @Message(level = MessageLevel.DEBUG,
+          text = "Request {0} is wrapped to url encoded form request.")
+  void wrappingRequestToUrlEncodedFormRequest(String requestURI);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/UrlEncodedFormRequest.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/UrlEncodedFormRequest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Map;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.eclipse.jetty.util.MultiMap;
+import org.eclipse.jetty.util.UrlEncoded;
+
+/**
+ * HttpServletRequest
+ *
+ * In section SRV.3.1.1 of Servlet spec, it has been stated that any access to request parameters
+ * of an "x-www-form-urlencoded" request (e.g. using HttpServletRequest#getParameter())
+ * can trigger the early consumption of the request InputStream.
+ *
+ * For example:
+ *    $ curl -u admin:admin-password -H "X-XSRF-Header: whatever" -k -X POST -d "a=1&b=2" https://localhost:8443/gateway/sandbox/hive?doAs=KNOX
+ *
+ * The getParameter("a") will parse (and CONSUME) request body "a=1&b=2" and return "1".
+ * The request body is treated as it was a query string, even though it is not part of the URL.
+ * The parameters from the body are mixed together with the query string parameters of the URL.
+ *
+ * The problem is that various authentication filters (such as HadoopAuthFilter) check if there is a doAs parameter in request.
+ * This will consume the input stream and the dispatch will forward an empty body to the service.
+ *
+ * To avoid this problem all "x-www-form-urlencoded" requests are wrapped into UrlEncodedFormRequest.
+ *
+ * This class ignores the request body when accessing the parameters (since KNOX as a proxy doesn't care about the payload either),
+ * and it only cares about the query string.
+ *
+ */
+public class UrlEncodedFormRequest extends HttpServletRequestWrapper {
+  private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
+  private final MultiMap<String> queryParams;
+
+  public UrlEncodedFormRequest(HttpServletRequest request) throws IOException {
+    super(request);
+    LOG.wrappingRequestToUrlEncodedFormRequest(request.getRequestURI());
+    this.queryParams = parseQueryString(request.getQueryString());
+  }
+
+  public static boolean isUrlEncodedForm(ServletRequest request) {
+    String contentType = request.getContentType();
+    return contentType != null && contentType.startsWith("application/x-www-form-urlencoded");
+  }
+
+  private MultiMap<String> parseQueryString(String queryString) {
+    MultiMap<String> params = new MultiMap<>();
+    if (queryString != null) {
+      UrlEncoded.decodeTo(queryString, params, getCharacterEncoding());
+    }
+    return params;
+  }
+
+  @Override
+  public String getParameter(String name) {
+    return queryParams.getValue(name, 0);
+  }
+
+  @Override
+  public String[] getParameterValues(String name) {
+    return getParameterMap().get(name);
+  }
+
+  @Override
+  public Map<String, String[]> getParameterMap() {
+    return queryParams.toStringArrayMap();
+  }
+
+  @Override
+  public Enumeration<String> getParameterNames() {
+    final Iterator<String> iterator = queryParams.keySet().iterator();
+    return new Enumeration<String>() {
+      @Override
+      public boolean hasMoreElements() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public String nextElement() {
+        return iterator.next();
+      }
+    };
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/UrlEncodedFormRequestTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/UrlEncodedFormRequestTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.knox.test.mock.MockHttpServletRequest;
+import org.apache.knox.test.mock.MockServletInputStream;
+import org.eclipse.jetty.io.RuntimeIOException;
+import org.junit.Test;
+
+public class UrlEncodedFormRequestTest {
+
+  @Test
+  public void testParametersAreComingFromQueryStringOnly() throws Exception {
+    MockHttpServletRequest originalRequest = makeRequest("a=1&b=2", "query1=x&query2=y&query2=y2");
+    assertEquals("1", originalRequest.getParameter("a"));
+    assertEquals("2", originalRequest.getParameter("b"));
+    UrlEncodedFormRequest wrappedRequest = new UrlEncodedFormRequest(originalRequest);
+    assertEquals("x", wrappedRequest.getParameter("query1"));
+    assertEquals("y", wrappedRequest.getParameter("query2"));
+    assertNull(wrappedRequest.getParameter("a"));
+    assertNull(wrappedRequest.getParameter("b"));
+    assertArrayEquals(new String[]{"x"}, wrappedRequest.getParameterValues("query1"));
+    assertArrayEquals(new String[]{"y", "y2"}, wrappedRequest.getParameterValues("query2"));
+    assertEquals(Arrays.asList("query1", "query2"), Collections.list(wrappedRequest.getParameterNames()));
+    assertArrayEquals(new String[]{"x"}, wrappedRequest.getParameterMap().get("query1"));
+    assertArrayEquals(new String[]{"y", "y2"}, wrappedRequest.getParameterMap().get("query2"));
+    assertNull(wrappedRequest.getParameterValues("unknown"));
+  }
+
+  private static MockHttpServletRequest makeRequest(String body, String queryString) {
+    MockHttpServletRequest request = new MockHttpServletRequest() {
+      private boolean parametersExtracted;
+      private Map<String, String> params = new HashMap<>();
+
+      @Override
+      public String getParameter(String name) { // mimic how the real request works
+        if (!parametersExtracted) {
+          try {
+            String body = IOUtils.toString(getInputStream(), StandardCharsets.UTF_8);
+            for (String parts : body.split("\\&")) {
+              params.put(parts.split("=")[0], parts.split("=")[1]);
+            }
+            parametersExtracted = true;
+          } catch (IOException e) {
+            throw new RuntimeIOException(e);
+          }
+        }
+        return params.get(name);
+      }
+    };
+    request.setQueryString(queryString);
+    request.setInputStream(new MockServletInputStream(
+            new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8))));
+    return request;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?


In section SRV.3.1.1 of Servlet spec states that any access to request parameters of an "x-www-form-urlencoded" request (e.g. using HttpServletRequest#getParameter()) can trigger the early consumption of the request InputStream.

For example:

```java
request.getParameter("doAs");
IOUtils.toString(request.getInputStream()); // <= This will be empty because getParameter() already consumed the stream
```

This causes knox to dispatch an empty request body to the service (HadoopAuthFilter always check the doAs param).

How is it fixed?

Knox as a proxy doesn't care about the request params coming from the request body. This patch introduces a wrapper class that only gets the parameters of the  "x-www-form-urlencoded" requests from the query string, ignoring the body altogether.

## How was this patch tested?

Tested it manually with curl.

```bash
$ curl -u admin:admin-password -H "X-XSRF-Header: whatever" -k -X POST -d "a=1&b=2" "https://localhost:8443/gateway/sandbox/hive?a=3"
```