### PR TITLE
KNOX-2940 - knoxcli create-alias/create-aliases command doesn't support values starting with dash

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -418,7 +418,9 @@ public class KnoxCLI extends Configured implements Tool {
         this.discoveryType = args[++i];
       } else if (args[i].equals("--master")) {
         // For testing only
-        if( i+1 >= args.length || args[i+1].startsWith( "-" ) ) {
+        if( i+1 >= args.length
+                || "--generate".equals(args[i + 1]) // missing value
+                || "--force".equals(args[i + 1])) {
           printKnoxShellUsage();
           return -1;
         }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -292,7 +292,10 @@ public class KnoxCLI extends Configured implements Tool {
       } else if (args[i].equals("list-alias")) {
         command = new AliasListCommand();
       } else if (args[i].equals("--value")) {
-        if (i + 1 >= args.length || args[i + 1].startsWith("-")) {
+        if (i + 1 >= args.length
+                || "--generate".equals(args[i + 1]) // missing value
+                || "--cluster".equals(args[i + 1])
+                || "--master".equals(args[i + 1])) {
           printKnoxShellUsage();
           return -1;
         }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -483,6 +483,67 @@ public class KnoxCLITest {
   }
 
   @Test
+  public void testMissingAliasValue() throws Exception {
+    outContent.reset();
+    String[] args1 = {"create-alias", "alias1", "--value"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(new GatewayConfigImpl());
+    rc = cli.run(args1);
+    assertEquals(-1, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains(KnoxCLI.AliasCreateCommand.USAGE));
+  }
+
+  @Test
+  public void testIncorrectCombinationOfValueAndGenerate() throws Exception {
+    outContent.reset();
+    String[] args1 = {"create-alias", "alias1", "--value", "--generate"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(new GatewayConfigImpl());
+    rc = cli.run(args1);
+    assertEquals(-1, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains(KnoxCLI.AliasCreateCommand.USAGE));
+  }
+
+  @Test
+  public void testGeneratingAliasWithLeadingDash() throws Exception {
+    outContent.reset();
+    String[] args1 = {"create-alias", "alias1", "--value", "---testvalue1---", "--master", "master"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(new GatewayConfigImpl());
+    rc = cli.run(args1);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("alias1 has been successfully " +
+            "created."));
+  }
+
+  @Test
+  public void testIncorrectCombinationOfValuesAndGenerate() throws Exception {
+    outContent.reset();
+    String[] args1 = {"create-aliases", "--alias", "alias1", "--value", "--cluster"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(new GatewayConfigImpl());
+    rc = cli.run(args1);
+    assertEquals(-1, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains(KnoxCLI.AliasCreateCommand.USAGE));
+  }
+
+  @Test
+  public void testMissingValueForBatchAliasCreation() throws Exception {
+    outContent.reset();
+    String[] args1 = {"create-aliases", "--alias", "alias1", "--value", "--alias", "alias2", "--value", "value1"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(new GatewayConfigImpl());
+    rc = cli.run(args1);
+    assertEquals(-1, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains(KnoxCLI.AliasCreateCommand.USAGE));
+  }
+
+  @Test
   public void testListAndDeleteOfAliasForInvalidClusterName() throws Exception {
     outContent.reset();
     String[] args1 =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified a check for the create-alias/create-aliases commands to support values with leading dash.

## How was this patch tested?

 missing value:

```bash
 bin/knoxcli.sh  create-alias a1 --value
 ``` 

value with dashes

 ```bash 
 bin/knoxcli.sh  create-alias a1 --value ---content---
 ```

Incorrect usage

 ```bash 
 bin/knoxcli.sh  create-alias a1 --value --generate
 ```

 ```bash 
 bin/knoxcli.sh  create-alias a1 --value --cluster
 ```

Batch alias with dashes

 ```bash
 bin/knoxcli.sh  create-aliases --alias --a1-- --value v1 --alias a2 --value --v2--
 ```

 Batch alias missing value

  ```bash
 bin/knoxcli.sh  create-aliases --alias --a1-- --value
 ```


Batch alias incorrect usage

```bash
bin/knoxcli.sh  create-aliases --alias --a1-- --value --generate
bin/knoxcli.sh  create-aliases --alias --a1-- --value --cluster
```



