### PR TITLE
KNOX-2896 - API services view on Knox Home page can be selected

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -302,6 +302,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String KNOX_HOMEPAGE_PROFILE_PREFIX =  "knox.homepage.profile.";
   private static final String KNOX_HOMEPAGE_PINNED_TOPOLOGIES =  "knox.homepage.pinned.topologies";
   private static final String KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES =  "knox.homepage.hidden.topologies";
+  private static final String KNOX_HOMEPAGE_API_SERVICES_VIEW_VERSION = "knox.homepage.api.services.view.version";
+
   private static final Set<String> KNOX_HOMEPAGE_HIDDEN_TOPOLOGIES_DEFAULT = new HashSet<>(Arrays.asList("admin", "manager", "knoxsso", "metadata", "homepage"));
   private static final String KNOX_HOMEPAGE_LOGOUT_ENABLED =  "knox.homepage.logout.enabled";
   private static final String GLOBAL_LOGOUT_PAGE_URL = "knox.global.logout.page.url";
@@ -1325,6 +1327,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     return pinnedTopologies == null ? Collections.emptySet() : new HashSet<>(pinnedTopologies);
   }
 
+  @Override
+  public String getApiServicesViewVersionOnHomepage() {
+    return getTrimmed(KNOX_HOMEPAGE_API_SERVICES_VIEW_VERSION, DEFAULT_API_SERVICES_VIEW_VERSION);
+  }
+
   /**
    * @return returns whether know token permissive failure is enabled
    */
@@ -1481,4 +1488,5 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public boolean isAsyncSupported() {
     return getBoolean(GATEWAY_SERVLET_ASYNC_SUPPORTED, GATEWAY_SERVLET_ASYNC_SUPPORTED_DEFAULT);
   }
+
 }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -242,7 +242,7 @@ public class KnoxMetadataResource {
               }
             });
           });
-          topologies.addTopology(topology.getName(), isPinnedTopology(topology.getName(), config), new TreeSet<>(apiServices), new TreeSet<>(uiServices));
+          topologies.addTopology(topology.getName(), isPinnedTopology(topology.getName(), config), config.getApiServicesViewVersionOnHomepage(), new TreeSet<>(apiServices), new TreeSet<>(uiServices));
         }
       }
     }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformation.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformation.java
@@ -32,6 +32,9 @@ public class TopologyInformation implements Comparable<TopologyInformation>{
   @XmlElement(name = "pinned")
   private boolean pinned;
 
+  @XmlElement(name = "apiServicesViewVersion")
+  private String apiServicesViewVersion;
+
   @XmlElement(name = "service")
   @XmlElementWrapper(name = "apiServices")
   private Set<ServiceModel> apiServices;
@@ -54,6 +57,14 @@ public class TopologyInformation implements Comparable<TopologyInformation>{
 
   public void setPinned(boolean pinned) {
     this.pinned = pinned;
+  }
+
+  public void setApiServicesViewVersion(String apiServicesViewVersion) {
+    this.apiServicesViewVersion = apiServicesViewVersion;
+  }
+
+  public String getApiServicesViewVersion() {
+    return apiServicesViewVersion;
   }
 
   public Set<ServiceModel> getApiServices() {

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformationWrapper.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/TopologyInformationWrapper.java
@@ -36,12 +36,13 @@ public class TopologyInformationWrapper {
     return topologies;
   }
 
-  public void addTopology(String name, boolean pinned, Set<ServiceModel> apiServices, Set<ServiceModel> uiServices) {
+  public void addTopology(String name, boolean pinned, String apiServicesViewVersion, Set<ServiceModel> apiServices, Set<ServiceModel> uiServices) {
     final TopologyInformation topology = new TopologyInformation();
     topology.setTopologyName(name);
     topology.setPinned(pinned);
     topology.setApiServices(apiServices);
     topology.setUiServices(uiServices);
+    topology.setApiServicesViewVersion(apiServicesViewVersion);
     this.topologies.add(topology);
   }
 

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -911,6 +911,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return Collections.emptySet();
   }
 
+  @Override
+  public String getApiServicesViewVersionOnHomepage() {
+    return DEFAULT_API_SERVICES_VIEW_VERSION;
+  }
+
   /**
    * @return returns whether know token permissive failure is enabled
    */
@@ -1051,4 +1056,5 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public boolean isAsyncSupported() {
     return false;
   }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -113,6 +113,8 @@ public interface GatewayConfig {
 
   int DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS = 3;
 
+  String DEFAULT_API_SERVICES_VIEW_VERSION = "v1";
+
   /**
    * The location of the gateway configuration.
    * Subdirectories will be: topologies
@@ -794,6 +796,11 @@ public interface GatewayConfig {
   Set<String> getPinnedTopologiesOnHomepage();
 
   /**
+   * @return the API services view version (v1/v2) on Knox homepage
+   */
+  String getApiServicesViewVersionOnHomepage();
+
+  /**
    * @return returns whether know token permissive validation is enabled
    */
   boolean isKnoxTokenPermissiveValidationEnabled();
@@ -879,4 +886,5 @@ public interface GatewayConfig {
    * @return true if the async supported flag is enabled in jetty gateway servlet; false otherwise (defaults to false)
    */
   boolean isAsyncSupported();
+
 }

--- a/knox-homepage-ui/angular.json
+++ b/knox-homepage-ui/angular.json
@@ -58,6 +58,8 @@
           },
           "configurations": {
             "production": {
+              "buildOptimizer": false,
+              "aot": false,
               "fileReplacements": [
                 {
                   "replace": "home/environments/environment.ts",
@@ -68,6 +70,7 @@
             },
             "development": {
               "buildOptimizer": false,
+              "aot": false,
               "optimization": false,
               "vendorChunk": true,
               "extractLicenses": false,

--- a/knox-homepage-ui/home/app/app.module.ts
+++ b/knox-homepage-ui/home/app/app.module.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import {NgModule} from '@angular/core';
+import {DataTableModule} from 'angular2-datatable';
 import {BrowserModule} from '@angular/platform-browser';
 import {HttpClientModule, HttpClientXsrfModule} from '@angular/common/http';
 import {MatGridListModule} from '@angular/material/grid-list';
@@ -31,6 +32,7 @@ import {HomepageService} from './homepage.service';
     imports: [BrowserModule,
         HttpClientModule,
         HttpClientXsrfModule,
+        DataTableModule,
         MatGridListModule,
         BsModalModule,
         RouterModule.forRoot([])

--- a/knox-homepage-ui/home/app/topologies/topology.information.component.html
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.html
@@ -53,10 +53,42 @@
             </mat-grid-tile>
         </mat-grid-list>
 
+        <!-- API services -->
+
         <h5 *ngIf="topology.apiServices.service.length > 0">API Services</h5>
 
-        <!-- API services -->
-        <mat-grid-list cols="4" rowHeight="130px">
+        <table *ngIf="topology.apiServicesViewVersion === 'v1'" class="table table-hover" [mfData]="topology.apiServices.service" #api="mfDataTable" [mfRowsOnPage]="5">
+            <colgroup>
+                <col width="30%">
+                <col width="70%">
+            </colgroup>
+            <thead>
+                <tr *ngIf="topology.apiServices.service.length === 0"><th colspan="2">No API services found</th></tr>
+                <tr *ngIf="topology.apiServices.service.length > 0"><th colspan="2">API services</th></tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let service of api.data">
+                    <td>
+                        <span class="inline-glyph glyphicon glyphicon-info-sign btn btn-xs"
+                        title="{{service.description}}"
+                        data-toggle="tooltip"></span>
+                        {{service.shortDesc}} <span class="small" *ngIf="service.version">(v{{service.version}})</span>
+                    </td>
+                    <td>
+                        <a href="{{service.serviceUrl}}">{{service.serviceUrl}}</a>
+                    </td>
+                </tr>
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colspan="4">
+                      <mfBootstrapPaginator [rowsOnPageSet]="[5,10,15]"></mfBootstrapPaginator>
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+
+        <mat-grid-list *ngIf="topology.apiServicesViewVersion === 'v2'" cols="4" rowHeight="130px">
             <mat-grid-tile *ngFor="let service of topology.apiServices.service" [colspan]="1" [rowspan]="1">
                 <span *ngIf="!this['enableServiceText_' + service.serviceName.toLowerCase()]" (click)="openApiServiceInformationModal(service)">
                     <img src="assets/service-logos/{{service.serviceName.toLowerCase()}}.png" height="50px" (error)="enableServiceText('enableServiceText_' + service.serviceName.toLowerCase())"/>

--- a/knox-homepage-ui/home/app/topologies/topology.information.ts
+++ b/knox-homepage-ui/home/app/topologies/topology.information.ts
@@ -19,6 +19,7 @@ import {Service} from './service';
 export class TopologyInformation {
     topology: string;
     pinned: boolean;
+    apiServicesViewVersion: string;
     apiServices: Service[];
     uiServices: Service[];
 }

--- a/knox-homepage-ui/package-lock.json
+++ b/knox-homepage-ui/package-lock.json
@@ -2967,6 +2967,14 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
     },
+    "angular2-datatable": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/angular2-datatable/-/angular2-datatable-0.6.0.tgz",
+      "integrity": "sha512-Fgg3hg3Pyg80Tp21Fu9qzsj9yx4941cIbbWpbKHJlQua5eketQPAp+yEbnz0KnaMprlpQg5IBe6xdIAg1G6aCQ==",
+      "requires": {
+        "lodash": "^4.0.0"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -6291,8 +6299,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/knox-homepage-ui/package.json
+++ b/knox-homepage-ui/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "^13.0.1",
     "@angular/platform-browser-dynamic": "^13.0.1",
     "@angular/router": "^13.0.1",
+    "angular2-datatable": "^0.6.0",
     "bootstrap": "^3.4.1",
     "core-js": "^2.6.11",
     "jquery": "^3.5.1",


### PR DESCRIPTION
## What changes were proposed in this pull request?

A new gateway-level configuration, called `knox.homepage.api.services.view.version`, is introduced that lets the end-users switch between the following API services views on the Knox Home page:
- v1: this is the old style list view (this is the default value)
- v2: the new style modal-window view

## How was this patch tested?
Manual testing with the following values in `gateway-site.xml`.

1. No `knox.homepage.api.services.view.version`
<img width="1786" alt="Screenshot 2023-09-19 at 10 37 31" src="https://github.com/apache/knox/assets/34065904/94cea67b-abda-4276-86c6-cec854108a97">

2. `knox.homepage.api.services.view.version = v1`
<img width="1786" alt="Screenshot 2023-09-19 at 10 37 31" src="https://github.com/apache/knox/assets/34065904/94cea67b-abda-4276-86c6-cec854108a97">

3. `knox.homepage.api.services.view.version = v2`
<img width="1781" alt="Screenshot 2023-09-19 at 10 37 51" src="https://github.com/apache/knox/assets/34065904/462ef54c-3243-40f8-be35-6514a0e6a55c">
<img width="1786" alt="Screenshot 2023-09-19 at 10 38 03" src="https://github.com/apache/knox/assets/34065904/93a6b648-15a0-4ee2-b2c6-beae55169e00">

