### PR TITLE
KNOX-2891 - Topology is not deployed if the referred provider file is…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -694,10 +694,10 @@ public class GatewayServer {
 
     cleanupTopologyDeployments();
 
+    handleHadoopXmlResources();
+
     // Start the topology monitor.
     monitor.startMonitor();
-
-    handleHadoopXmlResources();
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is an ordering issue between the topology service + hadoop xml resource monitor. The topology service is started first, and it'll immediately trigger an onChange event on all descriptors. Hadoop xml resource monitor will create the providers afterwards so it can happen that even the provider is available (in the hxr) the file is not yet generated therefore the topology won't be generated due to the missing provider.

## How was this patch tested?

1. Created a descriptor with a non existing provider

```
sample_topology2
providerConfigRef=testProviders2##WEBHDFS:url=https://dummy:7189
```

2. Restarteed kox

3. Observed the unresolved provider reference message in the log

```bash
[root@amagyar-1 ~]# grep "Unresolved provider configuration reference" /var/log/knox/gateway/gateway.log  | wc -l
1
```

4. Added the missing provider

```
providerConfigs:testProviders2
role=authentication#authentication.name=ShiroProvider
```

5. Restarted knox

6. No new unresolved  provider reference message, just the old one

```bash
[root@amagyar-1 ~]# grep "Unresolved provider configuration reference" /var/log/knox/gateway/gateway.log  | wc -l
1
```

7. Both topology + provider were generateed.

```bash
/var/lib/knox/gateway/conf/topologies/sample_topology2.xml
/var/lib/knox/gateway/conf/shared-providers/testProviders2.json 
````
