### PR TITLE
KNOX-2889 - Changed message level when logging Hadoop Authentication failure on impersonation paths

### DIFF
--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/IdentityAsserterMessages.java
@@ -61,6 +61,6 @@ public interface IdentityAsserterMessages {
   @Message( level = MessageLevel.DEBUG, text = "Proxy user Authentication successful" )
   void hadoopAuthProxyUserSuccess();
 
-  @Message( level = MessageLevel.DEBUG, text = "Proxy user Authentication failed: {0}" )
+  @Message( level = MessageLevel.ERROR, text = "Proxy user Authentication failed: {0}" )
   void hadoopAuthProxyUserFailed(@StackTrace Throwable t);
 }

--- a/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
+++ b/gateway-provider-security-hadoopauth/src/main/java/org/apache/knox/gateway/hadoopauth/HadoopAuthMessages.java
@@ -33,7 +33,7 @@ public interface HadoopAuthMessages {
   @Message( level = MessageLevel.DEBUG, text = "Proxy user Authentication successful" )
   void hadoopAuthProxyUserSuccess();
 
-  @Message( level = MessageLevel.DEBUG, text = "Proxy user Authentication failed: {0}" )
+  @Message( level = MessageLevel.ERROR, text = "Proxy user Authentication failed: {0}" )
   void hadoopAuthProxyUserFailed(@StackTrace Throwable t);
 
   @Message( level = MessageLevel.DEBUG, text = "Initialized the JWT federation filter" )


### PR DESCRIPTION
## What changes were proposed in this pull request?

I changed Hadoop Authentication message level from `DEBUG` to `ERROR`.

## How was this patch tested?

Re-deployed Knox, made sure to break token impersonation, and confirmed that logs showed the authentication failures on the `ERROR` level:
```
2023-03-20 10:22:48,956 36349731-605c-4b5f-ae05-006cff5feaf0 ERROR knox.gateway (CommonIdentityAssertionFilter.java:doFilter(223)) - Proxy user Authentication failed: org.apache.knox.gateway.util.AuthorizationException: org.apache.hadoop.security.authorize.AuthorizationException: User: admin is not allowed to impersonate bob
```