### PR TITLE
KNOX-2949 - Topology file is not deleted after deleting descriptor via hadoop xml resource

### DIFF
--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMonitor.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceMonitor.java
@@ -54,6 +54,7 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
   private static final HadoopXmlResourceMessages LOG = MessagesFactory.get(HadoopXmlResourceMessages.class);
   private final String sharedProvidersDir;
   private final String descriptorsDir;
+  private final String topologyDir;
   private final long monitoringInterval;
   private final HadoopXmlResourceParser hadoopXmlResourceParser;
   private final Map<Path, FileTime> lastReloadTimes;
@@ -63,6 +64,7 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
     this.hadoopXmlResourceParser = hadoopXmlResourceParser;
     this.sharedProvidersDir = gatewayConfig.getGatewayProvidersConfigDir();
     this.descriptorsDir = gatewayConfig.getGatewayDescriptorsDir();
+    this.topologyDir = gatewayConfig.getGatewayTopologyDir();
     this.monitoringInterval = gatewayConfig.getClouderaManagerDescriptorsMonitoringInterval();
     this.lastReloadTimes = new ConcurrentHashMap<>();
   }
@@ -109,6 +111,7 @@ public class HadoopXmlResourceMonitor implements AdvancedServiceDiscoveryConfigC
     final HadoopXmlResourceParserResult result = hadoopXmlResourceParser.parse(descriptorFilePath);
     processSharedProviders(result);
     processDescriptors(result);
+    processDeleted(topologyDir, result.getDeletedDescriptors(), ".xml");
     processDeleted(descriptorsDir, result.getDeletedDescriptors(), ".json");
     processDeleted(sharedProvidersDir, result.getDeletedProviders(), ".json");
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The descriptor monitor is supposed to delete a topology file after the corresponding descriptor was deleted. But right after knox restart this doesn't work, because the hadoop xml monitor is started first and the descriptor monitor second.

## How was this patch tested?

gateway-site.xml

```xml
<property>
    <name>gateway.cloudera.manager.descriptors.monitor.interval</name>
    <value>5000</value>
</property>
```

Create a descriptor + topology via hadoop xml resource.

```xml
 <configuration>
    <property>
        <name>topology3</name>
        <value>
            providerConfigRef=prov#
            app:knoxauth:param1.name=param1.value#
            app:admin-ui#
            HIVE:url=http://localhost:456#
            HIVE:version=1.0#
            HIVE:httpclient.connectionTimeout=5m#
            HIVE:httpclient.socketTimeout=100m
        </value>
    </property>
    <property>
        <name>providerConfigs:prov</name>
        <value>any</value>
    </property>
</configuration>
```

Delete descriptor (+topology):

```xml
<configuration>
    <property>
        <name>topology3</name>
        <value>
            remove
        </value>
    </property>
    <property>
        <name>providerConfigs:prov</name>
        <value>any</value>
    </property>
</configuration>
```

Check logs + file system

```
2023-08-15 14:49:50,131  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(123)) - Deleting file /Users/attilamagyar/development/test/conf/topologies/topology3.xml
2023-08-15 14:49:50,131  INFO  knox.gateway (HadoopXmlResourceMonitor.java:processDeleted(123)) - Deleting file /Users/attilamagyar/development/test/conf/descriptors/topology3.json
```