### PR TITLE
KNOX-2869 - Handling the case when previously persisted CM discovery config is empty

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -142,6 +142,12 @@ public interface ClouderaManagerServiceDiscoveryMessages {
            text = "Terminating monitoring of {1} @ {0} for configuration changes because there are no referencing descriptors.")
   void stoppingConfigMonitoring(String discoverySource, String clusterName);
 
+  @Message(level = MessageLevel.WARN, text = "Missing property in previously saved service discovery configuration {0}")
+  void missingServiceDiscoveryConfigProperty(String propertyName);
+
+  @Message(level = MessageLevel.DEBUG, text = "There is no cluster configuration for {0} @ {1} to check yet.")
+  void noClusterConfiguration(String clusterName, String discoveryAddress);
+
   @Message(level = MessageLevel.DEBUG, text = "Checking {0} @ {1} for configuration changes...")
   void checkingClusterConfiguration(String clusterName, String discoveryAddress);
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/DiscoveryConfigurationFileStore.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/DiscoveryConfigurationFileStore.java
@@ -17,6 +17,7 @@
 package org.apache.knox.gateway.topology.discovery.cm.monitor;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
@@ -86,27 +87,34 @@ public class DiscoveryConfigurationFileStore extends AbstractConfigurationStore
         try (InputStream in = Files.newInputStream(persisted.toPath())) {
           props.load(in);
 
-          result.add(new ServiceDiscoveryConfig() {
-            @Override
-            public String getAddress() {
-              return props.getProperty(PROP_CLUSTER_SOURCE);
-            }
+          if (StringUtils.isBlank(props.getProperty(PROP_CLUSTER_SOURCE))) {
+            log.missingServiceDiscoveryConfigProperty(PROP_CLUSTER_SOURCE);
+          } else if (StringUtils.isBlank(props.getProperty(PROP_CLUSTER_NAME))) {
+            log.missingServiceDiscoveryConfigProperty(PROP_CLUSTER_NAME);
+          } else {
+            result.add(new ServiceDiscoveryConfig() {
+              @Override
+              public String getAddress() {
+                return props.getProperty(PROP_CLUSTER_SOURCE);
+              }
 
-            @Override
-            public String getCluster() {
-              return props.getProperty(PROP_CLUSTER_NAME);
-            }
+              @Override
+              public String getCluster() {
+                return props.getProperty(PROP_CLUSTER_NAME);
+              }
 
-            @Override
-            public String getUser() {
-              return props.getProperty(PROP_CLUSTER_USER);
-            }
+              @Override
+              public String getUser() {
+                return props.getProperty(PROP_CLUSTER_USER);
+              }
 
-            @Override
-            public String getPasswordAlias() {
-              return props.getProperty(PROP_CLUSTER_ALIAS);
-            }
-          });
+              @Override
+              public String getPasswordAlias() {
+                return props.getProperty(PROP_CLUSTER_ALIAS);
+              }
+            });
+          }
+
         } catch (IOException e) {
           log.failedToLoadClusterMonitorServiceDiscoveryConfig(getMonitorType(), e);
         }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -204,6 +204,10 @@ public class PollingConfigurationAnalyzer implements Runnable {
         for (Map.Entry<String, List<String>> entry : configCache.getClusterNames().entrySet()) {
           String address = entry.getKey();
           for (String clusterName : entry.getValue()) {
+            if (configCache.getDiscoveryConfig(address, clusterName) == null) {
+              log.noClusterConfiguration(clusterName, address);
+              continue;
+            }
             log.checkingClusterConfiguration(clusterName, address);
 
             // Check here for existing descriptor references, and add to the removal list if there are not any
@@ -234,10 +238,10 @@ public class PollingConfigurationAnalyzer implements Runnable {
         }
         clustersToStopMonitoring.clear(); // reset the removal list
 
-        waitFor(interval);
       } catch (Exception e) {
         log.clouderaManagerConfigurationChangesMonitoringError(e);
       }
+      waitFor(interval);
     }
 
     log.stoppedClouderaManagerConfigMonitor();


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in the corresponding JIRA, Knox should handle the situation when a previously stored CM discovery config file exists, but it's empty. This may prevent the Knox Gateway from starting up.

## How was this patch tested?

Added new JUnit test cases to cover this event and ran manual testing:
- Stopped the Knox GW in a cluster where I had descriptors with CM service discovery enabled
- truncted the `$KNOX_GW_DATA_DIR/cm_clusters/xyz.conf` file
- restarted the Knox Gateway

Prior to my changes, the Knox GW did not start; After my fix, everything is working as expected.