### PR TITLE
KNOX-3002 - KnoxCLI command for generating descriptor for a role type from a list of hosts

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/DescriptorGenerator.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/DescriptorGenerator.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.knox.gateway.util;
 
 import java.io.File;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/DescriptorGenerator.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/DescriptorGenerator.java
@@ -1,0 +1,53 @@
+package org.apache.knox.gateway.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Locale;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.knox.gateway.model.DescriptorConfiguration;
+import org.apache.knox.gateway.model.Topology;
+
+public class DescriptorGenerator {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private final String descriptorName;
+  private final String providerName;
+  private final String serviceName;
+  private final ServiceUrls serviceUrls;
+
+  static {
+    /* skip printing out null fields */
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+  }
+
+  public DescriptorGenerator(String descriptorName, String providerName, String serviceName, ServiceUrls serviceUrls) {
+    this.descriptorName = descriptorName;
+    this.providerName = providerName;
+    this.serviceName = serviceName.toUpperCase(Locale.ROOT);
+    this.serviceUrls = serviceUrls;
+  }
+
+  public void saveDescriptor(File outputDir, boolean forceOverwrite) {
+    File outputFile = new File(outputDir, descriptorName);
+    if (outputFile.exists() && !forceOverwrite) {
+      throw new IllegalArgumentException(outputFile + "already exists");
+    }
+    DescriptorConfiguration descriptor = new DescriptorConfiguration();
+    descriptor.setName(FilenameUtils.removeExtension(descriptorName));
+    descriptor.setProviderConfig(FilenameUtils.removeExtension(providerName));
+    Topology.Service service = new Topology.Service();
+    service.setRole(serviceName);
+    service.setUrls(serviceUrls.toList());
+    descriptor.setServices(Arrays.asList(service));
+    try {
+      mapper.writerWithDefaultPrettyPrinter()
+              .writeValue(outputFile, descriptor);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -2462,11 +2462,11 @@ public class KnoxCLI extends Configured implements Tool {
     @Override
     public void execute() throws Exception {
       validateParams();
-      File outputDir = StringUtils.isBlank(KnoxCLI.this.outputDir) ? new File(".") : new File(KnoxCLI.this.outputDir);
+      File output = StringUtils.isBlank(outputDir) ? new File(".") : new File(outputDir);
       DescriptorGenerator generator =
               new DescriptorGenerator(descriptorName, providerName, serviceName, ServiceUrls.fromFile(urlsFilePath), params);
-      generator.saveDescriptor(outputDir, force);
-      out.println("Descriptor " + descriptorName + " was successfully saved to " + outputDir.getAbsolutePath() + "\n");
+      generator.saveDescriptor(output, force);
+      out.println("Descriptor " + descriptorName + " was successfully saved to " + output.getAbsolutePath() + "\n");
     }
 
     private void validateParams() {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -2346,7 +2346,7 @@ public class KnoxCLI extends Configured implements Tool {
             + "--descriptor-name (optional) name of descriptor json config file (including .json extension) \n"
             + "--topology-name (optional) topology-name can be use instead of --path option, if used, KnoxCLI will attempt to find topology from deployed topologies.\n"
             + "\t if not provided topology name will be used as descriptor name \n"
-            + "--output-dir (optional) output directory to save provider and descriptor config files \n"
+            + "--output-dir (optional) output directory to save provider and descriptor config files. Default is the current working directory. \n"
             + "\t if not provided config files will be saved in appropriate Knox config directory \n"
             + "--force (optional) force rewriting of existing files, if not used, command will fail when the configs files with same name already exist. \n"
             + "--cluster (optional) cluster name, required for service discovery \n"
@@ -2449,6 +2449,15 @@ public class KnoxCLI extends Configured implements Tool {
 
     @Override
     public void execute() throws Exception {
+      validateParams();
+      File outputDir = StringUtils.isBlank(KnoxCLI.this.outputDir) ? new File(".") : new File(KnoxCLI.this.outputDir);
+      DescriptorGenerator generator =
+              new DescriptorGenerator(descriptorName, providerName, serviceName, ServiceUrls.fromFile(urlsFilePath));
+      generator.saveDescriptor(outputDir, force);
+      out.println("Descriptor " + descriptorName + " was successfully saved to " + outputDir.getAbsolutePath() + "\n");
+    }
+
+    private void validateParams() {
       if (StringUtils.isBlank(FilenameUtils.getExtension(providerName))
               || StringUtils.isBlank(FilenameUtils.getExtension(descriptorName))) {
         throw new IllegalArgumentException("JSON extension is required for provider and descriptor file names");
@@ -2462,14 +2471,6 @@ public class KnoxCLI extends Configured implements Tool {
       if (StringUtils.isBlank(serviceName)) {
         throw new IllegalArgumentException("Missing --service-name");
       }
-      File outputDir = StringUtils.isBlank(KnoxCLI.this.outputDir) ? new File(".") : new File(KnoxCLI.this.outputDir);
-
-      DescriptorGenerator generator =
-              new DescriptorGenerator(descriptorName, providerName, serviceName, ServiceUrls.fromFile(new File(urlsFilePath)));
-      generator.saveDescriptor(
-              outputDir, force);
-
-      out.println("Descriptor " + descriptorName + " was successfully saved to " + outputDir.getAbsolutePath() + "\n");
     }
 
     @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -177,7 +177,7 @@ public class KnoxCLI extends Configured implements Tool {
   private String discoveryType;
   private String serviceName;
   private String urlsFilePath;
-  private final TreeMap<String, String> params = new TreeMap<>();
+  private final Map<String, String> params = new TreeMap<>();
 
   // For testing only
   private String master;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -43,6 +43,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -176,6 +177,7 @@ public class KnoxCLI extends Configured implements Tool {
   private String discoveryType;
   private String serviceName;
   private String urlsFilePath;
+  private final TreeMap<String, String> params = new TreeMap<>();
 
   // For testing only
   private String master;
@@ -539,8 +541,15 @@ public class KnoxCLI extends Configured implements Tool {
           return -1;
         }
       } else if (args[i].equalsIgnoreCase("generate-descriptor")) {
-        if (args.length >= 4) {
+        if (args.length >= 7) {
           command = new GenerateDescriptorCommand();
+        } else {
+          printKnoxShellUsage();
+          return -1;
+        }
+      } else if (args[i].equalsIgnoreCase("--param")) {
+        if (i + 2 < args.length) {
+          params.put(args[++i], args[++i]);
         } else {
           printKnoxShellUsage();
           return -1;
@@ -2436,6 +2445,8 @@ public class KnoxCLI extends Configured implements Tool {
             "generate-descriptor --service-urls-file \"path/to/urls.txt\" --service-name SERVICE_NAME \n" +
                     "--provider-name my-provider.json --descriptor-name my-descriptor.json \n" +
                     "[--output-dir /path/to/output_dir] \n" +
+                    "[--param key1 value1] \n" +
+                    "[--param key2 value2] \n" +
                     "[--force] \n";
     public static final String DESC =
             "Create Knox topology descriptor file for one service\n"
@@ -2445,6 +2456,7 @@ public class KnoxCLI extends Configured implements Tool {
                     + "--descriptor-name (required) name of descriptor to be created \n"
                     + "--provider-name (required) name of the referenced shared provider \n"
                     + "--output-dir (optional) output directory to save the descriptor file \n"
+                    + "--param (optional) service param name and value \n"
                     + "--force (optional) force rewriting of existing files, if not used, command will fail when the configs files with same name already exist. \n";
 
     @Override
@@ -2452,7 +2464,7 @@ public class KnoxCLI extends Configured implements Tool {
       validateParams();
       File outputDir = StringUtils.isBlank(KnoxCLI.this.outputDir) ? new File(".") : new File(KnoxCLI.this.outputDir);
       DescriptorGenerator generator =
-              new DescriptorGenerator(descriptorName, providerName, serviceName, ServiceUrls.fromFile(urlsFilePath));
+              new DescriptorGenerator(descriptorName, providerName, serviceName, ServiceUrls.fromFile(urlsFilePath), params);
       generator.saveDescriptor(outputDir, force);
       out.println("Descriptor " + descriptorName + " was successfully saved to " + outputDir.getAbsolutePath() + "\n");
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/ServiceUrls.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/ServiceUrls.java
@@ -14,6 +14,10 @@ import org.apache.commons.lang3.StringUtils;
 public class ServiceUrls {
   private final List<String> urls;
 
+  public static ServiceUrls fromFile(String urlsFilePath) {
+    return fromFile(new File(urlsFilePath));
+  }
+
   public static ServiceUrls fromFile(File urlsFilePath) {
     try {
       List<String> lines = FileUtils.readLines(urlsFilePath, Charset.defaultCharset()).stream()

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/ServiceUrls.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/ServiceUrls.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.knox.gateway.util;
 
 import java.io.File;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/ServiceUrls.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/ServiceUrls.java
@@ -1,0 +1,36 @@
+package org.apache.knox.gateway.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public class ServiceUrls {
+  private final List<String> urls;
+
+  public static ServiceUrls fromFile(File urlsFilePath) {
+    try {
+      List<String> lines = FileUtils.readLines(urlsFilePath, Charset.defaultCharset()).stream()
+              .map(String::trim)
+              .filter(StringUtils::isNotBlank)
+              .collect(Collectors.toList());
+      return new ServiceUrls(lines);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public ServiceUrls(List<String> urls) {
+    this.urls = urls;
+  }
+
+  public List<String> toList() {
+    return Collections.unmodifiableList(urls);
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.knox.gateway.util;
 
 import static org.junit.Assert.assertEquals;

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
@@ -43,9 +43,9 @@ public class DescriptorGeneratorTest {
   private static final List<String> URLS =
           Arrays.asList("http://amagyar-1.test.site:25000/", "http://amagyar-2.test.site:25000");
 
-  private static final Map<String,String> PARAMS = new HashMap<String,String>() {{
-    put("KEY_1", "VAL_1");
-  }};
+  private static final Map<String,String> PARAMS = new HashMap<>();
+  
+  static { PARAMS.put("KEY_1", "VAL_1"); }
 
   @Rule
   public TemporaryFolder folder= new TemporaryFolder();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
@@ -1,0 +1,55 @@
+package org.apache.knox.gateway.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.knox.gateway.model.DescriptorConfiguration;
+import org.apache.knox.gateway.model.Topology;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DescriptorGeneratorTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String TEST_DESC_1 = "test_desc1.json";
+  private static final String TEST_PROV_1 = "test_prov1.json";
+  private static final String IMPALA_UI = "IMPALAUI";
+  private static final List<String> URLS =
+          Arrays.asList("http://amagyar-1.test.site:25000/", "http://amagyar-2.test.site:25000");
+  @Rule
+  public TemporaryFolder folder= new TemporaryFolder();
+
+  @Test
+  public void testCreateDescriptor() throws Exception {
+    DescriptorGenerator generator = new DescriptorGenerator(TEST_DESC_1, TEST_PROV_1, IMPALA_UI, new ServiceUrls(URLS));
+    File outputDir = folder.newFolder().getAbsoluteFile();
+    File outputFile = new File(outputDir, TEST_DESC_1);
+    generator.saveDescriptor(outputDir, false);
+    System.out.println(FileUtils.readFileToString(outputFile, Charset.defaultCharset()));
+    DescriptorConfiguration result = mapper
+            .readerFor(DescriptorConfiguration.class)
+            .readValue(outputFile);
+    assertEquals(FilenameUtils.removeExtension(TEST_PROV_1), result.getProviderConfig());
+    assertEquals(FilenameUtils.removeExtension(TEST_DESC_1), result.getName());
+    assertEquals(1, result.getServices().size());
+    Topology.Service service = result.getServices().get(0);
+    assertEquals(IMPALA_UI, service.getRole());
+    assertEquals(URLS, service.getUrls());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOutputAlreadyExists() throws Exception {
+    DescriptorGenerator generator = new DescriptorGenerator(TEST_DESC_1, TEST_PROV_1, IMPALA_UI, new ServiceUrls(URLS));
+    File outputDir = folder.newFolder().getAbsoluteFile();
+    File outputFile = new File(outputDir, TEST_DESC_1);
+    outputFile.createNewFile();
+    generator.saveDescriptor(outputDir, false);
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
@@ -44,7 +44,6 @@ public class DescriptorGeneratorTest {
           Arrays.asList("http://amagyar-1.test.site:25000/", "http://amagyar-2.test.site:25000");
 
   private static final Map<String,String> PARAMS = new HashMap<>();
-  
   static { PARAMS.put("KEY_1", "VAL_1"); }
 
   @Rule

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/DescriptorGeneratorTest.java
@@ -22,7 +22,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
@@ -40,12 +42,17 @@ public class DescriptorGeneratorTest {
   private static final String IMPALA_UI = "IMPALAUI";
   private static final List<String> URLS =
           Arrays.asList("http://amagyar-1.test.site:25000/", "http://amagyar-2.test.site:25000");
+
+  private static final Map<String,String> PARAMS = new HashMap<String,String>() {{
+    put("KEY_1", "VAL_1");
+  }};
+
   @Rule
   public TemporaryFolder folder= new TemporaryFolder();
 
   @Test
   public void testCreateDescriptor() throws Exception {
-    DescriptorGenerator generator = new DescriptorGenerator(TEST_DESC_1, TEST_PROV_1, IMPALA_UI, new ServiceUrls(URLS));
+    DescriptorGenerator generator = new DescriptorGenerator(TEST_DESC_1, TEST_PROV_1, IMPALA_UI, new ServiceUrls(URLS), PARAMS);
     File outputDir = folder.newFolder().getAbsoluteFile();
     File outputFile = new File(outputDir, TEST_DESC_1);
     generator.saveDescriptor(outputDir, false);
@@ -59,11 +66,14 @@ public class DescriptorGeneratorTest {
     Topology.Service service = result.getServices().get(0);
     assertEquals(IMPALA_UI, service.getRole());
     assertEquals(URLS, service.getUrls());
+    assertEquals(1, service.getParams().size());
+    assertEquals("KEY_1", service.getParams().get(0).getName());
+    assertEquals("VAL_1", service.getParams().get(0).getValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testOutputAlreadyExists() throws Exception {
-    DescriptorGenerator generator = new DescriptorGenerator(TEST_DESC_1, TEST_PROV_1, IMPALA_UI, new ServiceUrls(URLS));
+    DescriptorGenerator generator = new DescriptorGenerator(TEST_DESC_1, TEST_PROV_1, IMPALA_UI, new ServiceUrls(URLS), PARAMS);
     File outputDir = folder.newFolder().getAbsoluteFile();
     File outputFile = new File(outputDir, TEST_DESC_1);
     outputFile.createNewFile();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a command to knoxcli that can generate a topology descriptor from a list of URLs.

Usage:

```
Create Knox topology descriptor file for one service
Options are as follows: 
--service-urls-file (required) path to a text file containing service urls 
--service-name (required) the name of the service, such as WEBHDFS, IMPALAUI or HIVE 
--descriptor-name (required) name of descriptor to be created 
--provider-name (required) name of the referenced shared provider 
--output-dir (optional) output directory to save the descriptor file 
--force (optional) force rewriting of existing files, if not used, command will fail when the configs files with same name 
already exist. 
--param service-param-name1 service-param-value1
--param service-param-nameN service-param-valueN
```

## How was this patch tested?
```bash
cat /tmp/urls.txt

http://url1.site:5000
http://url2.site:5000
```

```bash
$ bin/knoxcli.sh generate-descriptor --service-urls-file /tmp/urls.txt --service-name IMPALAUI --provider-name pam.json --descriptor-name impalads.json

Descriptor impalads.json was successfully saved to /Users/attilamagyar/development/test/.
```


```bash
cat impalads.txt

{
  "name" : "impalads",
  "provider-config-ref" : "pam",
  "services" : [ {
    "params" : { },
    "name" : "IMPALAUI",
    "urls" : [ "http://url1.site:5000", "http://url2.site:5000" ]
  } ]
}
```

