### PR TITLE
KNOX-2897 - Using Expect:100-continue wherever possible to upload big content

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateServiceTest.java
@@ -369,7 +369,7 @@ public class AliasBasedTokenStateServiceTest extends DefaultTokenStateServiceTes
     // Neither addAliasForCluster nor removeAliasForCluster should be called because updating expiration should happen in memory and let the
     // background persistence job done its job
     aliasService.addAliasesForCluster(anyString(), anyObject());
-    EasyMock.expectLastCall().andVoid().once(); // Expecting this during shutdown
+    EasyMock.expectLastCall().andVoid().atLeastOnce(); // Expecting this during shutdown
 
     //expecting this call when loading credentials from the keystore on startup
     EasyMock.expect(aliasService.getPasswordsForGateway()).andReturn(Collections.emptyMap()).anyTimes();

--- a/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas-api/2.0.0/service.xml
@@ -46,5 +46,10 @@
         <route path="/atlas/api/**"/>
     </routes>
 
-    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch" ha-classname="org.apache.knox.gateway.ha.dispatch.AtlasApiTrustedProxyHaDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.dispatch.DefaultDispatch" ha-classname="org.apache.knox.gateway.ha.dispatch.AtlasApiTrustedProxyHaDispatch">
+        <param>
+            <name>addExpect100Continue</name>
+            <value>true</value>
+        </param>
+    </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/atlas/2.1.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/atlas/2.1.0/service.xml
@@ -44,5 +44,9 @@
             <name>responseExcludeHeaders</name>
             <value>WWW-AUTHENTICATE</value>
         </param>
+        <param>
+            <name>addExpect100Continue</name>
+            <value>true</value>
+        </param>
     </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/hive/0.13.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/hive/0.13.0/service.xml
@@ -33,5 +33,9 @@
         <name>httpclient.socketTimeout</name>
         <value>5m</value>
       </param>
+      <param>
+        <name>addExpect100Continue</name>
+        <value>true</value>
+      </param>
     </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/1.0.0/service.xml
@@ -52,8 +52,8 @@
             <value>WWW-AUTHENTICATE</value>
         </param>
         <param>
-            <name>replayBufferSize</name>
-            <value>65</value>
+          <name>addExpect100Continue</name>
+          <value>true</value>
         </param>
     </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/rangerui/1.0.0/service.xml
@@ -44,5 +44,9 @@
             <name>responseExcludeHeaders</name>
             <value>WWW-AUTHENTICATE</value>
         </param>
+        <param>
+          <name>addExpect100Continue</name>
+          <value>true</value>
+        </param>
     </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/service.xml
@@ -61,10 +61,22 @@
         </route>
         <route path="/webhdfs/data/v1/**?**">
             <rewrite apply="WEBHDFS/webhdfs/inbound/datanode" to="request.url"/>
-            <dispatch contributor-name="http-client" ha-classname="org.apache.knox.gateway.dispatch.DefaultDispatch" />
+            <dispatch contributor-name="http-client" ha-classname="org.apache.knox.gateway.dispatch.DefaultDispatch">
+                <param>
+                    <name>addExpect100Continue</name>
+                    <!-- This should never be set to true -->
+                    <value>false</value>
+                </param>
+            </dispatch>
         </route>
     </routes>
-    <dispatch classname="org.apache.knox.gateway.hdfs.dispatch.HdfsHttpClientDispatch" ha-classname="org.apache.knox.gateway.hdfs.dispatch.WebHdfsHaDispatch"/>
+    <dispatch classname="org.apache.knox.gateway.hdfs.dispatch.HdfsHttpClientDispatch" ha-classname="org.apache.knox.gateway.hdfs.dispatch.WebHdfsHaDispatch">
+        <param>
+            <name>addExpect100Continue</name>
+            <!-- This should never be set to true -->
+            <value>false</value>
+        </param>
+    </dispatch>
     <testURLs>
         <testURL>/webhdfs/v1/?op=LISTSTATUS</testURL>
     </testURLs>

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsHttpClientDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/HdfsHttpClientDispatch.java
@@ -41,6 +41,11 @@ public class HdfsHttpClientDispatch extends ConfigurableDispatch {
   @Override
   protected HttpEntity createRequestEntity(HttpServletRequest request)
       throws IOException {
+    return createRequestEntity(request, false);
+  }
+
+  @Override
+  protected HttpEntity createRequestEntity(HttpServletRequest request, boolean useBufferedEntity) throws IOException {
     return null;
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -100,6 +100,9 @@ public interface SpiGatewayMessages {
   @Message( level = MessageLevel.INFO, text = "replayBufferSize is set to {0} for {1}" )
   void setReplayBufferSize(int replayBufferSize, String serviceRole);
 
+  @Message( level = MessageLevel.DEBUG, text = "addExpect100Continue is set to {0} for {1}" )
+  void setAddExpect100Continue(boolean addExpect100Continue, String serviceRole);
+
   @Message( level = MessageLevel.DEBUG, text = "Using two way SSL in {0}" )
   void usingTwoWaySsl(String serviceRole);
 
@@ -114,4 +117,10 @@ public interface SpiGatewayMessages {
 
   @Message( level = MessageLevel.INFO, text = "HTTP client retry non safe request is set to {0} for {1}" )
   void setRetryNonIndependent(boolean retryNonIndependent, String serviceRole);
+
+  @Message (level = MessageLevel.DEBUG, text = "Added Expect:100-continue header into the outbound request")
+  void addedExpect100Continue();
+
+  @Message (level = MessageLevel.DEBUG, text = "Received HTTP servlet request with length = {0}")
+  void receivedRequestWithLength(int length);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -31,7 +31,6 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
-import org.apache.knox.gateway.SpiGatewayMessages;
 import org.apache.knox.gateway.SpiGatewayResources;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
@@ -43,7 +42,6 @@ import org.apache.knox.gateway.config.Configure;
 import org.apache.knox.gateway.config.Default;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.Optional;
-import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
 import org.apache.knox.gateway.util.MimeTypes;
 
@@ -69,7 +67,6 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
   protected static final Set<String> EXCLUDE_SET_COOKIES_DEFAULT = new HashSet<>(Arrays.asList("hadoop.auth", "hive.server2.auth", "impala.auth"));
 
 
-  protected static final SpiGatewayMessages LOG = MessagesFactory.get(SpiGatewayMessages.class);
   protected static final SpiGatewayResources RES = ResourcesFactory.get(SpiGatewayResources.class);
   protected static final Auditor auditor = AuditServiceFactory.getAuditService().getAuditor(AuditConstants.DEFAULT_AUDITOR_NAME,
       AuditConstants.KNOX_SERVICE_NAME, AuditConstants.KNOX_COMPONENT_NAME);
@@ -84,6 +81,9 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
 
   //Buffer size in bytes
   private int replayBufferSize = -1;
+
+  //whether to add Expect:100-continue to PUT/POST requests like 'curl' does
+  private boolean addExpect100Continue;
 
   @Override
   public void destroy() {
@@ -119,6 +119,12 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
     }
     replayBufferSize = size;
     LOG.setReplayBufferSize(replayBufferSize, getServiceRole());
+  }
+
+  @Configure
+  protected void setAddExpect100Continue(@Default("false")boolean addExpect100Continue) {
+    this.addExpect100Continue = addExpect100Continue;
+    LOG.setAddExpect100Continue(addExpect100Continue, serviceRole);
   }
 
   /**
@@ -258,9 +264,13 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
    }
 
    protected HttpEntity createRequestEntity(HttpServletRequest request) throws IOException {
-      String contentType = request.getContentType();
-      int contentLength = request.getContentLength();
-      InputStream contentStream = request.getInputStream();
+     return createRequestEntity(request, false);
+   }
+
+   protected HttpEntity createRequestEntity(HttpServletRequest request, boolean useBufferedEntity) throws IOException {
+      final String contentType = request.getContentType();
+      final int contentLength = request.getContentLength();
+      final InputStream contentStream = request.getInputStream();
 
       HttpEntity entity;
       if (contentType == null) {
@@ -268,24 +278,28 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
       } else {
          entity = new InputStreamEntity(contentStream, contentLength, ContentType.parse(contentType));
       }
-      GatewayConfig config =
-         (GatewayConfig)request.getServletContext().getAttribute( GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE );
-      if( config != null && config.isHadoopKerberosSecured() ) {
-        //Check if delegation token is supplied in the request
-        boolean delegationTokenPresent = false;
-        String queryString = request.getQueryString();
-        if (queryString != null) {
-          delegationTokenPresent = queryString.startsWith("delegation=") || queryString.contains("&delegation=");
-        }
-        if (replayBufferSize < 0) {
-          replayBufferSize = config.getHttpServerRequestBuffer();
-        }
-        if (!delegationTokenPresent && replayBufferSize > 0 ) {
-          entity = new PartiallyRepeatableHttpEntity(entity, replayBufferSize);
+
+      final GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+      if (config != null && config.isHadoopKerberosSecured()) {
+        if (useBufferedEntity) {
+          entity = new KnoxBufferedHttpEntity(entity);
+        } else {
+          // To honor backward-compatibility we should keep replayBufferSize-based entity creation
+          if (replayBufferSize < 0) {
+            replayBufferSize = config.getHttpServerRequestBuffer();
+          }
+          if (!requestHasDelegationToken(request) && replayBufferSize > 0) {
+            entity = new PartiallyRepeatableHttpEntity(entity, replayBufferSize);
+          }
         }
       }
 
       return entity;
+   }
+
+   private boolean requestHasDelegationToken(HttpServletRequest request) {
+     final String queryString = request.getQueryString();
+     return queryString == null ? false : queryString.startsWith("delegation=") || queryString.contains("&delegation=");
    }
 
    @Override
@@ -310,11 +324,11 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
    @Override
    public void doPut(URI url, HttpServletRequest request, HttpServletResponse response)
          throws IOException {
-      HttpPut method = new HttpPut(url);
-      HttpEntity entity = createRequestEntity(request);
+      final HttpPut method = new HttpPut(url);
+      copyRequestHeaderFields(method, request, addExpect100Continue);
+      final HttpEntity entity = createRequestEntity(request, addExpect100Continue);
       method.setEntity(entity);
-      copyRequestHeaderFields(method, request);
-     executeRequestWrapper(method, request, response);
+      executeRequestWrapper(method, request, response);
    }
 
    @Override
@@ -324,17 +338,20 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
       HttpEntity entity = createRequestEntity(request);
       method.setEntity(entity);
       copyRequestHeaderFields(method, request);
-     executeRequestWrapper(method, request, response);
+      executeRequestWrapper(method, request, response);
    }
 
    @Override
    public void doPost(URI url, HttpServletRequest request, HttpServletResponse response)
          throws IOException, URISyntaxException {
+      final int contentLength = request.getContentLength();
+      LOG.receivedRequestWithLength(contentLength);
+      final boolean shouldAddExpect100Continue = addExpect100Continue && (contentLength > 1024 || contentLength == -1);
       HttpPost method = new HttpPost(url);
-      HttpEntity entity = createRequestEntity(request);
+      copyRequestHeaderFields(method, request, shouldAddExpect100Continue);
+      HttpEntity entity = createRequestEntity(request, shouldAddExpect100Continue);
       method.setEntity(entity);
-      copyRequestHeaderFields(method, request);
-     executeRequestWrapper(method, request, response);
+      executeRequestWrapper(method, request, response);
    }
 
    @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/KnoxBufferedHttpEntity.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/KnoxBufferedHttpEntity.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.dispatch;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.entity.HttpEntityWrapper;
+import org.apache.http.util.Args;
+
+/**
+ * A {@link BufferedHttpEntity} implementation with the following differences:
+ * <ul>
+ * <li>Reading the content of the given entity does not happen at instance creation time (i.e not in the constructor)
+ * <li>Content length calculation is not based on the buffer but a delegate to the wrapped entity
+ * </ul>
+ */
+public class KnoxBufferedHttpEntity extends HttpEntityWrapper {
+
+  private byte[] buffer;
+
+  public KnoxBufferedHttpEntity(final HttpEntity entity) throws IOException {
+    super(entity);
+    // this time we skip reading the entity content to buffer
+  }
+
+  @Override
+  public long getContentLength() {
+    return wrappedEntity.getContentLength();
+  }
+
+  @Override
+  public InputStream getContent() throws IOException {
+    readBuffer();
+    return this.buffer != null ? new ByteArrayInputStream(this.buffer) : super.getContent();
+  }
+
+  private boolean shouldPopulateBuffer() {
+    return !wrappedEntity.isRepeatable() || wrappedEntity.getContentLength() < 0;
+  }
+
+  private void readBuffer() throws IOException {
+    if (this.buffer == null && shouldPopulateBuffer()) {
+      final ByteArrayOutputStream out = new ByteArrayOutputStream();
+      wrappedEntity.writeTo(out);
+      out.flush();
+      this.buffer = out.toByteArray();
+    }
+  }
+
+  @Override
+  public boolean isChunked() {
+    return shouldPopulateBuffer() && super.isChunked();
+  }
+
+  /**
+   * Tells that this entity is repeatable.
+   *
+   * @return {@code true}
+   */
+  @Override
+  public boolean isRepeatable() {
+    return true;
+  }
+
+  @Override
+  public void writeTo(final OutputStream outStream) throws IOException {
+    Args.notNull(outStream, "Output stream");
+    readBuffer();
+    if (this.buffer != null) {
+      outStream.write(this.buffer);
+    } else {
+      super.writeTo(outStream);
+    }
+  }
+
+  @Override
+  public boolean isStreaming() {
+    return shouldPopulateBuffer() && super.isStreaming();
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This commit consists of the following changes:
- the new-style "Expect:100-continue" approach for PUT/POST requests is disabled by default
- the new-style "Expect:100-continue" approach is enabled for the ATLAS, ATLAS-API, HIVE, RANGER and RANGER-UI services
- make sure that this feature for the WEBHDFS service is turned off even in its own service definition file (so that if the default is changed back to true, we'll be safe)
- HTTP entity creation relies on the 'addExpect100Continue' boolean flag
- implemented the missing method overload in HdfsHttpClientDispatch
- KnoxBufferedHttpEntity shall not read content at entity creation time (content reading is postponed until dispatch time when the back-end service actually needs the data)

## How was this patch tested?

Manual testing on a live cluster with the affected services (ATLAS, HIVE, RANGER)
