### PR TITLE
KNOX-2887 - Add required changes to ozone-scm service definitions to handle DataNode WebUIs

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -32,10 +32,8 @@ Licensed to the Apache Software Foundation (ASF) under one or more
     </rule>
 
     <filter name="OZONE-SCM/filter/doc">
-        <content type="text/html">
+        <content type="*/html">
             <apply path="/docs" rule="OZONE-SCM/rule/docs"/>
-        </content>
-        <content type="*/javascript">
             <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
         </content>
     </filter>

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -76,6 +76,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
             <apply path="/docs" rule="OZONE-SCM/ozone-scm/outbound/filter/docs"/>
             <apply path="logLevel" rule="OZONE-SCM/ozone-scm/outbound/filter/logLevel"/>
             <apply path="stacks" rule="OZONE-SCM/ozone-scm/outbound/filter/stacks"/>
+            <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
         </content>
         <content type="*/javascript">
             <apply path="main\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/main"/>
@@ -120,19 +121,14 @@ Licensed to the Apache Software Foundation (ASF) under one or more
         <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host={{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}} "/>
     </rule>
 
-    <filter name="OZONE-SCM/filter/doc">
-        <content type="*/html">
-            <apply path="/docs" rule="OZONE-SCM/rule/docs"/>
-            <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
-        </content>
-    </filter>
-
     <!-- datanode inbound rules -->
+
     <rule dir="IN" name="OZONE-SCM/ozone-scm/datanode/inbound/request" pattern="*://*:*/**/ozone-scm/datanode/{path=**}?host={host}?{**}">
         <rewrite template="{host}/{path=**}?{**}"/>
     </rule>
 
     <!-- datanode outbound rules -->
+
     <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/dnjs" pattern="dn.js">
         <rewrite template="{gateway.url}/ozone-scm/datanode/dn.js?host={$inboundurl[host]}"/>
     </rule>

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -24,9 +24,89 @@ Licensed to the Apache Software Foundation (ASF) under one or more
         <rewrite template="{gateway.url}/ozone-scm/docs/index.html"/>
     </rule>
 
+    <!-- outbound rule for the datanode links on SCM UI -->
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/datanode/address">
+        <match pattern="{{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}"/>
+        <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host={{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}} "/>
+    </rule>
+
     <filter name="OZONE-SCM/filter/doc">
         <content type="text/html">
             <apply path="/docs" rule="OZONE-SCM/rule/docs"/>
+        </content>
+        <content type="*/javascript">
+            <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
+        </content>
+    </filter>
+
+    <!-- datanode inbound rules -->
+    <rule dir="IN" name="OZONE-SCM/ozone-scm/datanode/inbound/request" pattern="*://*:*/**/ozone-scm/datanode/{path=**}?host={host}?{**}">
+        <rewrite template="{host}/{path=**}?{**}"/>
+    </rule>
+
+    <!-- datanode outbound rules -->
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/dnjs" pattern="dn.js">
+        <rewrite template="{gateway.url}/ozone-scm/datanode/dn.js?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/main" pattern="main.html">
+        <rewrite template="main.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/dnoverview" pattern="dn-overview.html">
+        <rewrite template="dn-overview.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/jmx" pattern="/jmx?{**}">
+        <rewrite template="{gateway.url}/ozone-scm/datanode/jmx?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/jmx2" pattern="jmx?{**}">
+        <rewrite template="jmx?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/conf" pattern="conf?{**}">
+        <rewrite template="{gateway.url}/ozone-scm/datanode/conf?host={$inboundurl[host]}?{**}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/logLevel" pattern="logLevel">
+        <rewrite template="{gateway.url}/ozone-scm/datanode/logLevel/?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/stacks" pattern="stacks">
+        <rewrite template="{gateway.url}/ozone-scm/datanode/stacks/?host={$inboundurl[host]}"/>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/static">
+        <match pattern="/static/{path=**}">
+            <rewrite template="{gateway.url}/ozone-scm/datanode/static/{path=**}?host={$inboundurl[host]}"/>
+        </match>
+    </rule>
+
+    <rule dir="OUT" name="OZONE-SCM/ozone-scm/datanode/outbound/filter/docs">
+        <rewrite template="{gateway.url}/ozone-scm/documentation/docs/index.html?host={$inboundurl[host]}"/>
+    </rule>
+
+    <!-- datanode filter -->
+
+    <filter name="OZONE-SCM/ozone-scm/datanode/outbound/response">
+        <content type="*/html">
+            <apply path="dn.js" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/dnjs"/>
+            <apply path=".*\.js" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/static"/>
+            <apply path=".*\.css" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/static"/>
+            <apply path="/docs" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/docs"/>
+            <apply path="logLevel" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/logLevel"/>
+            <apply path="stacks" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/stacks"/>
+        </content>
+        <content type="*/javascript">
+            <apply path="main\.html" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/main"/>
+            <apply path="dn-overview\.html" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/dnoverview"/>
+            <apply path="docs/index\.html" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/docs"/>
+            <apply path="static/templates/.*\.html" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/static"/>
+            <apply path="/jmx" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/jmx"/>
+            <apply path="jmx\?qry" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/jmx2"/>
+            <apply path="conf\?cmd" rule="OZONE-SCM/ozone-scm/datanode/outbound/filter/conf"/>
         </content>
     </filter>
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -111,7 +111,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
             <apply path=".*\.png" rule="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs"/>
             <apply path=".*\.html" rule="OZONE-SCM/ozone-scm/documentation/outbound/filter/docs"/>
         </content>
-    </filter>  
+    </filter>
 
     <!-- outbound rule for the datanode links on SCM UI -->
 

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
@@ -24,5 +24,14 @@
       <route path="/ozone-scm/**">
          <rewrite apply="OZONE-SCM/filter/doc" to="response.body"/>
       </route>
+			<!-- datanode routes -->
+			<route path="/ozone-scm/datanode/">
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/outbound/response" to="response.body"/>
+			</route>
+			<route path="/ozone-scm/datanode/**">
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/outbound/response" to="response.body"/>
+			</route>
 	</routes>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
@@ -27,10 +27,10 @@
 				<rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
 				<rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
 			</route>
-      <route path="/ozone-scm/**">
-         <rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
-				 <rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
-      </route>
+		  <route path="/ozone-scm/**">
+				<rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
+			</route>
 			<!-- datanode routes -->
 			<route path="/ozone-scm/datanode/">
 				<rewrite apply="OZONE-SCM/ozone-scm/datanode/inbound/request" to="request.url"/>

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/service.xml
@@ -27,9 +27,9 @@
 				<rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
 				<rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
 			</route>
-		  <route path="/ozone-scm/**">
-				<rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
-				<rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
+      <route path="/ozone-scm/**">
+				 <rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
+				 <rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
 			</route>
 			<!-- datanode routes -->
 			<route path="/ozone-scm/datanode/">


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I added the datanode links correctly to the Ozone SCM UI and integrated the Datanode UI into Knox.

## How was this patch tested?

I tested it in a cluster and the datanode links on the SCM UI are redirecting to the correct Datanode UI and the content of the page is loaded correctly as well.

SCM UI when I am hovering over the datanode link it is showing the right URL (bottom of the page):
<img width="1727" alt="scm_dn_link" src="https://github.com/apache/knox/assets/50611074/bc4cf69e-37d4-407f-9062-dcf6b15b700f">

Datanode UI:
<img width="1726" alt="dn_ui" src="https://github.com/apache/knox/assets/50611074/98bebe91-f623-4146-a463-10f53175dd69">
