### PR TITLE
KNOX-2929 - Logged in user is shown on Knox UIs

### DIFF
--- a/gateway-admin-ui/admin-ui/app/app.module.ts
+++ b/gateway-admin-ui/admin-ui/app/app.module.ts
@@ -47,6 +47,7 @@ import {ResourceDetailComponent} from './resource-detail/resource-detail.compone
 import {ProviderConfigSelectorComponent} from './provider-config-selector/provider-config-selector.component';
 import {NewDescWizardComponent} from './new-desc-wizard/new-desc-wizard.component';
 import {ProviderConfigWizardComponent} from './provider-config-wizard/provider-config-wizard.component';
+import {SessionInformationComponent} from './sessionInformation/session.information.component';
 
 @NgModule({
     imports: [BrowserModule,
@@ -74,7 +75,8 @@ import {ProviderConfigWizardComponent} from './provider-config-wizard/provider-c
         ResourceDetailComponent,
         ProviderConfigSelectorComponent,
         NewDescWizardComponent,
-        ProviderConfigWizardComponent
+        ProviderConfigWizardComponent,
+        SessionInformationComponent
     ],
     providers: [TopologyService,
         ServiceDefinitionService,
@@ -85,7 +87,8 @@ import {ProviderConfigWizardComponent} from './provider-config-wizard/provider-c
         {provide: APP_BASE_HREF, useValue: '/'}
     ],
     bootstrap: [AppComponent,
-        GatewayVersionComponent
+        GatewayVersionComponent,
+        SessionInformationComponent
     ]
 })
 export class AppModule {

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.html
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.html
@@ -1,0 +1,15 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<div style="text-align: right; color: rgb(130, 180, 93);">Logged in as {{ getUser() }}</div>

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.ts
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {SessionInformationService} from './session.information.service';
+import {SessionInformation} from './session.information';
+
+@Component({
+    selector: 'app-session-information',
+    templateUrl: './session.information.component.html',
+    providers: [SessionInformationService]
+})
+
+export class SessionInformationComponent implements OnInit {
+
+    sessionInformation: SessionInformation;
+    logoutSupported = true;
+
+    constructor(private sessionInformationService: SessionInformationService) {
+        this['showSessionInformation'] = true;
+    }
+
+    getUser() {
+        if (this.sessionInformation) {
+          return this.sessionInformation.user;
+        } else {
+            console.debug('SessionInformationComponent --> getUser() --> dr.who');
+            return 'dr.who';
+        }
+    }
+
+    ngOnInit(): void {
+        console.debug('SessionInformationComponent --> ngOnInit() --> ');
+        this.sessionInformationService.getSessionInformation()
+            .then(sessionInformation => this.setSessonInformation(sessionInformation));
+    }
+
+    setSessonInformation(sessionInformation: SessionInformation) {
+        this.sessionInformation = sessionInformation;
+        console.debug('SessionInformationComponent --> setSessonInformation() --> ' + this.sessionInformation.user);
+    }
+}

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.service.ts
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.service.ts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import Swal from 'sweetalert2';
+
+import 'rxjs/add/operator/toPromise';
+import {SessionInformation} from './session.information';
+
+@Injectable()
+export class SessionInformationService {
+    pathParts = window.location.pathname.split('/');
+    topologyContext = '/' + this.pathParts[1] + '/' + this.pathParts[2] + '/';
+    sessionUrl = this.topologyContext + 'session/api/v1/sessioninfo';
+
+    constructor(private http: HttpClient) {}
+
+    getSessionInformation(): Promise<SessionInformation> {
+        let headers = new HttpHeaders();
+        headers = this.addJsonHeaders(headers);
+        return this.http.get(this.sessionUrl, { headers: headers})
+            .toPromise()
+            .then(response => response['sessioninfo'] as SessionInformation)
+            .catch((err: HttpErrorResponse) => {
+                console.debug('HomepageService --> getSessionInformation() --> ' + this.sessionUrl + '\n  error: ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    addJsonHeaders(headers: HttpHeaders): HttpHeaders {
+        return this.addCsrfHeaders(headers.append('Accept', 'application/json').append('Content-Type', 'application/json'));
+    }
+
+    addCsrfHeaders(headers: HttpHeaders): HttpHeaders {
+        return this.addXHRHeaders(headers.append('X-XSRF-Header', 'homepage'));
+    }
+
+    addXHRHeaders(headers: HttpHeaders): HttpHeaders {
+        return headers.append('X-Requested-With', 'XMLHttpRequest');
+    }
+
+    private handleError(error: HttpErrorResponse): Promise<any> {
+        Swal.fire({
+            icon: 'error',
+            title: 'Oops!',
+            text: 'Something went wrong!\n' + (error.error ? error.error : error.statusText),
+            confirmButtonColor: '#7cd1f9'
+        });
+        return Promise.reject(error.message || error);
+    }
+}

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.ts
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.ts
@@ -14,22 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { HttpClientModule } from '@angular/common/http';
-import { TokenGenerationComponent } from './token-generation.component';
-import { ReactiveFormsModule } from '@angular/forms';
-import { TokenGenService } from './token-generation.service';
-import { SessionInformationComponent } from './session.information.component';
 
-@NgModule({
-    imports: [BrowserModule,
-        HttpClientModule,
-        ReactiveFormsModule
-    ],
-    declarations: [TokenGenerationComponent, SessionInformationComponent],
-    providers: [TokenGenService],
-    bootstrap: [TokenGenerationComponent, SessionInformationComponent]
-})
-export class AppModule {
+export class SessionInformation {
+    user: string;
+    logoutUrl: string;
+    logoutPageUrl: string;
+    globalLgoutPageUrl: string;
 }

--- a/gateway-admin-ui/admin-ui/index.html
+++ b/gateway-admin-ui/admin-ui/index.html
@@ -42,6 +42,7 @@
                             style="max-width:200px; margin-top: -9px;"
                             src="assets/knox-logo-transparent.gif" alt="Apache Knox Manager"> </a>
                 </div>
+                <app-session-information></app-session-information>
             </div>
         </nav>
 

--- a/knox-token-generation-ui/token-generation/app/session.information.component.html
+++ b/knox-token-generation-ui/token-generation/app/session.information.component.html
@@ -1,0 +1,16 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The text color is the same as the Cloudera logo's color -->
+<div style="text-align: right; color: rgb(130, 180, 93);">Logged in as {{ getUser() }}</div>

--- a/knox-token-generation-ui/token-generation/app/session.information.component.ts
+++ b/knox-token-generation-ui/token-generation/app/session.information.component.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {TokenGenService} from './token-generation.service';
+import {SessionInformation} from './token-generation.models';
+
+@Component({
+    selector: 'app-session-information',
+    templateUrl: './session.information.component.html',
+    providers: [TokenGenService]
+})
+
+export class SessionInformationComponent implements OnInit {
+
+    sessionInformation: SessionInformation;
+    logoutSupported = true;
+
+    constructor(private tokenGenerationService: TokenGenService) {
+        this['showSessionInformation'] = true;
+    }
+
+    getUser() {
+        if (this.sessionInformation) {
+          return this.sessionInformation.user;
+        } else {
+          console.debug('SessionInformationComponent --> getUser() --> dr.who');
+          return 'dr.who';
+        }
+    }
+
+    ngOnInit(): void {
+        console.debug('SessionInformationComponent --> ngOnInit() --> ');
+        this.tokenGenerationService.getSessionInformation()
+            .then(sessionInformation => this.setSessionInformation(sessionInformation));
+    }
+
+    private setSessionInformation(sessionInformation: SessionInformation) {
+	    this.sessionInformation = sessionInformation;
+        console.debug('SessionInformationComponent --> setSessionInformation() --> ' + this.sessionInformation.user);
+    }
+
+}

--- a/knox-token-generation-ui/token-generation/app/token-generation.models.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.models.ts
@@ -50,3 +50,12 @@ export interface TokenData {
     lifespanHours: number;
     lifespanMins: number;
  }
+
+export class SessionInformation {
+    user: string;
+    logoutUrl: string;
+    logoutPageUrl: string;
+    globalLgoutPageUrl: string;
+    canSeeAllTokens: boolean;
+    currentKnoxSsoCookieTokenId: string;
+}

--- a/knox-token-generation-ui/token-generation/index.html
+++ b/knox-token-generation-ui/token-generation/index.html
@@ -27,6 +27,12 @@
 	</script>
 </head>
 <body class="login">
+    <div style="background: #222; padding-right: 15px; padding-left: 15px; margin-right: 1.75%; margin-left: 1.75%; position: relative; min-height: 110px; font-size:14px;">
+        <app-session-information></app-session-information>
+        <a class="navbar-brand" href="#"> <img style="max-width:200px;" src="assets/knox-logo-transparent.gif" alt="Apache Knox Home"></a>
+    </div>
+
     <app-token-generation></app-token-generation>
+</div>
 </body>
 </html>

--- a/knox-token-management-ui/token-management/app/app.module.ts
+++ b/knox-token-management-ui/token-management/app/app.module.ts
@@ -32,6 +32,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import {TokenManagementComponent} from './token.management.component';
 import {TokenManagementService} from './token.management.service';
+import {SessionInformationComponent} from './session.information.component';
 
 @NgModule({
     imports: [BrowserModule,
@@ -52,9 +53,9 @@ import {TokenManagementService} from './token.management.service';
         MatSlideToggleModule,
         MatCheckboxModule
     ],
-    declarations: [TokenManagementComponent],
+    declarations: [TokenManagementComponent, SessionInformationComponent],
     providers: [TokenManagementService],
-    bootstrap: [TokenManagementComponent]
+    bootstrap: [TokenManagementComponent, SessionInformationComponent]
 })
 export class AppModule {
 }

--- a/knox-token-management-ui/token-management/app/session.information.component.html
+++ b/knox-token-management-ui/token-management/app/session.information.component.html
@@ -1,0 +1,16 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The text color is the same as the Cloudera logo's color -->
+<div style="text-align: right; color: rgb(130, 180, 93);">Logged in as {{ getUser() }}</div>

--- a/knox-token-management-ui/token-management/app/session.information.component.ts
+++ b/knox-token-management-ui/token-management/app/session.information.component.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {TokenManagementService} from './token.management.service';
+import {SessionInformation} from './session.information';
+
+@Component({
+    selector: 'app-session-information',
+    templateUrl: './session.information.component.html',
+    providers: [TokenManagementService]
+})
+
+export class SessionInformationComponent implements OnInit {
+
+    sessionInformation: SessionInformation;
+    logoutSupported = true;
+
+    constructor(private tokenManagementService: TokenManagementService) {
+        this['showSessionInformation'] = true;
+    }
+
+    getUser() {
+        if (this.sessionInformation) {
+          return this.sessionInformation.user;
+        } else {
+          console.debug('SessionInformationComponent --> getUser() --> dr.who');
+          return 'dr.who';
+        }
+    }
+
+    ngOnInit(): void {
+        console.debug('SessionInformationComponent --> ngOnInit() --> ');
+        this.tokenManagementService.getSessionInformation()
+            .then(sessionInformation => this.setSessionInformation(sessionInformation));
+    }
+
+    private setSessionInformation(sessionInformation: SessionInformation) {
+	    this.sessionInformation = sessionInformation;
+        console.debug('SessionInformationComponent --> setSessionInformation() --> ' + this.sessionInformation.user);
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added information about the logged-in user on Knox UIs just like we had on the Knox Home page.

## How was this patch tested?

Manually tested:

<img width="1779" alt="Screenshot 2023-11-16 at 14 08 46" src="https://github.com/apache/knox/assets/34065904/e006de7b-d0d4-4181-8e0a-06f9c8b2d87b">
<img width="1785" alt="Screenshot 2023-11-16 at 14 09 01" src="https://github.com/apache/knox/assets/34065904/8cd23792-b0e2-4fc7-89b9-e18f0d5f29ad">
<img width="1759" alt="Screenshot 2023-11-16 at 14 09 11" src="https://github.com/apache/knox/assets/34065904/7663efff-d35e-4c0c-bec0-b4d7d144129e">