### PR TITLE
KNOX-2903 - Add restart command to gateway.sh

### DIFF
--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -68,6 +68,40 @@ export APP_ERR_FILE="$APP_LOG_DIR/$APP_NAME.err"
 DEFAULT_APP_RUNNING_IN_FOREGROUND="$GATEWAY_SERVER_RUN_IN_FOREGROUND"
 export APP_RUNNING_IN_FOREGROUND=${KNOX_GATEWAY_RUNNING_IN_FOREGROUND:-$DEFAULT_APP_RUNNING_IN_FOREGROUND}
 
+function startGateway() {
+  printEnv=0
+  while [[ $# -gt 0 ]]
+  do
+    key="$1"
+    case $key in
+      --printEnv)
+       printEnv=1
+       shift # past argument
+       ;;
+      --test-gateway-retry-attempts)
+       export APP_STATUS_TEST_RETRY_ATTEMPTS="$2"
+       shift # past argument
+       shift # past value
+       ;;
+      --test-gateway-retry-sleep)
+       export APP_STATUS_TEST_RETRY_SLEEP="$2"
+       shift # past argument
+       shift # past value
+       ;;
+      *)    # unknown option
+       shift # past argument
+       ;;
+    esac
+  done
+  if [ $printEnv -eq 1 ]; then
+    printEnv
+  fi
+  checkEnv
+  export TEST_APP_STATUS=true
+  # shellcheck disable=SC2119
+  appStart
+}
+
 function main {
    checkJava
 
@@ -76,42 +110,14 @@ function main {
          setupEnv
          ;;
       start)
-         printEnv=0
-         while [[ $# -gt 0 ]]
-         do
-           key="$1"
-
-           case $key in
-             --printEnv)
-               printEnv=1
-               shift # past argument
-               ;;
-             --test-gateway-retry-attempts)
-               export APP_STATUS_TEST_RETRY_ATTEMPTS="$2"
-               shift # past argument
-               shift # past value
-               ;;
-             --test-gateway-retry-sleep)
-               export APP_STATUS_TEST_RETRY_SLEEP="$2"
-               shift # past argument
-               shift # past value
-               ;;
-             *)    # unknown option
-               shift # past argument
-               ;;
-           esac
-         done
-
-         if [ $printEnv -eq 1 ]; then
-           printEnv
-         fi
-         checkEnv
-         export TEST_APP_STATUS=true
-         # shellcheck disable=SC2119
-         appStart
+         startGateway "$@"
          ;;
       stop)   
          appStop
+         ;;
+      restart)
+         appStop
+         startGateway "$@"
          ;;
       status)
          appStatus


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding restart command.

## How was this patch tested?

Normal restart:

```
bin/gateway.sh restart 

$ bin/gateway.sh restart 
Stopping Gateway with PID 54014 succeeded.
Starting Gateway Retry attempts = 5
succeeded with PID 54075.
amagyar-MBP16:test attilamagyar$ 
```

Extra params:

```
$ bin/gateway.sh restart --printEnv --test-gateway-retry-attempts 3 --test-gateway-retry-sleep 2
Stopping Gateway with PID 54075 succeeded.
APP_CONF_DIR = /Users/attilamagyar/development/test/conf
APP_LOG_DIR = /Users/attilamagyar/development/test/logs
APP_DATA_DIR = /Users/attilamagyar/development/test/data
APP_DBG_OPTS = -Xdebug -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n
APP_PID_DIR = /Users/attilamagyar/development/test/pids
APP_JAVA_LIB_PATH = -Djava.library.path=/Users/attilamagyar/development/test/ext/native
APP_JAR = /Users/attilamagyar/development/test/bin/gateway.jar
Starting Gateway Retry attempts = 3
Retry sleep = 2
Retry attempts = 3
Retry sleep = 2
Retry attempts = 3
Retry sleep = 2
succeeded with PID 54136.
amagyar-MBP16:test attilamagyar$ 
```