### PR TITLE
KNOX-2915 - We need reloadDescriptors() when starting the monitors

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -549,9 +549,11 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
         log.remoteConfigurationMonitorStartFailure(remoteMonitor.getClass().getTypeName(), e.getLocalizedMessage());
       }
     }
+
+    // Trigger descriptor discovery (KNOX-2301)
+    reloadDescriptors();
   }
 
-  // Trigger descriptor discovery (KNOX-2301)
   @Override
   public void reloadDescriptors() {
     log.loadingDescriptorsFromDirectory(descriptorsDirectory.getAbsolutePath());


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up to #760 which removed the `reloadDescriptors()` call but tests indicated we still need that.

## How was this patch tested?

Manual testing.
