### PR TITLE
KNOX-2871 - Refine should perform discovery check

### DIFF
--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -276,7 +276,7 @@ public class SimpleDescriptorHandlerFuncTest {
 
   private static final class NoOpServiceDiscovery implements ServiceDiscovery {
     static final String TYPE = "NO_OP";
-    static int discoveryCalled = 0;
+    static int discoveryCalled;
 
     @Override
     public String getType() {

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -108,6 +108,7 @@ public class SimpleDescriptorHandlerFuncTest {
           "            <param><name>localhost</name><value>sandbox,sandbox.hortonworks.com</value></param>\n" +
           "        </provider>\n" +
           "    </gateway>\n";
+  public static final String DISCOVERY_ADDRESS = "http://dummy_address";
 
 
   /*
@@ -147,7 +148,7 @@ public class SimpleDescriptorHandlerFuncTest {
       // Mock out the simple descriptor
       SimpleDescriptor testDescriptor = EasyMock.createNiceMock(SimpleDescriptor.class);
       EasyMock.expect(testDescriptor.getName()).andReturn("mysimpledescriptor").anyTimes();
-      EasyMock.expect(testDescriptor.getDiscoveryAddress()).andReturn(null).anyTimes();
+      EasyMock.expect(testDescriptor.getDiscoveryAddress()).andReturn(DISCOVERY_ADDRESS).anyTimes();
       EasyMock.expect(testDescriptor.getDiscoveryType()).andReturn(discoveryType).anyTimes();
       EasyMock.expect(testDescriptor.getDiscoveryUser()).andReturn(null).anyTimes();
       EasyMock.expect(testDescriptor.getProviderConfig()).andReturn(providerConfig.getAbsolutePath()).anyTimes();
@@ -245,6 +246,7 @@ public class SimpleDescriptorHandlerFuncTest {
       assertEquals("Unexpected alias value (should be master secret + topology name.",
                    testMasterSecret + testDescriptor.getName(), capturedPwd.getValue());
 
+      assertEquals(1, NoOpServiceDiscovery.discoveryCalled);
     } catch (Exception e) {
       e.printStackTrace();
       fail(e.getMessage());
@@ -274,6 +276,7 @@ public class SimpleDescriptorHandlerFuncTest {
 
   private static final class NoOpServiceDiscovery implements ServiceDiscovery {
     static final String TYPE = "NO_OP";
+    static int discoveryCalled = 0;
 
     @Override
     public String getType() {
@@ -290,12 +293,12 @@ public class SimpleDescriptorHandlerFuncTest {
 
         @Override
         public List<String> getServiceURLs(String serviceName) {
-          return null;
+          return Collections.emptyList();
         }
 
         @Override
         public List<String> getServiceURLs(String serviceName, Map<String, String> serviceParams) {
-          return null;
+          return Collections.emptyList();
         }
 
         @Override
@@ -307,6 +310,7 @@ public class SimpleDescriptorHandlerFuncTest {
 
     @Override
     public Cluster discover(GatewayConfig gwConfig, ServiceDiscoveryConfig config, String clusterName, Collection<String> includedServices) {
+      discoveryCalled++;
       return discover(gwConfig, config, clusterName);
     }
   }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.simple;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
@@ -210,8 +211,7 @@ public class SimpleDescriptorHandler {
      */
     private static boolean shouldPerformDiscovery(final SimpleDescriptor desc) {
         // If there is a discovery type specified, then discovery should be performed
-        final String discoveryType = desc.getDiscoveryType();
-        if (discoveryType != null && !discoveryType.isEmpty()) {
+        if (StringUtils.isNotBlank(desc.getDiscoveryType()) && StringUtils.isNotBlank(desc.getDiscoveryAddress())) {
             return true;
         }
         log.missingDiscoveryTypeInDescriptor(desc.getName());

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
@@ -29,7 +29,7 @@ public interface SimpleDescriptorMessages {
     void discoveryNotConfiguredForDescriptor(String descriptorName);
 
     @Message(level = MessageLevel.INFO,
-            text = "The \"{0}\" descriptor does not include discovery-type.")
+            text = "The \"{0}\" descriptor does not include discovery-type or discovery-address.")
     void missingDiscoveryTypeInDescriptor(String descriptorName);
 
     @Message(level = MessageLevel.WARN,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `discovery-type` is defined set to default `"ClouderaManager"` if it's missing, so a discovery is always triggered even if the `discovery-address` is missing.

This patch adds an additional check to see if the url is set or not.

## How was this patch tested?

descriptor: test.json

```json
{
  "provider-config-ref":"ldap",
  "discovery-type": "ClouderaManager",
  "discovery-address": "http://localhost/test",
  "cluster": "test",
  "services":[
    {"name":"NAMENODE"},
    {"name":"WEBHDFS"}
  ]
}
```

provider: ldap.json

```json
{
  "providers": [
    {
      "role": "authentication",
      "name": "ShiroProvider",
      "enabled": "true",
      "params": {
        "sessionTimeout": "20",
        "main.ldapRealm": "org.apache.knox.gateway.shirorealm.KnoxLdapRealm",
        "main.ldapContextFactory": "org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory",
        "main.ldapRealm.contextFactory": "$ldapContextFactory",
        "main.ldapRealm.userDnTemplate": "uid={0},ou=people,dc=hadoop,dc=apache,dc=org",
        "main.ldapRealm.contextFactory.url": "ldap://localhost:33389",
        "main.ldapRealm.contextFactory.authenticationMechanism": "simple",
        "urls./**": "authcBasic"
      }
    }
  ]
}
```

Checked that discovery was only triggered if both discovery address + type was defined.