### PR TITLE
KNOX-2912 - Don't fail over non idempotent requests unless it's a connect exception - ConnectionTimeout

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -220,7 +220,7 @@ public class ConfigurableHADispatch extends ConfigurableDispatch {
     } catch ( IOException e ) {
       /* if non-idempotent requests are not allowed to failover, unless it's a connection error */
       if(!isConnectionError(e.getCause()) && isNonIdempotentAndNonIdempotentFailoverDisabled(outboundRequest)) {
-        LOG.cannotFailoverNonIdempotentRequest(outboundRequest.getMethod(), e.toString());
+        LOG.cannotFailoverNonIdempotentRequest(outboundRequest.getMethod(), e.getCause());
         /* mark endpoint as failed */
         markEndpointFailed(outboundRequest, inboundRequest);
         throw e;

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
@@ -55,5 +55,5 @@ public interface HaDispatchMessages {
   void unsupportedEncodingException(String cause);
 
   @Message(level = MessageLevel.ERROR, text = "Request is non-idempotent {0}, failover prevented, to allow non-idempotent requests to failover set 'failoverNonIdempotentRequestEnabled=true' in HA config. Non connection related error: {1}")
-  void cannotFailoverNonIdempotentRequest(String method, String cause);
+  void cannotFailoverNonIdempotentRequest(String method, Throwable cause);
 }

--- a/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/AbstractHdfsHaDispatch.java
+++ b/gateway-service-webhdfs/src/main/java/org/apache/knox/gateway/hdfs/dispatch/AbstractHdfsHaDispatch.java
@@ -62,7 +62,7 @@ public abstract class AbstractHdfsHaDispatch extends ConfigurableHADispatch {
       } catch (StandbyException | SafeModeException | IOException e) {
         /* if non-idempotent requests are not allowed to failover */
         if(!failoverNonIdempotentRequestEnabled && nonIdempotentRequests.stream().anyMatch(outboundRequest.getMethod()::equalsIgnoreCase)) {
-          LOG.cannotFailoverNonIdempotentRequest(outboundRequest.getMethod(), e.toString());
+          LOG.cannotFailoverNonIdempotentRequest(outboundRequest.getMethod(), e.getCause());
           throw e;
         } else {
           printExceptionLogMessage(e, outboundRequest.getURI().toString());

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -81,7 +81,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
         <!-- ********** ********** ********** ********** ********** ********** -->
         <!-- ********** Test Dependencies                           ********** -->
         <!-- ********** ********** ********** ********** ********** ********** -->

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/HttpUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/HttpUtils.java
@@ -34,8 +34,12 @@ import java.util.Map;
 import java.util.StringTokenizer;
 
 public class HttpUtils {
-  private static final List<Class<? extends IOException>> connectionErrors = asList(UnknownHostException.class, NoRouteToHostException.class,
-          SocketException.class);
+  private static final List<Class<? extends IOException>> connectionErrors = asList(
+          UnknownHostException.class,
+          NoRouteToHostException.class,
+          SocketException.class,
+          org.apache.http.conn.ConnectTimeoutException.class
+  );
 
   public static Map<String, List<String>> splitQuery(String queryString)
       throws UnsupportedEncodingException {

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/HttpUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/HttpUtilsTest.java
@@ -227,5 +227,6 @@ public class HttpUtilsTest {
     assertThat(isConnectionError(new PortUnreachableException()), is(true));
     assertThat(isConnectionError(new IOException()), is(false));
     assertThat(isConnectionError(new RuntimeException()), is(false));
+    assertThat(isConnectionError(new org.apache.http.conn.ConnectTimeoutException()), is(true));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ConnectionTimeout was missing from the original patch

## How was this patch tested?

```xml
    <provider>
         <role>ha</role>
         <name>HaProvider</name>
         <enabled>true</enabled>
         <param>
            <name>HIVE</name>
            <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
         </param>
      </provider>
    </gateway>

    <service>
        <role>HIVE</role>
        <url>http://google.com:81</url>
        <url>http://localhost:1701</url>
    </service>
```


