### PR TITLE
KNOX-2946 - Cookie Path Scoping doesn't work when using default topology URL

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/CookieScopeServletFilter.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/CookieScopeServletFilter.java
@@ -27,9 +27,11 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.knox.gateway.filter.AbstractGatewayFilter;
 import org.apache.knox.gateway.filter.rewrite.impl.CookieScopeResponseWrapper;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
 public class CookieScopeServletFilter extends AbstractGatewayFilter {
-
+  private static final GatewaySpiMessages LOG = MessagesFactory.get(GatewaySpiMessages.class);
   private String gatewayPath;
   private String topologyName;
 
@@ -43,7 +45,12 @@ public class CookieScopeServletFilter extends AbstractGatewayFilter {
   @Override
   protected void doFilter( HttpServletRequest request, HttpServletResponse response, FilterChain chain )
       throws IOException, ServletException {
-    chain.doFilter(request, new CookieScopeResponseWrapper(response, gatewayPath, topologyName));
+    if ("true".equals(request.getAttribute(DEFAULT_TOPOLOGY_FORWARD_ATTRIBUTE_NAME))) {
+      LOG.ignoringCookiePathScopeForDefaultTopology();
+      chain.doFilter(request, response);
+    } else {
+      chain.doFilter(request, new CookieScopeResponseWrapper(response, gatewayPath, topologyName));
+    }
   }
 
 }

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/CookieScopeServletFilter.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/api/CookieScopeServletFilter.java
@@ -45,7 +45,7 @@ public class CookieScopeServletFilter extends AbstractGatewayFilter {
   @Override
   protected void doFilter( HttpServletRequest request, HttpServletResponse response, FilterChain chain )
       throws IOException, ServletException {
-    if ("true".equals(request.getAttribute(DEFAULT_TOPOLOGY_FORWARD_ATTRIBUTE_NAME))) {
+    if (Boolean.parseBoolean((String)request.getAttribute(DEFAULT_TOPOLOGY_FORWARD_ATTRIBUTE_NAME))) {
       LOG.ignoringCookiePathScopeForDefaultTopology();
       chain.doFilter(request, response);
     } else {

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/CookieScopeResponseWrapper.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/CookieScopeResponseWrapper.java
@@ -46,8 +46,8 @@ public class CookieScopeResponseWrapper extends GatewayResponseWrapper {
     public void addHeader(String name, String value) {
         if (SET_COOKIE.equals(name)) {
             String updatedCookie;
-            if (value.contains(COOKIE_PATH)) {
-                updatedCookie = value.replace(COOKIE_PATH, scopePath);
+            if (hasCookiePathAttribute(value)) {
+                updatedCookie = value.replaceAll("(?i)" + COOKIE_PATH, scopePath);
             } else {
                 // append the scope path
                 updatedCookie = String.format(Locale.ROOT, "%s %s;", value, scopePath);
@@ -56,6 +56,11 @@ public class CookieScopeResponseWrapper extends GatewayResponseWrapper {
         } else {
             super.addHeader(name, value);
         }
+    }
+
+    private boolean hasCookiePathAttribute(String value) {
+        return value != null
+                && value.toLowerCase(Locale.ROOT).contains(COOKIE_PATH.toLowerCase(Locale.ROOT));
     }
 
     @Override

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/CookieScopeResponseWrapperTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/CookieScopeResponseWrapperTest.java
@@ -61,6 +61,15 @@ public class CookieScopeResponseWrapperTest {
   }
 
   @Test
+  public void testRootLowerCasePath() {
+    CookieScopeResponseWrapper underTest = new CookieScopeResponseWrapper(mock, "gw");
+    underTest.addHeader("Set-Cookie", "SESSIONID=jn0zexg59r1jo1n66hd7tg5anl; path=/; HttpOnly;");
+
+    Assert.assertEquals("Set-Cookie", captureKey.getValue());
+    Assert.assertEquals("SESSIONID=jn0zexg59r1jo1n66hd7tg5anl; Path=/gw/; HttpOnly;", captureValue.getValue());
+  }
+
+  @Test
   public void testMultiSegmentPath() {
     CookieScopeResponseWrapper underTest = new CookieScopeResponseWrapper(mock, "some/path");
     underTest.addHeader("Set-Cookie", "SESSIONID=jn0zexg59r1jo1n66hd7tg5anl; Path=/; HttpOnly;");

--- a/gateway-server/src/main/java/org/apache/knox/gateway/filter/PortMappingHelperHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/filter/PortMappingHelperHandler.java
@@ -16,6 +16,8 @@
  */
 package org.apache.knox.gateway.filter;
 
+import static org.apache.knox.gateway.filter.AbstractGatewayFilter.DEFAULT_TOPOLOGY_FORWARD_ATTRIBUTE_NAME;
+
 import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
@@ -42,7 +44,6 @@ import java.util.Map;
  */
 public class PortMappingHelperHandler extends HandlerWrapper {
   private static final GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
-
   private final GatewayConfig config;
   private final String defaultTopologyRedirectContext;
 
@@ -148,6 +149,7 @@ public class PortMappingHelperHandler extends HandlerWrapper {
 
     final String newTarget = defaultTopologyRedirectContext + target;
     LOG.defaultTopologyForward(target, newTarget);
+    request.setAttribute(DEFAULT_TOPOLOGY_FORWARD_ATTRIBUTE_NAME, "true");
     super.handle(newTarget, baseRequest, newRequest, response);
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/filter/AbstractGatewayFilter.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/filter/AbstractGatewayFilter.java
@@ -37,7 +37,8 @@ public abstract class AbstractGatewayFilter implements Filter {
   public static final String TARGET_REQUEST_URL_ATTRIBUTE_NAME = "targetRequestUrl";
   public static final String SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME = "sourceRequestContextUrl";
   public static final String TARGET_SERVICE_ROLE = "targetServiceRole";
-//  public static final String RESPONSE_STREAMER_ATTRIBUTE_NAME = "responseStreamer";
+  public static final String DEFAULT_TOPOLOGY_FORWARD_ATTRIBUTE_NAME = "defaultTopologyForward";
+  //  public static final String RESPONSE_STREAMER_ATTRIBUTE_NAME = "responseStreamer";
   private static final GatewaySpiMessages LOG = MessagesFactory.get( GatewaySpiMessages.class );
 
   private FilterConfig config;

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -90,4 +90,7 @@ public interface GatewaySpiMessages {
 
   @Message(level=MessageLevel.DEBUG, text="Creating impersonation provider in {0} / {1} with prefix {2} and config {3}")
   void createImpersonationProvider(String topology, String role, String prefix, String properties);
+
+  @Message(level=MessageLevel.DEBUG, text="Ignoring cookie path scope filter for default topology")
+  void ignoringCookiePathScopeForDefaultTopology();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When cookie path scoping is enabled knox will update the Path attribute of the cookies with `/gateway/topology_name`.
This doesn't work when a service is accessed via the default topology name (there is no `gateway/topology_name` in the url).

## How was this patch tested?

Enable cookie scoping + set default topology to sandbox:

```xml
    <property>
        <name>default.app.topology.name</name>
        <value>sandbox</value>
    </property>
    <property>
        <name>gateway.scope.cookies.feature.enabled</name>
        <value>true</value>
    </property>
```

Set service url in sandbox.xml:

```xml
    <service>
        <role>HIVE</role>
        <url>http://localhost:1701</url>
    </service>
```

Set up a test http server:

```smalltalk
Teapot on
    GET: '/' -> [:req |  
        ZnResponse noContent
    	      addCookie: ((ZnCookie name: 'test' value:'val') path: '/original/path'); 
    	      yourself 
         ];
	start. 
```

Unblock cookies in service.xml (data/services/hive/0.13.0/service.xml):
```xml
       <param>
            <name>responseExcludeHeaders</name>
            <value>SET-COOKIE;asdfg</value>
      </param>
```

Cookie path is updated when using the full URL:

```
$ curl -u admin:admin-password -k -v https://localhost:8443/gateway/sandbox/hive

< HTTP/1.1 204 No Content
< Set-Cookie: test=val; Path=/gateway/sandbox/original/path
```

Cookie path is not updated when using the default URL:

```
$ curl -u admin:admin-password -k -v https://localhost:8443/hive

< HTTP/1.1 204 No Content
< Set-Cookie: test=val; path=/original/path
```