### PR TITLE
KNOX-3007 - Make http client cookie spec parameter configurable

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -128,6 +128,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String HTTP_CLIENT_MAX_CONNECTION = GATEWAY_CONFIG_FILE_PREFIX + ".httpclient.maxConnections";
   private static final String HTTP_CLIENT_CONNECTION_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".httpclient.connectionTimeout";
   private static final String HTTP_CLIENT_SOCKET_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".httpclient.socketTimeout";
+  private static final String HTTP_CLIENT_COOKIE_SPEC = GATEWAY_CONFIG_FILE_PREFIX + ".httpclient.cookieSpec";
   private static final String THREAD_POOL_MAX = GATEWAY_CONFIG_FILE_PREFIX + ".threadpool.max";
   public static final String HTTP_SERVER_REQUEST_BUFFER = GATEWAY_CONFIG_FILE_PREFIX + ".httpserver.requestBuffer";
   public static final String HTTP_SERVER_REQUEST_HEADER_BUFFER = GATEWAY_CONFIG_FILE_PREFIX + ".httpserver.requestHeaderBuffer";
@@ -1563,6 +1564,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public int getTokenMigrationProgressCount() {
     return getInt(TOKEN_MIGRATION_PROGRESS_COUNT, 10);
+  }
+
+  @Override
+  public String getHttpClientCookieSpec() {
+    return get(HTTP_CLIENT_COOKIE_SPEC, null);
   }
 
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -1568,7 +1568,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   @Override
   public String getHttpClientCookieSpec() {
-    return get(HTTP_CLIENT_COOKIE_SPEC, null);
+    return get(HTTP_CLIENT_COOKIE_SPEC);
   }
 
 }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1106,4 +1106,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return 1;
   }
 
+  @Override
+  public String getHttpClientCookieSpec() {
+    return null;
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -97,6 +97,9 @@ public interface SpiGatewayMessages {
   @Message( level = MessageLevel.INFO, text = "HTTP client socket timeout is set to {0} ms for {1}" )
   void setHttpClientSocketTimeout(int socketTimeout, String serviceRole);
 
+  @Message( level = MessageLevel.INFO, text = "HTTP client cookie spec is set to {0}" )
+  void setHttpClientCookieSpec(String cookieSpec);
+
   @Message( level = MessageLevel.INFO, text = "replayBufferSize is set to {0} for {1}" )
   void setReplayBufferSize(int replayBufferSize, String serviceRole);
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -934,4 +934,8 @@ public interface GatewayConfig {
    */
   int getTokenMigrationProgressCount();
 
+  /**
+   * @return CookieSpec for the HTTP client used by the dispatch, see org.apache.http.client.config.CookieSpecs
+   */
+  String getHttpClientCookieSpec();
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -376,10 +376,12 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
   }
 
   private static String getCookieSpec(FilterConfig filterConfig) {
+    String cookieSpec = filterConfig.getInitParameter("httpclient.cookieSpec");
+    if (StringUtils.isNotBlank(cookieSpec)) {
+      return cookieSpec;
+    }
     GatewayConfig globalConfig =
             (GatewayConfig)filterConfig.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
-    return globalConfig != null
-            ? globalConfig.getHttpClientCookieSpec()
-            : filterConfig.getInitParameter("httpclient.cookieSpec");
+    return globalConfig != null ? globalConfig.getHttpClientCookieSpec() : null;
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactory.java
@@ -238,6 +238,11 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
       builder.setSocketTimeout( socketTimeout );
       LOG.setHttpClientSocketTimeout(socketTimeout, serviceRole == null ? "N/A" : serviceRole);
     }
+    String cookieSpec = getCookieSpec(config);
+    if (cookieSpec != null) {
+      LOG.setHttpClientCookieSpec(cookieSpec);
+      builder.setCookieSpec(cookieSpec);
+    }
 
     // HttpClient 4.5.7 is broken for %2F handling with url normalization.
     // However, HttpClient 4.5.8+ (HTTPCLIENT-1968) has reasonable url
@@ -368,5 +373,13 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
         .appendMillis().toFormatter();
     Period p = Period.parse( s, f );
     return p.toStandardDuration().getMillis();
+  }
+
+  private static String getCookieSpec(FilterConfig filterConfig) {
+    GatewayConfig globalConfig =
+            (GatewayConfig)filterConfig.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    return globalConfig != null
+            ? globalConfig.getHttpClientCookieSpec()
+            : filterConfig.getInitParameter("httpclient.cookieSpec");
   }
 }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.GatewayServices;
@@ -61,7 +62,7 @@ public class DefaultHttpClientFactoryTest {
     expect(gatewayConfig.getHttpClientMaxConnections()).andReturn(32).once();
     expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).once();
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).once();
-    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn("standard").anyTimes();
+    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn(CookieSpecs.STANDARD).anyTimes();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
     expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
@@ -210,7 +211,7 @@ public class DefaultHttpClientFactoryTest {
     GatewayConfig gatewayConfig = createMock(GatewayConfig.class);
     expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).once();
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).once();
-    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn("standard").anyTimes();
+    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn(CookieSpecs.STANDARD).anyTimes();
 
     ServletContext servletContext = createMock(ServletContext.class);
     expect(servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gatewayConfig).atLeastOnce();
@@ -248,7 +249,7 @@ public class DefaultHttpClientFactoryTest {
     expect(gatewayConfig.getHttpClientMaxConnections()).andReturn(32).anyTimes();
     expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).anyTimes();
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).anyTimes();
-    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn("standard").anyTimes();
+    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn(CookieSpecs.STANDARD).anyTimes();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
     expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).anyTimes();

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -61,6 +61,7 @@ public class DefaultHttpClientFactoryTest {
     expect(gatewayConfig.getHttpClientMaxConnections()).andReturn(32).once();
     expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).once();
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).once();
+    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn("standard").anyTimes();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
     expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).once();
@@ -209,6 +210,7 @@ public class DefaultHttpClientFactoryTest {
     GatewayConfig gatewayConfig = createMock(GatewayConfig.class);
     expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).once();
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).once();
+    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn("standard").anyTimes();
 
     ServletContext servletContext = createMock(ServletContext.class);
     expect(servletContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(gatewayConfig).atLeastOnce();
@@ -246,6 +248,7 @@ public class DefaultHttpClientFactoryTest {
     expect(gatewayConfig.getHttpClientMaxConnections()).andReturn(32).anyTimes();
     expect(gatewayConfig.getHttpClientConnectionTimeout()).andReturn(20000).anyTimes();
     expect(gatewayConfig.getHttpClientSocketTimeout()).andReturn(20000).anyTimes();
+    expect(gatewayConfig.getHttpClientCookieSpec()).andReturn("standard").anyTimes();
 
     GatewayServices gatewayServices = createMock(GatewayServices.class);
     expect(gatewayServices.getService(ServiceType.KEYSTORE_SERVICE)).andReturn(keystoreService).anyTimes();

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dispatch/DefaultHttpClientFactoryTest.java
@@ -79,6 +79,7 @@ public class DefaultHttpClientFactoryTest {
     expect(filterConfig.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
     expect(filterConfig.getInitParameter("serviceRole")).andReturn(null).once();
     expect(filterConfig.getInitParameter("retryCount")).andReturn(null).once();
+    expect(filterConfig.getInitParameter("httpclient.cookieSpec")).andReturn(null).anyTimes();
 
     replay(keystoreService, gatewayConfig, gatewayServices, servletContext, filterConfig);
 
@@ -220,6 +221,7 @@ public class DefaultHttpClientFactoryTest {
     expect(filterConfig.getServletContext()).andReturn(servletContext).atLeastOnce();
     expect(filterConfig.getInitParameter("httpclient.connectionTimeout")).andReturn(null).once();
     expect(filterConfig.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
+    expect(filterConfig.getInitParameter("httpclient.cookieSpec")).andReturn(null).anyTimes();
 
     replay(gatewayConfig, servletContext, filterConfig);
 
@@ -264,6 +266,7 @@ public class DefaultHttpClientFactoryTest {
     expect(filterConfigSafe.getInitParameter("httpclient.maxConnections")).andReturn(null).once();
     expect(filterConfigSafe.getInitParameter("httpclient.connectionTimeout")).andReturn(null).once();
     expect(filterConfigSafe.getInitParameter("httpclient.socketTimeout")).andReturn(null).once();
+    expect(filterConfigSafe.getInitParameter("httpclient.cookieSpec")).andReturn(null).anyTimes();
     expect(filterConfigSafe.getInitParameter("serviceRole")).andReturn(null).once();
     expect(filterConfigSafe.getInitParameter("retryCount")).andReturn("3").anyTimes();
     expect(filterConfigSafe.getInitParameter("retryNonSafeRequest")).andReturn(null).anyTimes();
@@ -277,6 +280,7 @@ public class DefaultHttpClientFactoryTest {
     expect(filterConfigUnSafe.getInitParameter("serviceRole")).andReturn(null).once();
     expect(filterConfigUnSafe.getInitParameter("retryCount")).andReturn("3").anyTimes();
     expect(filterConfigUnSafe.getInitParameter("retryNonSafeRequest")).andReturn("true").anyTimes();
+    expect(filterConfigUnSafe.getInitParameter("httpclient.cookieSpec")).andReturn(null).anyTimes();
 
     replay(keystoreService, gatewayConfig, gatewayServices, servletContext, filterConfigSafe, filterConfigUnSafe);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the default cookie spec policy, the apache http client rejects cookies if their expiration date doesn't follow the expected format (EEE, dd-MMM-yy HH:mm:ss z).

For example a cookie with an expiration = `Sun, 06 Nov 1994 08:49:37 GMT` is rejected by default.

If the cookiespec is set to 'standard' the cookie will be accepted.

## How was this patch tested?

```smalltalk
Teapot on
    GET: '/' -> [:req |  ZnResponse noContent
    	addCookie: ((ZnCookie name: 'test' value:'val') expires: 'Sun, 06 Nov 1994 08:49:37 GMT'; yourself); 
    	addCookie: ((ZnCookie name: 'test2' value:'val') expiresTimeStamp: DateAndTime now; yourself);     	
    	addCookie: ((ZnCookie name: 'test3' value:'val') expires: 'Wed, 14-Feb-2024 09:23:27 GMT'; yourself);     	    	
    	yourself ];
	start. 
```

1.

```xml
    <property>
        <name>gateway.httpclient.cookieSpec</name>
        <value>default</value>
    </property>
```

```bash
$ curl -vk -u admin:admin-password https://localhost:8443/gateway/sandbox/hive
```

```
2024-02-19 10:39:43,751 bf18473d-4b63-4551-9e6a-b7ba49a531ab INFO  knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(243)) - HTTP client cookie spec is set to default
2024-02-19 10:39:47,167 85a5f49f-fb33-4dc0-8856-873d34efd366 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Date: Mon, 19 Feb 2024 09:39:47 GMT[\r][\n]"
2024-02-19 10:39:47,167 85a5f49f-fb33-4dc0-8856-873d34efd366 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Set-Cookie: test=val; expires=Sun, 06 Nov 1994 08:49:37 GMT[\r][\n]"
2024-02-19 10:39:47,168 85a5f49f-fb33-4dc0-8856-873d34efd366 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Set-Cookie: test2=val; expires=Mon, 19 Feb 2024 09:39:47 GMT[\r][\n]"
2024-02-19 10:39:47,168 85a5f49f-fb33-4dc0-8856-873d34efd366 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Set-Cookie: test3=val; expires=Wed, 14-Feb-2024 09:23:27 GMT[\r][\n]"
2024-02-19 10:39:47,168 85a5f49f-fb33-4dc0-8856-873d34efd366 DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "[\r][\n]"
2024-02-19 10:39:47,170 85a5f49f-fb33-4dc0-8856-873d34efd366 WARN  protocol.ResponseProcessCookies (ResponseProcessCookies.java:processCookies(130)) - Invalid cookie header: "Set-Cookie: test=val; expires=Sun, 06 Nov 1994 08:49:37 GMT". Invalid 'expires' attribute: Sun, 06 Nov 1994 08:49:37 GMT
2024-02-19 10:39:47,171 85a5f49f-fb33-4dc0-8856-873d34efd366 WARN  protocol.ResponseProcessCookies (ResponseProcessCookies.java:processCookies(130)) - Invalid cookie header: "Set-Cookie: test2=val; expires=Mon, 19 Feb 2024 09:39:47 GMT". Invalid 'expires' attribute: Mon, 19 Feb 2024 09:39:47 GMT
2024-02-19 10:39:47,172 85a5f49f-fb33-4dc0-8856-873d34efd366 DEBUG protocol.ResponseProcessCookies (ResponseProcessCookies.java:processCookies(119)) - Cookie accepted [test3="val", version:0, domain:localhost, path:/, expiry:Wed Feb 14 10:23:27 CET 2024]
```

2.

```xml
    <property>
        <name>gateway.httpclient.cookieSpec</name>
        <value>standard</value>
    </property>
```


```bash
$ curl -vk -u admin:admin-password https://localhost:8443/gateway/sandbox/hive
```

```
2024-02-19 10:38:34,374 1f05a150-b703-441c-a2f2-d1f34b3ffd3d INFO  knox.gateway (DefaultHttpClientFactory.java:getRequestConfig(243)) - HTTP client cookie spec is set to standard
2024-02-19 10:38:34,515 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Set-Cookie: test=val; 
expires=Sun, 06 Nov 1994 08:49:37 GMT[\r][\n]"
2024-02-19 10:38:34,516 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Set-Cookie: test2=val; expires=Mon, 19 Feb 2024 09:38:34 GMT[\r][\n]"
2024-02-19 10:38:34,516 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "Set-Cookie: test3=val; expires=Wed, 14-Feb-2024 09:23:27 GMT[\r][\n]"
2024-02-19 10:38:34,517 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG http.wire (Wire.java:wire(73)) - http-outgoing-0 << "[\r][\n]"
2024-02-19 10:38:34,524 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG protocol.ResponseProcessCookies (ResponseProcessCookies.java:processCookies(119)) - Cookie accepted [test="val", version:0, domain:localhost, path:/, expiry:Sun Nov 06 09:49:37 CET 1994]
2024-02-19 10:38:34,524 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG protocol.ResponseProcessCookies (ResponseProcessCookies.java:processCookies(119)) - Cookie accepted [test2="val", version:0, domain:localhost, path:/, expiry:Mon Feb 19 10:38:34 CET 2024]
2024-02-19 10:38:34,524 1f05a150-b703-441c-a2f2-d1f34b3ffd3d DEBUG protocol.ResponseProcessCookies (ResponseProcessCookies.java:processCookies(119)) - Cookie accepted [test3="val", version:0, domain:localhost, path:/, expiry:Wed Feb 14 10:23:27 CET 2024]
```