### PR TITLE
KNOX-2963 - CM service discovery should work when legacy mode is turned off

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGenerator.java
@@ -45,6 +45,8 @@ public interface ServiceModelGenerator {
 
   ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig);
 
-  ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException;
-
+  /**
+   * Implementations that requires CORE_SETTINGS service config should overide this method, instead of the one without coreSettings
+   */
+  ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettings) throws ApiException;
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGenerator.java
@@ -45,8 +45,5 @@ public interface ServiceModelGenerator {
 
   ServiceModelGeneratorHandleResponse handles(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig);
 
-  /**
-   * Implementations that requires CORE_SETTINGS service config should overide this method, instead of the one without coreSettings
-   */
-  ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettings) throws ApiException;
+  ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException;
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
@@ -86,11 +86,11 @@ public abstract class AbstractServiceModelGenerator implements ServiceModelGener
     return new ServiceModelGeneratorHandleResponse(getServiceType().equals(service.getType()) && getRoleType().equals(role.getType()));
   }
 
-  protected String getCoreOrServiceConfig(ApiServiceConfig coreConfig, ApiServiceConfig serviceConfig, String configName) {
-    if (coreConfig != null) {
+  protected String getCoreOrServiceConfig(ApiServiceConfig serviceConfig, ApiServiceConfig coreSettingsConfig, String configName) {
+    if (coreSettingsConfig != null) {
       // in Legacy Cloudera Manager API Clients Compatibility certain configs,
       // such as hdfs_hadoop_ssl_enabled are in the CORE_CONFIG
-      String configValue = getServiceConfigValue(coreConfig, configName);
+      String configValue = getServiceConfigValue(coreSettingsConfig, configName);
       if (configValue != null) {
         return configValue;
       }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGenerator.java
@@ -86,4 +86,15 @@ public abstract class AbstractServiceModelGenerator implements ServiceModelGener
     return new ServiceModelGeneratorHandleResponse(getServiceType().equals(service.getType()) && getRoleType().equals(role.getType()));
   }
 
+  protected String getCoreOrServiceConfig(ApiServiceConfig coreConfig, ApiServiceConfig serviceConfig, String configName) {
+    if (coreConfig != null) {
+      // in Legacy Cloudera Manager API Clients Compatibility certain configs,
+      // such as hdfs_hadoop_ssl_enabled are in the CORE_CONFIG
+      String configValue = getServiceConfigValue(coreConfig, configName);
+      if (configValue != null) {
+        return configValue;
+      }
+    }
+    return getServiceConfigValue(serviceConfig, configName); // Fall back to service config
+  }
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/atlas/AtlasServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/atlas/AtlasServiceModelGenerator.java
@@ -56,10 +56,10 @@ public class AtlasServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/cm/ClouderaManagerAPIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/cm/ClouderaManagerAPIServiceModelGenerator.java
@@ -71,7 +71,7 @@ public class ClouderaManagerAPIServiceModelGenerator
    */
   @Override
   public ServiceModel generateService(ApiService service,
-      ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig)
+                                 ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig)
       throws ApiException {
 
     final String basePath = getClient().getBasePath();

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGenerator.java
@@ -59,7 +59,7 @@ public class FlinkServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     final String hostname = role.getHostRef().getHostname();
     final String port = getRoleConfigValue(roleConfig, WEB_PORT);
     final boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/flink/FlinkServiceModelGenerator.java
@@ -59,7 +59,7 @@ public class FlinkServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreConfig) throws ApiException {
     final String hostname = role.getHostRef().getHostname();
     final String port = getRoleConfigValue(roleConfig, WEB_PORT);
     final boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hbase/HBaseUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hbase/HBaseUIServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class HBaseUIServiceModelGenerator extends AbstractServiceModelGenerator 
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port = getRoleConfigValue(roleConfig, MASTER_INFO_PORT); // TODO: Is there an SSL port, or is this property re-used?

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hbase/WebHBaseServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hbase/WebHBaseServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class WebHBaseServiceModelGenerator extends AbstractServiceModelGenerator
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port = getRoleConfigValue(roleConfig, REST_SERVER_PORT);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGenerator.java
@@ -47,11 +47,13 @@ public class HdfsUIServiceModelGenerator extends NameNodeServiceModelGenerator {
   public ServiceModel generateService(ApiService       service,
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+                                      ApiConfigList    roleConfig,
+                                      ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;
-    boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));
+    String sslEnabledConfig = getCoreOrServiceConfig(coreSettingsConfig, serviceConfig, SSL_ENABLED);
+    boolean sslEnabled = Boolean.parseBoolean(sslEnabledConfig);
     if(sslEnabled) {
       scheme = "https";
       port = getRoleConfigValue(roleConfig, HTTPS_PORT);
@@ -62,11 +64,11 @@ public class HdfsUIServiceModelGenerator extends NameNodeServiceModelGenerator {
     String namenodeUrl = String.format(Locale.getDefault(), "%s://%s:%s", scheme, hostname, port);
 
     ServiceModel model = createServiceModel(namenodeUrl);
-    model.addServiceProperty(SSL_ENABLED, getServiceConfigValue(serviceConfig, SSL_ENABLED));
+    model.addServiceProperty(SSL_ENABLED, sslEnabledConfig);
     model.addRoleProperty(role.getType(), HTTPS_PORT, getRoleConfigValue(roleConfig, HTTPS_PORT));
     model.addRoleProperty(role.getType(), HTTP_PORT, getRoleConfigValue(roleConfig, HTTP_PORT));
 
-    ServiceModel parent = super.generateService(service, serviceConfig, role, roleConfig);
+    ServiceModel parent = super.generateService(service, serviceConfig, role, roleConfig, coreSettingsConfig);
     addParentModelMetadata(model, parent);
 
     return model;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/HdfsUIServiceModelGenerator.java
@@ -52,7 +52,7 @@ public class HdfsUIServiceModelGenerator extends NameNodeServiceModelGenerator {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;
-    String sslEnabledConfig = getCoreOrServiceConfig(coreSettingsConfig, serviceConfig, SSL_ENABLED);
+    String sslEnabledConfig = getCoreOrServiceConfig(serviceConfig, coreSettingsConfig, SSL_ENABLED);
     boolean sslEnabled = Boolean.parseBoolean(sslEnabledConfig);
     if(sslEnabled) {
       scheme = "https";

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
@@ -62,7 +62,7 @@ public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
                                       ApiConfigList    roleConfig,
-                                      ApiServiceConfig coreConfig) throws ApiException {
+                                      ApiServiceConfig coreSettingsConfig) throws ApiException {
     boolean haEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, AUTOFAILOVER_ENABLED));
     String serviceUrl;
     if (haEnabled) {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/NameNodeServiceModelGenerator.java
@@ -61,7 +61,8 @@ public class NameNodeServiceModelGenerator extends AbstractServiceModelGenerator
   public ServiceModel generateService(ApiService       service,
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+                                      ApiConfigList    roleConfig,
+                                      ApiServiceConfig coreConfig) throws ApiException {
     boolean haEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, AUTOFAILOVER_ENABLED));
     String serviceUrl;
     if (haEnabled) {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hdfs/WebHdfsServiceModelGenerator.java
@@ -55,8 +55,8 @@ public class WebHdfsServiceModelGenerator extends HdfsUIServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) throws ApiException {
-    ServiceModel parent = super.generateService(service, serviceConfig, role, roleConfig);
+  public ServiceModel generateService(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
+    ServiceModel parent = super.generateService(service, serviceConfig, role, roleConfig, coreSettingsConfig);
     String serviceUrl = parent.getServiceUrl() + WEBHDFS_SUFFIX;
 
     ServiceModel model = createServiceModel(serviceUrl);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveOnTezServiceModelGenerator.java
@@ -49,11 +49,11 @@ public class HiveOnTezServiceModelGenerator extends HiveServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
-    ServiceModel model = super.generateService(service, serviceConfig, role, roleConfig);
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
+    ServiceModel model = super.generateService(service, serviceConfig, role, roleConfig, coreSettingsConfig);
     model.addRoleProperty(getRoleType(),
                           HIVEONTEZ_HTTP_PORT,
                           getRoleConfigValue(roleConfig, HIVEONTEZ_HTTP_PORT));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/HiveServiceModelGenerator.java
@@ -74,10 +74,10 @@ public class HiveServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));
     String scheme = sslEnabled ? "https" : "http";

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/WebHCatServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/WebHCatServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class WebHCatServiceModelGenerator extends AbstractServiceModelGenerator 
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String port = getRoleConfigValue(roleConfig, WEBHCAT_PORT);
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueLBServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueLBServiceModelGenerator.java
@@ -54,10 +54,10 @@ public class HueLBServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme = "http";
     String port = getRoleConfigValue(roleConfig, LISTEN_PORT);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hue/HueServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class HueServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port = getRoleConfigValue(roleConfig, HUE_HTTP_PORT);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaServiceModelGenerator.java
@@ -85,10 +85,10 @@ public class ImpalaServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
 
     boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/impala/ImpalaUIServiceModelGenerator.java
@@ -72,10 +72,10 @@ public class ImpalaUIServiceModelGenerator extends AbstractServiceModelGenerator
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
 
     String sslEnabled = getServiceConfigValue(serviceConfig, SSL_ENABLED);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/kudu/KuduUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/kudu/KuduUIServiceModelGenerator.java
@@ -56,10 +56,10 @@ public class KuduUIServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
 
     String sslEnabled = getRoleConfigValue(roleConfig, SSL_ENABLED);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/livy/LivyServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/livy/LivyServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class LivyServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port = getRoleConfigValue(roleConfig, LIVY_SERVER_PORT);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/nifi/NifiRegistryServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/nifi/NifiRegistryServiceModelGenerator.java
@@ -69,7 +69,7 @@ public class NifiRegistryServiceModelGenerator extends AbstractServiceModelGener
 
   @Override
   public ServiceModel generateService(ApiService service,
-      ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig)
+                                 ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig)
       throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/nifi/NifiServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/nifi/NifiServiceModelGenerator.java
@@ -69,7 +69,7 @@ public class NifiServiceModelGenerator extends AbstractServiceModelGenerator {
 
   @Override
   public ServiceModel generateService(ApiService service,
-      ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig)
+                                 ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig)
       throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/oozie/OozieServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/oozie/OozieServiceModelGenerator.java
@@ -56,10 +56,10 @@ public class OozieServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/OzoneHttpfsServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/OzoneHttpfsServiceModelGenerator.java
@@ -59,10 +59,10 @@ public class OzoneHttpfsServiceModelGenerator extends AbstractServiceModelGenera
     }
 
     @Override
-    public ServiceModel generateService(ApiService       service,
-                                        ApiServiceConfig serviceConfig,
-                                        ApiRole          role,
-                                        ApiConfigList    roleConfig) throws ApiException {
+    public ServiceModel generateService(ApiService service,
+                                   ApiServiceConfig serviceConfig,
+                                   ApiRole role,
+                                   ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
         String hostname = role.getHostRef().getHostname();
 
         boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/OzoneServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/OzoneServiceModelGenerator.java
@@ -58,10 +58,10 @@ public class OzoneServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
 
     boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/ReconServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/ReconServiceModelGenerator.java
@@ -58,10 +58,10 @@ public class ReconServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
 
     boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/SCMServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ozone/SCMServiceModelGenerator.java
@@ -58,10 +58,10 @@ public class SCMServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
 
     boolean sslEnabled = Boolean.parseBoolean(getRoleConfigValue(roleConfig, SSL_ENABLED));

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/phoenix/PhoenixServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class PhoenixServiceModelGenerator extends AbstractServiceModelGenerator 
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
 
     String hostname = role.getHostRef().getHostname();
     String sslEnabledRaw = getRoleConfigValue(roleConfig, SSL_ENABLED);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ranger/RangerServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/ranger/RangerServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class RangerServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/solr/SolrServiceModelGenerator.java
@@ -58,10 +58,10 @@ public class SolrServiceModelGenerator extends AbstractServiceModelGenerator {
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/SparkHistoryUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/spark/SparkHistoryUIServiceModelGenerator.java
@@ -55,10 +55,10 @@ public class SparkHistoryUIServiceModelGenerator extends AbstractServiceModelGen
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobHistoryUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobHistoryUIServiceModelGenerator.java
@@ -59,12 +59,13 @@ public class JobHistoryUIServiceModelGenerator extends AbstractServiceModelGener
   public ServiceModel generateService(ApiService       service,
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+                                      ApiConfigList    roleConfig,
+                                      ApiServiceConfig coreConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;
 
-    if(isSSLEnabled(service, serviceConfig)) {
+    if(isSSLEnabled(service, serviceConfig, coreConfig)) {
       scheme = "https";
       port = getRoleConfigValue(roleConfig, HTTPS_PORT);
     } else {
@@ -79,13 +80,13 @@ public class JobHistoryUIServiceModelGenerator extends AbstractServiceModelGener
     return model;
   }
 
-  private boolean isSSLEnabled(ApiService service, ApiServiceConfig serviceConfig)
+  private boolean isSSLEnabled(ApiService service, ApiServiceConfig serviceConfig, ApiServiceConfig coreConfig)
       throws ApiException {
     ServicesResourceApi servicesResourceApi = new ServicesResourceApi(getClient());
     String clusterName = service.getClusterRef().getClusterName();
     String hdfsService = getServiceConfigValue(serviceConfig, "hdfs_service");
     ApiServiceConfig hdfsServiceConfig = servicesResourceApi.readServiceConfig(clusterName, hdfsService, "full");
-    return Boolean.parseBoolean(getServiceConfigValue(hdfsServiceConfig, "hdfs_hadoop_ssl_enabled"));
+    return Boolean.parseBoolean(getCoreOrServiceConfig(coreConfig, hdfsServiceConfig, "hdfs_hadoop_ssl_enabled"));
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobHistoryUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobHistoryUIServiceModelGenerator.java
@@ -60,12 +60,12 @@ public class JobHistoryUIServiceModelGenerator extends AbstractServiceModelGener
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
                                       ApiConfigList    roleConfig,
-                                      ApiServiceConfig coreConfig) throws ApiException {
+                                      ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;
 
-    if(isSSLEnabled(service, serviceConfig, coreConfig)) {
+    if(isSSLEnabled(service, serviceConfig, coreSettingsConfig)) {
       scheme = "https";
       port = getRoleConfigValue(roleConfig, HTTPS_PORT);
     } else {
@@ -80,13 +80,13 @@ public class JobHistoryUIServiceModelGenerator extends AbstractServiceModelGener
     return model;
   }
 
-  private boolean isSSLEnabled(ApiService service, ApiServiceConfig serviceConfig, ApiServiceConfig coreConfig)
+  private boolean isSSLEnabled(ApiService service, ApiServiceConfig serviceConfig, ApiServiceConfig coreSettingsConfig)
       throws ApiException {
     ServicesResourceApi servicesResourceApi = new ServicesResourceApi(getClient());
     String clusterName = service.getClusterRef().getClusterName();
     String hdfsService = getServiceConfigValue(serviceConfig, "hdfs_service");
     ApiServiceConfig hdfsServiceConfig = servicesResourceApi.readServiceConfig(clusterName, hdfsService, "full");
-    return Boolean.parseBoolean(getCoreOrServiceConfig(coreConfig, hdfsServiceConfig, "hdfs_hadoop_ssl_enabled"));
+    return Boolean.parseBoolean(getCoreOrServiceConfig(hdfsServiceConfig, coreSettingsConfig, "hdfs_hadoop_ssl_enabled"));
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobTrackerServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/JobTrackerServiceModelGenerator.java
@@ -42,10 +42,10 @@ public class JobTrackerServiceModelGenerator extends ResourceManagerServiceModel
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
 
     String hostname = role.getHostRef().getHostname();
     String port = getRoleConfigValue(roleConfig, RM_PORT);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/ResourceManagerApiServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/ResourceManagerApiServiceModelGenerator.java
@@ -45,10 +45,10 @@ public class ResourceManagerApiServiceModelGenerator extends ResourceManagerServ
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
 
     String hostname = role.getHostRef().getHostname();
     String port = getRoleConfigValue(roleConfig, RM_PORT);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/ResourceManagerUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/ResourceManagerUIServiceModelGenerator.java
@@ -38,10 +38,11 @@ public class ResourceManagerUIServiceModelGenerator extends YarnUIServiceModelGe
   }
 
   @Override
-  protected String generateURL(ApiService       service,
+  protected String generateURL(ApiService service,
                                ApiServiceConfig serviceConfig,
-                               ApiRole          role,
-                               ApiConfigList    roleConfig) throws ApiException {
-    return (super.generateURL(service, serviceConfig, role, roleConfig) + RM_WS_SUFFIX);
+                               ApiRole role,
+                               ApiConfigList roleConfig,
+                               ApiServiceConfig coreConfig) throws ApiException {
+    return (super.generateURL(service, serviceConfig, role, roleConfig, coreConfig) + RM_WS_SUFFIX);
   }
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/YarnUIServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/yarn/YarnUIServiceModelGenerator.java
@@ -47,8 +47,8 @@ public class YarnUIServiceModelGenerator extends ResourceManagerServiceModelGene
                                       ApiServiceConfig serviceConfig,
                                       ApiRole          role,
                                       ApiConfigList    roleConfig,
-                                      ApiServiceConfig coreConfig) throws ApiException {
-    ServiceModel model = createServiceModel(generateURL(service, serviceConfig, role, roleConfig, coreConfig));
+                                      ApiServiceConfig coreSettingsConfig) throws ApiException {
+    ServiceModel model = createServiceModel(generateURL(service, serviceConfig, role, roleConfig, coreSettingsConfig));
     model.addRoleProperty(getRoleType(), RM_HTTP_PORT, getRoleConfigValue(roleConfig, RM_HTTP_PORT));
     model.addRoleProperty(getRoleType(), RM_HTTPS_PORT, getRoleConfigValue(roleConfig, RM_HTTPS_PORT));
 
@@ -78,13 +78,13 @@ public class YarnUIServiceModelGenerator extends ResourceManagerServiceModelGene
     return String.format(Locale.getDefault(), "%s://%s:%s", scheme, hostname, port);
   }
 
-  private boolean isSSLEnabled(ApiService service, ApiServiceConfig serviceConfig, ApiServiceConfig coreConfig)
+  private boolean isSSLEnabled(ApiService service, ApiServiceConfig serviceConfig, ApiServiceConfig coreSettingsConfig)
       throws ApiException {
     ServicesResourceApi servicesResourceApi = new ServicesResourceApi(getClient());
     String clusterName = service.getClusterRef().getClusterName();
     String hdfsService = getServiceConfigValue(serviceConfig, "hdfs_service");
     ApiServiceConfig hdfsServiceConfig = servicesResourceApi.readServiceConfig(clusterName, hdfsService, "full");
-    return Boolean.parseBoolean(getCoreOrServiceConfig(coreConfig, hdfsServiceConfig, "hdfs_hadoop_ssl_enabled"));
+    return Boolean.parseBoolean(getCoreOrServiceConfig(hdfsServiceConfig, coreSettingsConfig, "hdfs_hadoop_ssl_enabled"));
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/zeppelin/ZeppelinServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/zeppelin/ZeppelinServiceModelGenerator.java
@@ -56,10 +56,10 @@ public class ZeppelinServiceModelGenerator extends AbstractServiceModelGenerator
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) throws ApiException {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/zeppelin/ZeppelinWSServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/zeppelin/ZeppelinWSServiceModelGenerator.java
@@ -38,10 +38,10 @@ public class ZeppelinWSServiceModelGenerator extends ZeppelinServiceModelGenerat
   }
 
   @Override
-  public ServiceModel generateService(ApiService       service,
-                                      ApiServiceConfig serviceConfig,
-                                      ApiRole          role,
-                                      ApiConfigList    roleConfig) {
+  public ServiceModel generateService(ApiService service,
+                                 ApiServiceConfig serviceConfig,
+                                 ApiRole role,
+                                 ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) {
     String hostname = role.getHostRef().getHostname();
     String scheme;
     String port;

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
@@ -84,7 +84,8 @@ public abstract class AbstractServiceModelGeneratorTest extends AbstractCMDiscov
       model = newGenerator().generateService(createApiServiceMock(getServiceType()),
                                              createApiServiceConfigMock(serviceConfig),
                                              createApiRoleMock(getRoleType()),
-                                             createApiConfigListMock(roleConfig));
+                                             createApiConfigListMock(roleConfig),
+              null);
     } catch (ApiException e) {
       fail(e.getMessage());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If cloudera manager legacy mode is turned off then certain hdfs config values are moved under the CORE_SETTINGS service.

When the service model generator fetches `hdfs_hadoop_ssl_enabled` it will find a null value (since the real config is under CORE_SETTINGS) and it will generate a non-ssl URL even despite SSL is enabled.

Affected serives: hdfs ui, job history ui, yarn ui.

[Affected config properties](https://docs.cloudera.com/cloudera-manager/7.9.5/managing-clusters/topics/cm-core-configuration-paramters-migrated.html                    
): only `hdfs_hadoop_ssl_enabled`

## How was this patch tested?

Tested with HDFS in non legacy mode.
