### PR TITLE
KNOX-2943 - Handling CORE-SETTINGS service properly

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -253,6 +253,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.DEBUG, text = "Looking up roles from the configured Cloudera Manager discovery endpoint...")
   void lookupRolesFromCM();
 
+  @Message(level = MessageLevel.DEBUG, text = "No roles to look up for this service.")
+  void noRoles();
+
   @Message(level = MessageLevel.DEBUG, text = "Looking up role configuration from the configured Cloudera Manager discovery endpoint...")
   void lookupRoleConfigsFromCM();
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepository.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepository.java
@@ -176,8 +176,10 @@ class ClouderaManagerServiceDiscoveryRepository {
     }
 
     public void addRoles(ApiRoleList roles) {
-      for (ApiRole role : roles.getItems()) {
-        roleConfigsMap.put(role, new ApiConfigList());
+      if (roles != null && roles.getItems() != null) {
+        for (ApiRole role : roles.getItems()) {
+          roleConfigsMap.put(role, new ApiConfigList());
+        }
       }
     }
 

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepositoryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepositoryTest.java
@@ -120,6 +120,30 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
   }
 
   @Test
+  public void testAddNullRoles() throws Exception {
+    repository.registerCluster(serviceDiscoveryConfig);
+    final ApiService service = EasyMock.createNiceMock(ApiService.class);
+    EasyMock.expect(service.getName()).andReturn(ClouderaManagerServiceDiscovery.CORE_SETTINGS_TYPE).anyTimes();
+    EasyMock.replay(service);
+    repository.addService(serviceDiscoveryConfig, service);
+    repository.addRoles(serviceDiscoveryConfig, service, null);
+    assertNull(repository.getRoles(serviceDiscoveryConfig, service).getItems());
+  }
+
+  @Test
+  public void testAddNullRoleItems() throws Exception {
+    repository.registerCluster(serviceDiscoveryConfig);
+    final ApiService service = EasyMock.createNiceMock(ApiService.class);
+    EasyMock.expect(service.getName()).andReturn(ClouderaManagerServiceDiscovery.CORE_SETTINGS_TYPE).anyTimes();
+    final ApiRoleList roles = EasyMock.createNiceMock(ApiRoleList.class);
+    EasyMock.expect(roles.getItems()).andReturn(null).anyTimes();
+    EasyMock.replay(service, roles);
+    repository.addService(serviceDiscoveryConfig, service);
+    repository.addRoles(serviceDiscoveryConfig, service, roles);
+    assertNull(repository.getRoles(serviceDiscoveryConfig, service).getItems());
+  }
+
+  @Test
   public void testAddRoleConfig() throws Exception {
     final String serviceName = "HDFS-1";
     final String roleName = "NAMENODE-1";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixing NPEs in CM service discovery when it comes to CM's own CORE-SETTINGS service.

## How was this patch tested?

Tested in real CM-deployed cluster.
