### PR TITLE
KNOX-2995 - Support json parsing NaN values

### DIFF
--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonFilterReader.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonFilterReader.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -81,7 +82,7 @@ class JsonFilterReader extends Reader {
   }
 
   private void jsonParserConfigInit() {
-    parser.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
+    parser.enable( JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature() );
   }
 
   @Override

--- a/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonFilterReader.java
+++ b/gateway-provider-rewrite/src/main/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonFilterReader.java
@@ -77,6 +77,11 @@ class JsonFilterReader extends Reader {
     bufferingLevel = null;
     bufferingConfig = null;
     this.config = config;
+    jsonParserConfigInit();
+  }
+
+  private void jsonParserConfigInit() {
+    parser.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
   }
 
   @Override

--- a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonFilterReaderTest.java
+++ b/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/impl/json/JsonFilterReaderTest.java
@@ -93,6 +93,15 @@ public class JsonFilterReaderTest {
   }
 
   @Test
+  public void testNaN() throws IOException {
+    String inputJson = "NaN";
+    StringReader inputReader = new StringReader( inputJson );
+    JsonFilterReader filterReader = new TestJsonFilterReader( inputReader, null );
+    String outputJson = new String( IOUtils.toCharArray( filterReader ) );
+    JsonAssert.with(outputJson).assertThat("$", is(inputJson));
+  }
+
+  @Test
   public void testNull() throws IOException {
     String inputJson = "null";
     StringReader inputReader = new StringReader( inputJson );


### PR DESCRIPTION
# What changes were proposed in this pull request?
Implemented the changes I listed in [KNOX-2995](https://issues.apache.org/jira/browse/KNOX-2995):
- Solve the problem of page parsing failure when Json returns NaN value.
> Added JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS.mappedFeature() to support this feature

I click on the page with return json and the content of Resopnse is empty. like this :

![image](https://github.com/apache/knox/assets/50791733/3fb8a37f-1ea1-40dd-a00c-72c90fad5bc7)

Checking the gateway.log log shows the following error message.
![image](https://github.com/apache/knox/assets/50791733/9badb503-6841-445a-8b82-4e62f1a3e819)

The display results after my repair are as follows：
![image](https://github.com/apache/knox/assets/50791733/baa5d35d-a643-49b9-b55a-41482f453f5c)

# How was this patch tested?
I have added test cases. You can run the test cases to see if they are successful.
Run JsonFilterReaderTest.testNaN() function. 
Or look at the actual problems I encountered above to test.

