### PR TITLE
KNOX-2974 - Add a new endpoint 'extauthz' similar to pre that accepts  HTTP verbs other than GET and if configured ignores additional context path params

### DIFF
--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.auth;
+
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.security.SubjectUtils;
+
+import javax.security.auth.Subject;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.Response.ok;
+import static javax.ws.rs.core.Response.status;
+
+public abstract class AbstractAuthResource {
+  public static final String AUTH_ACTOR_ID_HEADER_NAME = "preauth.auth.header.actor.id.name";
+  public static final String AUTH_ACTOR_GROUPS_HEADER_PREFIX = "preauth.auth.header.actor.groups.prefix";
+  public static final String GROUP_FILTER_PATTERN = "preauth.group.filter.pattern";
+
+  static final AuthMessages LOG = MessagesFactory.get(AuthMessages.class);
+
+  static final String DEFAULT_AUTH_ACTOR_ID_HEADER_NAME = "X-Knox-Actor-ID";
+  static final String DEFAULT_AUTH_ACTOR_GROUPS_HEADER_PREFIX = "X-Knox-Actor-Groups";
+  static final Pattern DEFAULT_GROUP_FILTER_PATTERN = Pattern.compile(".*");
+
+  protected static final int MAX_HEADER_LENGTH = 1000;
+  protected static final String ACTOR_GROUPS_HEADER_FORMAT = "%s-%d";
+
+  protected String authHeaderActorIDName;
+  protected String authHeaderActorGroupsPrefix;
+  protected Pattern groupFilterPattern;
+
+  protected void initialize() {
+    authHeaderActorIDName = getInitParameter(AUTH_ACTOR_ID_HEADER_NAME, DEFAULT_AUTH_ACTOR_ID_HEADER_NAME);
+    authHeaderActorGroupsPrefix = getInitParameter(AUTH_ACTOR_GROUPS_HEADER_PREFIX, DEFAULT_AUTH_ACTOR_GROUPS_HEADER_PREFIX);
+    final String groupFilterPatternString = getInitParameter(GROUP_FILTER_PATTERN, null);
+    groupFilterPattern = groupFilterPatternString == null ? DEFAULT_GROUP_FILTER_PATTERN : Pattern.compile(groupFilterPatternString);
+  }
+
+  /* abstract method to get the response instance */
+  abstract HttpServletResponse getResponse();
+
+  /* Abstract method that gets context instance */
+  abstract ServletContext getContext();
+
+  String getInitParameter(String paramName, String defaultValue) {
+    final String initParam = getContext().getInitParameter(paramName);
+    return initParam == null ? defaultValue : initParam;
+  }
+
+  public Response doGetImpl() {
+    final Subject subject = SubjectUtils.getCurrentSubject();
+
+    final String primaryPrincipalName = subject == null ? null : SubjectUtils.getPrimaryPrincipalName(subject);
+    if (primaryPrincipalName == null) {
+      LOG.noPrincipalFound();
+      return status(HttpServletResponse.SC_UNAUTHORIZED).build();
+    }
+    getResponse().setHeader(authHeaderActorIDName, primaryPrincipalName);
+
+    // Populate actor groups headers
+    final Set<String> matchingGroupNames = subject == null ? Collections.emptySet()
+        : SubjectUtils.getGroupPrincipals(subject).stream().filter(group -> groupFilterPattern.matcher(group.getName()).matches()).map(group -> group.getName())
+        .collect(Collectors.toSet());
+    if (!matchingGroupNames.isEmpty()) {
+      final List<String> groupStrings = getGroupStrings(matchingGroupNames);
+      for (int i = 0; i < groupStrings.size(); i++) {
+        getResponse().addHeader(String.format(Locale.ROOT, ACTOR_GROUPS_HEADER_FORMAT, authHeaderActorGroupsPrefix, i + 1), groupStrings.get(i));
+      }
+    }
+    return ok().build();
+  }
+
+  private List<String> getGroupStrings(Collection<String> groupNames) {
+    if (groupNames.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<String> groupStrings = new ArrayList<>();
+    StringBuilder sb = new StringBuilder();
+    for (String groupName : groupNames) {
+      if (sb.length() + groupName.length() > MAX_HEADER_LENGTH) {
+        groupStrings.add(sb.toString());
+        sb = new StringBuilder();
+      }
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(groupName);
+    }
+    if (sb.length() > 0) {
+      groupStrings.add(sb.toString());
+    }
+    return groupStrings;
+  }
+
+}

--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AuthMessages.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AuthMessages.java
@@ -27,4 +27,7 @@ public interface AuthMessages {
   @Message(level = MessageLevel.ERROR, text = "There was a problem extracting authenticated principal from request.")
   void noPrincipalFound();
 
+  @Message(level = MessageLevel.INFO, text = "Serving request for path: {0}")
+  void pathValue(String path);
+
 }

--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/ExtAuthzResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/ExtAuthzResource.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.auth;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+@Path(ExtAuthzResource.RESOURCE_PATH)
+public class ExtAuthzResource extends AbstractAuthResource {
+  static final String RESOURCE_PATH = "auth/api/v1/extauthz";
+  static final String IGNORE_ADDITIONAL_PATH = "ignore.additional.path";
+  static final String DEFAULT_IGNORE_ADDITIONAL_PATH = "false";
+
+  private boolean ignoreAdditionalPath;
+
+  @Context
+  HttpServletResponse response;
+
+  @Context
+  ServletContext context;
+
+  @PostConstruct
+  public void init() {
+    initialize();
+    ignoreAdditionalPath = Boolean.parseBoolean(getInitParameter(IGNORE_ADDITIONAL_PATH, DEFAULT_IGNORE_ADDITIONAL_PATH));
+  }
+
+  @Override
+  HttpServletResponse getResponse() {
+    return response;
+  }
+
+  @Override
+  ServletContext getContext() {
+    return context;
+  }
+
+  /*
+  Enable all the http verbs,
+  wish there was a way to specify multiple paths on the same method
+  */
+  @GET
+  public Response doGet() {
+    return doGetImpl();
+  }
+
+  @POST
+  public Response doPostWithRootPath() {
+    return doGetImpl();
+  }
+
+  @PUT
+  public Response doPutWithRootPath() {
+    return doGetImpl();
+  }
+
+  @DELETE
+  public Response doDeleteWithRootPath() {
+    return doGetImpl();
+  }
+
+  @HEAD
+  public Response doHeadWithPath() {
+    return doGetImpl();
+  }
+
+  @OPTIONS
+  public Response doOptionsWithPath() {
+    return doGetImpl();
+  }
+
+  /*
+   * This method will handle additional paths.
+   * Currently, if there are any additional paths they are ignored.
+   */
+  @Path("{subResources:.*}")
+  @GET
+  public Response doGetWithPath(@Context UriInfo ui) {
+    if(ignoreAdditionalPath) {
+      LOG.pathValue(ui.getPath());
+      return doGet();
+    } else {
+      return  Response.status(Response.Status.NOT_FOUND).build();
+    }
+  }
+
+  @Path("{subResources:.*}")
+  @POST
+  public Response doPostWithPath(@Context UriInfo ui) {
+    return doGetWithPath(ui);
+  }
+
+  @Path("{subResources: .*}")
+  @PUT
+  public Response doPutWithPath(@Context UriInfo ui) {
+    return doGetWithPath(ui);
+  }
+
+  @Path("{subResources: .*}")
+  @DELETE
+  public Response doDeleteWithPath(@Context UriInfo ui) {
+    return doGetWithPath(ui);
+  }
+
+  @Path("{subResources: .*}")
+  @HEAD
+  public Response doHeadWithPath(@Context UriInfo ui) {
+    return doGetWithPath(ui);
+  }
+
+  @Path("{subResources: .*}")
+  @OPTIONS
+  public Response doOptionsWithPath(@Context UriInfo ui) {
+    return doGetWithPath(ui);
+  }
+
+}

--- a/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/ExtAuthzResourceTest.java
+++ b/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/ExtAuthzResourceTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.auth;
+
+import org.apache.knox.gateway.security.GroupPrincipal;
+import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.security.SubjectUtils;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.security.auth.Subject;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ExtAuthzResourceTest {
+
+  private static final String USER_NAME = "test-username";
+  private ServletContext context;
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private final Subject subject = new Subject();
+
+  @Before
+  public void setUp() {
+    subject.getPrincipals().add(new PrimaryPrincipal(USER_NAME));
+  }
+
+  @Test
+  public void testIgnoreAdditionalPaths() throws Exception {
+    configureCommonExpectations(null, null, Collections.singleton("group1"));
+    final ExtAuthzResource extAuthzResource = new ExtAuthzResource();
+    extAuthzResource.context = context;
+    extAuthzResource.response = response;
+    executeResourceWithAdditionalPath(extAuthzResource);
+    EasyMock.verify(response);
+  }
+
+
+  private void configureCommonExpectations(String actorIdHeaderName, String groupsHeaderPrefix, Collection<String> groups) {
+    context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getInitParameter(ExtAuthzResource.AUTH_ACTOR_ID_HEADER_NAME)).andReturn(actorIdHeaderName).anyTimes();
+    EasyMock.expect(context.getInitParameter(ExtAuthzResource.AUTH_ACTOR_GROUPS_HEADER_PREFIX)).andReturn(groupsHeaderPrefix).anyTimes();
+    EasyMock.expect(context.getInitParameter(ExtAuthzResource.IGNORE_ADDITIONAL_PATH)).andReturn("true").anyTimes();
+    request = EasyMock.createNiceMock(HttpServletRequest.class);
+    response = EasyMock.createNiceMock(HttpServletResponse.class);
+
+    if (SubjectUtils.getPrimaryPrincipalName(subject) != null) {
+      final String expectedActorIdHeader = actorIdHeaderName == null ? "X-Knox-Actor-ID" : actorIdHeaderName;
+      response.setHeader(expectedActorIdHeader, USER_NAME);
+      EasyMock.expectLastCall();
+    }
+
+    if (!groups.isEmpty()) {
+      groups.forEach(group -> subject.getPrincipals().add(new GroupPrincipal(group)));
+      final int groupStringSize = calculateGroupStringSize(groups);
+      final int expectedGroupHeaderCount = groupStringSize / 1000 + 1;
+      final String expectedGroupsHeaderPrefix = (groupsHeaderPrefix == null ? "X-Knox-Actor-Groups" : groupsHeaderPrefix)
+          + "-";
+      for (int i = 1; i <= expectedGroupHeaderCount; i++) {
+        response.addHeader(EasyMock.eq(expectedGroupsHeaderPrefix + i), EasyMock.anyString());
+        EasyMock.expectLastCall();
+      }
+    }
+    EasyMock.replay(context, request, response);
+  }
+
+  private int calculateGroupStringSize(Collection<String> groups) {
+    final AtomicInteger size = new AtomicInteger(0);
+    groups.forEach(group -> size.addAndGet(group.length()));
+    size.addAndGet(groups.size() - 1); // commas
+    return size.get();
+  }
+
+
+  private Response executeResourceWithAdditionalPath(final ExtAuthzResource extAuthzResource) throws PrivilegedActionException {
+    return (Response) Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+
+      @Override
+      public Object run() throws Exception {
+        extAuthzResource.init();
+        return extAuthzResource.doGetWithPath(new UriInfo() {
+          @Override
+          public String getPath() {
+            return "/gateway/sandbox/auth/api/v1/extauthz/does-not-exist";
+          }
+
+          @Override
+          public String getPath(boolean decode) {
+            return "/gateway/sandbox/auth/api/v1/extauthz/does-not-exist";
+          }
+
+          @Override
+          public List<PathSegment> getPathSegments() {
+            return null;
+          }
+
+          @Override
+          public List<PathSegment> getPathSegments(boolean decode) {
+            return null;
+          }
+
+          @Override
+          public URI getRequestUri() {
+            return null;
+          }
+
+          @Override
+          public UriBuilder getRequestUriBuilder() {
+            return null;
+          }
+
+          @Override
+          public URI getAbsolutePath() {
+            return null;
+          }
+
+          @Override
+          public UriBuilder getAbsolutePathBuilder() {
+            return null;
+          }
+
+          @Override
+          public URI getBaseUri() {
+            return null;
+          }
+
+          @Override
+          public UriBuilder getBaseUriBuilder() {
+            return null;
+          }
+
+          @Override
+          public MultivaluedMap<String, String> getPathParameters() {
+            return null;
+          }
+
+          @Override
+          public MultivaluedMap<String, String> getPathParameters(
+              boolean decode) {
+            return null;
+          }
+
+          @Override
+          public MultivaluedMap<String, String> getQueryParameters() {
+            return null;
+          }
+
+          @Override
+          public MultivaluedMap<String, String> getQueryParameters(
+              boolean decode) {
+            return null;
+          }
+
+          @Override
+          public List<String> getMatchedURIs() {
+            return null;
+          }
+
+          @Override
+          public List<String> getMatchedURIs(boolean decode) {
+            return null;
+          }
+
+          @Override
+          public List<Object> getMatchedResources() {
+            return null;
+          }
+
+          @Override
+          public URI resolve(URI uri) {
+            return null;
+          }
+
+          @Override
+          public URI relativize(URI uri) {
+            return null;
+          }
+        });
+      }
+
+    });
+  }
+
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

- New endpoint 'auth/api/v1/extauthz'  (similar to `auth/api/v1/pre`) that accepts  HTTP verbs other than GET 
- If configured ignores additional context path params

e.g.
```
knox git:(KNOX-2974) curl -X POST -iku guest:guest-password https://localhost:8443/gateway/sandbox/auth/api/v1/extauthz
HTTP/1.1 200 OK
Date: Mon, 30 Oct 2023 11:04:54 GMT
Set-Cookie: KNOXSESSIONID=node01fu988w96ue8n19ot0yixrdt6s7.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Sun, 29-Oct-2023 11:04:54 GMT; SameSite=lax
X-Knox-Actor-ID: guest
Content-Length: 0
```

```
knox git:(KNOX-2974) curl -X POST -iku guest:guest-password https://localhost:8443/gateway/sandbox/auth/api/v1/extauthz/xyz
HTTP/1.1 200 OK
Date: Mon, 30 Oct 2023 11:05:28 GMT
Set-Cookie: KNOXSESSIONID=node04574919y5ed372i1cdy8i25h8.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Sun, 29-Oct-2023 11:05:28 GMT; SameSite=lax
X-Knox-Actor-ID: guest
Content-Length: 0
```

Configuration parameter to enable/disable ignoring extra path (`/xyz` in previous example) is `ignore.additional.path`

```
<service>
	     <role>KNOX-AUTH-SERVICE</role>
	     <param>
	       <name>preauth.auth.header.actor.id.name</name>
	       <value>X-Knox-Actor-ID</value>
	     </param>
	     <param>
	       <name>preauth.auth.header.actor.groups.prefix</name>
	       <value>X-Knox-Actor-Groups</value>
	     </param>
	     <param>
	       <name>ignore.additional.path</name>
	       <value>true</value>
	     </param>
              ......
	</service>
```

**NOTE**: this endpoint is based on `auth/api/v1/pre` so all the option that are supported by [auth/api/v1/pre](https://knox.apache.org/books/knox-2-0-0/user-guide.html#auth/api/v1/pre) are supported by `auth/api/v1/extauthz`

## How was this patch tested?

This patch was tested locally