### PR TITLE
KNOX-2930 - Fix OM and SCM UIs to work in HA

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
@@ -17,17 +18,100 @@ Licensed to the Apache Software Foundation (ASF) under one or more
 
 
 <rules>
-    <rule dir="IN" name="OZONE-SCM/rule/inbound" pattern="*://*:*/**/ozone-scm/{path=**}?{**}">
-        <rewrite template="{$serviceUrl[OZONE-SCM]}/{path=**}?{**}"/>
-    </rule>
-    <rule dir="OUT" name="OZONE-SCM/rule/docs">
-        <rewrite template="{gateway.url}/ozone-scm/docs/index.html"/>
+    <!-- SCM inbound rule -->
+    <rule dir="IN" name="OZONE-SCM/ozone-scm/inbound/request" pattern="*://*:*/**/ozone-scm/{path=**}?host={host}?{**}">
+        <rewrite template="{host}/{path=**}?{**}"/>
     </rule>
 
-    <filter name="OZONE-SCM/filter/doc">
-        <content type="text/html">
-            <apply path="/docs" rule="OZONE-SCM/rule/docs"/>
+    <!-- SCM outbound rules -->
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/scmjs" pattern="scm.js">
+        <rewrite template="{gateway.url}/ozone-scm/scm.js?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/main" pattern="main.html">
+        <rewrite template="main.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/scmoverview" pattern="scm-overview.html">
+        <rewrite template="scm-overview.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/jmx" pattern="/jmx?{**}">
+        <rewrite template="{gateway.url}/ozone-scm/jmx?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/jmx2" pattern="jmx?{**}">
+        <rewrite template="jmx?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/conf" pattern="conf?{**}">
+        <rewrite template="{gateway.url}/ozone-scm/conf?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/logLevel" pattern="logLevel">
+        <rewrite template="{gateway.url}/ozone-scm/logLevel/?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/stacks" pattern="stacks">
+        <rewrite template="{gateway.url}/ozone-scm/stacks/?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/static">
+        <match pattern="/static/{path=**}">
+            <rewrite template="{gateway.url}/ozone-scm/static/{path=**}?host={$inboundurl[host]}"/>
+        </match>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/filter/docs">
+        <rewrite template="{gateway.url}/ozone-scm/documentation/docs/index.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <!-- SCM filter -->
+
+    <filter name="OZONE-SCM/ozone-scm/outbound/response">
+        <content type="*/html">
+            <apply path="scm.js" rule="OZONE-SCM/ozone-scm/outbound/filter/scmjs"/>
+            <apply path=".*\.js" rule="OZONE-SCM/ozone-scm/outbound/filter/static"/>
+            <apply path=".*\.css" rule="OZONE-SCM/ozone-scm/outbound/filter/static"/>
+            <apply path="/docs" rule="OZONE-SCM/ozone-scm/outbound/filter/docs"/>
+            <apply path="logLevel" rule="OZONE-SCM/ozone-scm/outbound/filter/logLevel"/>
+            <apply path="stacks" rule="OZONE-SCM/ozone-scm/outbound/filter/stacks"/>
+        </content>
+        <content type="*/javascript">
+            <apply path="main\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/main"/>
+            <apply path="scm-overview\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/scmoverview"/>
+            <apply path="docs/index\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/docs"/>
+            <apply path="static/templates/.*\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/static"/>
+            <apply path="/jmx" rule="OZONE-SCM/ozone-scm/outbound/filter/jmx"/>
+            <apply path="jmx\?qry" rule="OZONE-SCM/ozone-scm/outbound/filter/jmx2"/>
+            <apply path="conf\?cmd" rule="OZONE-SCM/ozone-scm/outbound/filter/conf"/>
         </content>
     </filter>
+
+    <!-- documentation inbound rule -->
+
+    <rule dir="IN" name="OZONE-SCM/ozone-scm/documentation/inbound/request" pattern="*://*:*/**/ozone-scm/documentation/{path=**}?host={host}?{**}">
+        <rewrite template="{host}/{path=**}?{**}"/>
+    </rule>
+
+    <!-- documentation outbound rule -->
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs">
+        <match pattern="{**}">
+            <rewrite template="{**}?host={$inboundurl[host]}"/>
+        </match>
+    </rule>
+
+    <!-- documentation filter -->
+
+    <filter name="OZONE-SCM/ozone-scm/documentation/outbound/response">
+        <content type="*/html">
+            <apply path=".*\.js" rule="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs"/>
+            <apply path=".*\.css" rule="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs"/>
+            <apply path=".*\.png" rule="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs"/>
+            <apply path=".*\.html" rule="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs"/>
+        </content>
+    </filter>
+
 </rules>
 

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
@@ -21,8 +22,20 @@
 		<shortDesc>OZONE SCM UI</shortDesc>
 	</metadata>
 	<routes>
+			<!-- SCM routes -->
+			<route path="/ozone-scm/">
+				<rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
+			</route>
       <route path="/ozone-scm/**">
-         <rewrite apply="OZONE-SCM/filter/doc" to="response.body"/>
-      </route>
+				 <rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
+				 <rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
+			</route>
+			<!-- documentation route -->
+			<route path="/ozone-scm/documentation/**">
+				<rewrite apply="OZONE-SCM/ozone-scm/documentation/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/documentation/outbound/response" to="response.body"/>
+			</route>
 	</routes>
+	<dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/ozone/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone/1.2.0/rewrite.xml
@@ -17,16 +17,107 @@ Licensed to the Apache Software Foundation (ASF) under one or more
 
 
 <rules>
-    <rule dir="IN" name="OZONE/ozone/inbound" pattern="*://*:*/**/ozone/{path=**}?{**}">
-        <rewrite template="{$serviceUrl[OZONE]}/{path=**}?{**}"/>
-    </rule>
-    <rule dir="OUT" name="OZONE/ozoneManager/docs">
-        <rewrite template="{gateway.url}/ozone/docs/index.html"/>
+
+    <!-- OM inbound rules -->
+
+    <rule dir="IN" name="OZONE/ozone/inbound/request" pattern="*://*:*/**/ozone/{path=**}?host={host}?{**}">
+        <rewrite template="{host}/{path=**}?{**}"/>
     </rule>
 
-    <filter name="OZONE/ozoneManager/doc">
-        <content type="text/html">
-            <apply path="/docs" rule="OZONE/ozoneManager/docs"/>
+    <!-- OM outbound rules -->
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/omjs" pattern="ozoneManager.js">
+        <rewrite template="{gateway.url}/ozone/ozoneManager.js?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/main" pattern="main.html">
+        <rewrite template="main.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/om-metrics" pattern="om-metrics.html">
+        <rewrite template="om-metrics.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/omoverview" pattern="om-overview.html">
+        <rewrite template="om-overview.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/jmx" pattern="/jmx?{**}">
+        <rewrite template="{gateway.url}/ozone/jmx?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/jmx2" pattern="jmx?{**}">
+        <rewrite template="jmx?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/conf" pattern="conf?{**}">
+        <rewrite template="{gateway.url}/ozone/conf?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/logLevel" pattern="logLevel">
+        <rewrite template="{gateway.url}/ozone/logLevel/?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/stacks" pattern="stacks">
+        <rewrite template="{gateway.url}/ozone/stacks/?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/static">
+        <match pattern="/static/{path=**}">
+            <rewrite template="{gateway.url}/ozone/static/{path=**}?host={$inboundurl[host]}"/>
+        </match>
+    </rule>
+
+    <rule dir="OUT" name="OZONE/ozone/outbound/filter/docs">
+        <rewrite template="{gateway.url}/ozone/documentation/docs/index.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <!-- OM filter -->
+
+    <filter name="OZONE/ozone/outbound/response">
+        <content type="*/html">
+            <apply path="ozoneManager.js" rule="OZONE/ozone/outbound/filter/omjs"/>
+            <apply path=".*\.js" rule="OZONE/ozone/outbound/filter/static"/>
+            <apply path=".*\.css" rule="OZONE/ozone/outbound/filter/static"/>
+            <apply path="/docs" rule="OZONE/ozone/outbound/filter/docs"/>
+            <apply path="logLevel" rule="OZONE/ozone/outbound/filter/logLevel"/>
+            <apply path="stacks" rule="OZONE/ozone/outbound/filter/stacks"/>
+        </content>
+        <content type="*/javascript">
+            <apply path="main\.html" rule="OZONE/ozone/outbound/filter/main"/>
+            <apply path="om-metrics\.html" rule="OZONE/ozone/outbound/filter/om-metrics"/>
+            <apply path="om-overview\.html" rule="OZONE/ozone/outbound/filter/omoverview"/>
+            <apply path="docs/index\.html" rule="OZONE/ozone/outbound/filter/docs"/>
+            <apply path="static/templates/.*\.html" rule="OZONE/ozone/outbound/filter/static"/>
+            <apply path="/jmx" rule="OZONE/ozone/outbound/filter/jmx"/>
+            <apply path="jmx\?qry" rule="OZONE/ozone/outbound/filter/jmx2"/>
+            <apply path="conf\?cmd" rule="OZONE/ozone/outbound/filter/conf"/>
         </content>
     </filter>
+
+    <!-- documentation inbound rule -->
+
+    <rule dir="IN" name="OZONE/ozone/documentation/inbound/request" pattern="*://*:*/**/ozone/documentation/{path=**}?host={host}?{**}">
+        <rewrite template="{host}/{path=**}?{**}"/>
+    </rule>
+
+    <!-- documentation outbound rule -->
+
+    <rule dir="OUT" name="OZONE/ozone/documentation/outbound/filter/docs">
+        <match pattern="{**}">
+            <rewrite template="{**}?host={$inboundurl[host]}"/>
+        </match>
+    </rule>
+
+    <!-- documentation filter -->
+
+    <filter name="OZONE/ozone/documentation/outbound/response">
+        <content type="*/html">
+            <apply path=".*\.js" rule="OZONE/ozone/documentation/outbound/filter/docs"/>
+            <apply path=".*\.css" rule="OZONE/ozone/documentation/outbound/filter/docs"/>
+            <apply path=".*\.png" rule="OZONE/ozone/documentation/outbound/filter/docs"/>
+            <apply path=".*\.html" rule="OZONE/ozone/documentation/outbound/filter/docs"/>
+        </content>
+    </filter>
+
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/ozone/1.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone/1.2.0/service.xml
@@ -21,8 +21,20 @@
 		<shortDesc>OZONE Manager UI</shortDesc>
 	</metadata>
 	<routes>
+			<!-- OM routes -->
+			<route path="/ozone/">
+				<rewrite apply="OZONE/ozone/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE/ozone/outbound/response" to="response.body"/>
+			</route>
       <route path="/ozone/**">
-         <rewrite apply="OZONE/ozoneManager/doc" to="response.body"/>
-      </route>
+				<rewrite apply="OZONE/ozone/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE/ozone/outbound/response" to="response.body"/>
+			</route>
+			<!-- documentation route -->
+			<route path="/ozone/documentation/**">
+				<rewrite apply="OZONE/ozone/documentation/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE/ozone/documentation/outbound/response" to="response.body"/>
+			</route>
 	</routes>
+	<dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
 </service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously if there were multiple OMs/SCMs in a cluster on the Knox UI if you clicked on any of the OM/SCM UIs it was consistently showing one of the OMs/SCMs UI, because `$serviceUrl[OZONE-SCM]` was picking the first URL from the three in the `cdp-proxy.xml`.

In this fix I add a `?host={host}` to the ending of the URLs and used that `{host}` later when rewriting the requests, so it will go to the correct host. I added a separate route for the documentation to work in the UIs. 

## How was this patch tested?

I tested it in a cluster. 
