### PR TITLE
KNOX-2961 - Knox SSO cookie Invalidation - Phase II

### DIFF
--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -487,6 +487,11 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
         }
 
         @Override
+        public Collection<KnoxToken> getAllTokens() {
+           return fetchTokens(null, false);
+        }
+
+        @Override
         public Collection<KnoxToken> getTokens(String userName) {
           return fetchTokens(userName, false);
         }
@@ -499,10 +504,14 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
         private Collection<KnoxToken> fetchTokens(String userName, boolean createdBy) {
           final Collection<KnoxToken> tokens = new TreeSet<>();
           final Predicate<Map.Entry<String, TokenMetadata>> filterPredicate;
-          if (createdBy) {
-            filterPredicate = entry -> userName.equals(entry.getValue().getCreatedBy());
+          if (userName == null) {
+            filterPredicate = entry -> true;
           } else {
-            filterPredicate = entry -> userName.equals(entry.getValue().getUserName());
+            if (createdBy) {
+              filterPredicate = entry -> userName.equals(entry.getValue().getCreatedBy());
+            } else {
+              filterPredicate = entry -> userName.equals(entry.getValue().getUserName());
+            }
           }
           tokenMetadata.entrySet().stream().filter(filterPredicate).forEach(metadata -> {
             String tokenId = metadata.getKey();

--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -127,6 +127,13 @@ limitations under the License.
         <description>Enable/disable logout from the Knox Homepage.</description>
     </property>
 
+    <!-- @since 2.1.0 KnoxSSO Cookie Invalidation -->
+    <property>
+        <name>gateway.knox.token.management.users.can.see.all.tokens</name>
+        <value>admin</value>
+        <description>A comma separated list of user names who can see all tokens on the Token Management page</description>
+    </property>
+
     <!-- @since 1.6.0 token management related properties -->
     <property>
         <name>gateway.knox.token.eviction.grace.period</name>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -281,6 +281,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".xforwarded.header.context.append.servicename";
 
   private static final String TOKEN_STATE_SERVER_MANAGED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.exp.server-managed";
+  private static final String USERS_CAN_SEE_ALL_TOKENS = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.management.users.can.see.all.tokens";
 
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
@@ -1487,6 +1488,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public boolean isAsyncSupported() {
     return getBoolean(GATEWAY_SERVLET_ASYNC_SUPPORTED, GATEWAY_SERVLET_ASYNC_SUPPORTED_DEFAULT);
+  }
+
+  @Override
+  public boolean canSeeAllTokens(String userName) {
+    final Collection<String> usersCanSeeAllTokens = getTrimmedStringCollection(USERS_CAN_SEE_ALL_TOKENS);
+    return usersCanSeeAllTokens == null ? false : usersCanSeeAllTokens.contains(userName);
   }
 
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -420,6 +420,11 @@ public class DefaultTokenStateService implements TokenStateService {
   }
 
   @Override
+  public Collection<KnoxToken> getAllTokens() {
+    return fetchTokens(null, false);
+  }
+
+  @Override
   public Collection<KnoxToken> getTokens(String userName) {
     return fetchTokens(userName, false);
   }
@@ -432,10 +437,14 @@ public class DefaultTokenStateService implements TokenStateService {
   private Collection<KnoxToken> fetchTokens(String userName, boolean createdBy) {
     final Collection<KnoxToken> tokens = new TreeSet<>();
     final Predicate<Map.Entry<String, TokenMetadata>> filterPredicate;
-    if (createdBy) {
-      filterPredicate = entry -> userName.equals(entry.getValue().getCreatedBy());
+    if (userName == null) {
+      filterPredicate = entry -> true;
     } else {
-      filterPredicate = entry -> userName.equals(entry.getValue().getUserName());
+      if (createdBy) {
+        filterPredicate = entry -> userName.equals(entry.getValue().getCreatedBy());
+      } else {
+        filterPredicate = entry -> userName.equals(entry.getValue().getUserName());
+      }
     }
     metadataMap.entrySet().stream().filter(filterPredicate).forEach(metadata -> {
       String tokenId = metadata.getKey();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -295,6 +295,16 @@ public class JDBCTokenStateService extends AbstractPersistentTokenStateService {
   }
 
   @Override
+  public Collection<KnoxToken> getAllTokens() {
+    try {
+      return tokenDatabase.getAllTokens();
+    } catch (SQLException e) {
+      log.errorFetchingAllTokensFromDatabase(e.getMessage(), e);
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
   public Collection<KnoxToken> getTokens(String userName) {
     try {
       return tokenDatabase.getTokens(userName);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -253,6 +253,9 @@ public interface TokenStateServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching metadata for {0} from the database : {1}")
   void errorFetchingMetadataFromDatabase(String tokenId, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching all tokens from the database : {0}")
+  void errorFetchingAllTokensFromDatabase(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
   @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching tokens for user {0} from the database : {1}")
   void errorFetchingTokensForUserFromDatabase(String userName, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 

--- a/gateway-service-knoxtoken/pom.xml
+++ b/gateway-service-knoxtoken/pom.xml
@@ -102,6 +102,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>
             <scope>test</scope>

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -452,8 +452,11 @@ public class TokenResource {
       final String userName = uriInfo.getQueryParameters().getFirst("userName");
       final String createdBy = uriInfo.getQueryParameters().getFirst("createdBy");
       final String userNameOrCreatedBy = uriInfo.getQueryParameters().getFirst("userNameOrCreatedBy");
+      final boolean allTokens = Boolean.parseBoolean(uriInfo.getQueryParameters().getFirst("allTokens"));
       final Collection<KnoxToken> userTokens;
-      if (userNameOrCreatedBy == null) {
+      if (allTokens) {
+        userTokens = tokenStateService.getAllTokens();
+      } else if (userNameOrCreatedBy == null) {
         userTokens = createdBy == null ? tokenStateService.getTokens(userName) : tokenStateService.getDoAsTokens(createdBy);
       } else {
         userTokens = new HashSet<>(tokenStateService.getTokens(userNameOrCreatedBy));

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -46,6 +46,7 @@ import javax.inject.Singleton;
 import javax.security.auth.Subject;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -56,6 +57,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import com.google.gson.Gson;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.KeyLengthException;
 import com.nimbusds.jose.crypto.MACSigner;
@@ -138,14 +140,18 @@ public class TokenResource {
   static final String GET_TSS_STATUS_PATH = "/getTssStatus";
   static final String RENEW_PATH = "/renew";
   static final String REVOKE_PATH = "/revoke";
+  static final String BATCH_REVOKE_PATH = "/revokeTokens";
   static final String ENABLE_PATH = "/enable";
+  static final String BATCH_ENABLE_PATH = "/enableTokens";
   static final String DISABLE_PATH = "/disable";
+  static final String BATCH_DISABLE_PATH = "/disableTokens";
   private static final String TARGET_ENDPOINT_PULIC_CERT_PEM = TOKEN_PARAM_PREFIX + "target.endpoint.cert.pem";
   static final String QUERY_PARAMETER_DOAS = "doAs";
   private static final String IMPERSONATION_ENABLED_TEXT = "impersonationEnabled";
   public static final String KNOX_TOKEN_INCLUDE_GROUPS = TOKEN_PARAM_PREFIX + "include.groups";
   public static final String KNOX_TOKEN_ISSUER = TOKEN_PARAM_PREFIX + "issuer";
   private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
+  private static final Gson GSON = new Gson();
   private long tokenTTL = TOKEN_TTL_DEFAULT;
   private String tokenType;
   private String tokenTTLAsText;
@@ -189,7 +195,8 @@ public class TokenResource {
     INVALID_TOKEN(40),
     UNKNOWN_TOKEN(50),
     ALREADY_DISABLED(60),
-    ALREADY_ENABLED(70);
+    ALREADY_ENABLED(70),
+    DISABLED_KNOXSSO_COOKIE(80);
 
     private final int code;
 
@@ -563,6 +570,22 @@ public class TokenResource {
   }
 
   @DELETE
+  @Path(BATCH_REVOKE_PATH)
+  @Produces({APPLICATION_JSON})
+  public Response revokeTokens(String tokenIds) {
+    final List<String> ids = GSON.fromJson(tokenIds, List.class);
+    Response response = null;
+    Response error = null;
+    for (String tokenId : ids) {
+      response = revoke(tokenId);
+      if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+        error = response;
+      }
+    }
+    return error == null ? response : error;
+  }
+
+  @DELETE
   @Path(REVOKE_PATH)
   @Produces({APPLICATION_JSON})
   public Response revoke(String token) {
@@ -583,8 +606,7 @@ public class TokenResource {
           errorStatus = Response.Status.FORBIDDEN;
           error = "SSO cookie (" + Tokens.getTokenIDDisplayText(tokenId) + ") cannot not be revoked." ;
           errorCode = ErrorCode.UNAUTHORIZED;
-        }
-        if (StringUtils.isBlank(error) && (triesToRevokeOwnToken(tokenId, revoker) || allowedRenewers.contains(revoker))) {
+        } else if (triesToRevokeOwnToken(tokenId, revoker) || allowedRenewers.contains(revoker)) {
           tokenStateService.revokeToken(tokenId);
           log.revokedToken(getTopologyName(),
               Tokens.getTokenDisplayText(token),
@@ -651,17 +673,47 @@ public class TokenResource {
   @Path(ENABLE_PATH)
   @Produces({ APPLICATION_JSON })
   public Response enable(String tokenId) {
-    return setTokenEnabledFlag(tokenId, true);
+    return setTokenEnabledFlag(tokenId, true, false);
+  }
+
+  @PUT
+  @Path(BATCH_ENABLE_PATH)
+  @Consumes({ APPLICATION_JSON })
+  @Produces({ APPLICATION_JSON })
+  public Response enableTokens(String tokenIds) {
+    return setTokenEnabledFlags(tokenIds, true);
   }
 
   @PUT
   @Path(DISABLE_PATH)
   @Produces({ APPLICATION_JSON })
   public Response disable(String tokenId) {
-    return setTokenEnabledFlag(tokenId, false);
+    return setTokenEnabledFlag(tokenId, false, false);
   }
 
-  private Response setTokenEnabledFlag(String tokenId, boolean enabled) {
+  @PUT
+  @Path(BATCH_DISABLE_PATH)
+  @Consumes({ APPLICATION_JSON })
+  @Produces({ APPLICATION_JSON })
+  public Response disableTokens(String tokenIds) {
+    return setTokenEnabledFlags(tokenIds, false);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Response setTokenEnabledFlags(String tokenIds, boolean enabled) {
+    final List<String> ids = GSON.fromJson(tokenIds, List.class);
+    Response response = null;
+    Response error = null;
+    for (String tokenId : ids) {
+      response = setTokenEnabledFlag(tokenId, enabled, true);
+      if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+        error = response;
+      }
+    }
+    return error == null ? response : error;
+  }
+
+  private Response setTokenEnabledFlag(String tokenId, boolean enabled, boolean batch) {
     String error = "";
     ErrorCode errorCode = ErrorCode.UNKNOWN;
     if (tokenStateService == null) {
@@ -670,12 +722,15 @@ public class TokenResource {
     } else {
       try {
         final TokenMetadata tokenMetadata = tokenStateService.getTokenMetadata(tokenId);
-        if (enabled && tokenMetadata.isEnabled()) {
+        if (!batch && enabled && tokenMetadata.isEnabled()) {
           error = "Token is already enabled";
           errorCode = ErrorCode.ALREADY_ENABLED;
-        } else if (!enabled && !tokenMetadata.isEnabled()) {
+        } else if (!batch && !enabled && !tokenMetadata.isEnabled()) {
           error = "Token is already disabled";
           errorCode = ErrorCode.ALREADY_DISABLED;
+        } else if (enabled && tokenMetadata.isKnoxSsoCookie()) {
+          error = "Disabled KnoxSSO Cookies cannot not be enabled";
+          errorCode = ErrorCode.DISABLED_KNOXSSO_COOKIE;
         } else {
           tokenMetadata.setEnabled(enabled);
           tokenStateService.addMetadata(tokenId, tokenMetadata);
@@ -685,7 +740,9 @@ public class TokenResource {
         errorCode = ErrorCode.UNKNOWN_TOKEN;
       }
     }
+
     if (error.isEmpty()) {
+      log.setEnabledFlag(getTopologyName(), enabled, Tokens.getTokenIDDisplayText(tokenId));
       return Response.status(Response.Status.OK).entity("{\n  \"setEnabledFlag\": \"true\",\n  \"isEnabled\": \"" + enabled + "\"\n}\n").build();
     } else {
       log.badSetEnabledFlagRequest(getTopologyName(), Tokens.getTokenIDDisplayText(tokenId), error);

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -36,6 +36,9 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) revoked token {1} ({2}) (renewer={3})")
   void revokedToken(String topologyName, String tokenDisplayText, String tokenId, String renewer);
 
+  @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) set enabled flag to {1} on token {2}")
+  void setEnabledFlag(String topologyName, boolean enabled, String tokenId);
+
   @Message( level = MessageLevel.ERROR, text = "Unable to issue token.")
   void unableToIssueToken(@StackTrace( level = MessageLevel.DEBUG) Exception e);
 

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1725,6 +1725,11 @@ public class TokenServiceResourceTest {
     }
 
     @Override
+    public Collection<KnoxToken> getAllTokens() {
+      return fetchTokens(null, false);
+    }
+
+    @Override
     public Collection<KnoxToken> getTokens(String userName) {
       return fetchTokens(userName, false);
     }
@@ -1737,10 +1742,14 @@ public class TokenServiceResourceTest {
     private Collection<KnoxToken> fetchTokens(String userName, boolean createdBy) {
       final Collection<KnoxToken> tokens = new TreeSet<>();
       final Predicate<Map.Entry<String, TokenMetadata>> filterPredicate;
-      if (createdBy) {
-        filterPredicate = entry -> userName.equals(entry.getValue().getCreatedBy());
+      if (userName == null) {
+        filterPredicate = entry -> true;
       } else {
-        filterPredicate = entry -> userName.equals(entry.getValue().getUserName());
+        if (createdBy) {
+          filterPredicate = entry -> userName.equals(entry.getValue().getCreatedBy());
+        } else {
+          filterPredicate = entry -> userName.equals(entry.getValue().getUserName());
+        }
       }
       tokenMetadata.entrySet().stream().filter(filterPredicate).forEach(metadata -> {
         String tokenId = metadata.getKey();

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformation.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformation.java
@@ -34,6 +34,9 @@ public class SessionInformation {
   @XmlElement
   private String globalLogoutPageUrl;
 
+  @XmlElement
+  private boolean canSeeAllTokens;
+
   public String getUser() {
     return user;
   }
@@ -64,6 +67,14 @@ public class SessionInformation {
 
   public void setGlobalLogoutPageUrl(String globalLogoutPageUrl) {
     this.globalLogoutPageUrl = globalLogoutPageUrl;
+  }
+
+  public boolean isCanSeeAllTokens() {
+    return canSeeAllTokens;
+  }
+
+  public void setCanSeeAllTokens(boolean canSeeAllTokens) {
+    this.canSeeAllTokens = canSeeAllTokens;
   }
 
 }

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
@@ -48,7 +48,8 @@ public class SessionResource {
   @Path("sessioninfo")
   public SessionInformation getSessionInformation() {
     final SessionInformation sessionInfo = new SessionInformation();
-    sessionInfo.setUser(SubjectUtils.getCurrentEffectivePrincipalName());
+    final String user = SubjectUtils.getCurrentEffectivePrincipalName();
+    sessionInfo.setUser(user);
     final GatewayConfig config = (GatewayConfig) context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
     if (config != null && config.homePageLogoutEnabled()) {
       String logoutUrl = getBaseGatewayUrl(config) + "/homepage/knoxssout/api/v1/webssout";
@@ -56,6 +57,7 @@ public class SessionResource {
       sessionInfo.setLogoutUrl(logoutUrl);
       sessionInfo.setLogoutPageUrl(getLogoutPageUrl(config));
       sessionInfo.setGlobalLogoutPageUrl(getGlobalLogoutPageUrl(config));
+      sessionInfo.setCanSeeAllTokens(config.canSeeAllTokens(user));
     }
 
     return sessionInfo;

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1057,4 +1057,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return false;
   }
 
+  @Override
+  public boolean canSeeAllTokens(String userName) {
+    return false;
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -887,4 +887,11 @@ public interface GatewayConfig {
    */
   boolean isAsyncSupported();
 
+  /**
+   * @return <code>true</code> if the supplied user is allowed to see all tokens
+   *         (i.e. not only tokens where userName or createdBy equals to the
+   *         userName) on the Token Management page; <code>false</code> otherwise
+   */
+  boolean canSeeAllTokens(String userName);
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenStateService.java
@@ -196,6 +196,11 @@ public interface TokenStateService extends Service {
   TokenMetadata getTokenMetadata(String tokenId) throws UnknownTokenException;
 
   /**
+   * @return a collection of all the existing (not yet evicted) tokens
+   */
+  Collection<KnoxToken> getAllTokens();
+
+  /**
    * @param userName The name of the user to get tokens for
    * @return a collection of tokens associated to the given user; it's an empty
    *         collection if there is no associated token found in the underlying

--- a/knox-token-management-ui/token-management/app/app.module.ts
+++ b/knox-token-management-ui/token-management/app/app.module.ts
@@ -24,6 +24,7 @@ import {MatSortModule} from '@angular/material/sort';
 import {MatPaginatorModule} from '@angular/material/paginator';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatInputModule} from '@angular/material/input';
+import {MatSlideToggleModule} from '@angular/material/slide-toggle';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
@@ -46,7 +47,8 @@ import {TokenManagementService} from './token.management.service';
         MatSortModule,
         MatPaginatorModule,
         MatProgressSpinnerModule,
-        MatInputModule
+        MatInputModule,
+        MatSlideToggleModule
     ],
     declarations: [TokenManagementComponent],
     providers: [TokenManagementService],

--- a/knox-token-management-ui/token-management/app/app.module.ts
+++ b/knox-token-management-ui/token-management/app/app.module.ts
@@ -25,6 +25,7 @@ import {MatPaginatorModule} from '@angular/material/paginator';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatInputModule} from '@angular/material/input';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
+import {MatCheckboxModule} from '@angular/material/checkbox';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
@@ -48,7 +49,8 @@ import {TokenManagementService} from './token.management.service';
         MatPaginatorModule,
         MatProgressSpinnerModule,
         MatInputModule,
-        MatSlideToggleModule
+        MatSlideToggleModule,
+        MatCheckboxModule
     ],
     declarations: [TokenManagementComponent],
     providers: [TokenManagementService],

--- a/knox-token-management-ui/token-management/app/knox.token.ts
+++ b/knox-token-management-ui/token-management/app/knox.token.ts
@@ -25,4 +25,8 @@ export class KnoxToken {
     expirationLong: number;
     maxLifetime: string;
     metadata: Metadata;
+
+    public toString = (): string => {
+        return 'KnoxToken (tokenId: ${this.tokenId})';
+    };
 }

--- a/knox-token-management-ui/token-management/app/session.information.ts
+++ b/knox-token-management-ui/token-management/app/session.information.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class SessionInformation {
+    user: string;
+    logoutUrl: string;
+    logoutPageUrl: string;
+    globalLgoutPageUrl: string;
+    canSeeAllTokens: boolean;
+}

--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -20,8 +20,16 @@
             <span class="glyphicon glyphicon-refresh"></span>
         </button>
         <span style="float: right;">
-            <mat-slide-toggle (change)="onChangeShowDisabledCookies($event)" [(ngModel)]="showDisabledKnoxSsoCookies" [color]="green">
+            <mat-slide-toggle (change)="onChangeShowDisabledCookies($event)" [(ngModel)]="showDisabledKnoxSsoCookies">
               Show Disabled KnoxSSO Cookies
+            </mat-slide-toggle>
+        </span>
+    </div>
+
+    <div *ngIf="userCanSeeAllTokens()">
+        <span style="float: right;">
+            <mat-slide-toggle (change)="onChangeShowMyTokensOnly($event)" [(ngModel)]="showMyTokensOnly">
+              Show My Tokens Only
             </mat-slide-toggle>
         </span>
     </div>

--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -19,8 +19,12 @@
         <button type="button" title="Refresh Knox Tokens" (click)="fetchKnoxTokens();">
             <span class="glyphicon glyphicon-refresh"></span>
         </button>
+        <span style="float: right;">
+            <mat-slide-toggle (change)="onChangeShowDisabledCookies($event)" [(ngModel)]="showDisabledKnoxSsoCookies" [color]="green">
+              Show Disabled KnoxSSO Cookies
+            </mat-slide-toggle>
+        </span>
     </div>
-
 
     <div class="table-responsive" style="width:100%; overflow: auto; overflow-y: auto; padding: 10px 0px 0px 0px;">
         <mat-form-field [floatLabel]="always" appearance="fill" #search>

--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -41,9 +41,28 @@
         </mat-form-field>
 
         <mat-table [dataSource]="knoxTokens" matSort #knoxTokensSort="matSort">
+            <ng-container matColumnDef="select">
+                <mat-header-cell *matHeaderCellDef>
+                    <mat-checkbox (change)="$event ? masterToggle() : null"
+                        [checked]="selection.hasValue() && isAllSelected()"
+                        [indeterminate]="selection.hasValue() && !isAllSelected()">
+                    </mat-checkbox>
+                </mat-header-cell>
+                <mat-cell *matCellDef="let knoxToken">
+                    <mat-checkbox *ngIf="!isDisabledKnoxSSoCookie(knoxToken)"
+                        (click)="$event.stopPropagation()"
+                        (change)="$event ? onRowSelectionChange(knoxToken) : null"
+                        [checked]="selection.isSelected(knoxToken)">
+                    </mat-checkbox>
+                </mat-cell>
+            </ng-container>
+
             <ng-container matColumnDef="tokenId">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="tokenId" style="text-align: center; justify-content: center;">Token ID</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;">{{knoxToken.tokenId}}</mat-cell>
+                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;">
+                  <div *ngIf="knoxToken.metadata.enabled">{{knoxToken.tokenId}}</div>
+                  <div *ngIf="!knoxToken.metadata.enabled" style="color:orange">{{knoxToken.tokenId}}</div>
+                </mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="issued">
@@ -75,8 +94,8 @@
             <ng-container matColumnDef="knoxSso">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="knoxSso" style="text-align: center; justify-content: center;">KnoxSSO</mat-header-cell>
                 <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;">
-                  <img *ngIf="isKnoxSSoCookie(knoxToken)" src="assets/green_checkmark.svg" style="height:20px; width:auto" />
-                  <img *ngIf="!isKnoxSSoCookie(knoxToken)" src="assets/red_cross_circle.svg" style="height:20px; width:auto" />
+                  <img *ngIf="isKnoxSsoCookie(knoxToken)" src="assets/green_checkmark.svg" style="height:20px; width:auto" />
+                  <img *ngIf="!isKnoxSsoCookie(knoxToken)" src="assets/red_cross_circle.svg" style="height:20px; width:auto" />
                 </mat-cell>
             </ng-container>
 
@@ -100,9 +119,9 @@
                 <mat-header-cell *matHeaderCellDef style="text-align: center; justify-content: center;">Actions</mat-header-cell>
                 <mat-cell *matCellDef="let knoxToken">
                     <button *ngIf="knoxToken.metadata.enabled && !isTokenExpired(knoxToken.expirationLong)" (click)="disableToken(knoxToken.tokenId);">Disable</button>
-                    <button *ngIf="!isKnoxSSoCookie(knoxToken) && !knoxToken.metadata.enabled && !isTokenExpired(knoxToken.expirationLong)" (click)="enableToken(knoxToken.tokenId);">Enable</button>
-                    <button *ngIf="!isKnoxSSoCookie(knoxToken)" (click)="revokeToken(knoxToken.tokenId);">Revoke</button>
-                    <p *ngIf="isKnoxSSoCookie(knoxToken) && !knoxToken.metadata.enabled" style="color:orange">Previously Disabled SSO Cookie!</p>
+                    <button *ngIf="!isKnoxSsoCookie(knoxToken) && !knoxToken.metadata.enabled && !isTokenExpired(knoxToken.expirationLong)" (click)="enableToken(knoxToken.tokenId);">Enable</button>
+                    <button *ngIf="!isKnoxSsoCookie(knoxToken)" (click)="revokeToken(knoxToken.tokenId);">Revoke</button>
+                    <p *ngIf="isDisabledKnoxSsoCookie(knoxToken)" style="color:orange">Previously Disabled SSO Cookie!</p>
                 </mat-cell>
             </ng-container>
 
@@ -111,6 +130,12 @@
 
         </mat-table>
         <mat-paginator #knoxTokensPaginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="25" [showFirstLastButtons]="true"></mat-paginator>
+    </div>
+
+    <div>
+        <button *ngIf="showDisableSelectedTokensButton" type="button" (click)="disableSelectedTokens();">&nbsp;Disable Selected Tokens&nbsp;&nbsp;</button>
+        <button *ngIf="showEnableSelectedTokensButton" type="button" (click)="enableSelectedTokens();">&nbsp;Enable Selected Tokens&nbsp;&nbsp;</button>
+        <button *ngIf="showRevokeSelectedTokensButton" type="button" (click)="revokeSelectedTokens();">&nbsp;Revoke Selected Tokens&nbsp;</button>
     </div>
 </div>
 

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -30,8 +30,11 @@ export class TokenManagementService {
     getAllKnoxTokensUrl = this.apiUrl + 'getUserTokens?allTokens=true';
     getKnoxTokensUrl = this.apiUrl + 'getUserTokens?userNameOrCreatedBy=';
     enableKnoxTokenUrl = this.apiUrl + 'enable';
+    enableKnoxTokensBatchUrl = this.apiUrl + 'enableTokens';
     disableKnoxTokenUrl = this.apiUrl + 'disable';
+    disableKnoxTokensBatchUrl = this.apiUrl + 'disableTokens';
     revokeKnoxTokenUrl = this.apiUrl + 'revoke';
+    revokeKnoxTokensBatchUrl = this.apiUrl + 'revokeTokens';
     getTssStatusUrl = this.apiUrl + 'getTssStatus';
 
     constructor(private http: HttpClient) {}
@@ -71,6 +74,24 @@ export class TokenManagementService {
             });
     }
 
+    setEnabledDisabledFlagsInBatch(enable: boolean, tokenIds: string[]): Promise<string> {
+        let xheaders = new HttpHeaders();
+        xheaders = this.addJsonHeaders(xheaders);
+        let urlToUse = enable ? this.enableKnoxTokensBatchUrl : this.disableKnoxTokensBatchUrl;
+        return this.http.put(urlToUse, JSON.stringify(tokenIds), {headers: xheaders, responseType: 'text'})
+            .toPromise()
+            .then(response => response)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('TokenManagementService --> setEnabledDisabledFlagsInBatch() --> ' + urlToUse
+                              + '\n  error: ' + err.status + ' ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
     revokeToken(tokenId: string) {
         let xheaders = new HttpHeaders();
         xheaders = this.addJsonHeaders(xheaders);
@@ -79,6 +100,24 @@ export class TokenManagementService {
             .then(response => response)
             .catch((err: HttpErrorResponse) => {
                 console.debug('TokenManagementService --> revokeToken() --> ' + this.revokeKnoxTokenUrl
+                              + '\n  error: ' + err.status + ' ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    revokeTokensInBatch(tokenIds: string[]) {
+        let xheaders = new HttpHeaders();
+        xheaders = this.addJsonHeaders(xheaders);
+        return this.http.request('DELETE', this.revokeKnoxTokensBatchUrl,
+                                 {headers: xheaders, body: JSON.stringify(tokenIds), responseType: 'text'})
+            .toPromise()
+            .then(response => response)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('TokenManagementService --> revokeTokensInBatch() --> ' + this.revokeKnoxTokensBatchUrl
                               + '\n  error: ' + err.status + ' ' + err.message);
                 if (err.status === 401) {
                     window.location.assign(document.location.pathname);

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -21,11 +21,13 @@ import Swal from 'sweetalert2';
 import 'rxjs/add/operator/toPromise';
 
 import {KnoxToken} from './knox.token';
+import {SessionInformation} from './session.information';
 
 @Injectable()
 export class TokenManagementService {
     sessionUrl = window.location.pathname.replace(new RegExp('token-management/.*'), 'session/api/v1/sessioninfo');
     apiUrl = window.location.pathname.replace(new RegExp('token-management/.*'), 'knoxtoken/api/v1/token/');
+    getAllKnoxTokensUrl = this.apiUrl + 'getUserTokens?allTokens=true';
     getKnoxTokensUrl = this.apiUrl + 'getUserTokens?userNameOrCreatedBy=';
     enableKnoxTokenUrl = this.apiUrl + 'enable';
     disableKnoxTokenUrl = this.apiUrl + 'disable';
@@ -34,10 +36,11 @@ export class TokenManagementService {
 
     constructor(private http: HttpClient) {}
 
-    getKnoxTokens(userName: string): Promise<KnoxToken[]> {
+    getKnoxTokens(userName: string, canSeeAllTokens: boolean): Promise<KnoxToken[]> {
         let headers = new HttpHeaders();
         headers = this.addJsonHeaders(headers);
-        return this.http.get(this.getKnoxTokensUrl + userName, { headers: headers})
+        let url = canSeeAllTokens ? this.getAllKnoxTokensUrl : (this.getKnoxTokensUrl + userName);
+        return this.http.get(url, { headers: headers})
             .toPromise()
             .then(response => response['tokens'] as KnoxToken[])
             .catch((err: HttpErrorResponse) => {
@@ -85,14 +88,14 @@ export class TokenManagementService {
             });
     }
 
-    getUserName(): Promise<string> {
+    getSessionInformation(): Promise<SessionInformation> {
         let headers = new HttpHeaders();
         headers = this.addJsonHeaders(headers);
         return this.http.get(this.sessionUrl, { headers: headers})
             .toPromise()
-            .then(response => response['sessioninfo'].user as string)
+            .then(response => response['sessioninfo'] as SessionInformation)
             .catch((err: HttpErrorResponse) => {
-                console.debug('TokenManagementService --> getUserName() --> ' + this.sessionUrl + '\n  error: ' + err.message);
+                console.debug('TokenManagementService --> getSessionInformation() --> ' + this.sessionUrl + '\n  error: ' + err.message);
                 if (err.status === 401) {
                     window.location.assign(document.location.pathname);
                 } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In phase II, the following features are implemented:
- Pre-configured users can see all tokens on the Token Management page.
- End-users can execute batch operations on selected Knox Tokens.
- Allowing end-users to show/hide previously disabled KnoxSSO Cookies on the Token Management page.

There is a new Gateway-level configuration that controls who can see all tokens on the Token Management UI:
```
     <property>
        <name>gateway.knox.token.management.users.can.see.all.tokens</name>
        <value>admin</value>
        <description>A comma-separated list of user names who can see all tokens on the Token Management page</description>
    </property>
```
OOTB, the `admin` user acts as the superuser who has the power of controlling tokens created for others. The rest of the users can only see their own tokens only (impersonated or not).

This is how the Token Management UI looks like after my changes:
<img width="1786" alt="Screenshot 2023-10-06 at 10 06 44" src="https://github.com/apache/knox/assets/34065904/304317b0-d23d-4b23-9f40-629fc9d96b2d">

As you can see, there is only one table (compared to the previous tables of own/impersonated tokens), where all the information is displayed in a compact form:
- Each row starts with a selection checkbox for batch operations (except for disabled KnoxSSO cookies, as there is no point in doing anything with them)
- The disabled token's `Token ID` value is shown in `orange`
- `Username` indicates the user for whom the token is created for
- `Impersonated` is a `boolean` flag indicating if this is an impersonated token:
  - `green check`: yes, this is impersonated. You'll see the user who created the token under the icon
  - `red cross`: no, this is not an impersonated token
- `KnoxSSO` is another `boolean` flag that indicates if this token is created by the `KNOXSSO` service if the feature was enabled
  - `green check`: yes, this is KnoxSSO cookie (token)
  - `red cross`: no, this is not a KnoxSSO cookie (it was created by a regular token API call or on the Token Generation page)
- In the `Actions` column you will see
  - the enable/disable/revoke actions are visible for impersonated tokens too
  - KnoxSSO cookies cannot be revoked nor re-enabled
  
Batch operations:
- when at least one token is selected, we show the following buttons under the table:
  - `Disable Selected Tokens`: when executed, all the selected tokens become disabled (if they were disabled originally, they will remain disabled)
  - `Enable Selected Tokens`: when executed, all the selected tokens become enabled (if they were enabled originally, they will remain enabled)
  - `Revoke Selected Tokens`: when executed, all the selected tokens will be revoked. Please note this option is shown only, if there is no KnoxSSO cookie (token) selected (i.e. batch revocation only works with regular tokens).

Toggles:
- `Show Disabled KnoxSSO Cookies`: this is `true` by default. Since disabled KnoxSSO cookies remain in the underlying token state service until they expire, it may bother users to see them in the tokens table. Flipping this toggle button helps to hide them.
- `Show My Tokens Only`: this toggle button is only visible to users, who can see all tokens. By default, this is `false`. Enabling it will filter the tokens table in a way such that it will contain tokens only that were generated for the logged in user (impersonated or not).

Token API changes:
- new API endpoints, `enableTokens` and `disableTokens`, to enable/disable tokens in one batch. Sample `curl` command:
```
curl -iku admin:admin-password -H "Content-Type: application/json" -d '["62445b09-adb3-4f18-a89d-e5091d87b815","c2ee4646-b695-49af-8910-371ae40f6f75","10c46471-0ff0-4e47-8dac-7c226255d80f"]' -X PUT https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/disableTokens
```
When this API is used, the state check (if it's already enabled/disabled) is not in use. That is, you can include already enabled/disabled tokens in your batch operation.

-  new API endpoint, `revokeTokens`, to revoke tokens in one batch. Sample `curl` command:
```
curl -iku admin:admin-password -H "Content-Type: application/json" -d '["62445b09-adb3-4f18-a89d-e5091d87b815","c2ee4646-b695-49af-8910-371ae40f6f75","10c46471-0ff0-4e47-8dac-7c226255d80f"]' -X DELETE https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/revokeTokens
```

- the `revoke` endpoint throws an error upon attempting to revoke a KnoxSSO cookie
```
$ curl -iku admin:admin-password  -H "Content-Type: application/json" -d 'c236d20c-4a05-4cfa-b35e-2ba6dc451de0' -X DELETE https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/revoke
HTTP/1.1 403 Forbidden
Date: Fri, 06 Oct 2023 08:55:25 GMT
Set-Cookie: KNOXSESSIONID=node03e9y0cy8giy31rh00xc1mrcfx0.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Thu, 05-Oct-2023 08:55:25 GMT; SameSite=lax
Content-Type: application/json
Content-Length: 113

{
  "revoked": "false",
  "error": "SSO cookie (c236d20c...2ba6dc451de0) cannot not be revoked.",
  "code": 20
}
```

- the `enable` endpoint throws an error upon attempting to enable a disabled KnoxSSO cookie:
```
$ curl -iku admin:admin-password  -H "Content-Type: application/json" -d '107824ab-c54d-4db3-b3b5-5c964892ad05' -X PUT https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/enable
HTTP/1.1 400 Bad Request
Date: Fri, 06 Oct 2023 08:57:58 GMT
Set-Cookie: KNOXSESSIONID=node011ejmvgcjnlpl13mchqmqjtdjc1.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Thu, 05-Oct-2023 08:57:58 GMT; SameSite=lax
Content-Type: application/json
Content-Length: 107

{
  "setEnabledFlag": "false",
  "error": "Disabled KnoxSSO Cookies cannot not be enabled",
  "code": 80
}
```
- the `getUserTokens` endpoint changed in a way that it accepts a new boolean query parameter called `allTokens`. If the value of this param is `true`, this API returns all tokens:
```
curl -iku admin:admin-password -X GET https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/getUserTokens?allTokens=true
```

## How was this patch tested?

Updated relevant JUnit tests and executed comprehensive manual testing.

