### PR TITLE
KNOX-2932 - Fix TLS Ciphers issue and add kerberos support to the docker image

### DIFF
--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jre-alpine
+FROM openjdk:8-jre-alpine3.8
 MAINTAINER Apache Knox <dev@knox.apache.org>
 
 # Make sure required packages are available
-RUN apk --no-cache add bash procps ca-certificates && update-ca-certificates
+RUN apk --no-cache add bash procps ca-certificates krb5 && update-ca-certificates
 
 # Create an knox user
 RUN addgroup -S knox && adduser -S -G knox knox


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently docker image appears to be broken with TLS failures, this appears to be due to the underlying alpine base image. This update upgrades the alpine base image (which also pulls in few security fixes) and adds support for kerberos.

## How was this patch tested?
This patch was tested locally.