### PR TITLE
KNOX-2944 - Honoring the impalad_specialization role configuration

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGenerator.java
@@ -100,6 +100,7 @@ public class ImpalaServiceModelGenerator extends AbstractServiceModelGenerator {
     ServiceModel model = createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/", scheme, hostname, port));
     model.addServiceProperty(SSL_ENABLED, getServiceConfigValue(serviceConfig, SSL_ENABLED));
     model.addRoleProperty(getRoleType(), HTTP_PORT, port);
+    model.addRoleProperty(getRoleType(), SPECIALIZATION, getRoleConfigValue(roleConfig, SPECIALIZATION));
 
     return model;
   }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGeneratorTest.java
@@ -36,7 +36,7 @@ public class ImpalaServiceModelGeneratorTest extends AbstractServiceModelGenerat
     final Map<String, String> roleConfig = new HashMap<>();
     roleConfig.put(ImpalaServiceModelGenerator.HTTP_PORT, "1357");
 
-    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig, false);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ensure that Impala Daemon's `specialization` role config is stored so that CM service discovery can detect changes in that property.

## How was this patch tested?

Tested in a real CM-deployed cluster and updated JUnit tests.