### PR TITLE
KNOX-2954 - Gateway metric name contain rowkey led to full gc

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrHttpClientBuilderProvider.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrHttpClientBuilderProvider.java
@@ -57,7 +57,7 @@ public class InstrHttpClientBuilderProvider implements
         }
         RequestLine requestLine = request.getRequestLine();
         URIBuilder uriBuilder = new URIBuilder(requestLine.getUri());
-        String resourcePath = InstrUtils.getResourcePath(uriBuilder.removeQuery().build().toString());
+        String resourcePath = InstrUtils.getServiceResourcePath(uriBuilder.removeQuery().build().toString());
         return MetricRegistry.name("service", name, context + resourcePath, methodNameString(request));
       } catch (URISyntaxException e) {
         throw new IllegalArgumentException(e);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/metrics/impl/instr/InstrUtils.java
@@ -26,7 +26,13 @@ public class InstrUtils {
     //of a path. For example, if the path is “/webhdfs/v1/d1/d2/d2/d4”, this pattern
     //can be used to get the first two ("/webhdfs/v1/"). The "?" in pattern
     //ensures not to be greedy in matching.
-    private static Pattern p = Pattern.compile("/.*?/.*?/");
+    private static final Pattern p = Pattern.compile("/.*?/.*?/");
+
+    //This regular expression pattern is used to parse the *first* element
+    //of a path. For example, if the path is “/webhdfs/v1/d1/d2/d2/d4”, this pattern
+    //can be used to get the first ("/webhdfs/"). The "?" in pattern
+    //ensures not to be greedy in matching.
+    private static final Pattern serviceP = Pattern.compile("/.*?/");
 
     /**
      * This function parses the pathinfo provided  in any servlet context and
@@ -37,9 +43,31 @@ public class InstrUtils {
      * @return resource path
      */
     public static String getResourcePath(String fullPath) {
+        return getMatchedPath(fullPath, p);
+    }
+
+    /**
+     * This function parses the pathinfo provided  in any servlet context and
+     * returns the segment that is related to the resource.
+     * For example, if the path is "/webhdfs/v1/d1/d2/d2/d4". it returns "/webhdfs/v1"
+     *
+     * @param fullPath full path to determine the resource from
+     * @return resource path
+     */
+    public static String getServiceResourcePath(String fullPath) {
+        return getMatchedPath(fullPath, serviceP);
+    }
+
+    /**
+     * This function return match Pattern pathinfo
+     * @param fullPath full path to determine the resource from
+     * @param pattern this regular expression pattern is used to parse element
+     * @return matched path
+     */
+    private static String getMatchedPath(String fullPath, Pattern pattern) {
         String resourcePath = "";
         if (fullPath != null && !fullPath.isEmpty()) {
-            Matcher m = p.matcher(fullPath);
+            Matcher m = pattern.matcher(fullPath);
             if (m.find()) {
                 resourcePath = m.group(0);
             } else {


### PR DESCRIPTION
Fix [KNOX-2954](https://issues.apache.org/jira/browse/KNOX-2954) 

## What changes were proposed in this pull request?
The name of service metric should not contain hbase rowkey

## How was this patch tested?

Apply this PR and recompile
Deploy new jar files to ${KNOX_HOME}/lib direcotry and restart gateway
Use rowkey to query from hbase
Use visualVM or other tool to check whether the name of service metric contains rowkey
