### PR TITLE
KNOX-2881 - KnoxCLI handles aliases when testing LDAP (system) authentication

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -941,7 +941,30 @@ public class KnoxCLITest {
             "1 alias(es) have been successfully created: [alias1]"));
   }
 
-  private class GatewayConfigMock extends GatewayConfigImpl{
+  @Test
+  public void testSystemUserAuthTest() throws Exception {
+    final String cluster = "sandbox";
+    final String alias = "ldapsystempassword";
+    final AliasService aliasService = KnoxCLI.getGatewayServices().getService(ServiceType.ALIAS_SERVICE);
+    try {
+      aliasService.addAliasForCluster(cluster, alias, "admin-password");
+      outContent.reset();
+      final GatewayConfigMock gatewayConfig = new GatewayConfigMock();
+      final URL topoURL = ClassLoader.getSystemResource("conf-demo/conf/topologies/" + cluster + ".xml");
+      gatewayConfig.setConfDir( new File(topoURL.getFile()).getParentFile().getParent() );
+      final KnoxCLI cli = new KnoxCLI();
+      cli.setConf(gatewayConfig);
+      final String[] args = { "system-user-auth-test", "--cluster", cluster };
+      final int rc = cli.run(args);
+      assertEquals(0, rc);
+      assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains(
+          "System password is stored as an alias " + alias + "; looking it up..."));
+    } finally {
+      aliasService.removeAliasForCluster(cluster, alias);
+    }
+  }
+
+  private class GatewayConfigMock extends GatewayConfigImpl {
     private String confDir;
     public void setConfDir(String location) {
       confDir = location;

--- a/gateway-server/src/test/resources/conf-demo/conf/topologies/sandbox.xml
+++ b/gateway-server/src/test/resources/conf-demo/conf/topologies/sandbox.xml
@@ -57,6 +57,14 @@
                 <value>simple</value>
             </param>
             <param>
+               <name>main.ldapRealm.contextFactory.systemUsername</name>
+               <value>uid=admin,ou=people,dc=hadoop,dc=apache,dc=org</value>
+            </param>
+            <param>
+               <name>main.ldapRealm.contextFactory.systemPassword</name>
+               <value>${ALIAS=ldapsystempassword}</value>
+            </param>
+            <param>
                 <name>urls./**</name>
                 <value>authcBasic</value>
             </param>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added alias service lookup when dealing with LDAP system passwords in a form of `${ALIAS=value}`. 

## How was this patch tested?

Added new unit test case to cover this improvement, and ran manual testing:
Added the following parameters in the KnoxSSO topology:
```
  <param>
      <name>main.ldapRealm.contextFactory.systemUsername</name>
      <value>uid=admin,ou=people,dc=hadoop,dc=apache,dc=org</value>
  </param>        
    
  <param>
    <name>main.ldapRealm.contextFactory.systemPassword</name>
    <value>${ALIAS=ldapsystempassword}</value>
  </param>
```
Saved `ldapsystempassword`:
```
$ bin/knoxcli.sh create-alias ldapsystempassword --value admin-password --cluster knoxsso
ldapsystempassword has been successfully created.
```
Prior to my changes; I got this:
```
$ bin/knoxcli.sh system-user-auth-test --cluster knoxsso
org.apache.shiro.authc.AuthenticationException: LDAP authentication failed.
[LDAP: error code 49 - INVALID_CREDENTIALS: Bind failed: ERR_229 Cannot authenticate user uid=admin,ou=people,dc=hadoop,dc=apache,dc=org]
For more information use --d for debug output.
```

After my changes:
```
$ bin/knoxcli.sh system-user-auth-test --cluster knoxsso
System password is stored as an alias ldapsystempassword; looking it up...
System LDAP Bind successful.
```
