### PR TITLE
KNOX-2893 - Prevent generating topology from read only descriptor

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -549,6 +549,9 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.INFO, text = "Prevented deletion of shared provider configuration because there are referencing descriptors: {0}" )
   void preventedDeletionOfSharedProviderConfiguration(String providerConfigurationPath);
 
+  @Message( level = MessageLevel.INFO, text = "Empty result returned by SimpleDescriptorHandler for decriptor {0}" )
+  void emptyHandleResult(String descriptorName);
+
   @Message( level = MessageLevel.INFO, text = "Generated topology {0} because the associated descriptor {1} changed." )
   void generatedTopologyForDescriptorChange(String topologyName, String descriptorName);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/monitor/DescriptorsMonitor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/monitor/DescriptorsMonitor.java
@@ -95,6 +95,11 @@ public class DescriptorsMonitor extends FileAlterationListenerAdaptor implements
     try {
       // When a simple descriptor has been created or modified, generate the new topology descriptor
       Map<String, File> result = SimpleDescriptorHandler.handle(gatewayConfig, file, topologiesDir, aliasService, GatewayServer.getGatewayServices());
+      if (result.isEmpty()) {
+        LOG.emptyHandleResult(FilenameUtils.getBaseName(file.getAbsolutePath()));
+        return;
+      }
+
       LOG.generatedTopologyForDescriptorChange(result.get(SimpleDescriptorHandler.RESULT_TOPOLOGY).getName(), file.getName());
 
       // Add the provider config reference relationship for handling updates to the provider config

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -239,6 +239,7 @@ public class DefaultTopologyServiceTest {
       Map<String, String> c = new HashMap<>();
 
       GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+      EasyMock.expect(config.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
       EasyMock.expect(config.getGatewayTopologyDir()).andReturn(topologyDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayConfDir()).andReturn(descriptorsDir.getParentFile().getAbsolutePath()).anyTimes();
       EasyMock.replay(config);
@@ -363,6 +364,7 @@ public class DefaultTopologyServiceTest {
       Map<String, String> c = new HashMap<>();
 
       GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+      EasyMock.expect(config.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
       EasyMock.expect(config.getGatewayTopologyDir()).andReturn(topologyDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayConfDir()).andReturn(descriptorsDir.getParentFile().getAbsolutePath()).anyTimes();
       EasyMock.replay(config);
@@ -462,6 +464,7 @@ public class DefaultTopologyServiceTest {
       Map<String, String> c = new HashMap<>();
 
       GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+      EasyMock.expect(config.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
       EasyMock.expect(config.getGatewayTopologyDir()).andReturn(topologyDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayConfDir()).andReturn(descriptorsDir.getParentFile().getAbsolutePath()).anyTimes();
       EasyMock.replay(config);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandlerTest.java
@@ -144,6 +144,7 @@ public class SimpleDescriptorHandlerTest {
                                        final String user,
                                        final String pwdAlias) throws Exception {
         GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+        EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
         EasyMock.replay(gc);
 
         // Write the externalized provider config to a temp file
@@ -256,6 +257,7 @@ public class SimpleDescriptorHandlerTest {
             serviceParameters.put("KNOXSSO", knoxssoParams);
 
             GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+            EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
             EasyMock.replay(gc);
 
             // Mock out the simple descriptor
@@ -434,6 +436,7 @@ public class SimpleDescriptorHandlerTest {
             File destDir = (new File(".")).getCanonicalFile();
 
             GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+            EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
             EasyMock.replay(gc);
 
             // Mock out the simple descriptor
@@ -547,6 +550,7 @@ public class SimpleDescriptorHandlerTest {
         File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
 
         GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+        EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
         EasyMock.replay(gc);
 
         // Mock out the simple descriptor
@@ -637,6 +641,7 @@ public class SimpleDescriptorHandlerTest {
             File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
 
             GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+            EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
             EasyMock.replay(gc);
 
             // Mock out the simple descriptor
@@ -831,6 +836,7 @@ public class SimpleDescriptorHandlerTest {
       try {
         final File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
         final GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+        EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
 
         final SimpleDescriptorImpl testDescriptor = new SimpleDescriptorImpl();
         testDescriptor.setProviderConfig(providerConfig.getAbsolutePath());
@@ -865,7 +871,10 @@ public class SimpleDescriptorHandlerTest {
         final File destDir = new File(System.getProperty("java.io.tmpdir")).getCanonicalFile();
         final File descriptorFile = new File(SimpleDescriptorHandlerTest.class.getResource("/conf-full/conf/descriptors/test-topology.json").getFile());
         final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
-        final Map<String, File> handleResult = SimpleDescriptorHandler.handle(null, descriptorFile, destDir, gatewayServices);
+        GatewayConfig gc = EasyMock.createNiceMock(GatewayConfig.class);
+        EasyMock.expect(gc.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
+        EasyMock.replay(gc);
+        final Map<String, File> handleResult = SimpleDescriptorHandler.handle(gc, descriptorFile, destDir, gatewayServices);
         topologyFile = handleResult.get(SimpleDescriptorHandler.RESULT_TOPOLOGY);
         final Document topologyXml = XmlUtils.readXml(topologyFile);
         assertThat(topologyXml, hasXPath("/topology/service/role", is(equalTo("KNOX"))));

--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -169,6 +169,7 @@ public class SimpleDescriptorHandlerFuncTest {
       GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
       List<InetSocketAddress> gatewayAddress = new ArrayList<>();
       gatewayAddress.add(new InetSocketAddress(0));
+      EasyMock.expect(config.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
       EasyMock.expect(config.getGatewayConfDir()).andReturn(testConfDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayDataDir()).andReturn(testDataDir.getAbsolutePath()).anyTimes();
       EasyMock.expect(config.getGatewayTopologyDir()).andReturn(testTopoDir.getAbsolutePath()).anyTimes();

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -103,6 +103,11 @@ public class SimpleDescriptorHandler {
 
     public static Map<String, File> handle(GatewayConfig config, SimpleDescriptor desc, File srcDirectory, File destDirectory, Service...gatewayServices) {
 
+        if (config.getReadOnlyOverrideTopologyNames().contains(desc.getName())) {
+            log.skipReadOnlyDescriptor(desc.getName());
+            return Collections.emptyMap();
+        }
+
         List<String> declaredServiceNames = new ArrayList<>();
         Set<String> validServiceNames = new TreeSet<>();
         Map<String, String> serviceVersions = new HashMap<>();

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
@@ -78,4 +78,6 @@ public interface SimpleDescriptorMessages {
             text = "Skipping redeployment of the {0} topology because it already exists and has not changed." )
     void skippingDeploymentOfGeneratedTopology(String topologyName);
 
+    @Message(level = MessageLevel.WARN, text = "Skipping read only descriptor: {0}.")
+    void skipReadOnlyDescriptor(String name);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

DescriptorMonitor should also skip generating topology when it's read only.

## How was this patch tested?

Manually.
