### PR TITLE
KNOX-2971 - Applying word wrapping in the comment and metadata columns on the Token Management UI

### DIFF
--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -101,12 +101,12 @@
 
             <ng-container matColumnDef="comment">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="metadata.comment" style="text-align: center; justify-content: center;">Comment</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;">{{knoxToken.metadata.comment}}</mat-cell>
+                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center; word-wrap:break-word; word-break: break-word;">{{knoxToken.metadata.comment}}</mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="metadata">
                 <mat-header-cell *matHeaderCellDef style="text-align: center; justify-content: center;">Additional Metadata</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;">
+                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center; word-wrap:break-word; word-break: break-word;">
                    <ul>
                        <li *ngFor="let metadata of getCustomMetadataArray(knoxToken)">
                            {{metadata[0]}} = {{metadata[1]}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

CSS fix of word wrapping in the `Comment` and `Additional Metadata` columns on the Token Management UI. 

## How was this patch tested?

Manually tested.

Before my change:

<img width="1780" alt="Screenshot 2023-10-19 at 15 26 56" src="https://github.com/apache/knox/assets/34065904/b3f19d76-8d5e-43da-a91d-ac35d8a3dc6f">

After my change:

<img width="1774" alt="Screenshot 2023-10-19 at 15 53 32" src="https://github.com/apache/knox/assets/34065904/00661dc3-a792-4df3-ae6a-cacc46e80008">
