### PR TITLE
KNOX-2938 - jwks.json doesn't have double quotes which makes json invalid

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/JWKSResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/JWKSResource.java
@@ -105,7 +105,7 @@ public class JWKSResource {
               + "\"\n}\n").build();
     }
     return Response.ok()
-        .entity(jwks.toJSONObject().toString()).build();
+            .entity(jwks.toString()).type(MediaType.APPLICATION_JSON_TYPE).build();
   }
 
   protected RSAPublicKey getPublicKey(final String keystore) throws KeystoreServiceException, KeyStoreException {

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/JWKSResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/JWKSResource.java
@@ -39,6 +39,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.security.KeyStore;
 import java.security.KeyStoreException;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Getting "knoxtoken/api/v1/jwks.json" generates an invalid json with missing double quotes.


E.g.:

```
{keys=[{kty=RSA, e=AQAB, use=sig, kid=zKJUa4BzKUq_oj69PH3OFeh1vsqrdPgXqNVAes6N-Xg, alg=RS256, n=gGOkOH_WEo3qgzDyY1QDIDb6NURmmc_3W89rI-fvuxVpKW-a-ePiRdRAlKWoTXu-wJ39QePixldzPj3SERmty25YN-PP5YXi798a6QmGtxcFlCtdqjYNFEimD9YJZF9zsBxTKMeLuJ7-k6LGh8ZcxSAykbEng29tEu5xvFdunMpXqWfWnYC1wu10PuuiBkyJ4PZyQ6P8QJHPL9ER9I0NwsxHnS3fnphJ8ZgdjJkINfeuOVwtSOKriMtX6qJ4rKyaZ2n9iEQSOum6CD8BNhbBo5FfrQzc8SENVbiGotCJe4hN6tIWn9OdooCo1PuXhbUEpAH-27QR5wZmuX9PS1GYxQ}]}
```

The problem only happens with a newer nimbus version (9.24), with an old 8.14.1 nimbus, both way work.

## How was this patch tested?

```bash
$ curl -vk https://localhost:8443/gateway/homepage/knoxtoken/api/v1/jwks.json
```

```json
{"keys":[{"kty":"RSA","e":"AQAB","use":"sig","kid":"aat5l9Yl_yOtOXFbVFaMp4XuXr1Cim17aDZeOt8_TAM","alg":"RS256","n":"oIQ9v5az4NG_uTnpai4n77W41Yil-11adJQn58OSOW4MB8ALCdco9OhixxE_mNa4uuaO5r9Yer9O4QqGMLT4n_Y4SAkyprv2Z1ncvtDtMTIg2lSfCCOIfzXY1o2Wpu0AZh22KGF5V4jQSrV2JplPg7tpmlnN-kaK7yfOGPE14gFrn5Vc8sVZwvXN47Et-DW8A1toP7eTgDeqX4ideQIsxyWtYqS-WIUbsAqq-JJUxCme_qg_YN6IURqdSIBkl3O8bqyNcS8pxRu9EkjW1oVUeH-AkggWPe-kn3PZ1mMoEmo0tD4O-g-epVNZ8naSMgNqUrGaS_pJBP15H_cwMGUJmw"}]}
````

