### PR TITLE
Uniform name of http method of client metric to lowerCase

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrumentedGatewayFilter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrumentedGatewayFilter.java
@@ -30,6 +30,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Map;
 
 public class InstrumentedGatewayFilter extends GatewayFilter {
@@ -91,7 +92,7 @@ public class InstrumentedGatewayFilter extends GatewayFilter {
       HttpServletRequest httpServletRequest = (HttpServletRequest) request;
       builder.append(InstrUtils.getResourcePath(httpServletRequest.getPathInfo()));
       builder.append('.');
-      builder.append(httpServletRequest.getMethod());
+      builder.append(httpServletRequest.getMethod().toLowerCase(Locale.ROOT));
       builder.append("-requests");
     }
     return metricRegistry.timer(builder.toString());


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)
fix [KNOX-2953](https://issues.apache.org/jira/browse/KNOX-2953)

## What changes were proposed in this pull request?
Uniform name of http method of client metric to lowerCase, when build metric name,  just like the service metric name at [InstrHttpClientBuilderProvider::methodNameString](https://github.com/apache/knox/blob/master/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrHttpClientBuilderProvider.java#L68)

## How was this patch tested?
1. Apply this PR and recompile
2.Deploy new jar files to ${KNOX_HOME}/lib direcotry and restart gateway 
3.Use curl -X Get and curl -X GET to query from hbase
4.Use visualVM or other tool to check whether the metric name is consistent

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
