### PR TITLE
KNOX-2945 - Removing redundant slash from target URL on Token Generation UI

### DIFF
--- a/knox-token-generation-ui/token-generation/app/token-generation.service.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.service.ts
@@ -97,7 +97,7 @@ export class TokenGenService {
                 accessPasscode: tokenData.passcode,
                 expiry: new Date(tokenData.expires_in).toLocaleString(),
                 homepageURL: this.baseURL + tokenData.homepage_url,
-                targetURL: window.location.protocol + '//' + window.location.host + '/' + this.baseURL + tokenData.target_url
+                targetURL: window.location.protocol + '//' + window.location.host + this.baseURL + tokenData.target_url
             };
         })
         .catch((error: HttpErrorResponse) => {


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in the JIRA, the `Target URL` field on the Token Generation UI was incorrect: it contained a double slash which led to 404 errors. This change removes the redundant slash from that URL. For instance:
```
https://localhost:8443//gateway/proxy-token/
```

## How was this patch tested?

Manual testing:
<img width="1782" alt="Screenshot 2023-07-24 at 11 55 14" src="https://github.com/apache/knox/assets/34065904/a3d574c3-3345-4739-8247-68a38f0678e3">

