### PR TITLE
KNOX-2978 - Race condition between Service Discovery and Polling Config Analyzer

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -253,8 +253,6 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
 
     log.discoveringCluster(clusterName);
 
-    repository.registerCluster(client.getConfig());
-
     Set<ServiceModel> serviceModels = new HashSet<>();
 
     List<ApiService> serviceList = getClusterServices(client.getConfig(), servicesResourceApi);
@@ -340,7 +338,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
   private List<ApiService> getClusterServices(ServiceDiscoveryConfig serviceDiscoveryConfig, ServicesResourceApi servicesResourceApi) throws ApiException {
     log.lookupClusterServicesFromRepository();
     List<ApiService> services = repository.getServices(serviceDiscoveryConfig);
-    if (services == null || services.isEmpty()) {
+    if (services.isEmpty()) {
       try {
         log.lookupClusterServicesFromCM();
         final ApiServiceList serviceList = servicesResourceApi.readServices(serviceDiscoveryConfig.getCluster(), VIEW_SUMMARY);

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepositoryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryRepositoryTest.java
@@ -56,14 +56,13 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
   @Before
   public void setUp() {
     repository.clear();
-    assertNull(repository.getServices(serviceDiscoveryConfig));
     repository.setCacheEntryTTL(GatewayConfig.DEFAULT_CM_SERVICE_DISCOVERY_CACHE_ENTRY_TTL);
+    assertTrue(repository.getServices(serviceDiscoveryConfig).isEmpty());
   }
 
   @Test
   public void testRegisterCluster() throws Exception {
-    assertNull(repository.getServices(serviceDiscoveryConfig));
-    repository.registerCluster(serviceDiscoveryConfig);
+    assertTrue(repository.getServices(serviceDiscoveryConfig).isEmpty());
     final List<ApiService> services = repository.getServices(serviceDiscoveryConfig);
     assertNotNull(services);
     assertTrue(services.isEmpty());
@@ -72,7 +71,6 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
   @Test
   public void testAddService() throws Exception {
     final String serviceName = "HDFS-1";
-    repository.registerCluster(serviceDiscoveryConfig);
     assertFalse(containsService(serviceName));
     final ApiService service = EasyMock.createNiceMock(ApiService.class);
     EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
@@ -86,7 +84,6 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
     final String serviceName = "HDFS-1";
     final String serviceConfigName = "myServiceConfigName";
     final String serviceConfigValue = "myServiceConfigValue";
-    repository.registerCluster(serviceDiscoveryConfig);
     final ApiService service = EasyMock.createNiceMock(ApiService.class);
     EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
     final ApiConfig serviceConfig = EasyMock.createNiceMock(ApiConfig.class);
@@ -105,7 +102,6 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
   public void testAddRole() throws Exception {
     final String serviceName = "HDFS-1";
     final String roleName = "NAMENODE-1";
-    repository.registerCluster(serviceDiscoveryConfig);
     final ApiService service = EasyMock.createNiceMock(ApiService.class);
     EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
     final ApiRole role = EasyMock.createNiceMock(ApiRole.class);
@@ -121,7 +117,6 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
 
   @Test
   public void testAddNullRoles() throws Exception {
-    repository.registerCluster(serviceDiscoveryConfig);
     final ApiService service = EasyMock.createNiceMock(ApiService.class);
     EasyMock.expect(service.getName()).andReturn(ClouderaManagerServiceDiscovery.CORE_SETTINGS_TYPE).anyTimes();
     EasyMock.replay(service);
@@ -132,7 +127,6 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
 
   @Test
   public void testAddNullRoleItems() throws Exception {
-    repository.registerCluster(serviceDiscoveryConfig);
     final ApiService service = EasyMock.createNiceMock(ApiService.class);
     EasyMock.expect(service.getName()).andReturn(ClouderaManagerServiceDiscovery.CORE_SETTINGS_TYPE).anyTimes();
     final ApiRoleList roles = EasyMock.createNiceMock(ApiRoleList.class);
@@ -150,7 +144,6 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
     final String roleConfigName = "myRoleConfig";
     final String roleConfigValue = "myRoleConfigValue";
 
-    repository.registerCluster(serviceDiscoveryConfig);
     final ApiService service = EasyMock.createNiceMock(ApiService.class);
     EasyMock.expect(service.getName()).andReturn(serviceName).anyTimes();
     final ApiRole role = EasyMock.createNiceMock(ApiRole.class);
@@ -174,6 +167,7 @@ public class ClouderaManagerServiceDiscoveryRepositoryTest {
   public void testCacheAutoEviction() throws Exception {
     final long entryTTL = 1;
     repository.setCacheEntryTTL(entryTTL);
+    repository.clear();
     testAddService();
     TimeUnit.SECONDS.sleep(entryTTL + 1);
     assertFalse(containsService("HDFS-1"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a config change is detected by the Polling Config Analyzer then then the cache used by the service discovery will be cleared. If this happens when discovery is in progress then a NullPointerException will happen.

```java
  private ServiceDetails getServiceDetails(ServiceDiscoveryConfig serviceDiscoveryConfig, ApiService service) {
    return getClusterServices(serviceDiscoveryConfig).getIfPresent(service); // <= NPE
  }
```

```java
  @Override
  public void onConfigurationChange(String source, String clusterName) {
    log.clearServiceDiscoveryRepository();
    repository.clear(); // this will cause the NPE
  }
```
This was observed on a live cluster when certain cluster properties was changed during knox startup.


## How was this patch tested?

- unit test