### PR TITLE
KNOX-2895 - KnoxShell supports dynamic truststore type when connecting to Knox

### DIFF
--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ClientContext.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ClientContext.java
@@ -20,7 +20,9 @@ package org.apache.knox.gateway.shell;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.SubsetConfiguration;
+import org.apache.commons.lang3.StringUtils;
 
+import java.security.KeyStore;
 import java.util.HashMap;
 
 public class ClientContext {
@@ -172,10 +174,10 @@ public class ClientContext {
       return this;
     }
 
-    public ConnectionContext withTruststore(final String truststoreLocation,
-        final String truststorePass) {
+    public ConnectionContext withTruststore(final String truststoreLocation, final String truststorePass, final String truststoreType) {
       configuration.addProperty("truststoreLocation", truststoreLocation);
       configuration.addProperty("truststorePass", truststorePass);
+      configuration.addProperty("truststoreType", truststoreType);
       return this;
     }
 
@@ -190,6 +192,11 @@ public class ClientContext {
 
     public String truststorePass() {
       return configuration.getString("truststorePass");
+    }
+
+    public String truststoreType() {
+      final String truststoreType = configuration.getString("truststoreType");
+      return StringUtils.isBlank(truststoreType) ? KeyStore.getDefaultType() : truststoreType;
     }
 
     public String endpointPublicCertPem() {

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/util/ClientTrustStoreHelper.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/util/ClientTrustStoreHelper.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.shell.util;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 
 /**
  * Provides useful helper methods related to gateway client trust store
@@ -33,6 +34,7 @@ public class ClientTrustStoreHelper {
   private static final String ENV_GATEWAY_CLIENT_TRUSTSTORE_DIR = "GATEWAY_CLIENT_TRUSTSTORE_DIR";
   private static final String ENV_GATEWAY_CLIENT_TRUSTSTORE_FILENAME = "GATEWAY_CLIENT_TRUSTSTORE_FILENAME";
   private static final String ENV_GATEWAY_CLIENT_TRUSTSTORE_PASSWORD = "GATEWAY_CLIENT_TRUSTSTORE_PASS";
+  private static final String ENV_GATEWAY_CLIENT_TRUSTSTORE_TYPE = "GATEWAY_CLIENT_TRUSTSTORE_TYPE";
 
   public static File getClientTrustStoreFile() {
     final String truststoreDir = fetchTrustStoreAttribute(ENV_GATEWAY_CLIENT_TRUSTSTORE_DIR, DEFAULT_GATEWAY_CLIENT_TRUSTSTORE_DIR);
@@ -42,6 +44,10 @@ public class ClientTrustStoreHelper {
 
   public static String getClientTrustStoreFilePassword() {
     return fetchTrustStoreAttribute(ENV_GATEWAY_CLIENT_TRUSTSTORE_PASSWORD, DEFAULT_GATEWAY_CLIENT_TRUSTSTORE_PASSWORD);
+  }
+
+  public static String getClientTrustStoreType() {
+    return fetchTrustStoreAttribute(ENV_GATEWAY_CLIENT_TRUSTSTORE_TYPE, KeyStore.getDefaultType());
   }
 
   private static String fetchTrustStoreAttribute(String environmentVariableName, String defaultValue) {

--- a/gateway-shell/src/test/java/org/apache/knox/gateway/shell/KnoxSessionTest.java
+++ b/gateway-shell/src/test/java/org/apache/knox/gateway/shell/KnoxSessionTest.java
@@ -27,11 +27,14 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.bootstrap.HttpServer;
 import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.apache.knox.gateway.shell.ClientContext.ConnectionContext;
 import org.junit.Test;
 
 import javax.security.auth.Subject;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.net.URISyntaxException;
+import java.security.KeyStore;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
@@ -197,6 +200,15 @@ public class KnoxSessionTest {
     } finally {
       server.stop();
     }
+  }
+
+  @Test
+  public void testTrustStoreTypeConfig() throws URISyntaxException {
+    final String url = "https://localhost:8443/gateway/dt";
+    ConnectionContext connectionContext = ClientContext.with(url).connection().withTruststore(null, null, null);
+    assertEquals(KeyStore.getDefaultType(), connectionContext.truststoreType());
+    connectionContext = ClientContext.with("https://localhost:8443/gateway/dt").connection().withTruststore(null, null, "BCFKS");
+    assertEquals("BCFKS", connectionContext.truststoreType());
   }
 
   public static int findFreePort() throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Until now, the truststore type was hardcoded to `JKS` in KnoxShell when handling trust stores. With this change, 

## How was this patch tested?

Added a new unit test case to cover this change and tested manually in a FIPS-enabled cluster where `BCFKS` (Bouncy Castle) truststores were used.
