### PR TITLE
KNOX-2923 - Support for JDK 17

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -164,6 +164,14 @@ function buildAppJavaOpts {
       addAppJavaOpts "${APP_JAVA_LIB_PATH}"
     fi
 
+    # Add properties to enable Knox to run on JDK 17
+    JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    CHECK_VERSION_17="17"
+    if [[ "$JAVA_VERSION" == *"$CHECK_VERSION_17"* ]]; then
+        echo "Java version is $CHECK_VERSION_17. Adding properties to enable Knox to run on JDK 17"
+        addAppJavaOpts " --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.pkcs=ALL-UNNAMED --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED"
+    fi
+
     # echo "APP_JAVA_OPTS =" "${APP_JAVA_OPTS[@]}"
 }
 

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -143,7 +143,7 @@ public class X509CertificateUtil {
 
       // AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
       Class<?> algorithmIdClass = Class.forName(getAlgorithmIdModuleName());
-      Field md5WithRSAField = algorithmIdClass.getDeclaredField("md5WithRSAEncryption_oid");
+      Field md5WithRSAField = algorithmIdClass.getDeclaredField("RSAEncryption_oid");
       md5WithRSAField.setAccessible(true);
       Class<?> objectIdentifierClass = Class.forName(getObjectIdentifierModuleName());
 

--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>@{argLine} --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.pkcs=ALL-UNNAMED --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED</argLine>
                     <excludedGroups>
                         org.apache.knox.test.category.SlowTests,org.apache.knox.test.category.ManualTests,org.apache.knox.test.category.VerifyTest,org.apache.knox.test.category.ReleaseTest
                     </excludedGroups>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds support for running Knox gateway on JDK 17. 

## How was this patch tested?
To test this patch, knox was compiled from source on JDK 8/11 and run on JDK 17. Make sure knox starts up and logs are clean.
