### PR TITLE
KNOX-2907 - PollingConfigurationAnalyzer ignores services without service model generator

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -45,12 +45,9 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -78,15 +75,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
   public static final String CM_SERVICE_TYPE  = "CM";
   public static final String CM_ROLE_TYPE  = "CM_SERVER";
 
-  private static Map<String, List<ServiceModelGenerator>> serviceModelGenerators = new HashMap<>();
-  static {
-    ServiceLoader<ServiceModelGenerator> loader = ServiceLoader.load(ServiceModelGenerator.class);
-    for (ServiceModelGenerator serviceModelGenerator : loader) {
-      List<ServiceModelGenerator> smgList =
-          serviceModelGenerators.computeIfAbsent(serviceModelGenerator.getServiceType(), k -> new ArrayList<>());
-      smgList.add(serviceModelGenerator);
-    }
-  }
+  private ServiceModelGeneratorsHolder serviceModelGeneratorsHolder = ServiceModelGeneratorsHolder.getInstance();
 
   private boolean debug;
 
@@ -277,7 +266,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
       serviceList.add(cmService);
 
       for (ApiService service : serviceList) {
-        final List<ServiceModelGenerator> modelGenerators = serviceModelGenerators.get(service.getType());
+        final List<ServiceModelGenerator> modelGenerators = serviceModelGeneratorsHolder.getServiceModelGenerators(service.getType());
         if (shouldSkipServiceDiscovery(modelGenerators, includedServices)) {
           //log.skipServiceDiscovery(service.getName(), service.getType());
           //continue;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -196,8 +196,8 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.DEBUG, text = "There is no any activation event found within the given time period")
   void noActivationEventFound();
 
-  @Message(level = MessageLevel.DEBUG, text = "Activation event relevance: {0} = {1}")
-  void activationEventRelevance(String eventId, String relevance);
+  @Message(level = MessageLevel.DEBUG, text = "Activation event relevance: {0} = {1} ({2} / {3} / {4} / {5})")
+  void activationEventRelevance(String eventId, String relevance, String command, String status, String serviceType, boolean serviceModelGeneratorExists);
 
   @Message(level = MessageLevel.DEBUG, text = "Activation event - {0} - has already been processed, skipping ...")
   void activationEventAlreadyProcessed(String eventId);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolder.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolder.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+public class ServiceModelGeneratorsHolder {
+
+  private static final ServiceModelGeneratorsHolder INSTANCE = new ServiceModelGeneratorsHolder();
+  private final Map<String, List<ServiceModelGenerator>> serviceModelGenerators = new HashMap<>();
+
+  private ServiceModelGeneratorsHolder() {
+    final ServiceLoader<ServiceModelGenerator> loader = ServiceLoader.load(ServiceModelGenerator.class);
+    for (ServiceModelGenerator serviceModelGenerator : loader) {
+      List<ServiceModelGenerator> smgList = serviceModelGenerators.computeIfAbsent(serviceModelGenerator.getServiceType(), k -> new ArrayList<>());
+      smgList.add(serviceModelGenerator);
+    }
+  }
+
+  public static ServiceModelGeneratorsHolder getInstance() {
+    return INSTANCE;
+  }
+
+  public List<ServiceModelGenerator> getServiceModelGenerators(String serviceType) {
+    return serviceModelGenerators.get(serviceType);
+  }
+
+}

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -221,8 +221,8 @@ public class PollingConfigurationAnalyzerTest {
 
     // Simulate a successful rolling cluster restart event
     ApiEvent rollingRestartEvent = createApiEvent(clusterName,
-                                                  PollingConfigurationAnalyzer.CM_SERVICE_TYPE,
-                                                  PollingConfigurationAnalyzer.CM_SERVICE,
+                                                  HiveOnTezServiceModelGenerator.SERVICE_TYPE,
+                                                  HiveOnTezServiceModelGenerator.SERVICE,
                                                   PollingConfigurationAnalyzer.ROLLING_RESTART_COMMAND,
                                                   PollingConfigurationAnalyzer.SUCCEEDED_STATUS,
                                                   "EV_CLUSTER_ROLLING_RESTARTED");
@@ -241,7 +241,7 @@ public class PollingConfigurationAnalyzerTest {
     final String clusterName = "Cluster 8";
 
     // Simulate a successful restart waiting for staleness event
-    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, PollingConfigurationAnalyzer.CM_SERVICE_TYPE, PollingConfigurationAnalyzer.CM_SERVICE,
+    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, HiveOnTezServiceModelGenerator.SERVICE_TYPE, HiveOnTezServiceModelGenerator.SERVICE,
         PollingConfigurationAnalyzer.RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS, "EV_CLUSTER_RESTARTED");
 
     final ChangeListener listener = doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
@@ -254,7 +254,7 @@ public class PollingConfigurationAnalyzerTest {
     final String clusterName = "Cluster 9";
 
     // Simulate a successful restart waiting for staleness event with id = 123
-    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, PollingConfigurationAnalyzer.CM_SERVICE_TYPE, PollingConfigurationAnalyzer.CM_SERVICE,
+    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, HiveOnTezServiceModelGenerator.SERVICE_TYPE, HiveOnTezServiceModelGenerator.SERVICE,
         PollingConfigurationAnalyzer.RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS, "EV_CLUSTER_RESTARTED",
         "123");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

CM's `PollingConfigurationAnalyzer` ignores events of service types that have no `ServiceModelGenerator` instances to avoid redundant topology redeployment.

## How was this patch tested?

Updated JUnit tests and executed comprehensive manual testing in a live CM cluster with lots of services.