### PR TITLE
KNOX-2883 Missing attach logging context from HadoopAuthFilter

### DIFF
--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilter.java
@@ -253,6 +253,7 @@ public class HadoopAuthFilter extends
     AuditContext context = auditService.getContext();
     if (context != null) {
       context.setUsername( principal.getName() );
+      auditService.attachContext(context);
       String sourceUri = (String)request.getAttribute( AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME );
       if (sourceUri != null) {
         auditor.audit( Action.AUTHENTICATION , sourceUri, ResourceType.URI, ActionOutcome.SUCCESS );


### PR DESCRIPTION
## What changes were proposed in this pull request?

`auditService.attachContext(context);` should be called so that the logging information is stored in the thread context.

## How was this patch tested?

Tested manually.