### PR TITLE
KNOX-2977 - The 'conf/descriptors' folder should be considered too when registering topology port mappings

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -649,16 +649,10 @@ public class GatewayServer {
     final ServiceDefinitionRegistry serviceDefinitionRegistry = services.getService(ServiceType.SERVICE_DEFINITION_REGISTRY);
     serviceDefinitionRegistry.addServiceDefinitionChangeListener(monitor);
 
-    final Collection<Topology> topologies = monitor.getTopologies();
     final Map<String, Integer> topologyPortMap = config.getGatewayPortMappings();
 
-    // List of all the topology that are deployed
-    final List<String> deployedTopologyList = new ArrayList<>();
-
-    for (final Topology t : topologies) {
-      deployedTopologyList.add(t.getName());
-    }
-
+    // List of all the topology that are deployed (or will be deployed soon)
+    final Set<String> deployedTopologyList = gatewayStatusService.collectTopologies(config);
 
     // Check whether the configured topologies for port mapping exist, if not
     // log WARN message and continue
@@ -768,7 +762,7 @@ public class GatewayServer {
    */
   private void checkMappedTopologiesExist(
       final Map<String, Integer> configTopologies,
-      final List<String> topologies) {
+      final Set<String> topologies) {
     for(final Map.Entry<String, Integer> entry : configTopologies.entrySet()) {
       // If the topologies defined in gateway-config.xml are not found in gateway
       if (!topologies.contains(entry.getKey())) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/GatewayStatusService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/GatewayStatusService.java
@@ -61,17 +61,17 @@ public class GatewayStatusService implements Service {
     Set<String> healthCheckTopologies = config.getHealthCheckTopologies();
     if (healthCheckTopologies.isEmpty()) {
       topologyNamesToCheck = collectTopologies(config);
+      LOG.collectedTopologiesForHealthCheck(topologyNamesToCheck);
     } else {
       topologyNamesToCheck = healthCheckTopologies;
     }
     LOG.startingStatusMonitor(topologyNamesToCheck);
   }
 
-  private Set<String> collectTopologies(GatewayConfig config) {
-    Set<String> result = new HashSet<>();
+  public Set<String> collectTopologies(GatewayConfig config) {
+    final Set<String> result = new HashSet<>();
     collectFiles(result, config.getGatewayTopologyDir(), ".xml");
     collectFiles(result, config.getGatewayDescriptorsDir(), ".json");
-    LOG.collectedTopologiesForHealthCheck(result);
     return result;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in KNOX-2977, from now on the `conf/descriptors` folder is also considered at topology mapping creating time.

## How was this patch tested?

Manually tested on a live cluster with WebHDFS and different port mappings.