### PR TITLE
KNOX-2990 - Using DerbyDatabaseTSS instead of AliasBasedTSS by default

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -216,6 +216,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
         </dependency>
@@ -467,19 +471,16 @@
         <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-shell</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbynet</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -280,8 +280,14 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   /* property that specifies list of services for which we need to append service name to the X-Forward-Context header */
   public static final String X_FORWARD_CONTEXT_HEADER_APPEND_SERVICES = GATEWAY_CONFIG_FILE_PREFIX + ".xforwarded.header.context.append.servicename";
 
-  private static final String TOKEN_STATE_SERVER_MANAGED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.exp.server-managed";
-  private static final String USERS_CAN_SEE_ALL_TOKENS = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.management.users.can.see.all.tokens";
+  private static final String KNOX_TOKEN_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token";
+  private static final String TOKEN_STATE_SERVER_MANAGED = KNOX_TOKEN_PREFIX + ".exp.server-managed";
+  private static final String USERS_CAN_SEE_ALL_TOKENS = KNOX_TOKEN_PREFIX + ".management.users.can.see.all.tokens";
+  private static final String SKIP_TOKEN_MIGRATION= KNOX_TOKEN_PREFIX + ".migration.skip";
+  private static final String ARCHIVE_MIGRATED_TOKENS= KNOX_TOKEN_PREFIX + ".migration.archive.tokens";
+  private static final String MIGRATE_EXPIRED_TOKENS= KNOX_TOKEN_PREFIX + ".migration.include.expired.tokens";
+  private static final String TOKEN_MIGRATION_PRINTS_VERBOSE_MESSAGES= KNOX_TOKEN_PREFIX + ".migration.verbose";
+  private static final String TOKEN_MIGRATION_PROGRESS_COUNT= KNOX_TOKEN_PREFIX + ".migration.progress.count";
 
   private static final String CLOUDERA_MANAGER_DESCRIPTORS_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.descriptors.monitor.interval";
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
@@ -295,12 +301,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 10000;
   private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT = 10000;
 
-  private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
-  private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
-  private static final String KNOX_TOKEN_ALIAS_PERSISTENCE_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.state.alias.persistence.interval";
-  private static final String KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.permissive.validation";
-  private static final String KNOX_TOKEN_HASH_ALGORITHM = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.hash.algorithm";
-  public static final String KNOX_TOKEN_USER_LIMIT = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.limit.per.user";
+  private static final String KNOX_TOKEN_EVICTION_INTERVAL = KNOX_TOKEN_PREFIX + ".eviction.interval";
+  private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = KNOX_TOKEN_PREFIX + ".eviction.grace.period";
+  private static final String KNOX_TOKEN_ALIAS_PERSISTENCE_INTERVAL = KNOX_TOKEN_PREFIX + ".state.alias.persistence.interval";
+  private static final String KNOX_TOKEN_PERMISSIVE_VALIDATION_ENABLED = KNOX_TOKEN_PREFIX + ".permissive.validation";
+  private static final String KNOX_TOKEN_HASH_ALGORITHM = KNOX_TOKEN_PREFIX + ".hash.algorithm";
+  public static final String KNOX_TOKEN_USER_LIMIT = KNOX_TOKEN_PREFIX + ".limit.per.user";
   private static final long KNOX_TOKEN_EVICTION_INTERVAL_DEFAULT = TimeUnit.MINUTES.toSeconds(5);
   private static final long KNOX_TOKEN_EVICTION_GRACE_PERIOD_DEFAULT = TimeUnit.HOURS.toSeconds(24);
   private static final long KNOX_TOKEN_ALIAS_PERSISTENCE_INTERVAL_DEFAULT = TimeUnit.SECONDS.toSeconds(15);
@@ -318,11 +324,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String KNOX_INCOMING_XFORWARDED_ENABLED = "gateway.incoming.xforwarded.enabled";
 
   //Gateway Database related properties
-  private static final String GATEWAY_DATABASE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".database.type";
-  private static final String GATEWAY_DATABASE_CONN_URL = GATEWAY_CONFIG_FILE_PREFIX + ".database.connection.url";
-  private static final String GATEWAY_DATABASE_HOST =  GATEWAY_CONFIG_FILE_PREFIX + ".database.host";
-  private static final String GATEWAY_DATABASE_PORT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.port";
-  private static final String GATEWAY_DATABASE_NAME =  GATEWAY_CONFIG_FILE_PREFIX + ".database.name";
+  public static final String GATEWAY_DATABASE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".database.type";
+  public static final String GATEWAY_DATABASE_CONN_URL = GATEWAY_CONFIG_FILE_PREFIX + ".database.connection.url";
+  public static final String GATEWAY_DATABASE_HOST =  GATEWAY_CONFIG_FILE_PREFIX + ".database.host";
+  public static final String GATEWAY_DATABASE_PORT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.port";
+  public static final String GATEWAY_DATABASE_NAME =  GATEWAY_CONFIG_FILE_PREFIX + ".database.name";
   private static final String GATEWAY_DATABASE_SSL_ENABLED =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.enabled";
   private static final String GATEWAY_DATABASE_VERIFY_SERVER_CERT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.verify.server.cert";
   private static final String GATEWAY_DATABASE_TRUSTSTORE_FILE =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.truststore.file";
@@ -1532,6 +1538,31 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
       }
     });
     return pathAliases;
+  }
+
+  @Override
+  public boolean skipTokenMigration() {
+    return getBoolean(SKIP_TOKEN_MIGRATION, false);
+  }
+
+  @Override
+  public boolean archiveMigratedTokens() {
+    return getBoolean(ARCHIVE_MIGRATED_TOKENS, false);
+  }
+
+  @Override
+  public boolean migrateExpiredTokens() {
+    return getBoolean(MIGRATE_EXPIRED_TOKENS, false);
+  }
+
+  @Override
+  public boolean printVerboseTokenMigrationMessages() {
+    return getBoolean(TOKEN_MIGRATION_PRINTS_VERBOSE_MESSAGES, true);
+  }
+
+  @Override
+  public int getTokenMigrationProgressCount() {
+    return getInt(TOKEN_MIGRATION_PROGRESS_COUNT, 10);
   }
 
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/CLIGatewayServices.java
@@ -53,6 +53,8 @@ public class CLIGatewayServices extends AbstractGatewayServices {
     addService(ServiceType.CRYPTO_SERVICE, gatewayServiceFactory.create(this, ServiceType.CRYPTO_SERVICE, config, options));
 
     addService(ServiceType.TOPOLOGY_SERVICE, gatewayServiceFactory.create(this, ServiceType.TOPOLOGY_SERVICE, config, options));
+
+    addService(ServiceType.TOKEN_STATE_SERVICE, gatewayServiceFactory.create(this, ServiceType.TOKEN_STATE_SERVICE, config, options));
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/AliasBasedTokenStateService.java
@@ -52,13 +52,15 @@ import org.apache.knox.gateway.util.Tokens;
 
 /**
  * A TokenStateService implementation based on the AliasService.
+ *
+ * @deprecated Since 2.1.0
  */
 public class AliasBasedTokenStateService extends AbstractPersistentTokenStateService implements TokenStatePeristerMonitorListener {
 
   static final String TOKEN_ALIAS_SUFFIX_DELIM   = "--";
-  static final String TOKEN_ISSUE_TIME_POSTFIX   = TOKEN_ALIAS_SUFFIX_DELIM + "iss";
-  static final String TOKEN_MAX_LIFETIME_POSTFIX = TOKEN_ALIAS_SUFFIX_DELIM + "max";
-  static final String TOKEN_META_POSTFIX         = TOKEN_ALIAS_SUFFIX_DELIM + "meta";
+  public static final String TOKEN_ISSUE_TIME_POSTFIX   = TOKEN_ALIAS_SUFFIX_DELIM + "iss";
+  public static final String TOKEN_MAX_LIFETIME_POSTFIX = TOKEN_ALIAS_SUFFIX_DELIM + "max";
+  public static final String TOKEN_META_POSTFIX         = TOKEN_ALIAS_SUFFIX_DELIM + "meta";
 
   protected AliasService aliasService;
 
@@ -80,6 +82,7 @@ public class AliasBasedTokenStateService extends AbstractPersistentTokenStateSer
 
   @Override
   public void init(final GatewayConfig config, final Map<String, String> options) throws ServiceLifecycleException {
+    log.deprecatedServiceUsage(this.getClass().getCanonicalName());
     super.init(config, options);
     if (aliasService == null) {
       throw new ServiceLifecycleException("The required AliasService reference has not been set.");

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -457,4 +457,5 @@ public class DefaultTokenStateService implements TokenStateService {
     });
     return tokens;
   }
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DerbyDBTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DerbyDBTokenStateService.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.GATEWAY_DATABASE_NAME;
+import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.GATEWAY_DATABASE_TYPE;
+import static org.apache.knox.gateway.services.security.AliasService.NO_CLUSTER_NAME;
+import static org.apache.knox.gateway.util.JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME;
+import static org.apache.knox.gateway.util.JDBCUtils.DATABASE_USER_ALIAS_NAME;
+import static org.apache.knox.gateway.util.JDBCUtils.DERBY_DB_TYPE;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.shell.jdbc.derby.DerbyDatabase;
+import org.apache.knox.gateway.util.FileUtils;
+
+public class DerbyDBTokenStateService extends JDBCTokenStateService {
+
+  public static final String DEFAULT_TOKEN_DB_USER_NAME = "knox";
+  public static final String DB_NAME = "tokens";
+
+  private DerbyDatabase derbyDatabase;
+  private Path derbyDatabaseFolder;
+  private MasterService masterService;
+
+  public void setMasterService(MasterService masterService) {
+    this.masterService = masterService;
+  }
+
+  @Override
+  public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+    try {
+      derbyDatabaseFolder = Paths.get(config.getGatewaySecurityDir(), DB_NAME);
+      startDerby();
+      ((Configuration) config).set(GATEWAY_DATABASE_TYPE, DERBY_DB_TYPE);
+      ((Configuration) config).set(GATEWAY_DATABASE_NAME, derbyDatabaseFolder.toString());
+      getAliasService().addAliasForCluster(NO_CLUSTER_NAME, DATABASE_USER_ALIAS_NAME, getDatabaseUserName());
+      getAliasService().addAliasForCluster(NO_CLUSTER_NAME, DATABASE_PASSWORD_ALIAS_NAME, getDatabasePassword());
+      super.init(config, options);
+
+      // we need the "x" permission too to be able to browse that folder (600 is not enough)
+      if (Files.exists(derbyDatabaseFolder)) {
+        FileUtils.chmod("700", derbyDatabaseFolder.toFile());
+      }
+    } catch (Exception e) {
+      throw new ServiceLifecycleException("Error while initiating DerbyDBTokenStateService: " + e, e);
+    }
+  }
+
+  private void startDerby() throws Exception {
+    derbyDatabase = new DerbyDatabase(derbyDatabaseFolder.toString());
+    derbyDatabase.create();
+    TimeUnit.SECONDS.sleep(1); // give a bit of time for the server to start
+  }
+
+  private String getDatabasePassword() throws Exception {
+    final char[] dbPasswordAliasValue = getAliasService().getPasswordFromAliasForGateway(DATABASE_PASSWORD_ALIAS_NAME);
+    return dbPasswordAliasValue != null ? new String(dbPasswordAliasValue) : new String(masterService.getMasterSecret());
+  }
+
+  private String getDatabaseUserName() throws Exception {
+    final char[] dbUserAliasValue = getAliasService().getPasswordFromAliasForGateway(DATABASE_USER_ALIAS_NAME);
+    return dbUserAliasValue != null ? new String(dbUserAliasValue) : DEFAULT_TOKEN_DB_USER_NAME;
+  }
+
+  @Override
+  public void stop() throws ServiceLifecycleException {
+    try {
+      if (derbyDatabase != null) {
+        derbyDatabase.shutdown();
+      }
+    } catch (Exception e) {
+      throw new ServiceLifecycleException("Error while shutting down Derby Database", e);
+    }
+  }
+
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JournalBasedTokenStateService.java
@@ -32,12 +32,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * @deprecated Since 2.1.0
+ */
 public class JournalBasedTokenStateService extends AbstractPersistentTokenStateService {
 
     private TokenStateJournal journal;
 
     @Override
     public void init(final GatewayConfig config, final Map<String, String> options) throws ServiceLifecycleException {
+        log.deprecatedServiceUsage(this.getClass().getCanonicalName());
         super.init(config, options);
 
         try {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateServiceMessages.java
@@ -261,4 +261,14 @@ public interface TokenStateServiceMessages {
 
   @Message(level = MessageLevel.ERROR, text = "An error occurred while fetching impersonation tokens for user {0} from the database : {1}")
   void errorFetchingDoAsTokensForUserFromDatabase(String userName, String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.WARN, text = "The configured TokenStateService implementation, {0}, is deprecated!")
+  void deprecatedServiceUsage(String className);
+
+  @Message(level = MessageLevel.INFO, text = "Skipping token migration!")
+  void skipTokenMigration();
+
+  @Message(level = MessageLevel.INFO, text = "{0}")
+  void info(String message);
+
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/ZookeeperTokenStateService.java
@@ -38,6 +38,8 @@ import org.apache.knox.gateway.util.Tokens;
  * A Zookeeper Token State Service is actually an Alias based TSS where the 'alias service' happens to be the 'zookeeper' implementation.
  * This means the only important thing that should be overridden here is the init method where the underlying alias service is configured
  * properly.
+ *
+ * @deprecated Since 2.1.0
  */
 public class ZookeeperTokenStateService extends AliasBasedTokenStateService implements RemoteTokenStateChangeListener {
 
@@ -55,6 +57,7 @@ public class ZookeeperTokenStateService extends AliasBasedTokenStateService impl
 
   @Override
   public void init(GatewayConfig config, Map<String, String> options) throws ServiceLifecycleException {
+    log.deprecatedServiceUsage(this.getClass().getCanonicalName());
     final ZookeeperRemoteAliasService zookeeperAliasService = (ZookeeperRemoteAliasService) aliasServiceFactory.create(gatewayServices, ALIAS_SERVICE, config, options,
         ZookeeperRemoteAliasService.class.getName());
     options.put(ZookeeperRemoteAliasService.OPTION_NAME_SHOULD_CREATE_TOKENS_SUB_NODE, "true");

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/TokenMigrationTool.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/TokenMigrationTool.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import static org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService.TOKEN_ISSUE_TIME_POSTFIX;
+import static org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService.TOKEN_MAX_LIFETIME_POSTFIX;
+import static org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService.TOKEN_META_POSTFIX;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.token.impl.TokenStateServiceMessages;
+
+public class TokenMigrationTool {
+
+  private static final TokenStateServiceMessages LOG = MessagesFactory.get(TokenStateServiceMessages.class);
+
+  private final AliasService aliasService;
+  private final TokenStateService tokenStateService;
+  private final PrintStream out;
+
+  private int progressCount = 10;
+  private boolean archiveMigratedTokens;
+  private boolean migrateExpiredTokens;
+  private boolean verbose;
+
+  public TokenMigrationTool(AliasService aliasService, TokenStateService tokenStateService, PrintStream out) {
+    this.aliasService = aliasService;
+    this.tokenStateService = tokenStateService;
+    this.out = out;
+  }
+
+  public void setProgressCount(int progressCount) {
+    this.progressCount = progressCount;
+  }
+
+  public void setArchiveMigratedTokens(boolean archiveMigratedTokens) {
+    this.archiveMigratedTokens = archiveMigratedTokens;
+  }
+
+  public void setMigrateExpiredTokens(boolean migrateExpiredTokens) {
+    this.migrateExpiredTokens = migrateExpiredTokens;
+  }
+
+  public void setVerbose(boolean verbose) {
+    this.verbose = verbose;
+  }
+
+  public void migrateTokensFromGatewayCredentialStore() {
+    try {
+      final Map<String, TokenData> tokenDataMap = new ConcurrentHashMap<>();
+      final long start = System.currentTimeMillis();
+      String logMessage = "Loading token aliases from the __gateway credential store. This could take a while.";
+      log(logMessage);
+      final Map<String, char[]> passwordAliasMap = aliasService.getPasswordsForGateway();
+      log("Token aliases loaded in " + (System.currentTimeMillis() - start) + " milliseconds");
+      String alias;
+      for (Map.Entry<String, char[]> passwordAliasMapEntry : passwordAliasMap.entrySet()) {
+        alias = passwordAliasMapEntry.getKey();
+        processAlias(passwordAliasMap, passwordAliasMapEntry, alias, tokenDataMap);
+      }
+
+      final long migrationStart = System.currentTimeMillis();
+      final AtomicInteger count = new AtomicInteger(0);
+      tokenDataMap.entrySet().forEach(entry -> {
+        int loggedCount = 0;
+        saveTokenIfComplete(tokenStateService, entry.getKey(), entry.getValue());
+        count.incrementAndGet();
+        // log some progress (it's very useful in case a huge amount of token related
+        // aliases in __gateway-credentials.jceks)
+        if (count.intValue() > 0 && (count.intValue() % progressCount == 0) && loggedCount != count.intValue()) {
+          loggedCount = count.intValue();
+          logProgress(count.intValue(), System.currentTimeMillis() - migrationStart);
+        }
+      });
+
+      logProgress(count.intValue(), System.currentTimeMillis() - migrationStart);
+
+      archiveTokens(tokenDataMap);
+
+      removeTokenAliasesFromGatewayCredentialStore(tokenDataMap);
+    } catch (AliasServiceException e) {
+      throw new RuntimeException("Error while migrating tokens from __gateway credential store: " + e.getMessage(), e);
+    }
+  }
+
+  private void log(String message) {
+    LOG.info(message);
+    if (out != null) {
+      out.println(message);
+    }
+  }
+
+  private void logProgress(int count, long duration) {
+    log(String.format(Locale.getDefault(), "Processed %d tokens in %d milliseconds", count, duration));
+  }
+
+  /*
+   *
+   * The AliasBasedTSS implementation persists 4 aliases in  __gateway-credentials.jceks:
+   *  - an alias which maps a token ID to its expiration time
+   *  - an alias with '--max' postfix which maps the maximum lifetime of the token identified by the 1st alias
+   *  - an alias with '--iss' postfix which maps the issue time of the token
+   *  - an alias with '-meta' postfix which maps an arbitrary metadata of the token
+   *
+   */
+  private void processAlias(final Map<String, char[]> passwordAliasMap, Map.Entry<String, char[]> passwordAliasMapEntry, String alias,
+      Map<String, TokenData> tokenDataMap) {
+    String tokenId = null;
+    long expiration, maxLifeTime;
+    if (alias.endsWith(TOKEN_MAX_LIFETIME_POSTFIX)) {
+      tokenId = alias.substring(0, alias.indexOf(TOKEN_MAX_LIFETIME_POSTFIX));
+      tokenDataMap.putIfAbsent(tokenId, new TokenData());
+      expiration = convertCharArrayToLong(passwordAliasMap.get(tokenId));
+      maxLifeTime = convertCharArrayToLong(passwordAliasMapEntry.getValue());
+      tokenDataMap.get(tokenId).expiration = expiration;
+      tokenDataMap.get(tokenId).maxLifeTime = maxLifeTime;
+    } else if (alias.endsWith(TOKEN_META_POSTFIX)) {
+      tokenId = alias.substring(0, alias.indexOf(TOKEN_META_POSTFIX));
+      tokenDataMap.putIfAbsent(tokenId, new TokenData());
+      tokenDataMap.get(tokenId).metadata = TokenMetadata.fromJSON(new String(passwordAliasMapEntry.getValue()));
+    } else if (alias.endsWith(TOKEN_ISSUE_TIME_POSTFIX)) {
+      tokenId = alias.substring(0, alias.indexOf(TOKEN_ISSUE_TIME_POSTFIX));
+      tokenDataMap.putIfAbsent(tokenId, new TokenData());
+      tokenDataMap.get(tokenId).issueTime = convertCharArrayToLong(passwordAliasMapEntry.getValue());
+    }
+  }
+
+  private long convertCharArrayToLong(char[] charArray) {
+    return Long.parseLong(new String(charArray));
+  }
+
+  private void saveTokenIfComplete(TokenStateService tokenStateService, String tokenId, TokenData tokenData) {
+    if (tokenId != null && tokenData.isComplete() && !tokenData.isProcessed()) {
+      if (migrateToken(tokenData)) {
+        tokenStateService.addToken(tokenId, tokenData.issueTime, tokenData.expiration, tokenData.maxLifeTime);
+        tokenStateService.addMetadata(tokenId, tokenData.metadata);
+        if (verbose) {
+          log("Migrated token " + Tokens.getTokenIDDisplayText(tokenId) + " into the configured TokenStateService backend.");
+        }
+      } else {
+        if (verbose) {
+          log("Skipping the migration of expired token with ID = " + Tokens.getTokenIDDisplayText(tokenId));
+        }
+      }
+    }
+    tokenData.processed = true;
+  }
+
+  private boolean migrateToken(TokenData tokenData) {
+    return tokenData.isExpired() ? migrateExpiredTokens : true;
+  }
+
+  private void archiveTokens(Map<String, TokenData> tokenDataMap) throws AliasServiceException {
+    if (archiveMigratedTokens) {
+      final String cluster = "__tokens";
+      log("Archiving token aliases in the " + cluster + " credential store...");
+      final long start = System.currentTimeMillis();
+      final Map<String, String> tokenAliasesToArchive = new HashMap<>();
+      tokenDataMap.entrySet().forEach(tokenDataMapEntry -> {
+        String tokenId = tokenDataMapEntry.getKey();
+        tokenDataMapEntry.getValue();
+        tokenAliasesToArchive.put(tokenId, String.valueOf(tokenDataMapEntry.getValue().expiration));
+        tokenAliasesToArchive.put(tokenId + TOKEN_MAX_LIFETIME_POSTFIX, String.valueOf(tokenDataMapEntry.getValue().maxLifeTime));
+        tokenAliasesToArchive.put(tokenId + TOKEN_ISSUE_TIME_POSTFIX, String.valueOf(tokenDataMapEntry.getValue().issueTime));
+        tokenAliasesToArchive.put(tokenId + TOKEN_META_POSTFIX, tokenDataMapEntry.getValue().metadata.toJSON());
+      });
+      aliasService.addAliasesForCluster(cluster, tokenAliasesToArchive);
+      log("Archived token related aliases in the " + cluster + " credential store in " + (System.currentTimeMillis() - start) + " millsieconds ");
+    }
+  }
+
+  private void removeTokenAliasesFromGatewayCredentialStore(Map<String, TokenData> tokenDataMap) throws AliasServiceException {
+    log("Removing token aliases from the __gateway credential store...");
+    final long start = System.currentTimeMillis();
+    final Set<String> tokenAliases = new HashSet<>();
+    tokenDataMap.entrySet().forEach(tokenDataMapEntry -> {
+      String tokenId = tokenDataMapEntry.getKey();
+      tokenAliases.addAll(Arrays.asList(tokenId, tokenId + TOKEN_MAX_LIFETIME_POSTFIX, tokenId + TOKEN_ISSUE_TIME_POSTFIX, tokenId + TOKEN_META_POSTFIX));
+    });
+    aliasService.removeAliasesForCluster(AliasService.NO_CLUSTER_NAME, tokenAliases);
+    log("Removed token related aliases from the __gateway credential store in " + (System.currentTimeMillis() - start) + " milliseconds");
+  }
+
+  private class TokenData {
+    boolean processed;
+    long issueTime = -1;
+    long maxLifeTime = -1;
+    long expiration = -2; // can be set to '-1' meaning it never expires
+    TokenMetadata metadata;
+
+    boolean isComplete() {
+      return issueTime != -1 && maxLifeTime != -1 && expiration != -2 && metadata != null;
+    }
+
+    boolean isProcessed() {
+      return processed;
+    }
+
+    boolean isExpired() {
+      return expiration == -1 ? false : expiration < System.currentTimeMillis();
+    }
+  }
+
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/factory/ServiceFactoryTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.services.factory;
 
+import static org.apache.knox.gateway.services.security.AliasService.NO_CLUSTER_NAME;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -25,13 +26,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -39,9 +44,14 @@ import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.TestService;
 import org.apache.knox.gateway.services.config.client.RemoteConfigurationRegistryClientService;
 import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.MasterService;
+import org.apache.knox.gateway.services.token.impl.DerbyDBTokenStateService;
+import org.apache.knox.gateway.util.JDBCUtils;
+import org.apache.knox.test.TestUtils;
 import org.easymock.EasyMock;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 
@@ -52,21 +62,55 @@ class ServiceFactoryTest {
   public ExpectedException expectedException = ExpectedException.none();
 
   protected final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
-  protected final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+  protected final GatewayConfigImpl gatewayConfig = EasyMock.createNiceMock(GatewayConfigImpl.class);
   protected final Map<String, String> options = new HashMap<>();
+  protected File tempDbFolder;
 
   protected void initConfig() {
+    initConfig(false);
+  }
+
+  protected void initConfig(boolean expectDbCredentialLookup) {
+    final String masterSecret = "M4st3RSecret!";
     final MasterService masterService = EasyMock.createNiceMock(MasterService.class);
+    expect(masterService.getMasterSecret()).andReturn(masterSecret.toCharArray()).anyTimes();
+    replay(masterService);
     expect(gatewayServices.getService(ServiceType.MASTER_SERVICE)).andReturn(masterService).anyTimes();
     final KeystoreService keystoreservice = EasyMock.createNiceMock(KeystoreService.class);
     expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreservice).anyTimes();
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    if (expectDbCredentialLookup) {
+      try {
+        aliasService.addAliasForCluster(NO_CLUSTER_NAME, JDBCUtils.DATABASE_USER_ALIAS_NAME, DerbyDBTokenStateService.DEFAULT_TOKEN_DB_USER_NAME);
+        EasyMock.expectLastCall().anyTimes();
+        aliasService.addAliasForCluster(NO_CLUSTER_NAME, JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME, masterSecret);
+        EasyMock.expectLastCall().anyTimes();
+        expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn(DerbyDBTokenStateService.DEFAULT_TOKEN_DB_USER_NAME.toCharArray()).anyTimes();
+        expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn(masterSecret.toCharArray()).anyTimes();
+
+        // prepare GatewayConfig
+        expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();
+        tempDbFolder = TestUtils.createTempDir(this.getClass().getName());
+        expect(gatewayConfig.getGatewaySecurityDir()).andReturn(tempDbFolder.getAbsolutePath()).anyTimes();
+        expect(gatewayConfig.getDatabaseName()).andReturn(Paths.get(tempDbFolder.getAbsolutePath(), DerbyDBTokenStateService.DB_NAME).toString()).anyTimes();
+      } catch (AliasServiceException | IOException e) {
+        // NOP
+      }
+    }
+    replay(aliasService);
     expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
     final RemoteConfigurationRegistryClientService registryClientService = EasyMock.createNiceMock(RemoteConfigurationRegistryClientService.class);
     expect(gatewayServices.getService(ServiceType.REMOTE_REGISTRY_CLIENT_SERVICE)).andReturn(registryClientService).anyTimes();
     replay(gatewayServices);
     expect(gatewayConfig.getServiceParameter(anyString(), anyString())).andReturn("").anyTimes();
     replay(gatewayConfig);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (tempDbFolder != null) {
+      FileUtils.forceDelete(tempDbFolder);
+    }
   }
 
   protected void testBasics(AbstractServiceFactory serviceFactory, ServiceType nonMatchingServiceType, ServiceType matchingServiceType) throws Exception {
@@ -110,9 +154,21 @@ class ServiceFactoryTest {
     return isServiceSet(serviceToCheck, "aliasService");
   }
 
+  protected boolean isAliasServiceSetOnParent(Service serviceToCheck) throws Exception {
+    return isServiceSetOnParent(serviceToCheck, "aliasService");
+  }
+
   private boolean isServiceSet(Service serviceToCheck, String expectedServiceName) throws Exception {
-    final Field aliasServiceField = FieldUtils.getDeclaredField(serviceToCheck.getClass(), expectedServiceName, true);
-    final Object aliasServiceValue = aliasServiceField.get(serviceToCheck);
-    return aliasServiceValue != null;
+    return isServiceSet(serviceToCheck.getClass(), serviceToCheck, expectedServiceName);
+  }
+
+  private boolean isServiceSetOnParent(Service serviceToCheck, String expectedServiceName) throws Exception {
+    return isServiceSet(serviceToCheck.getClass().getSuperclass(), serviceToCheck, expectedServiceName);
+  }
+
+  private boolean isServiceSet(Class<?> clazz, Service serviceToCheck, String expectedServiceName) throws Exception {
+    final Field expectedServiceField = FieldUtils.getDeclaredField(clazz, expectedServiceName, true);
+    final Object expectedServiceValue = expectedServiceField.get(serviceToCheck);
+    return expectedServiceValue != null;
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/JDBCUtilsTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 
 import com.mysql.cj.jdbc.MysqlDataSource;
-import org.apache.derby.jdbc.ClientDataSource;
+import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -135,23 +135,19 @@ public class JDBCUtilsTest {
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(EasyMock.anyString())).andReturn(null).anyTimes();
     EasyMock.replay(gatewayConfig, aliasService);
-    assertTrue(JDBCUtils.getDataSource(gatewayConfig, aliasService) instanceof ClientDataSource);
+    assertTrue(JDBCUtils.getDataSource(gatewayConfig, aliasService) instanceof EmbeddedDataSource);
   }
 
   @Test
   public void derbyDataSourceShouldHaveProperConnectionProperties() throws Exception {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(JDBCUtils.DERBY_DB_TYPE).anyTimes();
-    EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
-    EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(1527).anyTimes();
     EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("sampleDatabase");
     final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_USER_ALIAS_NAME)).andReturn("user".toCharArray()).anyTimes();
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(JDBCUtils.DATABASE_PASSWORD_ALIAS_NAME)).andReturn("password".toCharArray()).anyTimes();
     EasyMock.replay(gatewayConfig, aliasService);
-    final ClientDataSource dataSource = (ClientDataSource) JDBCUtils.getDataSource(gatewayConfig, aliasService);
-    assertEquals("localhost", dataSource.getServerName());
-    assertEquals(1527, dataSource.getPortNumber());
+    final EmbeddedDataSource dataSource = (EmbeddedDataSource) JDBCUtils.getDataSource(gatewayConfig, aliasService);
     assertEquals("sampleDatabase", dataSource.getDatabaseName());
     assertEquals("user", dataSource.getUser());
     assertEquals("password", dataSource.getPassword());

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -884,6 +884,11 @@ public class KnoxCLITest {
     assertThat( master2, not( is( master ) ) );
     assertThat( rc, is( 0 ) );
     assertThat(outContent.toString(StandardCharsets.UTF_8.name()), containsString("Master secret has been persisted to disk."));
+
+    // Need to delete the master file so that the it will not interfere with other tests
+    if( masterFile.exists() ) {
+      assertThat( "Failed to delete existing master file.", masterFile.delete(), is( true ) );
+    }
   }
 
   @Test
@@ -1320,7 +1325,7 @@ public class KnoxCLITest {
     } else {
       assertThat(commandOutput, containsString(alias + " has been successfully created."));
 
-      final AliasService aliasService = KnoxCLI.getGatewayServices().getService(ServiceType.ALIAS_SERVICE);
+      final AliasService aliasService = cli.getGatewayServices().getService(ServiceType.ALIAS_SERVICE);
       assertNotNull(new String(aliasService.getPasswordFromAliasForGateway(alias)));
     }
 

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -393,8 +393,8 @@ public class TokenResource {
         }
       }
     } else {
-      //if there is no custom configuration in the topology, then we allow keystore and DB back-end for the tokengen application
-      if ("AliasBasedTokenStateService".equals(actualTokenServiceName) || "JDBCTokenStateService".equals(actualTokenServiceName)) {
+      //if there is no custom configuration in the topology, then we allow DerbyDB and custom DB back-ends for the tokengen application
+      if ("DerbyDBTokenStateService".equals(actualTokenServiceName) || "JDBCTokenStateService".equals(actualTokenServiceName)) {
         tokenStateServiceStatusMap.put(TSS_ALLOWED_BACKEND_FOR_TOKENGEN, "true");
       }
     }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -961,7 +961,7 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
 
   @Override
   public String getDatabaseType() {
-    return null;
+    return "derbydb";
   }
 
   @Override
@@ -981,9 +981,8 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
 
   @Override
   public String getDatabaseName() {
-    return null;
+    return Paths.get(getGatewaySecurityDir(), "tokens").toString();
   }
-
 
   @Override
   public boolean isDatabaseSslEnabled() {
@@ -1081,4 +1080,30 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public long getServiceDiscoveryWriteTimeoutMillis() {
     return -1;
   }
+
+  @Override
+  public boolean skipTokenMigration() {
+    return true;
+  }
+
+  @Override
+  public boolean archiveMigratedTokens() {
+    return false;
+  }
+
+  @Override
+  public boolean migrateExpiredTokens() {
+    return false;
+  }
+
+  @Override
+  public boolean printVerboseTokenMigrationMessages() {
+    return false;
+  }
+
+  @Override
+  public int getTokenMigrationProgressCount() {
+    return 1;
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -903,4 +903,35 @@ public interface GatewayConfig {
   long getServiceDiscoveryReadTimeoutMillis();
 
   long getServiceDiscoveryWriteTimeoutMillis();
+
+  /**
+   * @return <code>true</code> if token migration must be skipped when a
+   *         JDBC-based TSS starts; <code>false</code> otherwise
+   */
+  boolean skipTokenMigration();
+
+  /**
+   * @return <code>true</code> if migrated tokens must be archived when a
+   *         JDBC-based starts; <code>false</code> otherwise
+   */
+  boolean archiveMigratedTokens();
+
+  /**
+   * @return <code>true</code> if expired tokens must be migrated when a
+   *         JDBC-based starts; <code>false</code> otherwise
+   */
+  boolean migrateExpiredTokens();
+
+  /**
+   * @return <code>true</code> if the token migration tool should print verbose
+   *         messages when a JDBC-based starts; <code>false</code> otherwise
+   */
+  boolean printVerboseTokenMigrationMessages();
+
+  /**
+   * @return the number of tokens after the token migration tool displays progress
+   *         in the logs when a JDBC-based TSS starts.
+   */
+  int getTokenMigrationProgressCount();
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/impl/CMFMasterService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/impl/CMFMasterService.java
@@ -17,7 +17,6 @@
  */
 package org.apache.knox.gateway.services.security.impl;
 
-import de.thetaphi.forbiddenapis.SuppressForbidden;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.net.ntp.TimeStamp;
@@ -146,7 +145,7 @@ public class CMFMasterService {
       FileUtils.writeLines(masterFile, StandardCharsets.UTF_8.name(), lines);
 
       // restrict os permissions to only the user running this process
-      chmod("600", masterFile);
+      org.apache.knox.gateway.util.FileUtils.chmod("600", masterFile);
     } catch (IOException e) {
       LOG.failedToPersistMasterSecret(e);
     }
@@ -175,32 +174,5 @@ public class CMFMasterService {
         LOG.failedToInitializeFromPersistentMaster(masterFile.getName(), e);
         throw e;
       }
-  }
-
-  @SuppressForbidden
-  private void chmod(String args, File file) throws IOException {
-      // TODO: move to Java 7 NIO support to add windows as well
-      // TODO: look into the following for Windows: Runtime.getRuntime().exec("attrib -r myFile");
-      if (isUnixEnv()) {
-          //args and file should never be null.
-          if (args == null || file == null) {
-            throw new IllegalArgumentException("nullArg");
-          }
-          if (!file.exists()) {
-            throw new IOException("fileNotFound");
-          }
-
-          // " +" regular expression for 1 or more spaces
-          final String[] argsString = args.split(" +");
-          List<String> cmdList = new ArrayList<>();
-          cmdList.add("/bin/chmod");
-          cmdList.addAll(Arrays.asList(argsString));
-          cmdList.add(file.getAbsolutePath());
-          new ProcessBuilder(cmdList).start();
-      }
-  }
-
-  private boolean isUnixEnv() {
-    return (File.separatorChar == '/');
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMigrationTarget.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMigrationTarget.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+/**
+ * The implementations of this marker interface can be used as token migration
+ * targets in KnoxCLI's migrate-token command.
+ *
+ */
+public interface TokenMigrationTarget {
+
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/FileUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/FileUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+
+public class FileUtils {
+
+  @SuppressForbidden
+  public static void chmod(String args, File file) throws IOException {
+    // TODO: move to Java 7 NIO support to add windows as well
+    // TODO: look into the following for Windows: Runtime.getRuntime().exec("attrib
+    // -r myFile");
+    if (isUnixEnv()) {
+      // args and file should never be null.
+      if (args == null || file == null) {
+        throw new IllegalArgumentException("nullArg");
+      }
+      if (!file.exists()) {
+        throw new IOException("fileNotFound");
+      }
+
+      // " +" regular expression for 1 or more spaces
+      final String[] argsString = args.split(" +");
+      List<String> cmdList = new ArrayList<>();
+      cmdList.add("/bin/chmod");
+      cmdList.addAll(Arrays.asList(argsString));
+      cmdList.add(file.getAbsolutePath());
+      new ProcessBuilder(cmdList).start();
+    }
+  }
+
+  private static boolean isUnixEnv() {
+    return File.separatorChar == '/';
+  }
+
+}

--- a/gateway-test-release/pom.xml
+++ b/gateway-test-release/pom.xml
@@ -345,6 +345,7 @@
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
                         <project.version>${project.version}</project.version>
+                        <derby.stream.error.file>/dev/null</derby.stream.error.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/gateway-test-release/webhdfs-kerb-test/pom.xml
+++ b/gateway-test-release/webhdfs-kerb-test/pom.xml
@@ -110,6 +110,7 @@
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
                         <project.version>${project.version}</project.version>
+                        <derby.stream.error.file>/dev/null</derby.stream.error.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/gateway-test-release/webhdfs-test/pom.xml
+++ b/gateway-test-release/webhdfs-test/pom.xml
@@ -102,6 +102,7 @@
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
                         <project.version>${project.version}</project.version>
+                        <derby.stream.error.file>/dev/null</derby.stream.error.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/gateway-test/pom.xml
+++ b/gateway-test/pom.xml
@@ -246,6 +246,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <scope>test</scope>
@@ -327,6 +333,7 @@
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
                         <project.version>${project.version}</project.version>
+                        <derby.stream.error.file>/dev/null</derby.stream.error.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/knox-token-generation-ui/token-generation/app/token-generation.component.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.component.ts
@@ -188,9 +188,9 @@ export class TokenGenerationComponent implements OnInit {
   private decideTssMessage() {
     if (this.tssStatus.tokenManagementEnabled) {
       if (this.tssStatus.allowedTssForTokengen) {
-        if (this.tssStatus.actualTssBackend === 'AliasBasedTokenStateService') {
-          this.setTssMessage('warning', `Token management backend is configured to store tokens in keystores.
-            This is only valid non-HA environments!`);
+        if (this.tssStatus.actualTssBackend === 'DerbyDBTokenStateService') {
+          this.setTssMessage('warning', `Token management backend is configured to store tokens in a Derby DB on local file system.
+            This is only valid in non-HA environments!`);
         } else {
           this.setTssMessage('info', 'Token management backend is properly configured for HA and production deployments.');
         }

--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,7 @@
                     </excludedGroups>
                     <systemPropertyVariables>
                         <project.version>${project.version}</project.version>
+                        <derby.stream.error.file>/dev/null</derby.stream.error.file>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -558,6 +559,9 @@
                             <includes>
                                 <include>**/*.java</include>
                             </includes>
+                            <systemPropertyVariables>
+                                <derby.stream.error.file>/dev/null</derby.stream.error.file>
+                            </systemPropertyVariables>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implemented the changes I listed in [KNOX-2990](https://issues.apache.org/jira/browse/KNOX-2990):

- deprecated the following TSS implementations:
  - AliasBasedTokenStateService
  - ZookeeperTokenStateService
  - JournalBasedTokenStateService
- implemented a DerbyDB storage that stores tokens in `$DATA_DIR/security/tokens` (this time it's not yet encrypted)
- file permissions are set on that folder to `700` (only the owner can access it)
- changed the default implementation in `TokenStateServiceFactory` to the new DerbyDatabaseTSS
- implemenedt a new KnoxCLI command that migrates existing tokens from credential stores to any JDBC-based TSS backend (tested it with the new DerbyDB TSS; see below)
- integrated this new KnoxCLI command in a way such that it runs when Knox Gateway is started: if token management is enabled, and the configured TSS implementation is a migration target (currently it's true for any JDBC-based TSS implementation)
- added some new `gateway-site.xml` properties:
  - `gateway.knox.token.migration.skip `: ensures that the previous automated step can be controlled (E.g. in case of unforeseen errors it can be turned off). Defaults
  - `gateway.knox.token.migration.archive.tokens `: indicates if migrated tokesn should be archived in another credential store called `__tokens`. Defaults to `false`.
  - `gateway.knox.token.migration.include.expired.tokens`: whether expired tokens should be migrated or skipped. Defaults to `false`.
  - `gateway.knox.token.migration.verbose`: if true, migrated/skipped tokens are added in the `[gateway|knoxcli].log` and, optionally, on the STDOUT (when running the KnoxCLI tool manually). Defaults to `true`, because it's very useful to have the chancee to cross-reference token IDs in case of error debugging.
  - `gateway.knox.token.migration.progress.count`: the number of tokens after the token migration tool displays progress in the logs and, optionally, on the STDOUT.
- modified the token generation page to accept the new DerbyDB TSS.

## How was this patch tested?

Configured Knox to have the `AliasBasedTSS` as the token state backend and to allow unlimited token creation:
```
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService</value>
    </property>

    <property>
        <name>gateway.knox.token.limit.per.user</name>
        <value>-1</value>
    </property>
```
Generated 456 tokens with random expiration times (456x4=1824 aliases) then stopped the Knox GW (to avoid the reaper thread removing expired tokens).
```
$ bin/knoxcli.sh list-alias | grep "items"
    1827
```
Executed the new KnoxCLI command to confirm it only migrates anything if the configured backend allows token migration:
```
$ bin/knoxcli.sh migrate-tokens --progressCount 15 --archiveMigrated true
This tool is meant to migrate tokens into a JDBC TokenStateService backend. However, the currently configured one (org.apache.knox.gateway.services.token.impl.AliasBasedTokenStateService) does not fulfill this requirement!
```

Before running the new KnoxLCI command again, I commented out the `gateway.service.tokenstate.impl` param in `gateway-site.xml` => the new default, DerbyDBTSS, was in place.

Executed the command again:
```
$ bin/knoxcli.sh migrate-tokens --progressCount 15 --archiveMigrated true > ~/migrationResultWithArchival.txt

$ bin/knoxcli.sh list-alias | grep items
3 items.

$ bin/knoxcli.sh list-alias --cluster __tokens | grep items
1824 items.

$ cat ~/migrationResultWithArchival.txt 
Migrating tokens from __gateway credential store into the configured TokenStateService backend...
Loading token aliases from the __gateway credential store. This could take a while.
Token aliased loaded in 178741 milliseconds
Processed 15 tokens in 102 milliseconds
Processed 30 tokens in 174 milliseconds
...
Processed 450 tokens in 2191 milliseconds
Processed 456 tokens in 2202 milliseconds
Archiving token aliases in the __tokens credential store...
Archived token related aliases in the __tokens credential store in 141849 millsieconds 
Removing token aliases from the __gateway credential store...
Removed token related aliases from the __gateway credential store in 38 milliseconds
```
---

Repeated the generate/migration step, but this time without token archival:
```
$ bin/knoxcli.sh migrate-tokens --progressCount 15 > ~/migrationResultWithoutArchival.txt

$ cat ~/migrationResultWithoutArchival.txt 
Migrating tokens from __gateway credential store into the configured TokenStateService backend...
Loading token aliases from the __gateway credential store. This could take a while.
Token aliased loaded in 182497 milliseconds
Processed 15 tokens in 160 milliseconds
Processed 30 tokens in 271 milliseconds
...
Processed 456 tokens in 1677 milliseconds
Removing token aliases from the __gateway credential store...
Removed token related aliases from the __gateway credential store in 61 milliseconds
```


I also tested the token migration tool integration during the Knox Gateway startup. I removed the previously created data/security/tokens folder, switched to AliasBasedTSS and created another 456 tokens. Then switched back to the default DerbyDBTSS and started the Knox GW. I confirmed the `$SECURITY_DIR/tokens` was created with the proper file permissions:
```
ls -al data/security/
total 16
drwxr-xr-x   6 sandormolnar  staff   192 Dec 15 15:26 .
drwxr-xr-x   8 sandormolnar  staff   256 Dec 15 15:27 ..
drwxr-xr-x  12 sandormolnar  staff   384 Dec 14 19:43 keystores
-rw-------   1 sandormolnar  staff   125 Dec  5 16:05 master
-rw-r--r--   1 sandormolnar  staff  2746 Dec 15 15:27 registry
drwx------   9 sandormolnar  staff   288 Dec 15 15:27 tokens
```
I also checked if the automated token migration tool works as expected:
```
2023-12-15 15:32:35,742  INFO  knox.gateway (GatewayServer.java:logSysProp(226)) - System Property: user.name=sandormolnar
2023-12-15 15:32:35,749  INFO  knox.gateway (GatewayServer.java:logSysProp(226)) - System Property: user.dir=/Users/sandormolnar/test/knoxGateway
2023-12-15 15:32:35,749  INFO  knox.gateway (GatewayServer.java:logSysProp(226)) - System Property: java.runtime.name=OpenJDK Runtime Environment
2023-12-15 15:32:35,750  INFO  knox.gateway (GatewayServer.java:logSysProp(226)) - System Property: java.runtime.version=1.8.0_282-bre_2021_01_20_16_37-b00
2023-12-15 15:32:35,750  INFO  knox.gateway (GatewayServer.java:logSysProp(226)) - System Property: java.home=/usr/local/Cellar/openjdk@8/1.8.0+282/libexec/openjdk.jdk/Contents/Home/jre
...
2023-12-15 15:32:38,960  INFO  knox.gateway (AbstractServiceFactory.java:logServiceUsage(103)) - Using org.apache.knox.gateway.services.token.impl.DerbyDBTokenStateService implementation for TokenStateService
...
2023-12-15 15:32:41,930  INFO  knox.gateway (AbstractGatewayServices.java:start(60)) - Starting service: org.apache.knox.gateway.services.token.impl.DerbyDBTokenStateService
2023-12-15 15:32:41,935  INFO  token.state (TokenMigrationTool.java:log(115)) - Loading token aliases from the __gateway credential store. This could take a while.
2023-12-15 15:35:43,701  INFO  token.state (TokenMigrationTool.java:log(115)) - Token aliases loaded in 181768 milliseconds
2023-12-15 15:35:43,864  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token c9ec7cff...84d5a729b6ce into the configured TokenStateService backend.
2023-12-15 15:35:43,874  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 69072c33...9f110e2f1306 into the configured TokenStateService backend.
2023-12-15 15:35:43,884  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 16287741...34aa267014a7 into the configured TokenStateService backend.
2023-12-15 15:35:43,893  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 999a0d0d...5aabfb0fd559 into the configured TokenStateService backend.
2023-12-15 15:35:43,893  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = 5b997b0b...0675a4858596
2023-12-15 15:35:43,901  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token b7a77264...da2a6073e70e into the configured TokenStateService backend.
2023-12-15 15:35:43,909  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 2f633b54...c999f0b60de0 into the configured TokenStateService backend.
2023-12-15 15:35:43,918  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token da39a301...9cb261dd7ef2 into the configured TokenStateService backend.
2023-12-15 15:35:43,918  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = aaefe17d...8b12ee327d56
2023-12-15 15:35:43,930  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 1e4cd999...216cefe35978 into the configured TokenStateService backend.
2023-12-15 15:35:43,931  INFO  token.state (TokenMigrationTool.java:log(115)) - Processed 10 tokens in 180 milliseconds
2023-12-15 15:35:43,939  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token cf645daa...82f09c49d216 into the configured TokenStateService backend.
2023-12-15 15:35:43,947  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token ddb2e440...1d0703bf6c0e into the configured TokenStateService backend.
2023-12-15 15:35:43,955  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 6bcc713d...b29554301c07 into the configured TokenStateService backend.
2023-12-15 15:35:43,972  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 8e4702e2...49c69244fea1 into the configured TokenStateService backend.
2023-12-15 15:35:43,972  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = c32c416c...58c1da09412d
2023-12-15 15:35:43,981  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token b1df6f9e...3d9e2045d3c8 into the configured TokenStateService backend.
2023-12-15 15:35:43,990  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token c502de50...16fdf21fdbe5 into the configured TokenStateService backend.
2023-12-15 15:35:43,990  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = 300ed0b2...98edda2ba28c
2023-12-15 15:35:44,002  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 3615f73b...c6da9f9d00e9 into the configured TokenStateService backend.
2023-12-15 15:35:44,002  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = 651bbf46...2732ac3a9643
2023-12-15 15:35:44,002  INFO  token.state (TokenMigrationTool.java:log(115)) - Processed 20 tokens in 251 milliseconds
2023-12-15 15:35:44,002  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = bb59702e...6d81029ffeaf
2023-12-15 15:35:44,002  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = 8d31e3a4...80082f334ee8
2023-12-15 15:35:44,011  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 4a541cc9...476a8e220dea into the configured TokenStateService backend.
2023-12-15 15:35:44,020  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 338d9037...055fbded8510 into the configured TokenStateService backend.
2023-12-15 15:35:44,029  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token d86ae463...0ef110b55d19 into the configured TokenStateService backend.
2023-12-15 15:35:44,029  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = b5f3d372...2f312d032ebc
2023-12-15 15:35:44,039  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 25af1953...fe8f02118652 into the configured TokenStateService backend.
2023-12-15 15:35:44,047  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 2d619987...af6a546411f0 into the configured TokenStateService backend.
2023-12-15 15:35:44,060  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token fff03417...de1ad8382afb into the configured TokenStateService backend.
2023-12-15 15:35:44,068  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token f248d413...dc39dc1d8b3b into the configured TokenStateService backend.
2023-12-15 15:35:44,068  INFO  token.state (TokenMigrationTool.java:log(115)) - Processed 30 tokens in 317 milliseconds
...
2023-12-15 15:35:45,355  INFO  token.state (TokenMigrationTool.java:log(115)) - Processed 440 tokens in 1604 milliseconds
2023-12-15 15:35:45,358  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 9e1ab647...bcb4ea563af2 into the configured TokenStateService backend.
2023-12-15 15:35:45,362  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 160f3ee2...5cf694f6843c into the configured TokenStateService backend.
2023-12-15 15:35:45,366  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 3f9b9624...21922baeac30 into the configured TokenStateService backend.
2023-12-15 15:35:45,366  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = a40018f2...2d2e6305efa7
2023-12-15 15:35:45,366  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = d1b077d7...8a022f2dfc18
2023-12-15 15:35:45,370  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 85cfb49c...bcb97b55e7a5 into the configured TokenStateService backend.
2023-12-15 15:35:45,374  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 0ad9d321...9342d5e25e3e into the configured TokenStateService backend.
2023-12-15 15:35:45,377  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token cfaa61cc...bfce4b97b33e into the configured TokenStateService backend.
2023-12-15 15:35:45,377  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = fbc8e097...0099e87d7c31
2023-12-15 15:35:45,380  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token fd196a8f...99b776c356b2 into the configured TokenStateService backend.
2023-12-15 15:35:45,381  INFO  token.state (TokenMigrationTool.java:log(115)) - Processed 450 tokens in 1630 milliseconds
2023-12-15 15:35:45,384  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token 014cc90a...8c0bd9d2e5c9 into the configured TokenStateService backend.
2023-12-15 15:35:45,388  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token fab69348...8f56a484b0d0 into the configured TokenStateService backend.
2023-12-15 15:35:45,388  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = fe735825...e2164a8e41ff
2023-12-15 15:35:45,391  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token dea78625...17246bfe26b6 into the configured TokenStateService backend.
2023-12-15 15:35:45,395  INFO  token.state (TokenMigrationTool.java:log(115)) - Migrated token f5f96bf4...2243435a3a84 into the configured TokenStateService backend.
2023-12-15 15:35:45,395  INFO  token.state (TokenMigrationTool.java:log(115)) - Skipping the migration of expired token with ID = 35af7cec...de414e7e78d1
2023-12-15 15:35:45,395  INFO  token.state (TokenMigrationTool.java:log(115)) - Processed 456 tokens in 1644 milliseconds
2023-12-15 15:35:45,395  INFO  token.state (TokenMigrationTool.java:log(115)) - Removing token aliases from the __gateway credential store...
2023-12-15 15:35:45,454  INFO  token.state (TokenMigrationTool.java:log(115)) - Removed token related aliases from the __gateway credential store in 59 milliseconds
```