### PR TITLE
KNOX-2879 - pty4j depends on log4j1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2200,6 +2200,12 @@
                 <groupId>org.jetbrains.pty4j</groupId>
                 <artifactId>pty4j</artifactId>
                 <version>${pty4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.pty4j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

pty4j depends on log4j1. Unfortunately 0.12.x pty4j is compiled with jdk11 so upgrade to a new version is not yet possible. This patch excludes the transitive dependency.

## How was this patch tested?

```bash
$ mvn dependency:tree
```

```bash
$ ls dep/*log4j*
dep/log4j-api-2.17.1.jar	dep/log4j-core-2.17.1.jar	dep/log4j-slf4j-impl-2.17.1.jar
```


Opened webshell on admin UI and tested the basic functionality

