### PR TITLE
KNOX-2980 - Applying word wrapping in various columns that can have 'long' content.

### DIFF
--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -59,7 +59,7 @@
 
             <ng-container matColumnDef="tokenId">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="tokenId" style="text-align: center; justify-content: center;">Token ID</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;" [style.font-weight]="getFontWeight(knoxToken)">
+                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center; word-wrap:break-word; word-break: break-word;" [style.font-weight]="getFontWeight(knoxToken)">
                   <div *ngIf="knoxToken.metadata.enabled">{{knoxToken.tokenId}}</div>
                   <div *ngIf="!knoxToken.metadata.enabled" style="color:orange">{{knoxToken.tokenId}}</div>
                 </mat-cell>
@@ -67,17 +67,17 @@
 
             <ng-container matColumnDef="issued">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="issueTime" style="text-align: center; justify-content: center;">Issued</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;" [style.font-weight]="getFontWeight(knoxToken)">{{formatDateTime(knoxToken.issueTimeLong)}}</mat-cell>
+                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center; word-wrap:break-word; word-break: break-word;" [style.font-weight]="getFontWeight(knoxToken)">{{formatDateTime(knoxToken.issueTimeLong)}}</mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="expires">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="expiration" style="text-align: center; justify-content: center;">Expires</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" [style.color]="getExpirationColor(knoxToken.expirationLong)" style="text-align: center; justify-content: center;" [style.font-weight]="getFontWeight(knoxToken)">{{formatDateTime(knoxToken.expirationLong)}}</mat-cell>
+                <mat-cell *matCellDef="let knoxToken" [style.color]="getExpirationColor(knoxToken.expirationLong)" style="text-align: center; justify-content: center; word-wrap:break-word; word-break: break-word;" [style.font-weight]="getFontWeight(knoxToken)">{{formatDateTime(knoxToken.expirationLong)}}</mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="userName">
                 <mat-header-cell *matHeaderCellDef mat-sort-header="userName" style="text-align: center; justify-content: center;">User Name</mat-header-cell>
-                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center;" [style.font-weight]="getFontWeight(knoxToken)">{{knoxToken.metadata.userName}}</mat-cell>
+                <mat-cell *matCellDef="let knoxToken" style="text-align: center; justify-content: center; word-wrap:break-word; word-break: break-word;" [style.font-weight]="getFontWeight(knoxToken)">{{knoxToken.metadata.userName}}</mat-cell>
             </ng-container>
 
             <ng-container matColumnDef="impersonated">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Applying word wrapping on the following columns in addition to metadata, comment:
- token id
- issued
- expires
- username

## How was this patch tested?

Manually tested by resizing my Chrome window:

<img width="1175" alt="Screenshot 2023-10-31 at 21 17 23" src="https://github.com/apache/knox/assets/34065904/e5b2e2d7-f39d-46f5-977d-bb91df333615">
<img width="1120" alt="Screenshot 2023-10-31 at 21 18 00" src="https://github.com/apache/knox/assets/34065904/10af6c4c-b0c9-4c1a-a8fb-5277c06f2b0d">
