### PR TITLE
KNOX-2979 - Removed redundant 'refresh' query parameter from the application logout link after originalUrl

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/app/logout.jsp
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/logout.jsp
@@ -90,17 +90,13 @@
 
         boolean validRedirect = false;
         String origUrl = request.getParameter("originalUrl");
-        String del = "?";
-        if (origUrl != null && origUrl.contains("?")) {
-          del = "&";
-        }
         if (origUrl != null) {
           validRedirect = RegExUtils.checkWhitelist(whitelist, origUrl);
         }
         if (("1".equals(request.getParameter("returnToApp")))) {
           if (validRedirect) {
-          	response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
-          	response.setHeader("Location",originalUrl + del + "refresh=1");
+            response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+            response.setHeader("Location", originalUrl);
             return;
           }
         }

--- a/knox-homepage-ui/home/app/homepage.service.ts
+++ b/knox-homepage-ui/home/app/homepage.service.ts
@@ -132,20 +132,6 @@ export class HomepageService {
     }
 
     private handleError(error: HttpErrorResponse): Promise<any> {
-        // location.reload();
-        let refresh;
-        this.route.queryParams.subscribe(params => {
-          refresh = params['refresh'];
-          console.debug('refresh = ' + refresh);
-          if (refresh) {
-            console.debug('Refreshing page...', window.location.href);
-            let url = window.location.pathname.replace(new RegExp('refresh=1/.*'), '?');
-            // var url = window.location.pathname;
-
-            // window.location.assign(url);
-            window.location.reload();
-          }
-        });
         Swal.fire({
             icon: 'error',
             title: 'Oops!',


### PR DESCRIPTION
## What changes were proposed in this pull request?

The redundant `refresh` query parameter is no longer added at the tail of the application logout link on Knox's logout page.

## How was this patch tested?

Manually tested with and without the `logoutProfile` and `logoutTopologies` session resource attributes.

<img width="1693" alt="Screenshot 2023-10-31 at 14 25 14" src="https://github.com/apache/knox/assets/34065904/283085df-5c2c-44c6-8a8e-b71c21e0f63c">
<img width="1658" alt="Screenshot 2023-10-31 at 14 25 23" src="https://github.com/apache/knox/assets/34065904/6e0ec23c-bde8-483d-a557-2566b6a8c732">
<img width="1770" alt="Screenshot 2023-10-31 at 14 25 44" src="https://github.com/apache/knox/assets/34065904/12ed1705-3b45-4db1-a84f-3b3100470a6b">

