### PR TITLE
KNOX-2912 - Don't fail over non idempotent requests unless it's a connect exception

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
@@ -54,6 +54,6 @@ public interface HaDispatchMessages {
   @Message(level = MessageLevel.ERROR, text = "Unsupported encoding, cause: {0}")
   void unsupportedEncodingException(String cause);
 
-  @Message(level = MessageLevel.ERROR, text = "Request is non-idempotent {0}, failover prevented, to allow non-idempotent requests to failover set 'failoverNonIdempotentRequestEnabled=true' in HA config. Cause {1}")
+  @Message(level = MessageLevel.ERROR, text = "Request is non-idempotent {0}, failover prevented, to allow non-idempotent requests to failover set 'failoverNonIdempotentRequestEnabled=true' in HA config. Non connection related error: {1}")
   void cannotFailoverNonIdempotentRequest(String method, String cause);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -181,7 +181,7 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
       // We do not want to expose back end host. port end points to clients, see JIRA KNOX-58
       auditor.audit( Action.DISPATCH, outboundRequest.getURI().toString(), ResourceType.URI, ActionOutcome.FAILURE );
       LOG.dispatchServiceConnectionException( outboundRequest.getURI(), e );
-      throw new IOException( RES.dispatchConnectionError() );
+      throw new IOException(RES.dispatchConnectionError(), e);
     }
     return inboundResponse;
   }

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/HttpUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/HttpUtilsTest.java
@@ -19,11 +19,17 @@ package org.apache.knox.gateway.util;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.PortUnreachableException;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.knox.gateway.util.HttpUtils.isConnectionError;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -211,5 +217,15 @@ public class HttpUtilsTest {
     assertThat( map.containsKey( "qry" ), is( true ) );
     assertThat( map.get( "qry" ).size(), is( 1 ) );
     assertThat( map.get( "qry" ).get(0), is( "Hadoop:service=NameNode,name=NameNodeInfo" ) );
+  }
+
+  @Test
+  public void testRelevantConnectionErrors() {
+    assertThat(isConnectionError(new UnknownHostException()), is(true));
+    assertThat(isConnectionError(new ConnectException()), is(true));
+    assertThat(isConnectionError(new NoRouteToHostException()), is(true));
+    assertThat(isConnectionError(new PortUnreachableException()), is(true));
+    assertThat(isConnectionError(new IOException()), is(false));
+    assertThat(isConnectionError(new RuntimeException()), is(false));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default Knox doesn't fail over in case of non-idempotent requests. In case of a connect exception (connection refused, unknown host, etc), it is safe to failover since the connection hasn't been established yes and the request body was not consumed.

## How was this patch tested?

Testet it manually with the following config:

```
    <provider>
         <role>ha</role>
         <name>HaProvider</name>
         <enabled>true</enabled>
         <param>
            <name>HIVE</name>
            <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
         </param>
      </provider>
    </gateway>

    <service>
        <role>HIVE</role>
        <!-- <url>http://localhost:1700</url> -->
        <url>http://10.255.255.1:1234</url>
        <url>http://localhost:1701</url>
    </service>
```