### PR TITLE
KNOX-2915 - Descriptors are reloaded before topology redeployment at startup

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -73,6 +73,9 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.INFO, text = "Loading topologies from directory: {0}" )
   void loadingTopologiesFromDirectory( String topologiesDir );
 
+  @Message( level = MessageLevel.INFO, text = "Loading descriptors from directory: {0}" )
+  void loadingDescriptorsFromDirectory(String descriptorsDir);
+
   @Message( level = MessageLevel.DEBUG, text = "Loading topology file: {0}" )
   void loadingTopologyFile( String fileName );
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -623,9 +623,15 @@ public class GatewayServer {
     // Load the current topologies.
     // Redeploy autodeploy topologies.
     File topologiesDir = calculateAbsoluteTopologiesDir();
-    log.loadingTopologiesFromDirectory(topologiesDir.getAbsolutePath());
     monitor = services.getService(ServiceType.TOPOLOGY_SERVICE);
+
+    // Descriptors should be reloaded before topology reloading at startup, so that any changes to descriptors
+    // will be realized before Knox deploys "old" topologies that would have re-deployed anyway in a matter of seconds
+    // by the descriptor monitor
+    monitor.reloadDescriptors();
+
     monitor.addTopologyChangeListener(listener);
+    log.loadingTopologiesFromDirectory(topologiesDir.getAbsolutePath());
     monitor.reloadTopologies();
     List<String> autoDeploys = config.getAutoDeployTopologyNames();
     if (autoDeploys != null) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -549,12 +549,12 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         log.remoteConfigurationMonitorStartFailure(remoteMonitor.getClass().getTypeName(), e.getLocalizedMessage());
       }
     }
-
-    // Trigger descriptor discovery (KNOX-2301)
-    triggerDescriptorDiscovery();
   }
 
-  private void triggerDescriptorDiscovery() {
+  // Trigger descriptor discovery (KNOX-2301)
+  @Override
+  public void reloadDescriptors() {
+    log.loadingDescriptorsFromDirectory(descriptorsDirectory.getAbsolutePath());
     for (File descriptor : getDescriptors()) {
       descriptorsMonitor.onFileChange(descriptor);
     }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
@@ -56,6 +56,8 @@ public interface TopologyService extends Service, ServiceDefinitionChangeListene
 
   Collection<File> getDescriptors();
 
+  void reloadDescriptors();
+
   void deleteTopology(Topology t);
 
   boolean deleteDescriptor(String name);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Descriptors are reloaded before topology redeployment at startup. Thus, Knox will have the up-to-date version of the XML topology files generated from the JSON descriptor before it's deployed as a web app in Knox.

## How was this patch tested?

Manually tested in a secure (i.e. Kerberos-enabled) cluster with high demand on getting a Knox Token using a topology with HadoopAuth authentication in place. Before my changes, the token generation failed 99% of the time. After the fix went in, all tokens were acquired properly.
