### PR TITLE
KNOX-2948 - HXR parser can handle the new 'provisionEncryptQueryStringCredential' boolean field in SimpleDescriptor

### DIFF
--- a/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParser.java
+++ b/gateway-topology-hadoop-xml/src/main/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParser.java
@@ -67,6 +67,7 @@ public class HadoopXmlResourceParser implements AdvancedServiceDiscoveryConfigCh
   private static final String CONFIG_NAME_DISCOVERY_PASSWORD_ALIAS = "discoveryPasswordAlias";
   private static final String CONFIG_NAME_DISCOVERY_CLUSTER = "cluster";
   private static final String CONFIG_NAME_PROVIDER_CONFIG_REFERENCE = "providerConfigRef";
+  private static final String CONFIG_NAME_PROVISION_ENCRYPT_QUERY_STRING_CREDENTIAL = "provisionEncryptQueryStringCredential";
   private static final String CONFIG_NAME_APPLICATION_PREFIX = "app";
   private static final String CONFIG_NAME_SERVICE_URL = "url";
   private static final String CONFIG_NAME_SERVICE_VERSION = "version";
@@ -265,6 +266,9 @@ public class HadoopXmlResourceParser implements AdvancedServiceDiscoveryConfigCh
           break;
         case CONFIG_NAME_PROVIDER_CONFIG_REFERENCE:
           descriptor.setProviderConfig(parameterPairParts[1].trim());
+          break;
+        case CONFIG_NAME_PROVISION_ENCRYPT_QUERY_STRING_CREDENTIAL:
+          descriptor.setProvisionEncryptQueryStringCredential(Boolean.valueOf(parameterPairParts[1].trim()));
           break;
         default:
           if (parameterName.startsWith(CONFIG_NAME_APPLICATION_PREFIX)) {

--- a/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
+++ b/gateway-topology-hadoop-xml/src/test/java/org/apache/knox/gateway/topology/hadoop/xml/HadoopXmlResourceParserTest.java
@@ -17,6 +17,7 @@
 package org.apache.knox.gateway.topology.hadoop.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -264,6 +265,7 @@ public class HadoopXmlResourceParserTest {
     assertEquals("alias", descriptor.getDiscoveryPasswordAlias());
     assertEquals("Cluster 1", descriptor.getCluster());
     assertEquals("topology1-provider", descriptor.getProviderConfig());
+    assertTrue(descriptor.isProvisionEncryptQueryStringCredential());
     assertEquals(2, descriptor.getApplications().size());
 
     assertApplication(descriptor, "knoxauth", Collections.singletonMap("param1.name", "param1.value"));
@@ -289,6 +291,7 @@ public class HadoopXmlResourceParserTest {
     assertEquals("http://host:456", descriptor.getDiscoveryAddress());
     assertEquals("Cluster 2", descriptor.getCluster());
     assertEquals("topology2-provider", descriptor.getProviderConfig());
+    assertFalse(descriptor.isProvisionEncryptQueryStringCredential());
     assertTrue(descriptor.getApplications().isEmpty());
 
     final Map<String, String> expectedServiceParameters = Stream.of(new String[][] { { "httpclient.connectionTimeout", "5m" }, { "httpclient.socketTimeout", "100m" }, })

--- a/gateway-topology-hadoop-xml/src/test/resources/testDescriptor.xml
+++ b/gateway-topology-hadoop-xml/src/test/resources/testDescriptor.xml
@@ -39,6 +39,7 @@ limitations under the License.
         discoveryAddress=http://host:456#
         cluster=Cluster 2#
         providerConfigRef=topology2-provider#
+        provisionEncryptQueryStringCredential=false#
         ATLAS-API:url=http://localhost:456#
         ATLAS-API:httpclient.connectionTimeout=5m#
         ATLAS-API:httpclient.socketTimeout=100m#


### PR DESCRIPTION
## What changes were proposed in this pull request?

My previous commit added support for a new boolean variable called `provisionEncryptQueryStringCredential` in a descriptor file. This commit makes it possible to set that new field using a Hadoop XML resource.

## How was this patch tested?

Unit testing.
