### PR TITLE
KNOX-3005 - Implemented KnoxSSO idle timeout

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -104,4 +104,11 @@ public interface JWTMessages {
 
   @Message( level = MessageLevel.WARN, text = "Invalid SSO cookie found! Cleaning up..." )
   void invalidSsoCookie();
+
+  @Message( level = MessageLevel.WARN, text = "User {0} with SSO token {1} exceeded the configured idle timeout of {2} seconds." )
+  void idleTimoutExceeded(String principal, String tokenId, long idleTimeout);
+
+  @Message( level = MessageLevel.INFO, text = "Idle timeout has been configured to {0} seconds in {1}" )
+  void configuredIdleTimeout(long idleTimeout, String topology);
+
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -51,6 +51,8 @@ import javax.servlet.ServletResponse;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
@@ -1084,6 +1086,14 @@ public abstract class AbstractJWTFilterTest  {
   }
 
   static class DummyServletOutputStream extends ServletOutputStream {
+
+      byte[] data;
+
+      @Override
+      public void write(byte[] b) throws IOException {
+          data = b;
+      }
+
       @Override
       public void write(int b) {
       }
@@ -1095,6 +1105,10 @@ public abstract class AbstractJWTFilterTest  {
       @Override
       public boolean isReady() {
         return false;
+      }
+
+      public byte[] getData() {
+        return data;
       }
   }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TestFilterConfig.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TestFilterConfig.java
@@ -17,7 +17,13 @@
  */
 package org.apache.knox.gateway.provider.federation;
 
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.easymock.EasyMock;
 
 import javax.servlet.FilterConfig;
@@ -28,14 +34,20 @@ import java.util.Properties;
 public class TestFilterConfig implements FilterConfig {
     public static final String TOPOLOGY_NAME_PROP = "test-topology-name";
 
-    Properties props;
+    private final Properties props;
+    private final TokenStateService tokenStateService;
 
     public TestFilterConfig() {
-        this.props = new Properties();
+      this(new Properties());
     }
 
     public TestFilterConfig(Properties props) {
-        this.props = props;
+      this(props, null);
+    }
+
+    public TestFilterConfig(Properties props, TokenStateService tokenStateService) {
+      this.props = props;
+      this.tokenStateService = tokenStateService;
     }
 
     @Override
@@ -51,6 +63,26 @@ public class TestFilterConfig implements FilterConfig {
         }
         ServletContext context = EasyMock.createNiceMock(ServletContext.class);
         EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn(topologyName).anyTimes();
+        if (tokenStateService != null) {
+          final GatewayServices gatewayServices = EasyMock.createNiceMock(GatewayServices.class);
+          EasyMock.expect(gatewayServices.getService(ServiceType.TOKEN_STATE_SERVICE)).andReturn(tokenStateService).anyTimes();
+
+          // tests with TSS need GatewayConfig and AliasService too for TokenMAC calculation
+          final AliasService aliasService  = EasyMock.createNiceMock(AliasService.class);
+          try {
+            EasyMock.expect(aliasService.getPasswordFromAliasForGateway(EasyMock.anyString())).andReturn("supersecretpassword".toCharArray()).anyTimes();
+          } catch (AliasServiceException e) {
+            // NOP - if the mock initialization failed there will be errors down the line
+          }
+          EasyMock.expect(gatewayServices.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
+
+          final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+          EasyMock.expect(gatewayConfig.getKnoxTokenHashAlgorithm()).andReturn(HmacAlgorithms.HMAC_SHA_256.getName()).anyTimes();
+          EasyMock.expect(context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gatewayConfig).anyTimes();
+
+          EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(gatewayServices).anyTimes();
+          EasyMock.replay(gatewayConfig, gatewayServices, aliasService);
+        }
         EasyMock.replay(context);
         return context;
     }

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -450,6 +450,7 @@ public class WebSSOResource {
       tokenStateService.addToken(tokenId, issueTime, token.getExpiresDate().getTime(), tokenStateService.getDefaultMaxLifetimeDuration());
       final TokenMetadata tokenMetadata = new TokenMetadata(token.getSubject());
       tokenMetadata.setKnoxSsoCookie(true);
+      tokenMetadata.useTokenNow();
       tokenStateService.addMetadata(tokenId, tokenMetadata);
       LOGGER.storedToken(getTopologyName(), Tokens.getTokenDisplayText(token.toString()), Tokens.getTokenIDDisplayText(tokenId));
     }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.services.security.token;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -37,9 +38,14 @@ public class TokenMetadata {
   public static final String PASSCODE = "passcode";
   public static final String CREATED_BY = "createdBy";
   public static final String KNOX_SSO_COOKIE = "knoxSSOCookie";
-  private static final List<String> KNOWN_MD_NAMES = Arrays.asList(USER_NAME, COMMENT, ENABLED, PASSCODE, CREATED_BY, KNOX_SSO_COOKIE);
+  public static final String LAST_USED_AT = "lastUsedAt";
+  private static final List<String> KNOWN_MD_NAMES = Arrays.asList(USER_NAME, COMMENT, ENABLED, PASSCODE, CREATED_BY, KNOX_SSO_COOKIE, LAST_USED_AT);
 
   private final Map<String, String> metadataMap = new HashMap<>();
+
+  public TokenMetadata() {
+    //creates an instance with an empty metadata map
+  }
 
   public TokenMetadata(String userName) {
     this(userName, null);
@@ -125,6 +131,15 @@ public class TokenMetadata {
 
   public boolean isKnoxSsoCookie() {
     return Boolean.parseBoolean(getMetadata(KNOX_SSO_COOKIE));
+  }
+
+  public void useTokenNow() {
+    saveMetadata(LAST_USED_AT, Instant.now().toString());
+  }
+
+  public Instant getLastUsedAt() {
+    final String lastUsedAt = getMetadata(LAST_USED_AT);
+    return lastUsedAt == null ? null : Instant.parse(lastUsedAt);
   }
 
   public String toJSON() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change the recently added KnoxSSO Cookie invalidation feature is extended like this:
- new token metadata is saved for KnoxSSO cookie called `lastUsedAt`
- the value of this token metadata is updated upon every successful KnoxSSO cookie verification. Therefore UI services that use KnoxSSO go through token verification every time they contact the Knox Gateway. When that verification succeeds, we know the KnoxSSO cookie was in use so that we can actualize the value.
- another new config was introduced on the topology level: `sso.idle.timeout.seconds`. The default value of this config is `-1`, meaning the idleness check should be ignored when verifying KnoxSSO cookies. This parameter should be added in the `SSOCookieProvider` federation filter block to enable the idle timeout enforcement.
- if the value of `sso.idle.timeout.seconds` is greater than `0`, KnoxSSO verification flow tests if the time from the previously saved `lastUsedAt` event exceeded the configured idle timeout. If that's true, the request is rejected and treated the same way as the KnoxSSO cookie was disabled: removes the cookie and redirects the browser to the login page (or to `knox.global.logout.page.url`, if it was configured).

The following is very important to emphasize:
- This new feature does NOT include the usual UI pop-up approach (like when the end-user is informed about being idle too long)
- It's also worth mentioning the idleness measurement solely depends on backend activities through the KnoxSSO Cookie federation filter and does NOT take any client-side action (such as scrolling on the page, client-side pagination, etc..) into account.

## How was this patch tested?

Added new JUnit test cases to test SSO cookie idleness. Apart from unit testing, I conducted the following E2E test run:

_Pre-requisites:_
1. Updated the `SSOCookieProvider` in the `homepage` and `manager` topologies:
```
      <provider>
         <role>federation</role>
         <name>SSOCookieProvider</name>
         <enabled>true</enabled>
         <param>
            <name>knox.token.exp.server-managed</name>
            <value>true</value>
         </param>
         <param>
            <name>sso.idle.timeout.seconds</name>
            <value>120</value>
         </param>
      </provider>
```
2. Enabled KnoxSSO cookie validation in the `knoxsso` topology:
```
        <param>
            <!-- since 2.1.0: KnoxSSO cookie validation -->
            <name>knox.token.exp.server-managed</name>
            <value>true</value>
        </param>
```
3. Configured the Knox Gateway to use my local PostgreSQL DB as the token backend:
```
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.JDBCTokenStateService</value>
    </property>
     <property>
        <name>gateway.database.type</name>
        <value>postgresql</value>
    </property>
    <property>
        <name>gateway.database.connection.url</name>
        <value>jdbc:postgresql://localhost:5432/postgres?user=***</value>
    </property>
```

_Test steps:_

When the Knox Gateway started, I logged into the Knox Home page and confirmed that the KnoxSSO cookie was saved in the DB:
```
postgres=# select * from knox_tokens kt, knox_token_metadata meta where kt.token_id = meta.token_id;
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               |    md_name    |         md_value         
--------------------------------------+---------------+---------------+---------------+--------------------------------------+---------------+--------------------------
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | userName      | admin
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | knoxSSOCookie | true
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | enabled       | true
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | lastUsedAt    | 2024-02-01T14:13:27.259Z
(4 rows)
```
This is what I had in the logs:
```
2024-02-01 15:13:26,343 fd43e7fa-97f3-4510-82d8-9762bba0c777 INFO  service.knoxsso (WebSSOResource.java:saveToken(455)) - Knox Token service (knoxsso) stored state for token eyJraW...Csgf5w (c6a2eb3e...7d7a48de0a69)
2024-02-01 15:13:26,344 fd43e7fa-97f3-4510-82d8-9762bba0c777 INFO  service.knoxsso (WebSSOResource.java:addJWTHadoopCookie(429)) - JWT cookie eyJraW...Csgf5w successfully added.
2024-02-01 15:13:26,344 fd43e7fa-97f3-4510-82d8-9762bba0c777 INFO  service.knoxsso (WebSSOResource.java:getAuthenticationToken(326)) - About to redirect to original URL: https://localhost:8443/gateway/homepage/home/
2024-02-01 15:13:26,905 64fbe8c1-9ad8-41b7-abf5-fd13ba445e87 WARN  federation.jwt (SSOCookieFederationFilter.java:init(100)) - Configuration for authentication provider URL is missing - will derive default URL.
2024-02-01 15:13:26,905 64fbe8c1-9ad8-41b7-abf5-fd13ba445e87 INFO  federation.jwt (SSOCookieFederationFilter.java:init(121)) - Idle timeout has been configured to 120 seconds in homepage
2024-02-01 15:13:27,125 64fbe8c1-9ad8-41b7-abf5-fd13ba445e87 INFO  service.session (SessionResource.java:getSessionInformation(64)) - Homepage Logout is enabled and will use the URL: https://localhost:8443/gateway/homepage/knoxssout/api/v1/webssout
2024-02-01 15:13:54,268 ba46c5a2-adef-4d15-8700-da4ab90f6793 INFO  federation.jwt (SignatureVerificationCache.java:initializeCacheForTopology(60)) - Initialized token signature verification cache for the manager topology.
2024-02-01 15:13:54,268 ba46c5a2-adef-4d15-8700-da4ab90f6793 WARN  federation.jwt (SSOCookieFederationFilter.java:init(100)) - Configuration for authentication provider URL is missing - will derive default URL.
2024-02-01 15:13:54,269 ba46c5a2-adef-4d15-8700-da4ab90f6793 INFO  federation.jwt (SSOCookieFederationFilter.java:init(121)) - Idle timeout has been configured to 120 seconds in manager
2024-02-01 15:13:54,430 ba46c5a2-adef-4d15-8700-da4ab90f6793 INFO  knox.gateway (AclsAuthorizationFilter.java:init(70)) - Initializing AclsAuthz Provider for: admin-ui
```
Navigated to the Admin UI (which uses the `manager` topology backed by the `SSOCookieProvider`) and confirmed the `lastUsedAt` token metadata was updated:
```
postgres=# select * from knox_tokens kt, knox_token_metadata meta where kt.token_id = meta.token_id;
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               |    md_name    |         md_value         
--------------------------------------+---------------+---------------+---------------+--------------------------------------+---------------+--------------------------
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | userName      | admin
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | knoxSSOCookie | true
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | enabled       | true
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | lastUsedAt    | 2024-02-01T14:13:55.508Z
(4 rows)
```

I also navigated to the Token Management page that also sends some requests to the Knox Gateway and confirmed the `lastUsedAt` token metadata was updated:
```
postgres=# select * from knox_tokens kt, knox_token_metadata meta where kt.token_id = meta.token_id;
               token_id               |  issue_time   |  expiration   | max_lifetime  |               token_id               |    md_name    |         md_value         
--------------------------------------+---------------+---------------+---------------+--------------------------------------+---------------+--------------------------
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | userName      | admin
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | knoxSSOCookie | true
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | enabled       | true
 c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | 1706796806265 | 1706883206000 | 1707401606265 | c6a2eb3e-6d43-4ffb-a779-7d7a48de0a69 | lastUsedAt    | 2024-02-01T14:14:23.930Z
(4 rows)
```

Then I waited more than 2 minutes (the pre-configured SSO idle timeout) and tried to refresh the Token Management table. As expected, the request was rejected and I was redirected to the Knox login page. In the logs I found the relevant entries:
```
2024-02-01 15:20:24,829 10387a50-5d45-4ef9-8bbd-253ead6f2b81 WARN  federation.jwt (AbstractJWTFilter.java:validateToken(354)) - User with SSO token c6a2eb3e...7d7a48de0a69 exceeded the configured idle timeout of 120 seconds.
2024-02-01 15:20:24,830 10387a50-5d45-4ef9-8bbd-253ead6f2b81 WARN  federation.jwt (SSOCookieFederationFilter.java:handleValidationError(208)) - Invalid SSO cookie found! Cleaning up...
```
The same happened when I tried to refresh the `Topologies` on the Admin UI.