### PR TITLE
KNOX-2968 - Batch token enable action should succeed even if enabled KnoxSSO cookies are selected

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -713,26 +713,26 @@ public class TokenResource {
     return error == null ? response : error;
   }
 
-  private Response setTokenEnabledFlag(String tokenId, boolean enabled, boolean batch) {
+  private Response setTokenEnabledFlag(String tokenId, boolean enable, boolean batch) {
     String error = "";
     ErrorCode errorCode = ErrorCode.UNKNOWN;
     if (tokenStateService == null) {
-      error = "Unable to " + (enabled ? "enable" : "disable") + " tokens because token management is not configured";
+      error = "Unable to " + (enable ? "enable" : "disable") + " tokens because token management is not configured";
       errorCode = ErrorCode.CONFIGURATION_ERROR;
     } else {
       try {
         final TokenMetadata tokenMetadata = tokenStateService.getTokenMetadata(tokenId);
-        if (!batch && enabled && tokenMetadata.isEnabled()) {
+        if (!batch && enable && tokenMetadata.isEnabled()) {
           error = "Token is already enabled";
           errorCode = ErrorCode.ALREADY_ENABLED;
-        } else if (!batch && !enabled && !tokenMetadata.isEnabled()) {
+        } else if (!batch && !enable && !tokenMetadata.isEnabled()) {
           error = "Token is already disabled";
           errorCode = ErrorCode.ALREADY_DISABLED;
-        } else if (enabled && tokenMetadata.isKnoxSsoCookie()) {
+        } else if (enable && tokenMetadata.isKnoxSsoCookie() && !tokenMetadata.isEnabled()) {
           error = "Disabled KnoxSSO Cookies cannot not be enabled";
           errorCode = ErrorCode.DISABLED_KNOXSSO_COOKIE;
         } else {
-          tokenMetadata.setEnabled(enabled);
+          tokenMetadata.setEnabled(enable);
           tokenStateService.addMetadata(tokenId, tokenMetadata);
         }
       } catch (UnknownTokenException e) {
@@ -742,8 +742,8 @@ public class TokenResource {
     }
 
     if (error.isEmpty()) {
-      log.setEnabledFlag(getTopologyName(), enabled, Tokens.getTokenIDDisplayText(tokenId));
-      return Response.status(Response.Status.OK).entity("{\n  \"setEnabledFlag\": \"true\",\n  \"isEnabled\": \"" + enabled + "\"\n}\n").build();
+      log.setEnabledFlag(getTopologyName(), enable, Tokens.getTokenIDDisplayText(tokenId));
+      return Response.status(Response.Status.OK).entity("{\n  \"setEnabledFlag\": \"true\",\n  \"isEnabled\": \"" + enable + "\"\n}\n").build();
     } else {
       log.badSetEnabledFlagRequest(getTopologyName(), Tokens.getTokenIDDisplayText(tokenId), error);
       return Response.status(Response.Status.BAD_REQUEST).entity("{\n  \"setEnabledFlag\": \"false\",\n  \"error\": \"" + error + "\",\n  \"code\": " + errorCode.toInt() + "\n}\n").build();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed a minor bug that prevented an otherwise enabled KnoxSSO Cookie's `enabled flag` set to true in a batch operation.

## How was this patch tested?

Manually tested:

<img width="1767" alt="Screenshot 2023-10-18 at 9 58 31" src="https://github.com/apache/knox/assets/34065904/5e6bc9bf-3d8d-4779-9b11-1f170e060579">
<img width="1790" alt="Screenshot 2023-10-18 at 9 58 59" src="https://github.com/apache/knox/assets/34065904/b94b733c-071f-4320-b7ee-930c789dc98f">
