### PR TITLE
KNOX-2950 - Handling application path aliases

### DIFF
--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -141,6 +141,13 @@ limitations under the License.
         <description>A duration (in seconds) beyond a token’s expiration to wait before evicting its state. This configuration only applies when server-managed token state is enabled either in gateway-site or at the topology level.</description>
     </property>
 
+    <!-- @since 2.1.0 application path aliases -->
+    <property>
+        <name>gateway.application.path.alias.token-generation</name>
+        <value>tokengen</value>
+    </property>
+
+
     <!-- Knox Admin related config -->
     <property>
         <name>gateway.knox.admin.groups</name>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -1496,4 +1496,20 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     return usersCanSeeAllTokens == null ? false : usersCanSeeAllTokens.contains(userName);
   }
 
+  @Override
+  public Map<String, Collection<String>> getApplicationPathAliases() {
+    return getPathAliases(".application");
+  }
+
+  private Map<String, Collection<String>> getPathAliases(String qualifier) {
+    final String prefix = GATEWAY_CONFIG_FILE_PREFIX + qualifier + DEPLOYMENT_PATH_ALIAS;
+    final Map<String, Collection<String>> pathAliases = new HashMap<>();
+    this.forEach(config -> {
+      if (config.getKey().startsWith(prefix)) {
+        pathAliases.put(config.getKey().substring(prefix.length()).toLowerCase(Locale.getDefault()), getTrimmedStringCollection(config.getKey()));
+      }
+    });
+    return pathAliases;
+  }
+
 }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1062,4 +1062,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return false;
   }
 
+  @Override
+  public Map<String, Collection<String>> getApplicationPathAliases() {
+    return Collections.emptyMap();
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -115,6 +115,8 @@ public interface GatewayConfig {
 
   String DEFAULT_API_SERVICES_VIEW_VERSION = "v1";
 
+  String DEPLOYMENT_PATH_ALIAS = ".path.alias.";
+
   /**
    * The location of the gateway configuration.
    * Subdirectories will be: topologies
@@ -893,5 +895,7 @@ public interface GatewayConfig {
    *         userName) on the Token Management page; <code>false</code> otherwise
    */
   boolean canSeeAllTokens(String userName);
+
+  Map<String, Collection<String>> getApplicationPathAliases();
 
 }

--- a/knox-homepage-ui/home/app/homepage.service.ts
+++ b/knox-homepage-ui/home/app/homepage.service.ts
@@ -27,8 +27,10 @@ import {SessionInformation} from './sessionInformation/session.information';
 
 @Injectable()
 export class HomepageService {
-    apiUrl = window.location.pathname.replace(new RegExp('home/.*'), 'api/v1/metadata/');
-    sessionUrl = window.location.pathname.replace(new RegExp('home/.*'), 'session/api/v1/sessioninfo');
+    pathParts = window.location.pathname.split('/');
+    topologyContext = '/' + this.pathParts[1] + '/' + this.pathParts[2] + '/';
+    apiUrl = this.topologyContext + 'api/v1/metadata/';
+    sessionUrl = this.topologyContext + 'session/api/v1/sessioninfo';
     generalProxyInformationUrl = this.apiUrl + 'info';
     publicCertUrl = this.apiUrl + 'publicCert?type=';
     topologiesUrl = this.apiUrl + 'topologies';

--- a/knox-token-generation-ui/token-generation/app/token-generation.service.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.service.ts
@@ -26,11 +26,11 @@ export class TokenGenService {
     readonly tssStatusRequestURL: string;
 
     constructor(private http: HttpClient) {
-        const loginPageSuffix = 'token-generation/index.html';
         const knoxtokenURL = 'knoxtoken/api/v1/token';
         const tssStatusURL = 'knoxtoken/api/v1/token/getTssStatus';
 
-        let topologyContext = window.location.pathname.replace(loginPageSuffix, '');
+        let pathParts = window.location.pathname.split('/');
+        let topologyContext = '/' + pathParts[1] + '/' + pathParts[2] + '/';
         let temporaryURL = topologyContext.substring(0, topologyContext.lastIndexOf('/'));
         this.baseURL = temporaryURL.substring(0, temporaryURL.lastIndexOf('/') + 1);
         this.tokenURL = topologyContext + knoxtokenURL;

--- a/knox-token-management-ui/token-management/app/token.management.component.ts
+++ b/knox-token-management-ui/token-management/app/token.management.component.ts
@@ -32,7 +32,9 @@ import {SelectionModel} from '@angular/cdk/collections';
 
 export class TokenManagementComponent implements OnInit {
 
-    tokenGenerationPageURL = window.location.pathname.replace(new RegExp('token-management/.*'), 'token-generation/index.html');
+    pathParts = window.location.pathname.split('/');
+    topologyContext = '/' + this.pathParts[1] + '/' + this.pathParts[2] + '/';
+    tokenGenerationPageURL = this.topologyContext + 'token-generation/index.html';
 
     userName: string;
     canSeeAllTokens: boolean;

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -25,10 +25,12 @@ import {SessionInformation} from './session.information';
 
 @Injectable()
 export class TokenManagementService {
-    sessionUrl = window.location.pathname.replace(new RegExp('token-management/.*'), 'session/api/v1/sessioninfo');
-    apiUrl = window.location.pathname.replace(new RegExp('token-management/.*'), 'knoxtoken/api/v1/token/');
-    getAllKnoxTokensUrl = this.apiUrl + 'getUserTokens?allTokens=true';
+    pathParts = window.location.pathname.split('/');
+    topologyContext = '/' + this.pathParts[1] + '/' + this.pathParts[2] + '/';
+    sessionUrl = this.topologyContext + 'session/api/v1/sessioninfo';
+    apiUrl = this.topologyContext + 'knoxtoken/api/v1/token/';
     getKnoxTokensUrl = this.apiUrl + 'getUserTokens?userNameOrCreatedBy=';
+    getAllKnoxTokensUrl = this.apiUrl + 'getUserTokens?allTokens=true';
     enableKnoxTokenUrl = this.apiUrl + 'enable';
     enableKnoxTokensBatchUrl = this.apiUrl + 'enableTokens';
     disableKnoxTokenUrl = this.apiUrl + 'disable';


### PR DESCRIPTION
## What changes were proposed in this pull request?

With this change, our end-users have a way to define custom application path aliases next to the ones we have OOTB to reach certain apps, UIs.
I added the following `gateway-site.xml` property(ies) to support this feature:
```
    <property>
        <name>gateway.application.path.alias.$original-application-path-to-match</name>
        <value>$comma-separated-list-of-alias-names</value>
    </property>
```
where
- $original-application-path-to-match indicates the existing application path we would like to have an alias for
- $comma-separated-list-of-alias-names marks the list of alias names to register (pointing to the same application as the original path above), separated by a comma if there are more

For instance:
```
    <property>
        <name>gateway.application.path.alias.token-generation</name>
        <value>tokengen</value>
    </property>
```
will allow end-users to reach the Token Generation UI on both `.../token-generation/index.html` and `.../tokengen/index.html`.

## How was this patch tested?

Updated JUnit tests and conducted manual testing:
1. Added the following application path aliases in `gateway-site.xml` (under the existing `token-generation/tokengen` entry):
```
    <property>
        <name>gateway.application.path.alias.token-management</name>
        <value>tokenman</value>
    </property>

    <property>
        <name>gateway.application.path.alias.home</name>
        <value>knoxhome, knox-home</value>
    </property>
```
2. Validated that the Token Generation page is reachable on both paths:
<img width="1784" alt="Screenshot 2023-08-18 at 12 41 09" src="https://github.com/apache/knox/assets/34065904/be4c1795-50b4-4465-8344-706ca1503203">
<img width="1783" alt="Screenshot 2023-08-18 at 12 41 20" src="https://github.com/apache/knox/assets/34065904/be931348-b5fc-4df3-937d-13f2e46f7629">

3. Validated that the Token Management page is reachable on both paths:
<img width="1773" alt="Screenshot 2023-08-18 at 12 42 44" src="https://github.com/apache/knox/assets/34065904/1c87d116-e3ec-445d-8183-aba87cf3a657">
<img width="1780" alt="Screenshot 2023-08-18 at 12 42 53" src="https://github.com/apache/knox/assets/34065904/df103cba-1b92-456c-b935-f0ec93a7f85f">

4. Validated that the Knox Home page is reachable on the original path (`/home`) as well as on the two path aliases:
<img width="1780" alt="Screenshot 2023-08-18 at 12 45 09" src="https://github.com/apache/knox/assets/34065904/e8353916-579f-443a-a1eb-05f11f175985">
<img width="1782" alt="Screenshot 2023-08-18 at 12 45 16" src="https://github.com/apache/knox/assets/34065904/5500aba3-f822-472f-aa51-acec09dec102">
<img width="1782" alt="Screenshot 2023-08-18 at 12 45 26" src="https://github.com/apache/knox/assets/34065904/91d72581-5328-47e9-9c36-77fa7e4a23d9">
