### PR TITLE
KNOX-2969 - KnoxSSO Cookies should be ignored while calculating token limit per user

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -33,6 +33,7 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -821,7 +822,13 @@ public class TokenResource {
 
     if (tokenStateService != null) {
       if (tokenLimitPerUser != -1) { // if -1 => unlimited tokens for all users
-        final Collection<KnoxToken> userTokens = tokenStateService.getTokens(userName);
+        final Collection<KnoxToken> allUserTokens = tokenStateService.getTokens(userName);
+        final Collection<KnoxToken> userTokens = new LinkedList<>();
+        allUserTokens.stream().forEach(token -> {
+          if(!token.getMetadata().isKnoxSsoCookie()) {
+            userTokens.add(token);
+          }
+        });
         if (userTokens.size() >= tokenLimitPerUser) {
           log.tokenLimitExceeded(userName);
           if (UserLimitExceededAction.RETURN_ERROR == userLimitExceededAction) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified the logic used for calculating the token limit per user in a way such that it ignores the previously generated KnoxSSO cookies. That is, a user can have as many KnoxSSO cookies as they want, but regular tokens are still limited.

## How was this patch tested?

Updated JUnit tests and executed manual testing:

1. Kept the default token limit per user = 10
2. I had three different sessions in different browsers as the `admin` user
3. Disabled one session
4. In one of the remaining sessions generated 10 tokens successfully (please note even the 8th, 9th, and 10th tokens were generated despite the fact I already had 3 KnoxSSO tokens for the same user)
5. The 11th token generation failed as expected

<img width="1779" alt="Screenshot 2023-10-18 at 13 24 10" src="https://github.com/apache/knox/assets/34065904/a670c8d7-c3f6-4eb5-a1d1-37a00a272822">
<img width="1779" alt="Screenshot 2023-10-18 at 13 24 21" src="https://github.com/apache/knox/assets/34065904/8cbbf21e-d092-4e0a-bb83-5b0d9eeff87f">
<img width="1776" alt="Screenshot 2023-10-18 at 13 24 31" src="https://github.com/apache/knox/assets/34065904/1776e8f4-4f11-4a86-8515-7ddb016450a6">
