### PR TITLE
KNOX-2966 - Improved logging around KnoxSSO cookie management

### DIFF
--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
@@ -39,8 +39,8 @@ public interface KnoxSSOMessages {
   @Message( level = MessageLevel.ERROR, text = "Original URL not found in request.")
   void originalURLNotFound();
 
-  @Message( level = MessageLevel.INFO, text = "JWT cookie successfully added.")
-  void addedJWTCookie();
+  @Message( level = MessageLevel.INFO, text = "JWT cookie {0} successfully added.")
+  void addedJWTCookie(String token);
 
   @Message( level = MessageLevel.ERROR, text = "Unable to issue token.")
   void unableToIssueToken(@StackTrace( level = MessageLevel.DEBUG) Exception e);

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -398,7 +398,8 @@ public class WebSSOResource {
   }
 
   private void addJWTHadoopCookie(String original, JWT token) {
-    LOGGER.addingJWTCookie(token.toString());
+    final String logSafeToken = Tokens.getTokenDisplayText(token.toString());
+    LOGGER.addingJWTCookie(logSafeToken);
     /*
      * In order to account for google chrome changing default value
      * of SameSite from None to Lax we need to craft Set-Cookie
@@ -424,7 +425,7 @@ public class WebSSOResource {
       }
       setCookie.append("; SameSite=").append(this.sameSiteValue);
       response.setHeader("Set-Cookie", setCookie.toString());
-      LOGGER.addedJWTCookie();
+      LOGGER.addedJWTCookie(logSafeToken);
     } catch (Exception e) {
       LOGGER.unableAddCookieToResponse(e.getMessage(),
           Arrays.toString(e.getStackTrace()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Better logging experience in KnoxSSO Cookie management.

## How was this patch tested?

Deployed Knox, logged in to the Knox Home page and checked logs:
```
2023-10-10 13:03:51,102 f268dade-b9ba-425d-b0d6-d3e97d6b9243 INFO  knox.gateway (CookieUtils.java:getCookiesForName(46)) - Unable to find cookie with name: hadoop-jwt
...
2023-10-10 13:04:01,683 d4e582d3-8b08-46cd-8540-60315b08a819 DEBUG service.knoxsso (WebSSOResource.java:addJWTHadoopCookie(402)) - Adding the following JWT token as a cookie: eyJraW...VHcD2Q
2023-10-10 13:04:01,684 d4e582d3-8b08-46cd-8540-60315b08a819 INFO  service.knoxsso (WebSSOResource.java:addJWTHadoopCookie(428)) - JWT cookie eyJraW...VHcD2Q successfully added.
```
