### PR TITLE
KNOX-2982 - Having one disabled one enabled identity-assertion providers doesn't work

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/deploy/ServiceDeploymentContributorBase.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/deploy/ServiceDeploymentContributorBase.java
@@ -21,6 +21,7 @@ import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
 import org.apache.knox.gateway.topology.Provider;
 import org.apache.knox.gateway.topology.Service;
+import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.topology.Version;
 
 import java.net.URISyntaxException;
@@ -82,7 +83,9 @@ public abstract class ServiceDeploymentContributorBase extends DeploymentContrib
   protected void addIdentityAssertionFilter( DeploymentContext context, Service service, ResourceDescriptor resource) {
     if( topologyContainsProviderType( context, "authentication" ) ||
         topologyContainsProviderType( context, "federation"  ) ) {
-      context.contributeFilter( service, resource, "identity-assertion", null, null );
+      Topology topology = context.getTopology();
+      Provider activeProvider = topology.getProvider("identity-assertion", null);
+      context.contributeFilter(service, resource, "identity-assertion", activeProvider != null ? activeProvider.getName() : null, null);
     }
   }
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Topology.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/topology/Topology.java
@@ -157,7 +157,10 @@ public class Topology {
         provider = nameMap.get( name );
       }
       else {
-        provider = (Provider) nameMap.values().toArray()[0];
+        provider = nameMap.values().stream()
+                .filter(Provider::isEnabled)
+                .findFirst()
+                .orElse((Provider) nameMap.values().toArray()[0]);
       }
     }
     return provider;

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/topology/TopologyTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/topology/TopologyTest.java
@@ -90,6 +90,25 @@ public class TopologyTest {
   }
 
   @Test
+  public void testGettingMultipleProvidersReturnsTheFirstEnabled() {
+    Topology topology = new Topology();
+
+    Provider disabledProvider = new Provider();
+    disabledProvider.setRole("identity-assertion");
+    disabledProvider.setName("disabled_prov");
+    disabledProvider.setEnabled(false);
+    topology.addProvider(disabledProvider);
+
+    Provider enabledProvider = new Provider();
+    enabledProvider.setName("enabled_prov");
+    enabledProvider.setRole("identity-assertion");
+    enabledProvider.setEnabled(true);
+    topology.addProvider(enabledProvider);
+
+    assertEquals("enabled_prov", topology.getProvider("identity-assertion", null).getName());
+  }
+
+  @Test
   public void testEmptyTopologiesWithSameName() {
     final String name = "tName";
     Topology t1 = createTopology(name, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there are multiple providers in one topology, knox gets the first one, without checking if it's enabled or disabled.

Therefore having 2 identity-assertion providers where the first is disabled and the 2nd is enabled, doesn't work.

We should find the first enabled provider instead.

## How was this patch tested?

1st provider enabled

```xml
<provider>
    <role>identity-assertion</role>
    <name>SwitchCase</name>
    <enabled>true</enabled>
    <param>
        <name>principal.case</name>
        <value>upper</value>
    </param>
    <param> 
        <name>group.principal.case</name>
        <value>upper</value>
    </param>    
</provider>
```

2nd provider disabled:

```xml
<provider>
  <role>identity-assertion</role>
  <name>Regex</name>
  <enabled>false</enabled>
  <param>
    <name>input</name>
    <value>ad(.*)</value>
  </param>  
  <param>   
    <name>output</name>
    <value>{1}max</value>
  </param>      
</provider>
```

```
curl -vk -u admin:admin-password https://localhost:8443/gateway/sandbox/hive

24/01/09 14:04:50 ||eddb35a8-c6d7-4ae7-9d50-b0b3e50fddaa|audit|127.0.0.1|HIVE|admin|ADMIN||identity-mapping|principal|admin|success|Effective User: ADMIN
24/01/09 14:04:50 ||eddb35a8-c6d7-4ae7-9d50-b0b3e50fddaa|audit|127.0.0.1|HIVE|admin|ADMIN||identity-mapping|principal|ADMIN|success|Groups: []
```


1st provider disabled

```xml
<provider>
    <role>identity-assertion</role>
    <name>SwitchCase</name>
    <enabled>false</enabled>
    <param>
        <name>principal.case</name>
        <value>upper</value>
    </param>
    <param> 
        <name>group.principal.case</name>
        <value>upper</value>
    </param>    
</provider>
```

2nd provider enabled:

```xml
<provider>
  <role>identity-assertion</role>
  <name>Regex</name>
  <enabled>true</enabled>
  <param>
    <name>input</name>
    <value>ad(.*)</value>
  </param>  
  <param>   
    <name>output</name>
    <value>{1}max</value>
  </param>      
</provider>
```

```bash
curl -vk -u admin:admin-password https://localhost:8443/gateway/sandbox/hive

24/01/09 14:06:26 ||2d376454-b232-4011-85bd-cdbc526962e6|audit|127.0.0.1|HIVE|admin|minmax||identity-mapping|principal|admin|success|Effective User: minmax
24/01/09 14:06:26 ||2d376454-b232-4011-85bd-cdbc526962e6|audit|127.0.0.1|HIVE|admin|minmax||identity-mapping|principal|minmax|success|Groups: []
```

Both disabled:

```bash
curl -vk -u admin:admin-password https://localhost:8443/gateway/sandbox/hive
24/01/10 13:37:15 ||2badf91c-5922-4577-8b59-78dff76558f1|audit|127.0.0.1|HIVE|admin|||authentication|uri|/gateway/sandbox/hive|success|Groups: []
```
