### PR TITLE
KNOX-2962 - Knox readiness check gateway-status endpoint should return the list of topologies for which it is waiting for

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/GatewayStatusService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/GatewayStatusService.java
@@ -45,10 +45,15 @@ public class GatewayStatusService implements Service {
       LOG.noTopologiesToCheck();
       return false;
     }
-    Set<String> missing = new HashSet<>(topologyNamesToCheck);
-    missing.removeAll(deployedTopologies);
+    Set<String> missing = pendingTopologies();
     LOG.checkingGatewayStatus(deployedTopologies, missing);
     return missing.isEmpty();
+  }
+
+  public synchronized Set<String> pendingTopologies() {
+    Set<String> missing = new HashSet<>(topologyNamesToCheck);
+    missing.removeAll(deployedTopologies);
+    return missing;
   }
 
   /**

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/impl/GatewayStatusServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/impl/GatewayStatusServiceTest.java
@@ -17,10 +17,12 @@
  */
 package org.apache.knox.gateway.services.topology.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 import org.apache.knox.gateway.config.GatewayConfig;
@@ -42,5 +44,21 @@ public class GatewayStatusServiceTest {
     assertFalse(statusService.status());
     statusService.onTopologyReady("t2");
     assertTrue(statusService.status());
+  }
+
+  @Test
+  public void testPendingTopologies() throws Exception {
+    GatewayStatusService statusService = new GatewayStatusService();
+    GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+    statusService.init(config, null);
+    assertFalse(statusService.status());
+    EasyMock.expect(config.getHealthCheckTopologies()).andReturn(new HashSet<>(Arrays.asList("t1", "t2"))).anyTimes();
+    EasyMock.replay(config);
+    statusService.initTopologiesToCheck();
+    assertEquals(new HashSet<>(Arrays.asList("t1", "t2")), statusService.pendingTopologies());
+    statusService.onTopologyReady("t1");
+    assertEquals(new HashSet<>(Arrays.asList("t2")), statusService.pendingTopologies());
+    statusService.onTopologyReady("t2");
+    assertEquals(Collections.emptySet(), statusService.pendingTopologies());
   }
 }

--- a/gateway-service-health/src/main/java/org/apache/knox/gateway/service/health/PingResource.java
+++ b/gateway-service-health/src/main/java/org/apache/knox/gateway/service/health/PingResource.java
@@ -101,7 +101,7 @@ public class PingResource {
             .getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
     GatewayStatusService statusService = services.getService(ServiceType.GATEWAY_STATUS_SERVICE);
     try (PrintWriter writer = response.getWriter()) {
-      writer.println(statusService.status() ? OK : PENDING);
+      writer.println(statusService.status() ? OK : PENDING + ": " + statusService.pendingTopologies());
     } catch (IOException e) {
       log.logException("status", e);
       return Response.serverError().entity(String.format(Locale.ROOT, "Failed to reply correctly due to : %s ", e)).build();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The gateway-status requests returns the list of pending topologies.

## How was this patch tested?

Added health topology:

```xml
<topology>
    <gateway>
        <provider>
            <role>authentication</role>
            <name>Anonymous</name>
            <enabled>true</enabled>
        </provider>
    </gateway>
    <service>
        <role>HEALTH</role>
    </service>
</topology>
```

and 2 invalid descriptors: test.json and test2.json

```
$ curl -vk https://localhost:8443/gateway/health/v1/gateway-status
```

Output
```
< HTTP/1.1 200 OK
< Date: Mon, 09 Oct 2023 10:36:50 GMT
< Cache-Control: must-revalidate,no-cache,no-store
< Content-Type: text/plain;charset=iso-8859-1
< Content-Length: 23
< 
PENDING: [test2, test]
```