### PR TITLE
KNOX-2947 - Deleting provider via hadoop xml resource should check if the provider is used by a descriptor

### DIFF
--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMessages.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMessages.java
@@ -91,4 +91,7 @@ public interface HadoopXmlResourceMessages {
 
   @Message(level = MessageLevel.INFO, text = "Deleting file {0}")
   void deleteFile(String name);
+
+  @Message(level = MessageLevel.WARN, text = "Not deleting provider {0} as it is referenced by on ore more descriptors.")
+  void notDeletingReferenceProvider(String provider);
 }

--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserResult.java
@@ -17,13 +17,17 @@
 package org.apache.knox.gateway.topology.hadoop.xml;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.topology.simple.ProviderConfiguration;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 
 class HadoopXmlResourceParserResult {
+  private static final HadoopXmlResourceMessages LOG = MessagesFactory.get(HadoopXmlResourceMessages.class);
   final Map<String, ProviderConfiguration> providers;
   final Set<SimpleDescriptor> descriptors;
   private final Set<String> deletedDescriptors;
@@ -38,7 +42,21 @@ class HadoopXmlResourceParserResult {
     this.providers = providers;
     this.descriptors = descriptors;
     this.deletedDescriptors = deletedDescriptors;
-    this.deletedProviders = deletedProviders;
+    this.deletedProviders = nonReferencedProviders(deletedProviders, descriptors);
+  }
+
+  private Set<String> nonReferencedProviders(Set<String> deletedProviders, Set<SimpleDescriptor> descriptors) {
+    Set<String> referencedProviders = descriptors.stream()
+            .map(SimpleDescriptor::getProviderConfig).collect(Collectors.toSet());
+    Set<String> result = new HashSet<>();
+    for (String provider : deletedProviders) {
+      if (referencedProviders.contains(provider)) {
+        LOG.notDeletingReferenceProvider(provider);
+      } else {
+        result.add(provider);
+      }
+    }
+    return result;
   }
 
   public Map<String, ProviderConfiguration> getProviders() {

--- a/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
+++ b/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
@@ -248,6 +248,13 @@ public class HadoopXmlResourceParserTest {
     assertEquals(new HashSet<>(Arrays.asList("admin", "knoxsso")), result.getDeletedProviders());
   }
 
+  @Test
+  public void testReferencedProviderIsNotDeleted() throws Exception {
+    String testConfigPath = this.getClass().getClassLoader().getResource("testDelete2.xml").getPath();
+    HadoopXmlResourceParserResult result = hadoopXmlResourceParser.parse(testConfigPath);
+    assertEquals(new HashSet<>(Arrays.asList("unused")), result.getDeletedProviders());
+  }
+
   private void validateTopology1Descriptors(SimpleDescriptor descriptor) {
     assertTrue(descriptor.isReadOnly());
     assertEquals("topology1", descriptor.getName());

--- a/gateway-topology-hadoop-xml/src/test/resources/testDelete2.xml
+++ b/gateway-topology-hadoop-xml/src/test/resources/testDelete2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+    <property>
+        <name>descriptor_name1</name>
+        <value>
+            discoveryType=ClouderaManager#
+            discoveryAddress=http://host:123#
+            discoveryUser=user#
+            discoveryPasswordAlias=alias#
+            cluster=Cluster 1#
+            providerConfigRef=used#
+            app:knoxauth:param1.name=param1.value#
+            app:admin-ui#
+            HIVE:url=http://localhost:456#
+            HIVE:version=1.0#
+            HIVE:httpclient.connectionTimeout=5m#
+            HIVE:httpclient.socketTimeout=100m
+        </value>
+    </property>
+    <property>
+        <name>providerConfigs:used, unused</name>
+        <value>remove</value>
+    </property>
+</configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validating if shared provider is used by a descriptor before deleting it via hadoop xml resource monitor.

## How was this patch tested?

Enabling monitor:

```xml
    <property>
        <name>gateway.cloudera.manager.descriptors.monitor.interval</name>
        <value>5000</value>
    </property>
```

hxr file

```xml
  <configuration>
    <property>
        <name>topology3</name>
        <value>
            discoveryType=ClouderaManager#
            discoveryAddress=http://host:123#
            discoveryUser=user#
            discoveryPasswordAlias=alias#
            cluster=Cluster 1#
            providerConfigRef=used#
            app:knoxauth:param1.name=param1.value#
            app:admin-ui#
            HIVE:url=http://localhost:456#
            HIVE:version=1.0#
            HIVE:httpclient.connectionTimeout=5m#
            HIVE:httpclient.socketTimeout=100m
        </value>
    </property>
    <property>
        <name>providerConfigs:used,unused</name>
        <value>remove</value>
    </property>
</configuration>
```

Observed log messages:

```
2023-08-14 13:08:50,085  WARN  knox.gateway (HadoopXmlResourceParserResult.java:check(54)) - Not deleting provider used as it is referenced by on ore more descriptors.
2023-08-14 13:08:50,111  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(120)) - Deleting file /Users/attilamagyar/development/test/conf/shared-providers/unused.json
```