### PR TITLE
KNOX-2972 - Session resource can generate application logout URL with profile/topologies query parameters

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/app/logout.jsp
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/logout.jsp
@@ -59,6 +59,7 @@
 
     <%
         String originalUrl = request.getParameter("originalUrl");
+        originalUrl = originalUrl.replaceAll("&", "%26");
         Topology topology = (Topology)request.getSession().getServletContext().getAttribute("org.apache.knox.gateway.topology");
         String whitelist = null;
         String cookieName = null;

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
@@ -24,10 +24,14 @@ import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.security.SubjectUtils;
@@ -44,10 +48,13 @@ public class SessionResource {
   @Context
   ServletContext context;
 
+  private String baseLogoutPageUrl;
+
   @GET
   @Produces({ APPLICATION_JSON, APPLICATION_XML })
   @Path("sessioninfo")
-  public SessionInformation getSessionInformation() {
+  public SessionInformation getSessionInformation(@QueryParam("logoutPageProfile") @DefaultValue("") String logoutPageProfile,
+      @QueryParam("logoutPageTopologies") @DefaultValue("") String logoutPageTopologies) {
     final SessionInformation sessionInfo = new SessionInformation();
     final String user = SubjectUtils.getCurrentEffectivePrincipalName();
     sessionInfo.setUser(user);
@@ -56,7 +63,7 @@ public class SessionResource {
       String logoutUrl = getBaseGatewayUrl(config) + "/homepage/knoxssout/api/v1/webssout";
       LOG.homePageLogoutEnabled(logoutUrl);
       sessionInfo.setLogoutUrl(logoutUrl);
-      sessionInfo.setLogoutPageUrl(getLogoutPageUrl(config));
+      sessionInfo.setLogoutPageUrl(getLogoutPageUrl(config, logoutPageProfile, logoutPageTopologies));
       sessionInfo.setGlobalLogoutPageUrl(getGlobalLogoutPageUrl(config));
     }
     sessionInfo.setCanSeeAllTokens(config != null ? config.canSeeAllTokens(user) : false);
@@ -66,15 +73,23 @@ public class SessionResource {
   }
 
   private String getBaseGatewayUrl(GatewayConfig config) {
-    return request.getRequestURL().substring(0,
-        request.getRequestURL().length() - request.getRequestURI().length()) +
-        "/" + config.getGatewayPath();
+    return request.getRequestURL().substring(0, request.getRequestURL().length() - request.getRequestURI().length()) + "/" + config.getGatewayPath();
   }
 
-  private String getLogoutPageUrl(GatewayConfig config) {
-    return getBaseGatewayUrl(config) +
-        "/knoxsso/knoxauth/logout.jsp?originalUrl=" + getBaseGatewayUrl(config) +
-        "/homepage/home";
+  private String getLogoutPageUrl(GatewayConfig config, String logoutPageProfile, String logoutPageTopologies) {
+    if (baseLogoutPageUrl == null) {
+      baseLogoutPageUrl = getBaseGatewayUrl(config) + "/knoxsso/knoxauth/logout.jsp?originalUrl=" + getBaseGatewayUrl(config) + "/homepage/home";
+    }
+    final StringBuilder logoutPageUrlBuilder = new StringBuilder(baseLogoutPageUrl);
+    String delimiter = "%3F"; //'?'
+    if (StringUtils.isNotBlank(logoutPageProfile)) {
+      logoutPageUrlBuilder.append(delimiter).append("profile=").append(logoutPageProfile);
+      delimiter = "%26";  // '&'
+    }
+    if (StringUtils.isNotBlank(logoutPageTopologies)) {
+      logoutPageUrlBuilder.append(delimiter).append("topologies=").append(logoutPageTopologies);
+    }
+    return logoutPageUrlBuilder.toString();
   }
 
   private String getGlobalLogoutPageUrl(GatewayConfig config) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated the `api/v1/sessioninfo` REST API endpoint in `SessionResouce` in a way such that it can generate a `logoutPageUrl` (used by the application logout link in Knox's logout flow) with `profile` and `topologies` query parameters in the `originalUrl` part.

## How was this patch tested?

Using `curl`:

1. Without any query params:
```
$ curl -ik --cookie "hadoop-jwt=eyJra...APA" -X GET "https://localhost:8443/gateway/homepage/session/api/v1/sessioninfo"
HTTP/1.1 200 OK
Date: Fri, 20 Oct 2023 10:47:30 GMT
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1;mode=block
Content-Type: application/xml
Content-Length: 574

<?xml version="1.0" encoding="UTF-8"?>
<sessioninfo>
   <user>admin</user>
   <logoutUrl>https://localhost:8443/gateway/homepage/knoxssout/api/v1/webssout</logoutUrl>
   <logoutPageUrl>https://localhost:8443/gateway/knoxsso/knoxauth/logout.jsp?originalUrl=https://localhost:8443/gateway/homepage/home</logoutPageUrl>
   <globalLogoutPageUrl>https://dev-p8gzwjyj66yvfble.eu.auth0.com/oidc/logout</globalLogoutPageUrl>
   <canSeeAllTokens>true</canSeeAllTokens>
   <currentKnoxSsoCookieTokenId>40005574-61f2-4507-aa9f-0171b787ed4c</currentKnoxSsoCookieTokenId>
</sessioninfo>
```

2. Only with the `logoutPageProfile` param:
```
$ curl -ik --cookie "hadoop-jwt=eyJra...APA" -X GET "https://localhost:8443/gateway/homepage/session/api/v1/sessioninfo?logoutPageProfile=token"
HTTP/1.1 200 OK
Date: Fri, 20 Oct 2023 10:48:05 GMT
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1;mode=block
Content-Type: application/xml
Content-Length: 588

<?xml version="1.0" encoding="UTF-8"?>
<sessioninfo>
   <user>admin</user>
   <logoutUrl>https://localhost:8443/gateway/homepage/knoxssout/api/v1/webssout</logoutUrl>
   <logoutPageUrl>https://localhost:8443/gateway/knoxsso/knoxauth/logout.jsp?originalUrl=https://localhost:8443/gateway/homepage/home%3Fprofile=token</logoutPageUrl>
   <globalLogoutPageUrl>https://dev-p8gzwjyj66yvfble.eu.auth0.com/oidc/logout</globalLogoutPageUrl>
   <canSeeAllTokens>true</canSeeAllTokens>
   <currentKnoxSsoCookieTokenId>40005574-61f2-4507-aa9f-0171b787ed4c</currentKnoxSsoCookieTokenId>
</sessioninfo>
```
3. Only with the `logoutPageTopologies` param:
```
$ curl -ik --cookie "hadoop-jwt=eyJra...APA" -X GET "https://localhost:8443/gateway/homepage/session/api/v1/sessioninfo?logoutPageTopologies=sandbox"
HTTP/1.1 200 OK
Date: Fri, 20 Oct 2023 10:48:52 GMT
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1;mode=block
Content-Type: application/xml
Content-Length: 593

<?xml version="1.0" encoding="UTF-8"?>
<sessioninfo>
   <user>admin</user>
   <logoutUrl>https://localhost:8443/gateway/homepage/knoxssout/api/v1/webssout</logoutUrl>
   <logoutPageUrl>https://localhost:8443/gateway/knoxsso/knoxauth/logout.jsp?originalUrl=https://localhost:8443/gateway/homepage/home%3Ftopologies=sandbox</logoutPageUrl>
   <globalLogoutPageUrl>https://dev-p8gzwjyj66yvfble.eu.auth0.com/oidc/logout</globalLogoutPageUrl>
   <canSeeAllTokens>true</canSeeAllTokens>
   <currentKnoxSsoCookieTokenId>40005574-61f2-4507-aa9f-0171b787ed4c</currentKnoxSsoCookieTokenId>
</sessioninfo>
```
4. Both with 'logoutPageProfile' and `logoutPageTopologies` params:
```
$ curl -ik --cookie "hadoop-jwt=eyJra...APA" -X GET "https://localhost:8443/gateway/homepage/session/api/v1/sessioninfo?logoutPageTopologies=sandbox&logoutPageProfile=full"
HTTP/1.1 200 OK
Date: Fri, 20 Oct 2023 08:07:26 GMT
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1;mode=block
Content-Type: application/xml
Content-Length: 610

<?xml version="1.0" encoding="UTF-8"?>
<sessioninfo>
   <user>admin</user>
   <logoutUrl>https://localhost:8443/gateway/homepage/knoxssout/api/v1/webssout</logoutUrl>
   <logoutPageUrl>https://localhost:8443/gateway/knoxsso/knoxauth/logout.jsp?originalUrl=https://localhost:8443/gateway/homepage/home%3Fprofile=full%26topologies=sandbox</logoutPageUrl>
   <globalLogoutPageUrl>https://dev-p8gzwjyj66yvfble.eu.auth0.com/oidc/logout</globalLogoutPageUrl>
   <canSeeAllTokens>true</canSeeAllTokens>
   <currentKnoxSsoCookieTokenId>40005574-61f2-4507-aa9f-0171b787ed4c</currentKnoxSsoCookieTokenId>
</sessioninfo>
```

I also tested the entire flow by temporarily modifying the `home` application. I updated the [sessionUrl](https://github.com/apache/knox/blob/master/knox-homepage-ui/home/app/homepage.service.ts#L33) variable:
```
sessionUrl = this.topologyContext + 'session/api/v1/sessioninfo'
```
became
```
sessionUrl = this.topologyContext + 'session/api/v1/sessioninfo?logoutPageProfile=token&logoutPageTopologies=sandbox'
```
After I redeployed Knox I confirmed that I got the correct link on the logout page and after clicking the `Return to Application` link and logging in again, the given query parameters were applied.
<img width="1787" alt="Screenshot 2023-10-20 at 15 12 42" src="https://github.com/apache/knox/assets/34065904/43e20f67-0f26-47e6-b1d6-757c507a7b9c">
<img width="1784" alt="Screenshot 2023-10-20 at 15 13 53" src="https://github.com/apache/knox/assets/34065904/996bdb8a-0418-4138-84cc-45a52bd77f10">
<img width="1787" alt="Screenshot 2023-10-20 at 15 14 13" src="https://github.com/apache/knox/assets/34065904/2a0fb66f-227f-4055-8407-7446418cc621">

