### PR TITLE
KNOX-3001 - Avoid double XML-escaping during topology persistence from descriptors

### DIFF
--- a/gateway-server/src/test/resources/conf-full/conf/shared-providers/test-providers.json
+++ b/gateway-server/src/test/resources/conf-full/conf/shared-providers/test-providers.json
@@ -11,7 +11,7 @@
       "main.ldapRealm.contextFactory.authenticationMechanism" : "simple",
       "main.ldapRealm.contextFactory.url" : "ldap://localhost:33389",
       "main.ldapRealm.userDnTemplate" : "uid=0ou=people,dc=hadoop,dc=apache,dc=org",
-      "main.ldapRealm.userSearchFilter" : "(&(&(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)(memberOf=CN=SecXX-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)))",
+      "main.ldapRealm.userSearchFilter" : "(&(&amp;(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)(memberOf=CN=SecXX-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)))",
       "redirectToUrl" : "/${GATEWAY_PATH}/knoxsso/knoxauth/login.html",
       "restrictedCookies" : "rememberme,WWW-Authenticate",
       "sessionTimeout" : "30",

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -471,7 +471,7 @@ public class SimpleDescriptorHandler {
                 for (Map.Entry<String, String> param : provider.getParams().entrySet()) {
                     sw.write("            <param>\n");
                     sw.write("                <name>" + param.getKey() + "</name>\n");
-                    sw.write("                <value>" + StringEscapeUtils.escapeXml11(param.getValue()) + "</value>\n");
+                    sw.write("                <value>" + getXmlEscapedValue(param.getValue()) + "</value>\n");
                     sw.write("            </param>\n");
                 }
 
@@ -565,7 +565,7 @@ public class SimpleDescriptorHandler {
                         if (!(svcParam.getKey().toLowerCase(Locale.ROOT)).startsWith(SimpleDescriptor.DISCOVERY_PARAM_PREFIX)) {
                             sw.write("        <param>\n");
                             sw.write("            <name>" + svcParam.getKey() + "</name>\n");
-                            sw.write("            <value>" + StringEscapeUtils.escapeXml11(svcParam.getValue()) + "</value>\n");
+                            sw.write("            <value>" + getXmlEscapedValue(svcParam.getValue()) + "</value>\n");
                             sw.write("        </param>\n");
                         }
                     }
@@ -595,7 +595,7 @@ public class SimpleDescriptorHandler {
                         for (Entry<String, String> entry : appParams.entrySet()) {
                             sw.write("        <param>\n");
                             sw.write("            <name>" + entry.getKey() + "</name>\n");
-                            sw.write("            <value>" + StringEscapeUtils.escapeXml11(entry.getValue()) + "</value>\n");
+                            sw.write("            <value>" + getXmlEscapedValue(entry.getValue()) + "</value>\n");
                             sw.write("        </param>\n");
                         }
                     }
@@ -633,6 +633,15 @@ public class SimpleDescriptorHandler {
         result.put(RESULT_TOPOLOGY, topologyDescriptor);
 
         return result;
+    }
+
+    /*
+     * First, undoes any previous manual XML escape.
+     * Second applies XML-escape on the result of the first step.
+     */
+    private static String getXmlEscapedValue(String value) {
+      final String unescapedValue = StringEscapeUtils.unescapeXml(value);
+      return StringEscapeUtils.escapeXml10(unescapedValue);
     }
 
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in [KNOX-3001](https://issues.apache.org/jira/browse/KNOX-3001), if the shared provider, descriptor, service, or application originally contains XML-escaped values, Knox will persist topologies in a way such that those already escaped values become doubly-escaped.
To avoid this issue the following was implemented:
- unescape the value first
- escape the unescaped result

## How was this patch tested?

I updated existing JUnit tests where a shared provider config contains both a single `&` and an escaped `&amp;` in its .json file. The test then proves the generated XML is parsed properly and contains the desired `&` value in the SAX document.

I also ran integration tests with the following shared-provider and descriptor files:
```
$ cat conf/shared-providers/smolnar.json 
{
  "providers" : [ {
    "role" : "webappsec",
    "name" : "WebAppSec",
    "enabled" : true,
    "params" : {
      "xframe.options.enabled" : "true"
    }
  }, {
    "role" : "authentication",
    "name" : "ShiroProvider",
    "enabled" : true,
    "params" : {
      "main.ldapContextFactory" : "org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory",
      "main.ldapRealm" : "org.apache.knox.gateway.shirorealm.KnoxLdapRealm",
      "main.ldapRealm.authenticationCachingEnabled" : "false",
      "main.ldapRealm.contextFactory" : "$ldapContextFactory",
      "main.ldapRealm.contextFactory.authenticationMechanism" : "simple",
      "main.ldapRealm.contextFactory.url" : "ldap://localhost:33389",
      "main.ldapRealm.userDnTemplate" : "uid=0ou=people,dc=hadoop,dc=apache,dc=org",
      "main.ldapRealm.userSearchFilter" : "(&(&amp;(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)(memberOf=CN=SecXX-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)))",
      "redirectToUrl" : "/${GATEWAY_PATH}/knoxsso/knoxauth/login.html",
      "restrictedCookies" : "rememberme,WWW-Authenticate",
      "sessionTimeout" : "30",
      "urls./**" : "authcBasic"
    }
  }, {
    "role" : "identity-assertion",
    "name" : "Default",
    "enabled" : true,
    "params" : { }
  } ],
  "readOnly" : true
}

$ cat conf/descriptors/smolnar.json 
{
   "provider-config-ref": "smolnar",
   "services": [
      {
        "name": "KNOXSSO",
        "params": {
            "knoxsso.token.ttl": "86400000",
            "knoxsso.token.sigalg": "",
            "knoxsso.redirect.whitelist.regex": "^https?:\\/\\/(.*smolnar\\.root\\.xyz\\.com)(?::[0-9]+)?(?:\\/.*)?$"
         }
      }
   ],
   "applications": [
     {
       "name": "knoxauth"
     }
   ]
}
```

Then I confirmed that the generated topology is in good shape:
```
$ cat conf/topologies/smolnar.xml 
<?xml version="1.0" encoding="utf-8"?>
<!--==============================================-->
<!-- DO NOT EDIT. This is an auto-generated file. -->
<!--==============================================-->
<topology>
    <generated>true</generated>
    <gateway>
        <provider>
            <role>webappsec</role>
            <name>WebAppSec</name>
            <enabled>true</enabled>
            <param>
                <name>xframe.options.enabled</name>
                <value>true</value>
            </param>
        </provider>
        <provider>
            <role>authentication</role>
            <name>ShiroProvider</name>
            <enabled>true</enabled>
            <param>
                <name>main.ldapContextFactory</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm</name>
                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
            </param>
            <param>
                <name>main.ldapRealm.authenticationCachingEnabled</name>
                <value>false</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory</name>
                <value>$ldapContextFactory</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
                <value>simple</value>
            </param>
            <param>
                <name>main.ldapRealm.contextFactory.url</name>
                <value>ldap://localhost:33389</value>
            </param>
            <param>
                <name>main.ldapRealm.userDnTemplate</name>
                <value>uid=0ou=people,dc=hadoop,dc=apache,dc=org</value>
            </param>
            <param>
                <name>main.ldapRealm.userSearchFilter</name>
                <value>(&amp;(&amp;(objectclass=person)(sAMAccountName={0}))(|(memberOf=CN=SecXX-users,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)(memberOf=CN=SecXX-rls-serviceuser,OU=ManagedGroups,OU=Groups,OU=XX,OU=xx,DC=xx,DC=int)))</value>
            </param>
            <param>
                <name>redirectToUrl</name>
                <value>/${GATEWAY_PATH}/knoxsso/knoxauth/login.html</value>
            </param>
            <param>
                <name>restrictedCookies</name>
                <value>rememberme,WWW-Authenticate</value>
            </param>
            <param>
                <name>sessionTimeout</name>
                <value>30</value>
            </param>
            <param>
                <name>urls./**</name>
                <value>authcBasic</value>
            </param>
        </provider>
        <provider>
            <role>identity-assertion</role>
            <name>Default</name>
            <enabled>true</enabled>
        </provider>
    </gateway>

    <service>
        <role>KNOXSSO</role>
        <param>
            <name>knoxsso.token.ttl</name>
            <value>86400000</value>
        </param>
        <param>
            <name>knoxsso.token.sigalg</name>
            <value></value>
        </param>
        <param>
            <name>knoxsso.redirect.whitelist.regex</name>
            <value>^https?:\/\/(.*smolnar\.root\.xyz\.com)(?::[0-9]+)?(?:\/.*)?$</value>
        </param>
    </service>
    <application>
        <name>knoxauth</name>
    </application>
</topology>
```