### PR TITLE
KNOX-2894 - NPE when invalid composite provider name is given

### DIFF
--- a/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-composite/src/main/java/org/apache/knox/gateway/deploy/impl/CompositeAuthzDeploymentContributor.java
@@ -19,7 +19,9 @@ package org.apache.knox.gateway.deploy.impl;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.deploy.DeploymentContext;
+import org.apache.knox.gateway.deploy.DeploymentException;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
+import org.apache.knox.gateway.deploy.ProviderDeploymentContributor;
 import org.apache.knox.gateway.deploy.ProviderDeploymentContributorBase;
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
@@ -62,8 +64,13 @@ public class CompositeAuthzDeploymentContributor extends ProviderDeploymentContr
     List<String> names = parseProviderNames(providerNames);
     for (String name : names) {
       getProviderSpecificParams(resource, params, providerParams, name);
-      DeploymentFactory.getProviderContributor("authorization", name)
-              .contributeFilter(context, provider, service, resource, params);
+      ProviderDeploymentContributor contributor = DeploymentFactory.getProviderContributor("authorization", name);
+      if (contributor == null) {
+        throw new DeploymentException(
+                "Invalid composite provider name: " + name + " role: " + provider.getRole() +
+                        " provider: " + provider.getName() + " topology: " + context.getTopology().getName());
+      }
+      contributor.contributeFilter(context, provider, service, resource, params);
       params.clear();
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

NullPointerException is thrown when the referenced provider is invalid in a composite provider.

```
<provider>
  <role>authorization</role>
  <name>CompositeAuthz</name>
  <enabled>true</enabled>
  <param>
      <name>composite.provider.names</name>
      <value>x</value>
  </param>
</provider>
```

## How was this patch tested?

Manually:

```
2023-03-29 10:19:20,541  ERROR knox.gateway (DeploymentFactory.java:contributeServices(514)) - Failed to contribute service [role=WEBHDFS, name=null]: org.apache.knox.gateway.deploy.DeploymentException: Invalid composite provider name: x role: authorization provider: CompositeAuthz topology: sandbox
org.apache.knox.gateway.deploy.DeploymentException: Invalid composite provider name: x role: authorization provider: CompositeAuthz topology: sandbox
    at org.apache.knox.gateway.deploy.impl.CompositeAuthzDeploymentContributor.contributeFilter(CompositeAuthzDeploymentContributor.java:71) ~[gateway-provider-security-authz-composite-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
````
