### PR TITLE
KNOX-2989 - Multi arch support for Knox images

### DIFF
--- a/gateway-docker/pom.xml
+++ b/gateway-docker/pom.xml
@@ -34,6 +34,11 @@
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-release</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.43.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -59,7 +64,12 @@
         </plugins>
     </build>
     <profiles>
-        <!-- Profile for building official Docker images. Not bound to build phases since that would require anyone build to have the Docker engine installed on their machine -->
+        <!--
+        Profile for building official Docker images.
+        Not bound to build phases since that would require anyone build to have the
+        Docker engine installed on their machine.
+        Builds multi arch docker images, based on ${docker.platforms} property see: https://dmp.fabric8.io/#docker:build
+         -->
         <profile>
             <id>docker</id>
             <build>
@@ -89,47 +99,53 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>com.spotify</groupId>
-                        <artifactId>dockerfile-maven-plugin</artifactId>
-                        <version>${dockerfile-maven-plugin.version}</version>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <version>${docker-maven-plugin.version}</version>
                         <configuration>
-                            <contextDirectory>${project.build.outputDirectory}/docker</contextDirectory>
-                            <buildArgs>
-                                <RELEASE_FILE>knox-${project.version}.zip</RELEASE_FILE>
-                            </buildArgs>
+                            <images>
+                                <image>
+                                    <alias>knox-gateway-buildx</alias>
+                                    <name>knox-gateway:${project.version}</name>
+
+                                    <build>
+                                        <contextDir>${project.build.outputDirectory}/docker</contextDir>
+                                        <args>
+                                            <RELEASE_FILE>knox-${project.version}.zip</RELEASE_FILE>
+                                            <ENTRYPOINT>gateway-entrypoint.sh</ENTRYPOINT>
+                                            <EXPOSE_PORT>8443</EXPOSE_PORT>
+                                        </args>
+                                        <entryPoint>gateway-entrypoint.sh</entryPoint>
+                                        <buildx>
+                                            <platforms>
+                                                <platform>${docker.platforms}</platform>
+                                            </platforms>
+                                        </buildx>
+                                    </build>
+                                </image>
+
+                                <image>
+                                    <alias>knox-demo-ldap-buildx</alias>
+                                    <name>knox-demo-ldap:${project.version}</name>
+                                    <build>
+                                        <contextDir>${project.build.outputDirectory}/docker</contextDir>
+                                        <args>
+                                            <RELEASE_FILE>knox-${project.version}.zip</RELEASE_FILE>
+                                            <ENTRYPOINT>ldap-entrypoint.sh</ENTRYPOINT>
+                                            <EXPOSE_PORT>33389</EXPOSE_PORT>
+                                        </args>
+                                        <entryPoint>ldap-entrypoint.sh</entryPoint>
+                                    </build>
+                                </image>
+                            </images>
                         </configuration>
                         <executions>
                             <execution>
-                                <id>gateway</id>
-                                <phase>package</phase>
+                                <id>default</id>
                                 <goals>
                                     <goal>build</goal>
-                                    <goal>tag</goal>
                                 </goals>
-                                <configuration>
-                                    <repository>apache/knox-gateway</repository>
-                                    <tag>${project.version}</tag>
-                                    <buildArgs>
-                                        <ENTRYPOINT>gateway-entrypoint.sh</ENTRYPOINT>
-                                        <EXPOSE_PORT>8443</EXPOSE_PORT>
-                                    </buildArgs>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>ldap</id>
                                 <phase>package</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                    <goal>tag</goal>
-                                </goals>
-                                <configuration>
-                                    <repository>apache/knox-demo-ldap</repository>
-                                    <tag>${project.version}</tag>
-                                    <buildArgs>
-                                        <ENTRYPOINT>ldap-entrypoint.sh</ENTRYPOINT>
-                                        <EXPOSE_PORT>33389</EXPOSE_PORT>
-                                    </buildArgs>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,8 @@
         <xml-jaxb.version>2.3.0</xml-jaxb.version>
         <xml-matchers.version>0.10</xml-matchers.version>
         <zookeeper.version>3.8.1</zookeeper.version>
+        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR:
1. Adds multi arch support for Knox images
2. Moves away from the currently used plugin that is not maintained and updates Knox docker plugin to https://github.com/fabric8io/docker-maven-plugin which is actively maintained and is feature rich.

Nothing changes as far are building process goes. What changes is now we have an ability to push multi-arch docker images to a remote repo

```
mvn -Ddocker.push.registry=my.docker.io/smore -U clean verify install -Prelease,package,docker  docker:push
``` 
For more details on configuration options see https://dmp.fabric8.io/#docker:push

## How was this patch tested?
This patch was tested locally. 


