### PR TITLE
KNOX-2931 - Some special characters in the rewrite rule cannot be escaped

### DIFF
--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest.java
@@ -410,6 +410,30 @@ public class UrlRewriteProcessorTest {
     processor.destroy();
   }
 
+  @Test
+  public void testRuleWithDoubleBrackets() throws IOException, URISyntaxException {
+    UrlRewriteEnvironment environment = EasyMock.createNiceMock( UrlRewriteEnvironment.class );
+    HttpServletRequest request = EasyMock.createNiceMock( HttpServletRequest.class );
+    HttpServletResponse response = EasyMock.createNiceMock( HttpServletResponse.class );
+    EasyMock.replay(environment, request, response);
+
+    UrlRewriteProcessor processor = new UrlRewriteProcessor();
+    UrlRewriteRulesDescriptor config = UrlRewriteRulesDescriptorFactory.load(
+            "xml", getTestResourceReader( "rewrite_escape.xml"));
+    processor.initialize(environment, config);
+
+    Template outputUrl = processor.rewrite( null,
+            Parser.parseLiteral("{{prot}}://{{hostname}}:{{portno}}"),
+            UrlRewriter.Direction.OUT,
+            "test_rule");
+
+    assertThat(
+            outputUrl.toString(), is( "GATEWAY?host={{prot}}://{{hostname}}:{{portno}}"));
+
+    processor.destroy();
+  }
+
+
   /**
    * Turn a string containing URL parameters, e.g.
    *

--- a/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite_escape.xml
+++ b/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite_escape.xml
@@ -1,0 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<rules>
+    <rule dir="OUT" name="test_rule">
+        <rewrite template="GATEWAY?host=\{\{prot\}\}://\{\{hostname\}\}:\{\{portno\}\}"/>
+    </rule>
+</rules>

--- a/gateway-util-urltemplate/src/main/java/org/apache/knox/gateway/util/urltemplate/Expander.java
+++ b/gateway-util-urltemplate/src/main/java/org/apache/knox/gateway/util/urltemplate/Expander.java
@@ -204,11 +204,11 @@ public class Expander {
     }
   }
 
-  private static String unescape(String actualPattern) {
-    if (actualPattern == null) {
+  private static String unescape(String pattern) {
+    if (pattern == null) {
       return null;
     }
-    return actualPattern
+    return pattern
             .replace("\\" + TEMPLATE_OPEN_MARKUP, String.valueOf(TEMPLATE_OPEN_MARKUP))
             .replace("\\" + TEMPLATE_CLOSE_MARKUP, String.valueOf(TEMPLATE_CLOSE_MARKUP));
   }

--- a/gateway-util-urltemplate/src/main/java/org/apache/knox/gateway/util/urltemplate/Expander.java
+++ b/gateway-util-urltemplate/src/main/java/org/apache/knox/gateway/util/urltemplate/Expander.java
@@ -17,6 +17,9 @@
  */
 package org.apache.knox.gateway.util.urltemplate;
 
+import static org.apache.knox.gateway.util.urltemplate.Parser.TEMPLATE_CLOSE_MARKUP;
+import static org.apache.knox.gateway.util.urltemplate.Parser.TEMPLATE_OPEN_MARKUP;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -184,7 +187,7 @@ public class Expander {
             String pattern = value.getOriginalPattern();
             if (pattern != null) {
               builder.append('=');
-              builder.append(pattern);
+              builder.append(unescape(pattern));
             }
             break;
           case (Segment.DEFAULT):
@@ -199,6 +202,15 @@ public class Expander {
         }
       }
     }
+  }
+
+  private static String unescape(String actualPattern) {
+    if (actualPattern == null) {
+      return null;
+    }
+    return actualPattern
+            .replace("\\" + TEMPLATE_OPEN_MARKUP, String.valueOf(TEMPLATE_OPEN_MARKUP))
+            .replace("\\" + TEMPLATE_CLOSE_MARKUP, String.valueOf(TEMPLATE_CLOSE_MARKUP));
   }
 
   private static void expandExtraQuery( Template template, Set<String> names, Params params, StringBuilder builder, AtomicInteger index ) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone SCM UI uses placeholders such as `{{typestat.portval.toLowerCase()}}` in the HTML which are supposed to be replaced by JavaScript code. However this is the same syntax what knox uses for template variables. If no escaping is used knox will populate the the template variable with an empty string since it has no value.

But escaping `{` didn't work originally in rewrite templates (so `\{x\}` resulted literally `\{x\}`).

## How was this patch tested?

sandbox topology:

```xml
<service>
    <role>OZONE-SCM</role>
    <url>http://localhost:1701</url>
</service>
```

service.xml

```xml
<service role="OZONE-SCM" name="ozone-scm" version="1.2.0">
    <metadata>
        <type>UI</type>
        <context>/ozone-scm/index.html?host={{BACKEND_HOST}}</context>
        <shortDesc>OZONE SCM UI</shortDesc>
    </metadata>
    <routes>
        <route path="/ozone-scm/index.html">
            <rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
            <rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
        </route>
    </routes>
    <dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
</service>
````

rewrite.xml

```xml
<rules>
    <rule dir="IN" name="OZONE-SCM/ozone-scm/inbound/request" pattern="*://*:*/**/ozone-scm/{path=**}?host={host}?{**}">
        <rewrite template="{host}/{path=**}?{**}"/>
    </rule>

    <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/datanode/address">
        <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host=\{\{typestat.portval.toLowerCase()\}\}://\{\{typestat.hostname\}\}:\{\{typestat.portno\}\}"/>
    </rule>

    <filter name="OZONE-SCM/ozone-scm/outbound/response">
        <content type="*/html">
            <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>

        </content>
    </filter>
</rules>
```

Http server to emulate the service

```smalltalk
Teapot on
    GET: 'index.html' -> 
        '<a href="{{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}">{{typestat.hostname}}</a>';
	start. 
```

URL to check: 

https://localhost:8443/gateway/sandbox/ozone-scm/index.html?host=http://localhost:1701

Result:

```html
<a href="https://localhost:8443/gateway/sandbox/ozone-scm/datanode/index.html?host={{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}">{{typestat.hostname}}</a>
```