### PR TITLE
KNOX-2905 - GatewayDescriptorImporter is not thread safe

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServlet.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServlet.java
@@ -185,13 +185,8 @@ public class GatewayServlet implements Servlet, Filter {
   private static GatewayFilter createFilter( InputStream stream, ServletContext servletContext ) throws ServletException {
     try {
       GatewayFilter filter = null;
-      if( stream != null ) {
-        try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)){
-          GatewayDescriptor descriptor = GatewayDescriptorFactory.load("xml", reader);
-          filter = GatewayFactory.create( descriptor );
-        } finally {
-          stream.close();
-        }
+      if (stream != null) {
+        filter = GatewayFactory.create(createGatewayDescriptor(stream));
       }
       GatewayConfig gatewayConfig = (GatewayConfig) servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
       if (gatewayConfig.isMetricsEnabled()) {
@@ -207,6 +202,14 @@ public class GatewayServlet implements Servlet, Filter {
       return filter;
     } catch( IOException | URISyntaxException e ) {
       throw new ServletException( e );
+    }
+  }
+
+  private static synchronized GatewayDescriptor createGatewayDescriptor(InputStream stream) throws IOException {
+    try (InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)){
+      return GatewayDescriptorFactory.load("xml", reader);
+    } finally {
+      stream.close();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The gateway descriptor importer is not thread safe and it is called from two different threads.

## How was this patch tested?

* I verified that calling the importer from multiple threads cause various parser exceptions (see the Jira ticket for more details).
* Tested with multiple knox restarts + curl requests at the same time.

