### PR TITLE
KNOX-2997 - Add kafka ui support in service definition.

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/kafkaui.1.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/kafkaui.1.0.0/rewrite.xml
@@ -1,0 +1,109 @@
+<!--
+        Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<rules>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound" pattern="*://*:*/**/kafka/">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound1" pattern="*://*:*/**/kafka/?{**}">
+        <rewrite template="{$serviceUrl[KAFKAUI]}"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound/root" pattern="*://*:*/**/kafka/{**}">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/{**}"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound/root1" pattern="*://*:*/**/kafka/{**}?{**}">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/{**}?{**}"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound/updateClusters" pattern="*://*:*/**/kafka/updataCluster?c={**}">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/updateCluster?c={**}"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound/clusters" pattern="*://*:*/**/kafka/clusters/{**}?t={**}">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/clusters/{**}?t={**}"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound/clusters0" pattern="*://*:*/**/kafka/clusters">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/clusters"/>
+    </rule>
+    <rule dir="IN" name="KAFKAUI/kafkaui/inbound/kafka/assets" pattern="*://*:*/**/kafka/assets/{**}">
+        <rewrite template="{$serviceUrl[KAFKAUI]}/assets/{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/assets" pattern="/assets/{**}">
+        <rewrite template="{$frontend[path]}/kafka/assets/{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href" pattern="/clusters/{**}">
+        <rewrite template="{$frontend[path]}/kafka/clusters/{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href" pattern="/clusters?{**}">
+        <rewrite template="{$frontend[path]}/kafka/clusters?{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/clusters" pattern="/clusters/{**}?t={**}">
+        <rewrite template="{$frontend[path]}/kafka/clusters/{**}?t={**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/addCluster" pattern="/addCluster">
+        <rewrite template="{$frontend[path]}/kafka/addCluster"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/addCluster1" pattern="/addCluster/{**}">
+        <rewrite template="{$frontend[path]}/kafka/addCluster/{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/updateCluster3" pattern="/updateCluster?c={**}">
+        <rewrite template="{$frontend[path]}/kafka/updateCluster?c={**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/updateCluster" pattern="/updateCluster/{**}">
+        <rewrite template="{$frontend[path]}/kafka/updateCluster/{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/updateCluster1" pattern="/updateCluster/{**}?{**}">
+        <rewrite template="{$frontend[path]}/kafka/updateCluster/{**}?{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/updateCluster2" pattern="updateCluster/{**}?{**}">
+        <rewrite template="{$frontend[path]}/kafka/updateCluster/{**}?{**}"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/index" pattern="/">
+        <rewrite template="{$frontend[path]}/kafka"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/href/index2" pattern="/?user.name={*}">
+        <rewrite template="{$frontend[path]}/kafka/?user.name={*}"/>
+    </rule>
+    <filter name="KAFKAUI/kafkaui/outbound/headers2">
+        <content type="application/x-http-headers">
+            <apply path="Location" rule="KAFKAUI/kafkaui/outbound/headers/location"/>
+        </content>
+    </filter>
+    <rule flow="OR" dir="OUT" name="KAFKAUI/kafkaui/outbound/headers/location">
+        <match pattern="*://*:*/**/clusters/{**}">
+            <rewrite template="{$frontend[url]}/clusters/{**}"/>
+        </match>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/extrapath">
+        <rewrite template="{$frontend[path]}/kafka/assets"/>
+    </rule>
+    <rule dir="OUT" name="KAFKAUI/kafkaui/outbound/lib/jquery">
+        <rewrite template="{$frontend[url]}/kafka/assets/lib/jquery/jquery.js"/>
+    </rule>
+    <filter name="KAFKAUI/kafkaui/outbound/links">
+        <content type="application/javascript">
+            <apply path="/assets/lib/jquery/jquery.js" rule="KAFKAUI/kafkaui/outbound/lib/jquery"/>
+            <apply path="/" rule="KAFKAUI/kafkaui/outbound/clusters"/>
+        </content>
+        <content type="text/css">
+            <apply path="/assets" rule="KAFKAUI/kafkaui/outbound/assets"/>
+            <apply path="/" rule="KAFKAUI/kafkaui/outbound/clusters"/>
+        </content>
+        <content type="text/html">
+            <apply path="/assets/lib/jquery/jquery.js" rule="KAFKAUI/kafkaui/outbound/lib/jquery"/>
+        </content>
+        <content type="*/html">
+        </content>
+    </filter>
+</rules>

--- a/gateway-service-definitions/src/main/resources/services/kafkaui.1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/kafkaui.1.0.0/service.xml
@@ -32,9 +32,5 @@
     </routes>
     <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch"
               ha-classname="org.apache.knox.gateway.ha.dispatch.ConfigurableHADispatch">
-        <param>
-            <name>responseExcludeHeaders</name>
-            <value>WWW-AUTHENTICATE</value>
-        </param>
     </dispatch>
 </service>

--- a/gateway-service-definitions/src/main/resources/services/kafkaui.1.0.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/kafkaui.1.0.0/service.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<service role="KAFKAUI" name="kafkaui" version="1.0.0">
+    <metadata>
+        <type>UI</type>
+        <context>/kafka/</context>
+        <shortDesc>kafka Web UI</shortDesc>
+        <description></description>
+    </metadata>
+    <routes>
+        <route path="/kafka/">
+        </route>
+        <route path="/kafka/**">
+        </route>
+        <route path="/kafka/**?**">
+        </route>
+    </routes>
+    <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch"
+              ha-classname="org.apache.knox.gateway.ha.dispatch.ConfigurableHADispatch">
+        <param>
+            <name>responseExcludeHeaders</name>
+            <value>WWW-AUTHENTICATE</value>
+        </param>
+    </dispatch>
+</service>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Apache Kafka is a distributed streaming platform initially developed by LinkedIn and later open-sourced as an Apache Software Foundation project. Designed for handling real-time data streams, Kafka supports high throughput, persistent storage, and horizontal scalability.kafka has its own ui.

We can support it in knox service definition.

## How was this patch tested?
![image](https://github.com/apache/knox/assets/50791733/c8bca09b-1a2a-429c-9b6b-bae591013e12)
![image](https://github.com/apache/knox/assets/50791733/9978d695-9ac9-411a-8af8-92632fd8ece7)

