### PR TITLE
KNOX-2960 - DefaultDispatch doesn't forward inbound request headers in case of requestType=OPTIONS

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -304,6 +304,7 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
    public void doOptions(URI url, HttpServletRequest request, HttpServletResponse response)
          throws IOException {
       HttpOptions method = new HttpOptions(url);
+     copyRequestHeaderFields(method, request);
      executeRequestWrapper(method, request, response);
    }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Incoming Headers are not going through when using OPTIONS type HTTP requests.

## How was this patch tested?

Sandbox topology

```xml
    <service>
        <role>HIVE</role>
        <url>http://localhost:1701/headers</url>
        <param>
            <name>replayBufferSize</name>
            <value>8</value>
        </param>
    </service>
```

Test HTTP server that logs out the received headers:

```smalltalk
Teapot on
    OPTIONS: '/headers' -> [:req | 
    	req headersDo: [:n :v | Transcript show: ('Received: ', n, '=', v); cr ]. 'OK' ];
    start. 
```

```
$ curl -X OPTIONS -u admin:admin-password -H 'My-Header: My-Value' -vk https://localhost:8443/gateway/sandbox/hive
```

Transcript content:

```
Received: X-Forwarded-Proto=https
Received: X-Forwarded-Port=8443
Received: X-Forwarded-Host=localhost:8443
Received: X-Forwarded-Server=localhost
Received: X-Forwarded-Context=/gateway/sandbox
Received: Accept=*/*
Received: User-Agent=curl/7.64.1
Received: My-Header=My-Value
Received: Authorization=Basic YWRtaW46Kg==
Received: Host=localhost:1701
Received: Connection=Keep-Alive
Received: X-Zinc-Remote-Address=127.0.0.1
```