### PR TITLE
KNOX-2996 - Add proxy for hdfs UI network topology

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/hdfsui/3.0.0/rewrite.xml
@@ -155,6 +155,9 @@
   <rule dir="OUT" name="HDFSUI/hdfs/outbound/logs/files" pattern="/logs/{**}">
     <rewrite template="{gateway.url}/hdfs/logs/{**}?host={$inboundurl[host]}"/>
   </rule>
+  <rule dir="OUT" name="HDFSUI/hdfs/outbound/topology" pattern="topology">
+    <rewrite template="{gateway.url}/hdfs/topology/?host={$inboundurl[host]}"/>
+  </rule>
 
   <!-- for explorer page rewrite -->
   <rule dir="OUT" name="HDFSUI/hdfs/outbound/explorerhtml/tab-overview" pattern="dfshealth.html#tab-overview">


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Add proxy for hdfs UI network topology, Clicking the hdfs UI network topology proxy failed, the page should be displayed and should not be Error.


issues: [knox-2996](https://issues.apache.org/jira/browse/KNOX-2996)

