### PR TITLE
KNOX-2958 - Fixed API samples for certain services

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/cm-api/1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/cm-api/1.0.0/service.xml
@@ -30,12 +30,12 @@
             <sample>
                 <description>Fetch all CM-managed clusters</description>
                 <method>GET</method>
-                <path>clusters</path>
+                <path>/v41/clusters</path>
             </sample>
             <sample>
                 <description>Fetches HDFS service details from cluster named 'c1'</description>
                 <method>GET</method>
-                <path>clusters/c1/services/HDFS</path>
+                <path>/v41/clusters/c1/services/HDFS</path>
             </sample>
             <sample>
                 <description>You can checkout CM's API (v41) document here</description>

--- a/gateway-service-definitions/src/main/resources/services/oozie/5.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/oozie/5.0.0/service.xml
@@ -25,12 +25,12 @@
             <sample>
                 <description>Fetch the supported Oozie protocol versions by the server</description>
                 <method>GET</method>
-                <path>oozie/versions</path>
+                <path>/oozie/versions</path>
             </sample>
              <sample>
                 <description>Fetch the system status</description>
                 <method>GET</method>
-                <path>oozie/v1/admin/status</path>
+                <path>/oozie/v1/admin/status</path>
             </sample>
             <sample>
                 <description>You may check out Apache Oozie's REST API documentation here</description>

--- a/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/service.xml
@@ -25,17 +25,17 @@
             <sample>
                 <description>List all files under 'testPath'</description>
                 <method>GET</method>
-                <path>v1/testPath?op=LISTSTATUS</path>
+                <path>/v1/testPath?op=LISTSTATUS</path>
             </sample>
             <sample>
                 <description>Rename a File/Directory under </description>
                 <method>PUT</method>
-                <path>v1/testPath/testFile?op=RENAME&amp;destination=testPath/renamedFile</path>
+                <path>/v1/testPath/testFile?op=RENAME&amp;destination=testPath/renamedFile</path>
             </sample>
             <sample>
                 <description>Get Home Directory</description>
                 <method>GET</method>
-                <path>v1/?op=GETHOMEDIRECTORY</path>
+                <path>/v1/?op=GETHOMEDIRECTORY</path>
             </sample>
             <sample>
                 <description>You may check out Apache WebHDFS's REST API documentation here</description>

--- a/gateway-service-definitions/src/main/resources/services/yarn-rm/2.5.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarn-rm/2.5.0/service.xml
@@ -25,12 +25,12 @@
             <sample>
                 <description>Fetch cluster info</description>
                 <method>GET</method>
-                <path>ws/v1/cluster/info</path>
+                <path>/ws/v1/cluster/info</path>
             </sample>
             <sample>
                 <description>Fetch cluster metrics</description>
                 <method>GET</method>
-                <path>ws/v1/cluster/metrics</path>
+                <path>/ws/v1/cluster/metrics</path>
             </sample>
             <sample>
                 <description>You may check out Apache YARN Resource Manager's REST API documentation here</description>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/ServiceModel.java
@@ -178,7 +178,8 @@ public class ServiceModel implements Comparable<ServiceModel> {
           resolvedSample.setValue(sample.getValue());
         } else {
           final String method = StringUtils.isBlank(sample.getMethod()) ? "GET" : sample.getMethod();
-          resolvedSample.setValue(String.format(Locale.ROOT, CURL_SAMPLE_TEMPLATE, method, getServiceUrl(), sample.getPath()));
+          final String path = sample.getPath().startsWith("/") ? sample.getPath() : ("/" + sample.getPath());
+          resolvedSample.setValue(String.format(Locale.ROOT, CURL_SAMPLE_TEMPLATE, method, getServiceUrl(), path));
         }
         samples.add(resolvedSample);
       });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Testing uncovered some API samples in the existing service definition files that needed to be fixed.

Additionally, a general improvement is implemented that adds the missing slash at the beginning of the path element if it was missing from the service definition sample.

## How was this patch tested?

Added unit tests and confirmed that API samples are actually changed on the UI:
<img width="886" alt="Screenshot 2023-10-31 at 10 26 44" src="https://github.com/apache/knox/assets/34065904/1cc6f3fc-e379-42b1-b518-b29f5262bff0">
<img width="890" alt="Screenshot 2023-10-31 at 10 27 09" src="https://github.com/apache/knox/assets/34065904/cdfb7433-7659-4237-b1a4-59c1241add52">
<img width="891" alt="Screenshot 2023-10-31 at 10 27 21" src="https://github.com/apache/knox/assets/34065904/ae0385b2-c497-4759-b0f6-8dc12a31dcda">
To see the new-style API service dialog it's essential that you set the following property in `gateway-site.xml`:
```
    <property>
        <name>knox.homepage.api.services.view.version</name>
        <value>v2</value>
    </property>
```