### PR TITLE
KNOX-2993 - Logging error stack trace at INFO level when failed to parse a descriptor

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -581,7 +581,7 @@ public interface GatewayMessages {
 
   @Message( level = MessageLevel.ERROR, text = "An error occurred while processing {0} : {1}" )
   void simpleDescriptorHandlingError(String simpleDesc,
-                                     @StackTrace(level = MessageLevel.DEBUG) Exception e);
+                                     @StackTrace(level = MessageLevel.INFO) Exception e);
 
   @Message(level = MessageLevel.DEBUG, text = "Successfully wrote configuration: {0}")
   void wroteConfigurationFile(String filePath);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a very small, but even more important change because it helps us a lot during the troubleshooting of service discovery or simple descriptor handler issues: related error stack traces are displayed on `INFO` level.

## How was this patch tested?

Manually tested:
```
2023-12-15 16:57:35,494  ERROR knox.gateway (DescriptorsMonitor.java:onFileChange(123)) - An error occurred while processing dt.json : java.lang.IllegalArgumentException: Unresolved provider configuration reference: kerberos-providers
java.lang.IllegalArgumentException: Unresolved provider configuration reference: kerberos-providers
	at org.apache.knox.gateway.topology.simple.SimpleDescriptorHandler.handleProviderConfiguration(SimpleDescriptorHandler.java:266) ~[gateway-topology-simple-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.knox.gateway.topology.simple.SimpleDescriptorHandler.generateTopology(SimpleDescriptorHandler.java:416) ~[gateway-topology-simple-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.knox.gateway.topology.simple.SimpleDescriptorHandler.handle(SimpleDescriptorHandler.java:199) ~[gateway-topology-simple-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.knox.gateway.topology.simple.SimpleDescriptorHandler.handle(SimpleDescriptorHandler.java:97) ~[gateway-topology-simple-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.knox.gateway.services.topology.monitor.DescriptorsMonitor.onFileChange(DescriptorsMonitor.java:97) [gateway-server-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.knox.gateway.services.topology.monitor.DescriptorsMonitor.onFileCreate(DescriptorsMonitor.java:64) [gateway-server-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
	at org.apache.commons.io.monitor.FileAlterationObserver.doCreate(FileAlterationObserver.java:391) [commons-io-2.8.0.jar:2.8.0]
	at org.apache.commons.io.monitor.FileAlterationObserver.checkAndNotify(FileAlterationObserver.java:346) [commons-io-2.8.0.jar:2.8.0]
	at org.apache.commons.io.monitor.FileAlterationObserver.checkAndNotify(FileAlterationObserver.java:305) [commons-io-2.8.0.jar:2.8.0]
	at org.apache.commons.io.monitor.FileAlterationMonitor.run(FileAlterationMonitor.java:184) [commons-io-2.8.0.jar:2.8.0]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_282]
```
