### PR TITLE
KNOX-2901 - Deleting a descriptor/provider via hadoop xml resource

### DIFF
--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMessages.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMessages.java
@@ -75,9 +75,12 @@ public interface HadoopXmlResourceMessages {
   @Message(level = MessageLevel.WARN, text = "Skipping read only provider: {0}.")
   void skipReadOnlyProvider(String key);
 
-  @Message(level = MessageLevel.INFO, text = "Found Knox deleted descriptors {0} in {1}")
+  @Message(level = MessageLevel.INFO, text = "Found deleted descriptors {0} in {1}")
   void foundKnoxDeletedDescriptors(String descriptorList, String path);
 
-  @Message(level = MessageLevel.INFO, text = "Found Knox deleted provider configurations {0} in {1}")
+  @Message(level = MessageLevel.INFO, text = "Found deleted provider configurations {0} in {1}")
   void foundKnoxDeletedProviderConfigurations(String providerConfigurationList, String path);
+
+  @Message(level = MessageLevel.INFO, text = "Deleting file {0}")
+  void deleteFile(String name);
 }

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMessages.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMessages.java
@@ -74,4 +74,10 @@ public interface HadoopXmlResourceMessages {
 
   @Message(level = MessageLevel.WARN, text = "Skipping read only provider: {0}.")
   void skipReadOnlyProvider(String key);
+
+  @Message(level = MessageLevel.INFO, text = "Found Knox deleted descriptors {0} in {1}")
+  void foundKnoxDeletedDescriptors(String descriptorList, String path);
+
+  @Message(level = MessageLevel.INFO, text = "Found Knox deleted provider configurations {0} in {1}")
+  void foundKnoxDeletedProviderConfigurations(String providerConfigurationList, String path);
 }

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMonitor.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMonitor.java
@@ -50,7 +50,6 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
   private static final HadoopXmlResourceMessages LOG = MessagesFactory.get(HadoopXmlResourceMessages.class);
   private final String sharedProvidersDir;
   private final String descriptorsDir;
-  private final String topologiesDir;
   private final long monitoringInterval;
   private final HadoopXmlResourceParser hadoopXmlResourceParser;
   private FileTime lastReloadTime;
@@ -59,7 +58,6 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
     this.hadoopXmlResourceParser = hadoopXmlResourceParser;
     this.sharedProvidersDir = gatewayConfig.getGatewayProvidersConfigDir();
     this.descriptorsDir = gatewayConfig.getGatewayDescriptorsDir();
-    this.topologiesDir = gatewayConfig.getGatewayTopologyDir();
     this.monitoringInterval = gatewayConfig.getClouderaManagerDescriptorsMonitoringInterval();
   }
 
@@ -101,7 +99,6 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
     processSharedProviders(result);
     processDescriptors(result);
     processDeleted(descriptorsDir, result.getDeletedDescriptors(), ".json");
-    processDeleted(topologiesDir, result.getDeletedDescriptors(), ".xml");
     processDeleted(sharedProvidersDir, result.getDeletedProviders(), ".json");
   }
 

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMonitor.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMonitor.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -97,6 +98,12 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
     final HadoopXmlResourceParserResult result = hadoopXmlResourceParser.parse(descriptorFilePath, topologyName);
     processSharedProviders(result);
     processDescriptors(result);
+    processDeleted(descriptorsDir, result.getDeletedDescriptors());
+    processDeleted(sharedProvidersDir, result.getDeletedProviders());
+  }
+
+  private void processDeleted(String parentDirectory, Set<String> deletedFileNames) {
+    deletedFileNames.forEach(each -> new File(parentDirectory, each + ".json").delete());
   }
 
   private void processSharedProviders(final HadoopXmlResourceParserResult result) {

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParser.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParser.java
@@ -143,11 +143,7 @@ public class HadoopXmlResourceParser implements AdvancedServiceDiscoveryConfigCh
       if (xmlConfigurationKey.startsWith(CONFIG_NAME_PROVIDER_CONFIGS_PREFIX)) {
         final String[] providerConfigurations = xmlConfigurationKey.replace(CONFIG_NAME_PROVIDER_CONFIGS_PREFIX, "").split(",");
         Arrays.asList(providerConfigurations).stream().map(providerConfigurationName -> providerConfigurationName.trim()).forEach(providerConfigurationName -> {
-          if (gatewayConfig.getReadOnlyOverrideProviderNames().contains(providerConfigurationName)) {
-            log.skipReadOnlyProvider(providerConfigurationName);
-          } else {
-            parseProvider(providerConfigurationName, xmlDescriptor.getValue(), providers, deletedProviders);
-          }
+          parseProvider(providerConfigurationName, xmlDescriptor.getValue(), providers, deletedProviders);
         });
       } else if (topologyName == null || xmlConfigurationKey.equals(topologyName)) {
           parseDescriptor(xmlConfigurationKey, xmlDescriptor.getValue(), descriptors, deletedDescriptors);
@@ -157,6 +153,10 @@ public class HadoopXmlResourceParser implements AdvancedServiceDiscoveryConfigCh
   }
 
   private void parseProvider(String providerConfigurationName, String value, Map<String, ProviderConfiguration> providers, Set<String> deletedProviders) {
+    if (gatewayConfig.getReadOnlyOverrideProviderNames().contains(providerConfigurationName)) {
+      log.skipReadOnlyProvider(providerConfigurationName);
+      return;
+    }
     final File providerConfigFile = resolveProviderConfiguration(providerConfigurationName);
     try {
       final ProviderConfiguration providerConfiguration = getProviderConfiguration(providers, providerConfigFile, providerConfigurationName);

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
@@ -26,8 +26,8 @@ import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 class HadoopXmlResourceParserResult {
   final Map<String, ProviderConfiguration> providers;
   final Set<SimpleDescriptor> descriptors;
-  private Set<String> deletedDescriptors;
-  private Set<String> deletedProviders;
+  private final Set<String> deletedDescriptors;
+  private final Set<String> deletedProviders;
 
   HadoopXmlResourceParserResult() {
     this(Collections.emptyMap(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
@@ -17,7 +17,6 @@
 package org.apache.knox.gateway.topology.hadoop.xml;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
@@ -17,6 +17,7 @@
 package org.apache.knox.gateway.topology.hadoop.xml;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -26,14 +27,19 @@ import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 class HadoopXmlResourceParserResult {
   final Map<String, ProviderConfiguration> providers;
   final Set<SimpleDescriptor> descriptors;
+  private Set<String> deletedDescriptors;
+  private Set<String> deletedProviders;
 
   HadoopXmlResourceParserResult() {
-    this(Collections.emptyMap(), Collections.emptySet());
+    this(Collections.emptyMap(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
   }
 
-  HadoopXmlResourceParserResult(Map<String, ProviderConfiguration> providers, Set<SimpleDescriptor> descriptors) {
+  HadoopXmlResourceParserResult(Map<String, ProviderConfiguration> providers, Set<SimpleDescriptor> descriptors,
+                                Set<String> deletedDescriptors, Set<String> deletedProviders) {
     this.providers = providers;
     this.descriptors = descriptors;
+    this.deletedDescriptors = deletedDescriptors;
+    this.deletedProviders = deletedProviders;
   }
 
   public Map<String, ProviderConfiguration> getProviders() {
@@ -44,4 +50,11 @@ class HadoopXmlResourceParserResult {
     return Collections.unmodifiableSet(descriptors);
   }
 
+  public Set<String> getDeletedDescriptors() {
+    return deletedDescriptors;
+  }
+
+  public Set<String> getDeletedProviders() {
+    return deletedProviders;
+  }
 }

--- a/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
+++ b/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
@@ -26,7 +26,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +246,14 @@ public class HadoopXmlResourceParserTest {
     assertEquals(address, descriptor.getDiscoveryAddress());
     assertEquals(cluster, descriptor.getCluster());
     assertEquals("ClouderaManager", descriptor.getDiscoveryType());
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    String testConfigPath = this.getClass().getClassLoader().getResource("testDelete.xml").getPath();
+    HadoopXmlResourceParserResult result = hadoopXmlResourceParser.parse(testConfigPath);
+    assertEquals(new HashSet<>(Arrays.asList("topology1", "topology2")), result.getDeletedDescriptors());
+    assertEquals(new HashSet<>(Arrays.asList("admin", "knoxsso")), result.getDeletedProviders());
   }
 
   private void validateTopology1Descriptors(SimpleDescriptor descriptor) {

--- a/gateway-topology-hadoop-xml/src/test/resources/testDelete.xml
+++ b/gateway-topology-hadoop-xml/src/test/resources/testDelete.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+    <property>
+        <name>topology1</name>
+        <value> remove </value>
+    </property>
+    <property>
+        <name>topology2</name>
+        <value>
+            remove
+        </value>
+    </property>
+    <property>
+        <name>topology3</name>
+        <value>
+            discoveryType=ClouderaManager#
+            discoveryAddress=http://host:123#
+            discoveryUser=user#
+            discoveryPasswordAlias=alias#
+            cluster=Cluster 1#
+            providerConfigRef=topology1-provider#
+            app:knoxauth:param1.name=param1.value#
+            app:admin-ui#
+            HIVE:url=http://localhost:456#
+            HIVE:version=1.0#
+            HIVE:httpclient.connectionTimeout=5m#
+            HIVE:httpclient.socketTimeout=100m
+        </value>
+    </property>
+    <property>
+        <name>providerConfigs:admin, knoxsso</name>
+        <value>remove</value>
+    </property>
+    <property>
+        <name>providerConfigs:prov2</name>
+        <value>
+            role=authentication#
+            authentication.name=ShiroProvider#
+            authentication.param.sessionTimeout=30#
+            authentication.param.main.ldapRealm=org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm#
+            authentication.param.main.ldapContextFactory=org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory#
+            authentication.param.main.ldapRealm.contextFactory=$ldapContextFactory#
+            authentication.param.main.ldapRealm.contextFactory.authenticationMechanism=simple#
+            authentication.param.main.ldapRealm.contextFactory.url=ldap://localhost:33389#
+            authentication.param.main.ldapRealm.contextFactory.systemUsername=uid=guest,ou=people,dc=hadoop,dc=apache,dc=org#
+            authentication.param.main.ldapRealm.contextFactory.systemPassword=${ALIAS=knoxLdapSystemPassword}#
+            authentication.param.main.ldapRealm.userDnTemplate=uid={0},ou=people,dc=hadoop,dc=apache,dc=org#
+            authentication.param.urls./**=authcBasic
+        </value>
+    </property>
+</configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?



## How was this patch tested?

1. Enabled hadoop xml resource monitor:

```
    <property>
        <name>gateway.cloudera.manager.descriptors.monitor.interval</name>
        <value>5000</value>
    </property>
```

2. Created the following hxr:  conf/descriptors/test.hxr

```
  <configuration>
    <property>
        <name>dt1</name>
        <value> remove </value>
    </property>
    <property>
        <name>dt2</name>
        <value>
            remove
        </value>
    </property>
    <property>
        <name>topology3</name>
        <value>
            discoveryType=ClouderaManager#
            discoveryAddress=http://host:123#
            discoveryUser=user#
            discoveryPasswordAlias=alias#
            cluster=Cluster 1#
            providerConfigRef=topology1-provider#
            app:knoxauth:param1.name=param1.value#
            app:admin-ui#
            HIVE:url=http://localhost:456#
            HIVE:version=1.0#
            HIVE:httpclient.connectionTimeout=5m#
            HIVE:httpclient.socketTimeout=100m
        </value>
    </property>
    <property>
        <name>providerConfigs:dp1, dp2</name>
        <value>remove</value>
    </property>
    <property>
        <name>providerConfigs:prov2</name>
        <value>
            role=authentication#
            authentication.name=ShiroProvider#
            authentication.param.sessionTimeout=30#
            authentication.param.main.ldapRealm=org.apache.hadoop.gateway.shirorealm.KnoxLdapRealm#
            authentication.param.main.ldapContextFactory=org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory#
            authentication.param.main.ldapRealm.contextFactory=$ldapContextFactory#
            authentication.param.main.ldapRealm.contextFactory.authenticationMechanism=simple#
            authentication.param.main.ldapRealm.contextFactory.url=ldap://localhost:33389#
            authentication.param.main.ldapRealm.contextFactory.systemUsername=uid=guest,ou=people,dc=hadoop,dc=apache,dc=org#
            authentication.param.main.ldapRealm.contextFactory.systemPassword=${ALIAS=knoxLdapSystemPassword}#
            authentication.param.main.ldapRealm.userDnTemplate=uid={0},ou=people,dc=hadoop,dc=apache,dc=org#
            authentication.param.urls./**=authcBasic
        </value>
    </property>
</configuration>
```


Checked the logs and the file system:

```
2023-04-24 11:07:26,590  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(111)) - Deleting file /Users/attilamagyar/development/test/conf/shared-providers/dp1.json
2023-04-24 11:07:26,590  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(111)) - Deleting file /Users/attilamagyar/development/test/conf/shared-providers/dp2.json
```

```
2023-04-24 11:07:26,589  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(111)) - Deleting file /Users/attilamagyar/development/test/conf/topologies/dt1.xml
2023-04-24 11:07:26,589  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(111)) - Deleting file /Users/attilamagyar/development/test/conf/topologies/dt2.xml
```

```
2023-04-24 11:07:26,589  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(111)) - Deleting file /Users/attilamagyar/development/test/conf/descriptors/dt1.json
2023-04-24 11:07:26,589  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(111)) - Deleting file /Users/attilamagyar/development/test/conf/descriptors/dt2.json
```




