### PR TITLE
KNOX-3000 - Add configurable socket / read timeout parameter to discovery client

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -276,6 +276,6 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.DEBUG, text = "Found downscale event for role: {0} hosts: {1}")
   void foundDownScaleEvent(String role, Set<String> hosts);
 
-  @Message(level = MessageLevel.DEBUG, text = "Service discovery client connect timeout {0}ms, read timeout {1}ms, write timeout {2}ms")
+  @Message(level = MessageLevel.DEBUG, text = "Service discovery client connect timeout {0} ms, read timeout {1} ms, write timeout {2} ms")
   void discoveryClientTimeout(long connectTimeout, long readTimeout, long writeTimeout);
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.topology.discovery.cm;
 import java.util.Set;
 
 import com.cloudera.api.swagger.client.ApiException;
+import com.squareup.okhttp.OkHttpClient;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
@@ -275,4 +276,7 @@ public interface ClouderaManagerServiceDiscoveryMessages {
 
   @Message(level = MessageLevel.DEBUG, text = "Found downscale event for role: {0} hosts: {1}")
   void foundDownScaleEvent(String role, Set<String> hosts);
+
+  @Message(level = MessageLevel.DEBUG, text = "Service discovery client connect timeout {0}ms, read timeout {1}ms, write timeout {2}ms")
+  void discoveryClientTimeout(long connectTimeout, long readTimeout, long writeTimeout);
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -19,7 +19,6 @@ package org.apache.knox.gateway.topology.discovery.cm;
 import java.util.Set;
 
 import com.cloudera.api.swagger.client.ApiException;
-import com.squareup.okhttp.OkHttpClient;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -287,6 +287,13 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_REPOSITORY_CACHE_ENTRY_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.repository.cache.entry.ttl";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPS = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.maximum.retry.attemps";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.connect.timeout.msec";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.read.timeout.msec";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.write.timeout.msec";
+
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT = 10000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 10000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT = 10000;
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";
@@ -1499,6 +1506,21 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public Map<String, Collection<String>> getApplicationPathAliases() {
     return getPathAliases(".application");
+  }
+
+  @Override
+  public long getServiceDiscoveryConnectTimeoutMillis() {
+    return getLong(CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT, CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT);
+  }
+
+  @Override
+  public long getServiceDiscoveryReadTimeoutMillis() {
+    return getLong(CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT, CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT);
+  }
+
+  @Override
+  public long getServiceDiscoveryWriteTimeoutMillis() {
+    return getLong(CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT, CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT);
   }
 
   private Map<String, Collection<String>> getPathAliases(String qualifier) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -287,13 +287,13 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String CLOUDERA_MANAGER_ADVANCED_SERVICE_DISCOVERY_CONF_MONITOR_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.advanced.service.discovery.config.monitor.interval";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_REPOSITORY_CACHE_ENTRY_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.repository.cache.entry.ttl";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPS = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.maximum.retry.attemps";
-  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.connect.timeout.msec";
-  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.read.timeout.msec";
-  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.write.timeout.msec";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.connect.timeout.ms";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.read.timeout.ms";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.write.timeout.ms";
 
-  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT = 20000;
-  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 20000;
-  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT = 20000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT = 10000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 10000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT = 10000;
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -291,9 +291,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.read.timeout.msec";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.write.timeout.msec";
 
-  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT = 10000;
-  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 10000;
-  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT = 10000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT = 20000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 20000;
+  private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT = 20000;
 
   private static final String KNOX_TOKEN_EVICTION_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.interval";
   private static final String KNOX_TOKEN_EVICTION_GRACE_PERIOD = GATEWAY_CONFIG_FILE_PREFIX + ".knox.token.eviction.grace.period";

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1067,4 +1067,18 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return Collections.emptyMap();
   }
 
+  @Override
+  public long getServiceDiscoveryConnectTimeoutMillis() {
+    return -1;
+  }
+
+  @Override
+  public long getServiceDiscoveryReadTimeoutMillis() {
+    return -1;
+  }
+
+  @Override
+  public long getServiceDiscoveryWriteTimeoutMillis() {
+    return -1;
+  }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -898,4 +898,9 @@ public interface GatewayConfig {
 
   Map<String, Collection<String>> getApplicationPathAliases();
 
+  long getServiceDiscoveryConnectTimeoutMillis();
+
+  long getServiceDiscoveryReadTimeoutMillis();
+
+  long getServiceDiscoveryWriteTimeoutMillis();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding configurable connect, read and write timeout parameters to CM's discovery client.

## How was this patch tested?

gateway-site.xml

```xml
<property>
    <name>gateway.cloudera.manager.service.discovery.connect.timeout.ms</name>
    <value>15000</value>
</property>

<property>
    <name>gateway.cloudera.manager.service.discovery.read.timeout.ms</name>
    <value>16000</value>
</property>

<property>
    <name>gateway.cloudera.manager.service.discovery.write.timeout.ms</name>
    <value>17000</value>
</property>
```    

```bash
cat conf/descriptors/test.json

{
  "name" : "cdp-proxy",
  "discovery-type" : "ClouderaManager",
  "discovery-address" : "http://HOST:7180",
  "discovery-user" : "test",
  "discovery-pwd-alias" : "pass",
  "provider-config-ref" : "default-providers",
  "read-only" : true,
  "cluster" : "Cluster 1",
  "services" : [ {
    "name" : "CM-API",
    "version" : null,
    "urls" : null
  }
 ]
}
```

```bash
./bin/knoxcli.sh create-alias pass --value pass
```

gateway.log

```
2024-01-17 12:52:05,839  DEBUG discovery.cm (DiscoveryApiClient.java:configureTimeouts(147)) - Service discovery client connect timeout 15,000ms, read timeout 16,000ms, write timeout 17,000ms
```
