### PR TITLE
KNOX-2951 - During discovery if cm is not reachable and throws SocketException then retry is not happening

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -40,7 +40,6 @@ import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.monitor.ClouderaManagerClusterConfigurationMonitor;
 
-import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -41,6 +41,9 @@ import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.monitor.ClouderaManagerClusterConfigurationMonitor;
 
 import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -234,7 +237,9 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
     if (maxRetryAttempts > 0 && maxRetryAttempts > retryAttempts.getAndIncrement()) {
       final Throwable cause = e.getCause();
       if (cause != null) {
-        if (ConnectException.class.isAssignableFrom(cause.getClass())) {
+        if (SocketException.class.isAssignableFrom(cause.getClass())
+                || SocketTimeoutException.class.isAssignableFrom(cause.getClass())
+                || UnknownHostException.class.isAssignableFrom(cause.getClass())) {
           return true;
         }
       }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -62,7 +62,7 @@ import org.easymock.EasyMock;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
-import java.net.ConnectException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1352,7 +1352,7 @@ public class ClouderaManagerServiceDiscoveryTest {
     @Override
     public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
       if (executeCount.getAndIncrement() < GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS - 2) {
-        throw new ApiException(new ConnectException("Failed to connect to CM HOST"));
+        throw new ApiException(new SocketTimeoutException("Failed to connect to CM HOST"));
       }
       return super.execute(call, returnType);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Service discovery was not retried after a SocketTimeoutException.

## How was this patch tested?

Unittest.