### PR TITLE
KNOX-2939 - Provider file configured with invalid syntax still gets created with few missing provider contents

### DIFF
--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParser.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParser.java
@@ -202,6 +202,8 @@ public class HadoopXmlResourceParser implements AdvancedServiceDiscoveryConfigCh
         provider.setName(roleConfiguration.replace(CONFIG_NAME_PROVIDER_CONFIGS_NAME_PREFIX, ""));
       } else if (roleConfiguration.startsWith(CONFIG_NAME_PROVIDER_CONFIGS_ENABLED_PREFIX)) {
         provider.setEnabled(Boolean.valueOf(roleConfiguration.replace(CONFIG_NAME_PROVIDER_CONFIGS_ENABLED_PREFIX, "")));
+      } else {
+        throw new IllegalArgumentException("Invalid role configuration: " + roleConfiguration + " in provider: " + provider.getName());
       }
     }
     return provider;

--- a/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
+++ b/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
@@ -234,6 +234,14 @@ public class HadoopXmlResourceParserTest {
     assertService(descriptor, "HIVE", "1.0", Collections.singletonList("http://localhost:456"), expectedServiceParameters);
   }
 
+  @Test
+  public void testInvalidProviderConfig() {
+    String testConfigPath = this.getClass().getClassLoader().getResource("testInvalidProvider.xml").getPath();
+    HadoopXmlResourceParserResult parserResult = hadoopXmlResourceParser.parse(testConfigPath);
+    assertEquals(1, parserResult.getProviders().size());
+    assertNotNull(parserResult.getProviders().get("valid"));
+  }
+
   private void validateTopology2Descriptors(SimpleDescriptor descriptor, boolean nifiExpected) {
     assertTrue(descriptor.isReadOnly());
     assertEquals("topology2", descriptor.getName());

--- a/gateway-topology-hadoop-xml/src/test/resources/testInvalidProvider.xml
+++ b/gateway-topology-hadoop-xml/src/test/resources/testInvalidProvider.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+    <property>
+        <name>providerConfigs:invalid1,invalid2</name>
+        <value>
+            authentication;::::::::authentication.name=ShiroProvider#
+            authentication.param.main.pamRealm=org.apache.knox.gateway.shirorealm.KnoxPamRealm#
+            authentication.param.main.pamRealm.service=login#
+            authentication.sessionTimeout=30#
+            authentication.urls./**=authcBasic#role=identity-assertion#identity-assertion.name=Default#
+            role=authorization#
+            authorization.name=XASecurePDPKnox##
+            authorization..dummy=false
+        </value>
+    </property>
+    <property>
+        <name>providerConfigs:valid</name>
+        <value>
+            authentication.name=ShiroProvider#
+            authentication.param.main.pamRealm=org.apache.knox.gateway.shirorealm.KnoxPamRealm#
+            authentication.param.main.pamRealm.service=login#
+            authentication.sessionTimeout=30#
+            authentication.urls./**=authcBasic#role=identity-assertion#identity-assertion.name=Default#
+            role=authorization#
+            authorization.name=XASecurePDPKnox#
+        </value>
+    </property>
+</configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a provider configuration is invalid knox will save invalid file.

## How was this patch tested?

Enabled hadoop xml resource monitor:
```xml
    <property>
        <name>gateway.cloudera.manager.descriptors.monitor.interval</name>
        <value>5000</value>
    </property>
```

Create conf/descriptors/test.hxr with the following content:

```xml
<configuration>
    <property>
        <name>providerConfigs:invalid1,invalid2</name>
        <value>
            authentication;::::::::authentication.name=ShiroProvider#
            authentication.param.main.pamRealm=org.apache.knox.gateway.shirorealm.KnoxPamRealm#
            authentication.param.main.pamRealm.service=login#
            authentication.sessionTimeout=30#
            authentication.urls./**=authcBasic#role=identity-assertion#identity-assertion.name=Default#
            role=authorization#
            authorization.name=XASecurePDPKnox##
            authorization..dummy=false
        </value>
    </property>
    <property>
        <name>providerConfigs:valid</name>
        <value>
            authentication.name=ShiroProvider#
            authentication.param.main.pamRealm=org.apache.knox.gateway.shirorealm.KnoxPamRealm#
            authentication.param.main.pamRealm.service=login#
            authentication.sessionTimeout=30#
            authentication.urls./**=authcBasic#role=identity-assertion#identity-assertion.name=Default#
            role=authorization#
            authorization.name=XASecurePDPKnox#
        </value>
    </property>
</configuration>
```

Check logs:

```bash
2023-07-18 14:54:47,943 INFO  knox.gateway (HadoopXmlResourceParser.java:parse(104)) - Parsing  Knox resources in Hadoop style XML /Users/attilamagyar/development/test/conf/descriptors/test.hxr. Looking up all topologies...
2023-07-18 14:54:47,947 ERROR knox.gateway (HadoopXmlResourceParser.java:lambda$null$2(141)) - Parsing Knox shared provider configuration invalid1 failed: Invalid role configuration: .dummy=false in provider: XASecurePDPKnox
2023-07-18 14:54:47,947 ERROR knox.gateway (HadoopXmlResourceParser.java:lambda$null$2(141)) - Parsing Knox shared provider configuration invalid2 failed: Invalid role configuration: .dummy=false in provider: XASecurePDPKnox
2023-07-18 14:54:47,949 INFO  knox.gateway (HadoopXmlResourceParser.java:logParserResult(122)) - Found Knox provider configurations valid in /Users/attilamagyar/development/test/conf/descriptors/test.hxr
2023-07-18 14:54:47,961 INFO  knox.gateway (HadoopXmlResourceMonitor.java:lambda$processSharedProviders$1(109)) - Saved Knox shared provider into /Users/attilamagyar/development/test/conf/shared-providers/valid.json
```

Check FS:

```
$ ls conf/shared-providers/
README			default-providers.json	valid.json
```