### PR TITLE
KNOX-3003 - Services with more than one serviceUrl metadata are grouped on the Knox Home page

### DIFF
--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -229,9 +229,8 @@ public class KnoxMetadataResource {
           Set<ServiceModel> apiServices = new HashSet<>();
           Set<ServiceModel> uiServices = new HashSet<>();
           topology.getServices().stream().filter(service -> !UNREAL_SERVICES.contains(service.getRole())).forEach(service -> {
-            service.getUrls().forEach(serviceUrl -> {
-              ServiceModel serviceModel = getServiceModel(request, config.getGatewayPath(), topology.getName(), service, getServiceMetadata(serviceDefinitionRegistry, service),
-                  serviceUrl);
+            if (!service.getUrls().isEmpty()) {
+              final ServiceModel serviceModel = getServiceModel(request, config.getGatewayPath(), topology.getName(), service, getServiceMetadata(serviceDefinitionRegistry, service));
               if (ServiceModel.Type.UI == serviceModel.getType()) {
                 uiServices.add(serviceModel);
               } else if (ServiceModel.Type.API_AND_UI == serviceModel.getType()) {
@@ -240,7 +239,7 @@ public class KnoxMetadataResource {
               } else {
                 apiServices.add(serviceModel);
               }
-            });
+            }
           });
           topologies.addTopology(topology.getName(), isPinnedTopology(topology.getName(), config), config.getApiServicesViewVersionOnHomepage(), new TreeSet<>(apiServices), new TreeSet<>(uiServices));
         }
@@ -264,14 +263,13 @@ public class KnoxMetadataResource {
     return serviceDefinition.isPresent() ? serviceDefinition.get().getService().getMetadata() : null;
   }
 
-  private ServiceModel getServiceModel(HttpServletRequest request, String gatewayPath, String topologyName, Service service, Metadata serviceMetadata, String serviceUrl) {
+  private ServiceModel getServiceModel(HttpServletRequest request, String gatewayPath, String topologyName, Service service, Metadata serviceMetadata) {
     final ServiceModel serviceModel = new ServiceModel();
     serviceModel.setRequest(request);
     serviceModel.setGatewayPath(gatewayPath);
     serviceModel.setTopologyName(topologyName);
     serviceModel.setService(service);
     serviceModel.setServiceMetadata(serviceMetadata);
-    serviceModel.setServiceUrl(serviceUrl);
     return serviceModel;
   }
 

--- a/knox-homepage-ui/home/app/topologies/service.ts
+++ b/knox-homepage-ui/home/app/topologies/service.ts
@@ -20,7 +20,7 @@ export class Service {
     description: string;
     serviceName: string;
     version: string;
-    serviceUrl: string;
+    serviceUrls: string[];
     shortDesc: string;
     type: string;
     context: string;

--- a/knox-homepage-ui/home/app/topologies/topology.information.component.css
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.css
@@ -34,3 +34,7 @@ mat-grid-tile-footer figcaption h3 {
   transition: all 0.3s linear;
   visibility: visible;
 }
+
+/deep/ .groupServiceInformationModal {
+    width: 80%;
+}

--- a/knox-homepage-ui/home/app/topologies/topology.information.component.html
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.html
@@ -38,18 +38,31 @@
         <!-- UI services -->
         <mat-grid-list cols="4" rowHeight="130px">
             <mat-grid-tile *ngFor="let service of topology.uiServices.service" [colspan]="1" [rowspan]="1">
-                 <a href="{{service.serviceUrl}}" target="_blank" *ngIf="!this['enableServiceText_' + service.serviceName.toLowerCase()]">
+
+                <!-- Services with 1 service URL -->
+                <div *ngIf="service.serviceUrls.length === 1">
+                    <a href="{{service.serviceUrls[0]}}" target="_blank" *ngIf="!this['enableServiceText_' + service.serviceName.toLowerCase()]">
+                        <img src="assets/service-logos/{{service.serviceName.toLowerCase()}}.png" height="50px" (error)="enableServiceText('enableServiceText_' + service.serviceName.toLowerCase())"/>
+                    </a>
+                    <a href="{{service.serviceUrls[0]}}" target="_blank" *ngIf="this['enableServiceText_' + service.serviceName.toLowerCase()]">
+                        {{service.shortDesc}}
+                    </a>
+                    <mat-grid-tile-footer class="tile-shortDesc">
+                        <h3>{{service.shortDesc}} <span class="small" *ngIf="service.version">(v{{service.version}})</span></h3>
+                    </mat-grid-tile-footer>
+                    <mat-grid-tile-footer class="tile-longDesc" style="height:100px;">
+                        <h3>{{service.description}}</h3>
+                    </mat-grid-tile-footer>
+                </div>
+
+                <!-- Services with more than 1 service URL -->
+                <div *ngIf="service.serviceUrls.length > 1" (click)="openGroupServiceInformationModal(service)">
                     <img src="assets/service-logos/{{service.serviceName.toLowerCase()}}.png" height="50px" (error)="enableServiceText('enableServiceText_' + service.serviceName.toLowerCase())"/>
-                </a>
-                 <a href="{{service.serviceUrl}}" target="_blank" *ngIf="this['enableServiceText_' + service.serviceName.toLowerCase()]">
-                    {{service.shortDesc}}
-                </a>
-                <mat-grid-tile-footer class="tile-shortDesc">
-                    <h3>{{service.shortDesc}} <span class="small" *ngIf="service.version">(v{{service.version}})</span></h3>
-                </mat-grid-tile-footer>
-                <mat-grid-tile-footer class="tile-longDesc" style="height:100px;">
-                    <h3>{{service.description}}</h3>
-                </mat-grid-tile-footer>
+                    <mat-grid-tile-footer class="tile-shortDesc">
+                        <h3>{{service.shortDesc}} ({{service.serviceUrls.length}})</h3>
+                    </mat-grid-tile-footer>
+                </div>
+
             </mat-grid-tile>
         </mat-grid-list>
 
@@ -75,7 +88,10 @@
                         {{service.shortDesc}} <span class="small" *ngIf="service.version">(v{{service.version}})</span>
                     </td>
                     <td>
-                        <a href="{{service.serviceUrl}}">{{service.serviceUrl}}</a>
+                        <ng-container *ngFor="let serviceUrl of service.serviceUrls">
+                            <a href="{{serviceUrl}}">{{serviceUrl}}</a>
+                            <br *ngIf="service.serviceUrls.length > 1" />
+                        </ng-container>
                     </td>
                 </tr>
             </tbody>
@@ -141,7 +157,7 @@
                        <div *ngIf="!selectedApiService.samples || selectedApiService.samples.sample.length < 1">
                          <tr><td style="font-weight: bold;">There is no any sample found in service metadata</td></tr>
                          <tr>
-                           <td>&nbsp;You may check out the service's documentation and find out how to use its REST API. The service's URL is <a href="{{selectedApiService.serviceUrl}}" target="_blank">{{selectedApiService.serviceUrl}}</a></td>
+                           <td>&nbsp;You may check out the service's documentation and find out how to use its REST API. The service's URL is <a href="{{selectedApiService.serviceUrls[0]}}" target="_blank">{{selectedApiService.serviceUrls[0]}}</a></td>
                          </tr>
                        </div>
                      </table>
@@ -149,8 +165,42 @@
                </tr>
            </table>
        </div>
+       
     </bs-modal-body>
     <bs-modal-footer>
         <button type="button" class="btn btn-primary btn-sm" (click)="apiServiceInformationModal.close()">Close</button>
+    </bs-modal-footer>
+</bs-modal>
+
+
+<bs-modal #groupServiceInformationModal cssClass="groupServiceInformationModal" [animation]="true">
+    <bs-modal-header [showDismiss]="true" *ngIf="selectedGroupService">
+        <h4 class="modal-title">{{selectedGroupService.shortDesc}} <span class="small" *ngIf="selectedGroupService.version">(v{{selectedGroupService.version}})</span></h4>
+    </bs-modal-header>
+     <bs-modal-body *ngIf="selectedGroupService">
+         <span>
+             {{selectedGroupService.description}}
+         </span>
+         <br/><br/>
+         <span align="center">
+            <input type="text" placeholder="Search by hostname, port..." (input)="filterServiceUrls($event.target.value)" style="width: 50%">
+         </span>
+
+        <mat-grid-list cols="4" rowHeight="130px">
+            <mat-grid-tile *ngFor="let serviceUrl of filteredServiceUrls" [colspan]="1" [rowspan]="1">
+                <a href="{{serviceUrl}}" target="_blank" *ngIf="!this['enableServiceText_' + selectedGroupService.serviceName.toLowerCase()]">
+                    <img src="assets/service-logos/{{selectedGroupService.serviceName.toLowerCase()}}.png" height="50px" (error)="enableServiceText('enableServiceText_' + selectedGroupService.serviceName.toLowerCase())"/>
+                </a>
+                <a href="{{serviceUrl}}" target="_blank" *ngIf="this['enableServiceText_' + selectedGroupService.serviceName.toLowerCase()]">
+                    {{selectedGroupService.shortDesc}}
+                </a>
+                <mat-grid-tile-footer class="tile-shortDesc">
+                    <h3>{{selectedGroupService.shortDesc}} {{getServiceUrlHostAndPort(serviceUrl)}}</h3>
+                </mat-grid-tile-footer>
+            </mat-grid-tile>
+        </mat-grid-list>
+     </bs-modal-body>
+    <bs-modal-footer>
+        <button type="button" class="btn btn-primary btn-sm" (click)="groupServiceInformationModal.close()">Close</button>
     </bs-modal-footer>
 </bs-modal>

--- a/knox-homepage-ui/home/app/topologies/topology.information.component.ts
+++ b/knox-homepage-ui/home/app/topologies/topology.information.component.ts
@@ -34,9 +34,14 @@ export class TopologyInformationsComponent implements OnInit {
     @ViewChild('apiServiceInformationModal')
     apiServiceInformationModal: BsModalComponent;
 
+    @ViewChild('groupServiceInformationModal')
+    groupServiceInformationModal: BsModalComponent;
+
     topologies: TopologyInformation[];
     desiredTopologies: string[];
     selectedApiService: Service;
+    selectedGroupService: Service;
+    filteredServiceUrls: string[];
 
     setTopologies(topologies: TopologyInformation[]) {
         this.topologies = topologies;
@@ -106,4 +111,26 @@ export class TopologyInformationsComponent implements OnInit {
         this.apiServiceInformationModal.open('lg');
     }
 
+    openGroupServiceInformationModal(groupService: Service) {
+        this.selectedGroupService = groupService;
+        this.filteredServiceUrls = this.selectedGroupService.serviceUrls;
+        this.groupServiceInformationModal.open();
+    }
+
+    getServiceUrlHostAndPort(serviceUrl: string): string {
+	    let hostStart = serviceUrl.indexOf('host=');
+        if (hostStart > 0 ) {
+            return ' - ' + serviceUrl.slice(hostStart).replace('host=', '').replace('&port=', ':')
+                   .replace('https://', '').replace('http://', '');
+        }
+	    return '';
+    }
+
+    filterServiceUrls(filterText: string): void {
+	    if (filterText === '') {
+		    this.filteredServiceUrls = this.selectedGroupService.serviceUrls;
+	    } else {
+		    this.filteredServiceUrls = this.selectedGroupService.serviceUrls.filter(serviceUrl => serviceUrl.includes(filterText));
+        }
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two important pieces of this PR:
1. the `getTopologies` REST API endpoint in `KnoxMetadataResource` was modified in a way such that it includes only one item per service role (IMPALAUI, WEBHDFS, HUE, HBASEUI, etc...) with a list of service URLs from now on. In previous versions it was different: the response had `N` items per service role with a unique service URL.

```
$ curl -H 'Accept: application/json' -iku admin:admin-password https://localhost:8443/gateway/sandbox/api/v1/metadata/topologies?name=sandbox
HTTP/1.1 200 OK
Date: Wed, 31 Jan 2024 09:32:09 GMT
Set-Cookie: KNOXSESSIONID=node0pafwbogn50gjy2zjiaxuchwx0.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Tue, 30-Jan-2024 09:32:09 GMT; SameSite=lax
Content-Type: application/json
Transfer-Encoding: chunked

{
    "topologyInformations": {
        "topologyInformation": [
            {
                "topology": "sandbox",
                "pinned": false,
                "apiServicesViewVersion": "v1",
                "apiServices": {
                    "service": [
                        {
                            "context": "/webhdfs",
                            "description": "An HTTP REST API which supports the complete FileSystem interface for HDFS.",
                            "samples": {
                                "sample": [
                                    {
                                        "description": "List all files under 'testPath'",
                                        "value": "curl -iv -X GET \"https://localhost:8443/gateway/sandbox/webhdfs/v1/testPath?op=LISTSTATUS\""
                                    },
                                    {
                                        "description": "Rename a File/Directory under ",
                                        "value": "curl -iv -X PUT \"https://localhost:8443/gateway/sandbox/webhdfs/v1/testPath/testFile?op=RENAME&destination=testPath/renamedFile\""
                                    },
                                    {
                                        "description": "Get Home Directory",
                                        "value": "curl -iv -X GET \"https://localhost:8443/gateway/sandbox/webhdfs/v1/?op=GETHOMEDIRECTORY\""
                                    },
                                    {
                                        "description": "You may check out Apache WebHDFS's REST API documentation here",
                                        "value": "https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html"
                                    }
                                ]
                            },
                            "serviceName": "WEBHDFS",
                            "serviceUrls": [
                                "https://localhost:8443/gateway/sandbox/webhdfs"
                            ],
                            "shortDesc": "Web HDFS",
                            "type": "API",
                            "version": ""
                        }
                    ]
                },
                "uiServices": {
                    "service": [
                        {
                            "context": "/hbase/webui/master?&host={{HOST}}&port={{PORT}}",
                            "description": "The HBase Master web UI is a simple but useful tool, to get an overview of the current status of the cluster...",
                            "samples": {
                                "sample": []
                            },
                            "serviceName": "HBASEUI",
                            "serviceUrls": [
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost1&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost10&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost11&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost12&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost13&port=8889",
                                ...
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost6&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost7&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost8&port=8889",
                                "https://localhost:8443/gateway/sandbox/hbase/webui/master?&host=localhost9&port=8889"
                            ],
                            "shortDesc": "HBase UI",
                            "type": "UI",
                            "version": "2.1.0"
                        },
                        {
                            "context": "/hdfs/?host={{BACKEND_HOST}}",
                            "description": "The namenode UI or the namenode web interface is used to monitor the status of the namenode.",
                            "samples": {
                                "sample": []
                            },
                            "serviceName": "HDFSUI",
                            "serviceUrls": [
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost10:8889",
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost11:8889",
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost12:8889",
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost13:8889",
                                ...
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost6:8889",
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost7:8889",
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost8:8889",
                                "https://localhost:8443/gateway/sandbox/hdfs/?host=http://localhost9:8889"
                            ],
                            "shortDesc": "HDFS Namenode UI",
                            "type": "UI",
                            "version": ""
                        },
                        {
                            "context": "/hue/",
                            "description": "Hue UI is a Web interface for analyzing data with Apache Hadoop",
                            "samples": {
                                "sample": []
                            },
                            "serviceName": "HUE",
                            "serviceUrls": [
                                "https://localhost:8443/gateway/sandbox/hue/"
                            ],
                            "shortDesc": "Hue UI",
                            "type": "UI",
                            "version": ""
                        },
                        {
                            "context": "/impalaui?scheme={{SCHEME}}&host={{HOST}}&port={{PORT}}",
                            "description": "Each of the Impala daemons (impalad, statestored, and catalogd) includes a built-in web server that displays diagnostic and status information.",
                            "samples": {
                                "sample": []
                            },
                            "serviceName": "IMPALAUI",
                            "serviceUrls": [
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost1&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost10&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost11&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost12&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost13&port=8889",
                                ...
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost6&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost7&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost8&port=8889",
                                "https://localhost:8443/gateway/sandbox/impalaui?scheme=http&host=localhost9&port=8889"
                            ],
                            "shortDesc": "Impala UI",
                            "type": "UI",
                            "version": ""
                        }
                    ]
                }
            }
        ]
    }
}
```

2. The Knox Home page is also modified: if a service role has more than one service URL, the number of instances is visible next to the service role name within the `Topologies` section. Clicking the service icon or the service name will result in a modal window that lists all instances of the given service role.
I also added a filter box where end-users can search by hostname and/or port to make it easier for them to narrow down those instances precisely for what they are looking for.

<img width="1775" alt="Screenshot 2024-01-31 at 10 56 22" src="https://github.com/apache/knox/assets/34065904/3dda9ddf-7314-41f3-8198-e0729cf7d5d1">

<img width="1777" alt="Screenshot 2024-01-31 at 10 59 15" src="https://github.com/apache/knox/assets/34065904/8bfb95dc-4b18-4feb-9945-f7974dbc766c">

## How was this patch tested?

Updated existing unit tests to cover the changes in `ServiceModel` and tested the new feature E2E locally (see sample JSON response and the new Home page layout above).