### PR TITLE
KNOX-2994 - PollingConfigurationAnalyzer starts after the Knox GW is up and running

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -133,6 +133,10 @@ public interface ClouderaManagerServiceDiscoveryMessages {
            text = "Started ClouderaManager cluster configuration monitor (checking every {0} seconds)")
   void startedClouderaManagerConfigMonitor(long pollingInterval);
 
+  @Message(level = MessageLevel.INFO,
+      text = "The Knox Gateway is not yet ready to monitor ClouderaManager cluster configuration changes.")
+  void gatewayIsNotYetReadyToMonitorClouderaManagerConfigs();
+
   @Message(level = MessageLevel.INFO, text = "Stopping ClouderaManager cluster configuration monitor")
   void stoppingClouderaManagerConfigMonitor();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Actual cluster configuration change monitoring should not happen until the Knox Gateway is fully up and running and all the topologies are deployed.

## How was this patch tested?

Updated existing unit tests and added a new test case to cover this new functionality. Apart from this, I also conducted an E2E test round on a live CM cluster (I set the `gateway.cluster.config.monitor.cm.interval` to `5` to make sure we see config monitor attempts every 5 seconds).
After I restarted Knox I confirmed the feature is working:
```
2024-01-03 12:55:15,551  INFO  knox.gateway (GatewayServer.java:startGateway(389)) - Starting gateway...
...
2024-01-03 12:55:15,607  INFO  discovery.cm (PollingConfigurationAnalyzer.java:run(203)) - Started ClouderaManager cluster configuration monitor (checking every 5 seconds)
2024-01-03 12:55:15,607  INFO  knox.gateway (GatewayStatusService.java:status(45)) - Checking gateway status. No topologies to check
2024-01-03 12:55:15,608  INFO  discovery.cm (PollingConfigurationAnalyzer.java:run(215)) - The Knox Gateway is not yet ready to monitor ClouderaManager cluster configuration changes.
...
2024-01-03 12:55:20,609  INFO  knox.gateway (GatewayStatusService.java:status(50)) - Checking gateway status. Deployed topologies: [health]. Waiting for: [cdp-proxy, metadata, cdp-proxy-token, manager, knoxsso, admin, kt-kerberos, tokenexchange, cdp-proxy-api, homepage]
...
2024-01-03 12:55:25,610  INFO  knox.gateway (GatewayStatusService.java:status(50)) - Checking gateway status. Deployed topologies: [health]. Waiting for: [cdp-proxy, metadata, cdp-proxy-token, manager, knoxsso, admin, kt-kerberos, tokenexchange, cdp-proxy-api, homepage]
2024-01-03 12:55:25,610  INFO  discovery.cm (PollingConfigurationAnalyzer.java:run(215)) - The Knox Gateway is not yet ready to monitor ClouderaManager cluster configuration changes.
...
2024-01-03 12:55:30,611  INFO  knox.gateway (GatewayStatusService.java:status(50)) - Checking gateway status. Deployed topologies: [health]. Waiting for: [cdp-proxy, metadata, cdp-proxy-token, manager, knoxsso, admin, kt-kerberos, tokenexchange, cdp-proxy-api, homepage]
2024-01-03 12:55:30,611  INFO  discovery.cm (PollingConfigurationAnalyzer.java:run(215)) - The Knox Gateway is not yet ready to monitor ClouderaManager cluster configuration changes.
...
2024-01-03 12:55:35,612  INFO  knox.gateway (GatewayStatusService.java:status(50)) - Checking gateway status. Deployed topologies: [metadata, knoxsso, health, tokenexchange, homepage]. Waiting for: [cdp-proxy, cdp-proxy-token, manager, admin, kt-kerberos, cdp-proxy-api]
2024-01-03 12:55:35,612  INFO  discovery.cm (PollingConfigurationAnalyzer.java:run(215)) - The Knox Gateway is not yet ready to monitor ClouderaManager cluster configuration changes.
...
2024-01-03 12:55:40,613  INFO  knox.gateway (GatewayStatusService.java:status(50)) - Checking gateway status. Deployed topologies: [metadata, manager, knoxsso, health, admin, kt-kerberos, tokenexchange, cdp-proxy-api, homepage]. Waiting for: [cdp-proxy, cdp-proxy-token]
2024-01-03 12:55:40,613  INFO  discovery.cm (PollingConfigurationAnalyzer.java:run(215)) - The Knox Gateway is not yet ready to monitor ClouderaManager cluster configuration changes.
...
2024-01-03 12:55:45,613  INFO  knox.gateway (GatewayStatusService.java:status(50)) - Checking gateway status. Deployed topologies: [cdp-proxy, metadata, manager, cdp-proxy-token, knoxsso, health, admin, kt-kerberos, tokenexchange, cdp-proxy-api, homepage]. Waiting for: []
2024-01-03 12:55:45,614  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:monitorClusterConfigurationChanges(234)) - Checking Cluster 1 @ https://ccycloud-1.smolnar.root.comops.site:7183 for configuration changes...
2024-01-03 12:55:45,638  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(465)) - Querying configuration activation events from Cluster 1 @ https://ccycloud-1.smolnar.root.comops.site:7183 since 2024-01-03T12:55:21.944Z
2024-01-03 12:55:45,723  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(474)) - There is no any activation event found within the given time period
2024-01-03 12:55:50,723  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:monitorClusterConfigurationChanges(234)) - Checking Cluster 1 @ https://ccycloud-1.smolnar.root.comops.site:7183 for configuration changes...
2024-01-03 12:55:50,747  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(465)) - Querying configuration activation events from Cluster 1 @ https://ccycloud-1.smolnar.root.comops.site:7183 since 2024-01-03T12:55:35.639Z
2024-01-03 12:55:50,765  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(474)) - There is no any activation event found within the given time period
2024-01-03 12:55:55,766  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:monitorClusterConfigurationChanges(234)) - Checking Cluster 1 @ https://ccycloud-1.smolnar.root.comops.site:7183 for configuration changes...
2024-01-03 12:55:55,788  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:getRelevantEvents(465)) - Querying configuration activation events from Cluster 1 @ https://ccycloud-1.smolnar.root.comops.site:7183 since 2024-01-03T12:55:40.747Z
2024-01-03 12:55:55,811  DEBUG discovery.cm (PollingConfigurationAnalyzer.java:isRelevantEvent(494)) - Activation event relevance: eae8da4f-4c7c-446a-a533-d7baf45216e2 = false (Restart / SUCCEEDED / KNOX / false)
```
