### PR TITLE
KNOX-2985 - Introduced KNOXTOKEN API v2 and deprecated v1 methods

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -96,6 +96,15 @@ import org.apache.knox.gateway.util.Tokens;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 
+/**
+ * @deprecated The public REST API endpoints in this class (bound to
+ *             '/knoxtoken/v1/api/token/...') are no longer acceptable for
+ *             token-related operations. Please use the
+ *             '/knoxtoken/v2/api/token/...' path instead.
+ *
+ * @see TokenResourceV2
+ */
+@Deprecated
 @Singleton
 @Path(TokenResource.RESOURCE_PATH)
 public class TokenResource {
@@ -137,15 +146,15 @@ public class TokenResource {
   private static final long TOKEN_TTL_DEFAULT = 30000L;
   static final String TOKEN_API_PATH = "knoxtoken/api/v1";
   static final String RESOURCE_PATH = TOKEN_API_PATH + "/token";
-  static final String GET_USER_TOKENS = "/getUserTokens";
-  static final String GET_TSS_STATUS_PATH = "/getTssStatus";
-  static final String RENEW_PATH = "/renew";
-  static final String REVOKE_PATH = "/revoke";
-  static final String BATCH_REVOKE_PATH = "/revokeTokens";
-  static final String ENABLE_PATH = "/enable";
-  static final String BATCH_ENABLE_PATH = "/enableTokens";
-  static final String DISABLE_PATH = "/disable";
-  static final String BATCH_DISABLE_PATH = "/disableTokens";
+  protected static final String GET_USER_TOKENS = "/getUserTokens";
+  protected static final String GET_TSS_STATUS_PATH = "/getTssStatus";
+  protected static final String RENEW_PATH = "/renew";
+  protected static final String REVOKE_PATH = "/revoke";
+  protected static final String BATCH_REVOKE_PATH = "/revokeTokens";
+  protected static final String ENABLE_PATH = "/enable";
+  protected static final String BATCH_ENABLE_PATH = "/enableTokens";
+  protected static final String DISABLE_PATH = "/disable";
+  protected static final String BATCH_DISABLE_PATH = "/disableTokens";
   private static final String TARGET_ENDPOINT_PULIC_CERT_PEM = TOKEN_PARAM_PREFIX + "target.endpoint.cert.pem";
   static final String QUERY_PARAMETER_DOAS = "doAs";
   private static final String IMPERSONATION_ENABLED_TEXT = "impersonationEnabled";
@@ -501,9 +510,15 @@ public class TokenResource {
     return Response.status(Response.Status.OK).entity(JsonUtils.renderAsJsonString(tokenStateServiceStatusMap)).build();
   }
 
-  @PUT
+  /**
+   * @deprecated This method is no longer acceptable for token renewal. Please
+   *             use the '/knoxtoken/v2/api/token/renew' path; instead which is a
+   *             PUT HTTP request.
+   */
+  @POST
   @Path(RENEW_PATH)
   @Produces({APPLICATION_JSON})
+  @Deprecated
   public Response renew(String token) {
     Response resp;
 
@@ -586,9 +601,15 @@ public class TokenResource {
     return error == null ? response : error;
   }
 
-  @DELETE
+  /**
+   * @deprecated This method is no longer acceptable for token revocation. Please
+   *             use the '/knoxtoken/v2/api/token/revoke' path; instead which is a
+   *             DELETE HTTP request.
+   */
+  @POST
   @Path(REVOKE_PATH)
   @Produces({APPLICATION_JSON})
+  @Deprecated
   public Response revoke(String token) {
     Response resp;
 

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResourceV2.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResourceV2.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+
+import javax.inject.Singleton;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * V2 of the public KNOXTOKEN API with the following changes:
+ * <ul>
+ * <li><code>renew</code> is now a <code>PUT</code> request (in V1 it was
+ * <code>POST</code>)</li>
+ * <li><code>revoke</code> is now a <code>DELETE</code> request (in V1, it was a
+ * <code>POST</code>)</li>
+ * </ul>
+ *
+ */
+@Singleton
+@Path(TokenResourceV2.RESOURCE_PATH)
+public class TokenResourceV2 extends TokenResource {
+
+  static final String RESOURCE_PATH = "knoxtoken/api/v2/token";
+
+  // REST endpoints with the same HTTP method
+
+  @Override
+  @GET
+  @Produces({ APPLICATION_JSON, APPLICATION_XML })
+  public Response doGet() {
+    return super.doGet();
+  }
+
+  @Override
+  @POST
+  @Produces({ APPLICATION_JSON, APPLICATION_XML })
+  public Response doPost() {
+    return super.doPost();
+  }
+
+  @Override
+  @GET
+  @Path(GET_TSS_STATUS_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response getTokenStateServiceStatus() {
+    return super.getTokenStateServiceStatus();
+  }
+
+  @Override
+  @GET
+  @Path(GET_USER_TOKENS)
+  @Produces({ APPLICATION_JSON, APPLICATION_XML })
+  public Response getUserTokens(@Context UriInfo uriInfo) {
+    return super.getUserTokens(uriInfo);
+  }
+
+  @Override
+  @DELETE
+  @Path(BATCH_REVOKE_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response revokeTokens(String tokenIds) {
+    return super.revokeTokens(tokenIds);
+  }
+
+  @Override
+  @PUT
+  @Path(ENABLE_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response enable(String tokenId) {
+    return super.enable(tokenId);
+  }
+
+  @Override
+  @PUT
+  @Path(BATCH_ENABLE_PATH)
+  @Consumes({ APPLICATION_JSON })
+  @Produces({ APPLICATION_JSON })
+  public Response enableTokens(String tokenIds) {
+    return super.enableTokens(tokenIds);
+  }
+
+  @Override
+  @PUT
+  @Path(DISABLE_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response disable(String tokenId) {
+    return super.disable(tokenId);
+  }
+
+  @Override
+  @PUT
+  @Path(BATCH_DISABLE_PATH)
+  @Consumes({ APPLICATION_JSON })
+  @Produces({ APPLICATION_JSON })
+  public Response disableTokens(String tokenIds) {
+    return super.disableTokens(tokenIds);
+  }
+
+  // REST endpoints where the HTTP method changed
+
+  @Override
+  @SuppressWarnings("deprecation")
+  @PUT
+  @Path(RENEW_PATH)
+  public Response renew(String token) {
+    return super.renew(token);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  @DELETE
+  @Path(REVOKE_PATH)
+  @Produces({ APPLICATION_JSON })
+  public Response revoke(String token) {
+    return super.revoke(token);
+  }
+
+}

--- a/knox-token-generation-ui/token-generation/app/token-generation.service.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.service.ts
@@ -26,8 +26,8 @@ export class TokenGenService {
     readonly tssStatusRequestURL: string;
 
     constructor(private http: HttpClient) {
-        const knoxtokenURL = 'knoxtoken/api/v1/token';
-        const tssStatusURL = 'knoxtoken/api/v1/token/getTssStatus';
+        const knoxtokenURL = 'knoxtoken/api/v2/token';
+        const tssStatusURL = 'knoxtoken/api/v2/token/getTssStatus';
 
         let pathParts = window.location.pathname.split('/');
         let topologyContext = '/' + pathParts[1] + '/' + pathParts[2] + '/';

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -28,7 +28,7 @@ export class TokenManagementService {
     pathParts = window.location.pathname.split('/');
     topologyContext = '/' + this.pathParts[1] + '/' + this.pathParts[2] + '/';
     sessionUrl = this.topologyContext + 'session/api/v1/sessioninfo';
-    apiUrl = this.topologyContext + 'knoxtoken/api/v1/token/';
+    apiUrl = this.topologyContext + 'knoxtoken/api/v2/token/';
     getKnoxTokensUrl = this.apiUrl + 'getUserTokens?userNameOrCreatedBy=';
     getAllKnoxTokensUrl = this.apiUrl + 'getUserTokens?allTokens=true';
     enableKnoxTokenUrl = this.apiUrl + 'enable';


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two major changes:
- introduced v2 in the KNOXTOKEN service REST API enpoints
- deprecated `renew` and `revoke` in v1

## How was this patch tested?

Manually tested the Token Generation and Token Management UIs (create, enable/disable, revoke tokens) and confirmed that `renew` and `revoke` work with different HTTP methods using different versions:

```
$ curl -iku admin:admin-password -d $JWT -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/renew
HTTP/1.1 200 OK
Date: Thu, 09 Nov 2023 10:31:46 GMT
Set-Cookie: KNOXSESSIONID=node0f1emmld2e9jl1tpkwa87qmn800.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 08-Nov-2023 10:31:46 GMT; SameSite=lax
Content-Type: application/json
Content-Length: 54

{
  "renewed": "true",
  "expires": "1699612307203"
}


$ curl -iku admin:admin-password -d $JWT -X PUT https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/renew
HTTP/1.1 200 OK
Date: Thu, 09 Nov 2023 10:32:14 GMT
Set-Cookie: KNOXSESSIONID=node0m4890e208yz6u8kyw358gajq2.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 08-Nov-2023 10:32:14 GMT; SameSite=lax
Content-Type: text/plain
Content-Length: 54

{
  "renewed": "true",
  "expires": "1699612334777"
}
```

```
$ curl -iku admin:admin-password -d '550c6963-24d8-43fb-94af-2dac7d4abaad' -X POST https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token/revoke
HTTP/1.1 200 OK
Date: Thu, 09 Nov 2023 10:35:33 GMT
Set-Cookie: KNOXSESSIONID=node0an2jchc2tjph1eet774usk5hr3.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 08-Nov-2023 10:35:33 GMT; SameSite=lax
Content-Type: application/json
Content-Length: 24

{
  "revoked": "true"
}

$  curl -iku admin:admin-password -d '1dc60396-9dea-4ff8-887f-521e08801555' -X DELETE https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/revoke
HTTP/1.1 200 OK
Date: Thu, 09 Nov 2023 10:36:21 GMT
Set-Cookie: KNOXSESSIONID=node01pez8nde6mmbq1g433vhta029x4.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 08-Nov-2023 10:36:21 GMT; SameSite=lax
Content-Type: application/json
Content-Length: 24

{
  "revoked": "true"
}
```