### PR TITLE
KNOX-3006 - PAM module occasionally generates garbage group names

### DIFF
--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.kohsuke</groupId>
+            <groupId>org.glassfish.main.libpam4j</groupId>
             <artifactId>libpam4j</artifactId>
         </dependency>
 

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxPamRealm.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxPamRealm.java
@@ -87,7 +87,7 @@ public class KnoxPamRealm extends AuthorizingRealm {
 
   private static final AuditService auditService = AuditServiceFactory.getAuditService();
   private static final Auditor auditor = auditService.getAuditor(AuditConstants.DEFAULT_AUDITOR_NAME,
-          AuditConstants.KNOX_SERVICE_NAME, AuditConstants.KNOX_COMPONENT_NAME);
+      AuditConstants.KNOX_SERVICE_NAME, AuditConstants.KNOX_COMPONENT_NAME);
 
   private final HashService hashService = new DefaultHashService();
   private final KnoxShiroMessages shiroLog = MessagesFactory.get(KnoxShiroMessages.class);
@@ -132,7 +132,7 @@ public class KnoxPamRealm extends AuthorizingRealm {
 
   @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
-          throws AuthenticationException {
+      throws AuthenticationException {
     PAM pam = null;
     UnixUser user = null;
     try {
@@ -148,9 +148,9 @@ public class KnoxPamRealm extends AuthorizingRealm {
     }
 
     HashRequest hashRequest = new HashRequest.Builder()
-            .setSource(token.getCredentials())
-            .setAlgorithmName(HASHING_ALGORITHM)
-            .build();
+                                  .setSource(token.getCredentials())
+                                  .setAlgorithmName(HASHING_ALGORITHM)
+                                  .build();
     Hash credentialsHash = hashService.computeHash(hashRequest);
 
     /* Coverity Scan CID 1361684 */
@@ -158,12 +158,12 @@ public class KnoxPamRealm extends AuthorizingRealm {
       handleAuthFailure(token, "Failed to compute hash", null);
     }
     return new SimpleAuthenticationInfo(new UnixUserPrincipal(user), credentialsHash.toHex(),
-            credentialsHash.getSalt(), getName());
+        credentialsHash.getSalt(), getName());
   }
 
   private void handleAuthFailure(AuthenticationToken token, String errorMessage, Exception e) {
     auditor.audit(Action.AUTHENTICATION, token.getPrincipal().toString(),
-            ResourceType.PRINCIPAL, ActionOutcome.FAILURE, errorMessage);
+        ResourceType.PRINCIPAL, ActionOutcome.FAILURE, errorMessage);
     shiroLog.failedLoginInfo(token);
 
     if (e != null) {

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxPamRealm.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxPamRealm.java
@@ -87,7 +87,7 @@ public class KnoxPamRealm extends AuthorizingRealm {
 
   private static final AuditService auditService = AuditServiceFactory.getAuditService();
   private static final Auditor auditor = auditService.getAuditor(AuditConstants.DEFAULT_AUDITOR_NAME,
-      AuditConstants.KNOX_SERVICE_NAME, AuditConstants.KNOX_COMPONENT_NAME);
+          AuditConstants.KNOX_SERVICE_NAME, AuditConstants.KNOX_COMPONENT_NAME);
 
   private final HashService hashService = new DefaultHashService();
   private final KnoxShiroMessages shiroLog = MessagesFactory.get(KnoxShiroMessages.class);
@@ -132,24 +132,7 @@ public class KnoxPamRealm extends AuthorizingRealm {
 
   @Override
   protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken token)
-      throws AuthenticationException {
-    UnixUser user = lookupUnixUser(token);
-
-    HashRequest hashRequest = new HashRequest.Builder()
-                                  .setSource(token.getCredentials())
-                                  .setAlgorithmName(HASHING_ALGORITHM)
-                                  .build();
-    Hash credentialsHash = hashService.computeHash(hashRequest);
-
-    /* Coverity Scan CID 1361684 */
-    if (credentialsHash == null) {
-      handleAuthFailure(token, "Failed to compute hash", null);
-    }
-    return new SimpleAuthenticationInfo(new UnixUserPrincipal(user), credentialsHash.toHex(),
-        credentialsHash.getSalt(), getName());
-  }
-
-  private synchronized UnixUser lookupUnixUser(AuthenticationToken token) {
+          throws AuthenticationException {
     PAM pam = null;
     UnixUser user = null;
     try {
@@ -163,12 +146,24 @@ public class KnoxPamRealm extends AuthorizingRealm {
         pam.dispose();
       }
     }
-    return user;
+
+    HashRequest hashRequest = new HashRequest.Builder()
+            .setSource(token.getCredentials())
+            .setAlgorithmName(HASHING_ALGORITHM)
+            .build();
+    Hash credentialsHash = hashService.computeHash(hashRequest);
+
+    /* Coverity Scan CID 1361684 */
+    if (credentialsHash == null) {
+      handleAuthFailure(token, "Failed to compute hash", null);
+    }
+    return new SimpleAuthenticationInfo(new UnixUserPrincipal(user), credentialsHash.toHex(),
+            credentialsHash.getSalt(), getName());
   }
 
   private void handleAuthFailure(AuthenticationToken token, String errorMessage, Exception e) {
     auditor.audit(Action.AUTHENTICATION, token.getPrincipal().toString(),
-        ResourceType.PRINCIPAL, ActionOutcome.FAILURE, errorMessage);
+            ResourceType.PRINCIPAL, ActionOutcome.FAILURE, errorMessage);
     shiroLog.failedLoginInfo(token);
 
     if (e != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <json-smart.version>2.4.8</json-smart.version>
         <junit.version>4.13.2</junit.version>
         <lang-tag.version>1.5</lang-tag.version>
-        <libpam4j.version>1.11</libpam4j.version>
+        <libpam4j.version>5.1.0</libpam4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -2039,7 +2039,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.kohsuke</groupId>
+                <groupId>org.glassfish.main.libpam4j</groupId>
                 <artifactId>libpam4j</artifactId>
                 <version>${libpam4j.version}</version>
             </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

PAM module returns garbage group names due to a thread safety problem:

```
2024-02-07 12:41:44,954 23da5c8b-2664-4c94-a356-fd569eff930c INFO  knox.gateway (KnoxPamRealm.java:doGetAuthorizationInfo(129)) - Computed roles/groups: [nifire39965:] for principal: knoxui
2024-02-07 12:41:44,956 6778ee4d-f655-4d09-b111-2e28ca3f1d4b INFO  knox.gateway (KnoxPamRealm.java:doGetAuthorizationInfo(129)) - Computed roles/groups: [mapredx] for principal: knoxui
2024-02-07 12:41:44,957 9829bbe7-ff7f-4c87-9a65-cbc589be7583 INFO  knox.gateway (KnoxPamRealm.java:doGetAuthorizationInfo(129)) - Computed roles/groups: [mail:x:12] for principal: knoxui
2024-02-07 12:42:03,082 a02943fc-2d6b-402f-b938-041fb64eee0a INFO  knox.gateway (KnoxPamRealm.java:doGetAuthorizationInfo(129)) - Computed roles/groups: [cdro] for principal: knoxui
```

Switching to org.glassfish.main.libpam4j:libpam4j solves the problem.

## How was this patch tested?

By using the following script:

```
#/bin/bash

task(){
   curl -vk -u knoxui:password https://HOST:8443/gateway/cdp-proxy-api/webhdfs/v1/?op=GETHOMEDIRECTORY
}

for i in {1..15000}
do
   echo "$i"
   task &
done
```


