### PR TITLE
KNOX-3008 - Displaying hostname and custom banner text on the Knox Home page and other UIs

### DIFF
--- a/gateway-admin-ui/admin-ui/app/app.module.ts
+++ b/gateway-admin-ui/admin-ui/app/app.module.ts
@@ -48,6 +48,7 @@ import {ProviderConfigSelectorComponent} from './provider-config-selector/provid
 import {NewDescWizardComponent} from './new-desc-wizard/new-desc-wizard.component';
 import {ProviderConfigWizardComponent} from './provider-config-wizard/provider-config-wizard.component';
 import {SessionInformationComponent} from './sessionInformation/session.information.component';
+import {SafeHtmlPipe} from './sessionInformation/session.information.component';
 
 @NgModule({
     imports: [BrowserModule,
@@ -76,7 +77,8 @@ import {SessionInformationComponent} from './sessionInformation/session.informat
         ProviderConfigSelectorComponent,
         NewDescWizardComponent,
         ProviderConfigWizardComponent,
-        SessionInformationComponent
+        SessionInformationComponent,
+        SafeHtmlPipe
     ],
     providers: [TopologyService,
         ServiceDefinitionService,

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.html
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.html
@@ -13,3 +13,5 @@
   limitations under the License.
 -->
 <div style="text-align: right; color: rgb(130, 180, 93);">Logged in as {{ getUser() }}</div>
+<div style="margin-left: 15%; text-align: center; color: rgb(130,180, 93); max-width: 70%; word-wrap: break-word;" [innerHTML]="getBannerText() | safeHtml"></div>
+

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.ts
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.component.ts
@@ -14,9 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, Pipe, PipeTransform} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
 import {SessionInformationService} from './session.information.service';
 import {SessionInformation} from './session.information';
+
+@Pipe({ name: 'safeHtml' })
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value) {
+    return this.sanitizer.bypassSecurityTrustHtml(value);
+  }
+}
 
 @Component({
     selector: 'app-session-information',
@@ -40,6 +50,14 @@ export class SessionInformationComponent implements OnInit {
             console.debug('SessionInformationComponent --> getUser() --> dr.who');
             return 'dr.who';
         }
+    }
+
+    getBannerText() {
+        if (this.sessionInformation) {
+            console.debug('SessionInformationComponent --> getBannerHtml() --> ' + this.sessionInformation.bannerText);
+            return this.sessionInformation.bannerText;
+        }
+        return '';
     }
 
     ngOnInit(): void {

--- a/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.ts
+++ b/gateway-admin-ui/admin-ui/app/sessionInformation/session.information.ts
@@ -20,4 +20,5 @@ export class SessionInformation {
     logoutUrl: string;
     logoutPageUrl: string;
     globalLgoutPageUrl: string;
+    bannerText: string;
 }

--- a/gateway-release/home/conf/topologies/manager.xml
+++ b/gateway-release/home/conf/topologies/manager.xml
@@ -86,6 +86,9 @@
    <service>
       <role>KNOX</role>
    </service>
+   <service>
+      <role>KNOX-SESSION</role>
+   </service>
    <application>
       <name>admin-ui</name>
    </application>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -324,6 +324,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String GLOBAL_LOGOUT_PAGE_URL = "knox.global.logout.page.url";
   private static final String KNOX_INCOMING_XFORWARDED_ENABLED = "gateway.incoming.xforwarded.enabled";
 
+  private static final String UI_BANNER_TEXT = GATEWAY_CONFIG_FILE_PREFIX + ".ui.banner.text";
+
   //Gateway Database related properties
   public static final String GATEWAY_DATABASE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".database.type";
   public static final String GATEWAY_DATABASE_CONN_URL = GATEWAY_CONFIG_FILE_PREFIX + ".database.connection.url";
@@ -1569,6 +1571,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getHttpClientCookieSpec() {
     return get(HTTP_CLIENT_COOKIE_SPEC);
+  }
+
+  @Override
+  public String getBannerText() {
+    return get(UI_BANNER_TEXT, "");
   }
 
 }

--- a/gateway-service-metadata/pom.xml
+++ b/gateway-service-metadata/pom.xml
@@ -78,5 +78,9 @@
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.kstruct</groupId>
+            <artifactId>gethostname4j</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/GeneralProxyInformation.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/GeneralProxyInformation.java
@@ -32,6 +32,10 @@ public class GeneralProxyInformation {
   private String version;
 
   @XmlElement
+  @ApiModelProperty(value = "The name of the host where this Knox Gateway is running")
+  private String hostname;
+
+  @XmlElement
   @ApiModelProperty(value = "The Admin UI URL")
   private String adminUiUrl;
 
@@ -57,6 +61,14 @@ public class GeneralProxyInformation {
 
   public void setVersion(String version) {
     this.version = version;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = hostname;
   }
 
   public String getAdminUiUrl() {

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -72,6 +72,8 @@ import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.util.JsonUtils;
 import org.apache.knox.gateway.util.X509CertificateUtil;
 
+import com.kstruct.gethostname4j.Hostname;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
@@ -101,6 +103,7 @@ public class KnoxMetadataResource {
       final ServerInfoService serviceInfoService = gatewayServices.getService(ServiceType.SERVER_INFO_SERVICE);
       final String versionInfo = serviceInfoService.getBuildVersion() + " (hash=" + serviceInfoService.getBuildHash() + ")";
       proxyInfo.setVersion(versionInfo);
+      proxyInfo.setHostname(Hostname.getHostname());
       proxyInfo.setAdminApiBookUrl(
           String.format(Locale.ROOT, "https://knox.apache.org/books/knox-%s/user-guide.html#Admin+API", getAdminApiBookVersion(serviceInfoService.getBuildVersion())));
       final GatewayConfig config = (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformation.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionInformation.java
@@ -40,6 +40,9 @@ public class SessionInformation {
   @XmlElement
   private String currentKnoxSsoCookieTokenId;
 
+  @XmlElement
+  private String bannerText;
+
   public String getUser() {
     return user;
   }
@@ -86,6 +89,14 @@ public class SessionInformation {
 
   public void setCurrentKnoxSsoCookieTokenId(String currentKnoxSsoCookieTokenId) {
     this.currentKnoxSsoCookieTokenId = currentKnoxSsoCookieTokenId;
+  }
+
+  public String getBannerText() {
+    return bannerText;
+  }
+
+  public void setBannerText(String bannerText) {
+    this.bannerText = bannerText;
   }
 
 }

--- a/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
+++ b/gateway-service-session/src/main/java/org/apache/knox/gateway/service/session/SessionResource.java
@@ -68,6 +68,7 @@ public class SessionResource {
     }
     sessionInfo.setCanSeeAllTokens(config != null ? config.canSeeAllTokens(user) : false);
     sessionInfo.setCurrentKnoxSsoCookieTokenId((String) this.request.getAttribute(TokenUtils.ATTR_CURRENT_KNOXSSO_COOKIE_TOKEN_ID));
+    sessionInfo.setBannerText(config != null ? config.getBannerText() : "");
 
     return sessionInfo;
   }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1111,4 +1111,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return null;
   }
 
+  @Override
+  public String getBannerText() {
+    return null;
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -938,4 +938,10 @@ public interface GatewayConfig {
    * @return CookieSpec for the HTTP client used by the dispatch, see org.apache.http.client.config.CookieSpecs
    */
   String getHttpClientCookieSpec();
+
+  /**
+   * @return a text that should be displayed on all Knox UIs within the banner on the top.
+   */
+  String getBannerText();
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dto/HomePageProfile.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dto/HomePageProfile.java
@@ -27,6 +27,7 @@ import java.util.Set;
 public class HomePageProfile {
   static final String GPI_PREFIX = "gpi_";
   static final String GPI_VERSION = GPI_PREFIX + "version";
+  static final String GPI_HOSTNAME = GPI_PREFIX + "hostname";
   static final String GPI_CERT = GPI_PREFIX + "cert";
   static final String GPI_ADMIN_UI = GPI_PREFIX + "admin_ui";
   static final String GPI_ADMIN_API = GPI_PREFIX + "admin_api";
@@ -41,6 +42,7 @@ public class HomePageProfile {
 
   public HomePageProfile(Collection<String> profileConfiguration) {
     addElement(GPI_VERSION, profileConfiguration);
+    addElement(GPI_HOSTNAME, profileConfiguration);
     addElement(GPI_CERT, profileConfiguration);
     addElement(GPI_ADMIN_UI, profileConfiguration);
     addElement(GPI_ADMIN_API, profileConfiguration);
@@ -73,14 +75,14 @@ public class HomePageProfile {
   }
 
   public static Collection<String> getFullProfileElements() {
-    return Arrays.asList(GPI_VERSION, GPI_CERT, GPI_ADMIN_UI, GPI_ADMIN_API, GPI_METADATA_API, GPI_TOKENS, GPI_WEBSHELL);
+    return Arrays.asList(GPI_VERSION, GPI_HOSTNAME, GPI_CERT, GPI_ADMIN_UI, GPI_ADMIN_API, GPI_METADATA_API, GPI_TOKENS, GPI_WEBSHELL);
   }
 
   public static Collection<String> getThinProfileElemens() {
-    return Arrays.asList(GPI_VERSION, GPI_CERT);
+    return Arrays.asList(GPI_VERSION, GPI_HOSTNAME, GPI_CERT);
   }
 
   public static Collection<String> getTokenProfileElements() {
-    return Arrays.asList(GPI_VERSION, GPI_CERT, GPI_TOKENS);
+    return Arrays.asList(GPI_VERSION, GPI_HOSTNAME, GPI_CERT, GPI_TOKENS);
   }
 }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/dto/HomePageProfileTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/dto/HomePageProfileTest.java
@@ -32,7 +32,7 @@ public class HomePageProfileTest {
   @Test
   public void testEmptyConfiguration() throws Exception {
     final HomePageProfile profile = new HomePageProfile(Collections.emptySet());
-    assertEquals(8, profile.getProfileElements().size());
+    assertEquals(9, profile.getProfileElements().size());
     profile.getProfileElements().forEach((key, value) -> {
       if (key.startsWith(HomePageProfile.GPI_PREFIX)) {
         assertFalse(Boolean.parseBoolean(value));
@@ -75,7 +75,7 @@ public class HomePageProfileTest {
   @Test
   public void testTokenProfileElements() throws Exception {
     final Collection<String> tokenProfileElements = HomePageProfile.getTokenProfileElements();
-    assertEquals(3, tokenProfileElements.size());
+    assertEquals(4, tokenProfileElements.size());
     assertTrue(tokenProfileElements.containsAll(Arrays.asList(HomePageProfile.GPI_VERSION, HomePageProfile.GPI_CERT, HomePageProfile.GPI_TOKENS)));
   }
 

--- a/knox-homepage-ui/home/app/app.module.ts
+++ b/knox-homepage-ui/home/app/app.module.ts
@@ -26,6 +26,7 @@ import {APP_BASE_HREF} from '@angular/common';
 import {GeneralProxyInformationComponent} from './generalProxyInformation/general.proxy.information.component';
 import {TopologyInformationsComponent} from './topologies/topology.information.component';
 import {SessionInformationComponent} from './sessionInformation/session.information.component';
+import {SafeHtmlPipe} from './sessionInformation/session.information.component';
 import {HomepageService} from './homepage.service';
 
 @NgModule({
@@ -39,7 +40,8 @@ import {HomepageService} from './homepage.service';
     ],
     declarations: [GeneralProxyInformationComponent,
                    TopologyInformationsComponent,
-                   SessionInformationComponent
+                   SessionInformationComponent,
+                   SafeHtmlPipe
     ],
     providers: [HomepageService,
       {

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.html
@@ -26,6 +26,10 @@
                 <td>Knox Version</td>
                 <td>{{ getVersion() }}</td>
             </tr>
+            <tr *ngIf="this['showKnoxHostname']">
+                <td>Hostname</td>
+                <td>{{ getHostname() }}</td>
+            </tr>
             <tr *ngIf="this['showPublicCerts']">
                 <td>TLS Public Certificate</td>
                 <td>

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.component.ts
@@ -33,6 +33,7 @@ export class GeneralProxyInformationComponent implements OnInit {
     constructor(private homepageService: HomepageService, private route: ActivatedRoute) {
         this['showGeneralProxyInformation'] = false;
         this['showKnoxVersion'] = true;
+        this['showKnoxHostname'] = true;
         this['showPublicCerts'] = true;
         this['showAdminUI'] = true;
         this['showAdminAPI'] = true;
@@ -44,6 +45,13 @@ export class GeneralProxyInformationComponent implements OnInit {
     getVersion() {
         if (this.generalProxyInformation) {
             return this.generalProxyInformation.version;
+          }
+          return '';
+    }
+
+    getHostname() {
+        if (this.generalProxyInformation) {
+            return this.generalProxyInformation.hostname;
           }
           return '';
     }
@@ -118,6 +126,7 @@ export class GeneralProxyInformationComponent implements OnInit {
     setProfileFlags(profile: JSON) {
     	    console.debug('Setting GPI profile flags...');
         this['showKnoxVersion'] = (profile['gpi_version'] === 'true');
+        this['showKnoxHostname'] = (profile['gpi_hostname'] === 'true');
         this['showPublicCerts'] = (profile['gpi_cert'] === 'true');
         this['showAdminUI'] = (profile['gpi_admin_ui'] === 'true');
         this['showAdminAPI'] = (profile['gpi_admin_api'] === 'true');

--- a/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.ts
+++ b/knox-homepage-ui/home/app/generalProxyInformation/general.proxy.information.ts
@@ -17,6 +17,7 @@
 
 export class GeneralProxyInformation {
     version: string;
+    hostname: string;
     adminUiUrl: string;
     webShellUrl: string;
     adminApiBookUrl: string;

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.component.html
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.component.html
@@ -14,3 +14,4 @@
 -->
 <div style="text-align: right; color: rgb(130, 180, 93);">Welcome {{ getUser() }}</div>
 <div *ngIf="logoutSupported" style="text-align: right;"><a class="btn btn-primary" (click)="logout()">logout</a></div>
+<div style="margin-left: 15%; text-align: center; color: rgb(130,180, 93); max-width: 70%; word-wrap: break-word;" [innerHTML]="getBannerText() | safeHtml"></div>

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.component.ts
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.component.ts
@@ -14,9 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, Pipe, PipeTransform} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
 import {HomepageService} from '../homepage.service';
 import {SessionInformation} from './session.information';
+
+@Pipe({ name: 'safeHtml' })
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value) {
+    return this.sanitizer.bypassSecurityTrustHtml(value);
+  }
+}
 
 @Component({
     selector: 'app-session-information',
@@ -57,6 +67,14 @@ export class SessionInformationComponent implements OnInit {
             return this.sessionInformation.logoutPageUrl;
         }
         return null;
+    }
+
+    getBannerText() {
+        if (this.sessionInformation) {
+            console.debug('SessionInformationComponent --> getBannerHtml() --> ' + this.sessionInformation.bannerText);
+            return this.sessionInformation.bannerText;
+        }
+        return '';
     }
 
     logout() {

--- a/knox-homepage-ui/home/app/sessionInformation/session.information.ts
+++ b/knox-homepage-ui/home/app/sessionInformation/session.information.ts
@@ -20,4 +20,5 @@ export class SessionInformation {
     logoutUrl: string;
     logoutPageUrl: string;
     globalLgoutPageUrl: string;
+    bannerText: string;
 }

--- a/knox-token-generation-ui/token-generation/app/app.module.ts
+++ b/knox-token-generation-ui/token-generation/app/app.module.ts
@@ -21,13 +21,14 @@ import { TokenGenerationComponent } from './token-generation.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TokenGenService } from './token-generation.service';
 import { SessionInformationComponent } from './session.information.component';
+import { SafeHtmlPipe } from './session.information.component';
 
 @NgModule({
     imports: [BrowserModule,
         HttpClientModule,
         ReactiveFormsModule
     ],
-    declarations: [TokenGenerationComponent, SessionInformationComponent],
+    declarations: [TokenGenerationComponent, SessionInformationComponent, SafeHtmlPipe],
     providers: [TokenGenService],
     bootstrap: [TokenGenerationComponent, SessionInformationComponent]
 })

--- a/knox-token-generation-ui/token-generation/app/session.information.component.html
+++ b/knox-token-generation-ui/token-generation/app/session.information.component.html
@@ -14,3 +14,4 @@
 -->
 <!-- The text color is the same as the Cloudera logo's color -->
 <div style="text-align: right; color: rgb(130, 180, 93);">Logged in as {{ getUser() }}</div>
+<div style="margin-left: 15%; text-align: center; color: rgb(130,180, 93); max-width: 70%; word-wrap: break-word;" [innerHTML]="getBannerText() | safeHtml"></div>

--- a/knox-token-generation-ui/token-generation/app/session.information.component.ts
+++ b/knox-token-generation-ui/token-generation/app/session.information.component.ts
@@ -14,9 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, Pipe, PipeTransform} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
 import {TokenGenService} from './token-generation.service';
 import {SessionInformation} from './token-generation.models';
+
+@Pipe({ name: 'safeHtml' })
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value) {
+    return this.sanitizer.bypassSecurityTrustHtml(value);
+  }
+}
 
 @Component({
     selector: 'app-session-information',
@@ -40,6 +50,14 @@ export class SessionInformationComponent implements OnInit {
           console.debug('SessionInformationComponent --> getUser() --> dr.who');
           return 'dr.who';
         }
+    }
+
+    getBannerText() {
+        if (this.sessionInformation) {
+            console.debug('SessionInformationComponent --> getBannerHtml() --> ' + this.sessionInformation.bannerText);
+            return this.sessionInformation.bannerText;
+        }
+        return '';
     }
 
     ngOnInit(): void {

--- a/knox-token-generation-ui/token-generation/app/token-generation.models.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.models.ts
@@ -58,4 +58,5 @@ export class SessionInformation {
     globalLgoutPageUrl: string;
     canSeeAllTokens: boolean;
     currentKnoxSsoCookieTokenId: string;
+    bannerText: string;
 }

--- a/knox-token-management-ui/token-management/app/app.module.ts
+++ b/knox-token-management-ui/token-management/app/app.module.ts
@@ -33,6 +33,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {TokenManagementComponent} from './token.management.component';
 import {TokenManagementService} from './token.management.service';
 import {SessionInformationComponent} from './session.information.component';
+import {SafeHtmlPipe} from './session.information.component';
 
 @NgModule({
     imports: [BrowserModule,
@@ -53,7 +54,7 @@ import {SessionInformationComponent} from './session.information.component';
         MatSlideToggleModule,
         MatCheckboxModule
     ],
-    declarations: [TokenManagementComponent, SessionInformationComponent],
+    declarations: [TokenManagementComponent, SessionInformationComponent, SafeHtmlPipe],
     providers: [TokenManagementService],
     bootstrap: [TokenManagementComponent, SessionInformationComponent]
 })

--- a/knox-token-management-ui/token-management/app/session.information.component.html
+++ b/knox-token-management-ui/token-management/app/session.information.component.html
@@ -14,3 +14,5 @@
 -->
 <!-- The text color is the same as the Cloudera logo's color -->
 <div style="text-align: right; color: rgb(130, 180, 93);">Logged in as {{ getUser() }}</div>
+<div style="margin-left: 15%; text-align: center; color: rgb(130,180, 93); max-width: 70%; word-wrap: break-word;" [innerHTML]="getBannerText() | safeHtml"></div>
+

--- a/knox-token-management-ui/token-management/app/session.information.component.ts
+++ b/knox-token-management-ui/token-management/app/session.information.component.ts
@@ -14,9 +14,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, Pipe, PipeTransform} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
 import {TokenManagementService} from './token.management.service';
 import {SessionInformation} from './session.information';
+
+@Pipe({ name: 'safeHtml' })
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value) {
+    return this.sanitizer.bypassSecurityTrustHtml(value);
+  }
+}
 
 @Component({
     selector: 'app-session-information',
@@ -40,6 +50,14 @@ export class SessionInformationComponent implements OnInit {
           console.debug('SessionInformationComponent --> getUser() --> dr.who');
           return 'dr.who';
         }
+    }
+
+    getBannerText() {
+        if (this.sessionInformation) {
+            console.debug('SessionInformationComponent --> getBannerHtml() --> ' + this.sessionInformation.bannerText);
+            return this.sessionInformation.bannerText;
+        }
+        return '';
     }
 
     ngOnInit(): void {

--- a/knox-token-management-ui/token-management/app/session.information.ts
+++ b/knox-token-management-ui/token-management/app/session.information.ts
@@ -22,4 +22,5 @@ export class SessionInformation {
     globalLgoutPageUrl: string;
     canSeeAllTokens: boolean;
     currentKnoxSsoCookieTokenId: string;
+    bannerText: string;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
         <findsecbugs-plugin.version>1.11.0</findsecbugs-plugin.version>
         <forbiddenapis.version>3.1</forbiddenapis.version>
         <frontend-maven-plugin.version>1.11.0</frontend-maven-plugin.version>
+        <gethostname4j.version>1.0.0</gethostname4j.version>
         <glassfish-jaxb.version>2.3.3</glassfish-jaxb.version>
         <gson.version>2.8.9</gson.version>
         <groovy.version>3.0.7</groovy.version>
@@ -1559,6 +1560,18 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.kstruct</groupId>
+                <artifactId>gethostname4j</artifactId>
+                <version>${gethostname4j.version}</version>
+                <exclusions>
+                     <exclusion>
+                          <groupId>net.java.dev.jna</groupId>
+                          <artifactId>jna-platform</artifactId>
+                     </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <findsecbugs-plugin.version>1.11.0</findsecbugs-plugin.version>
         <forbiddenapis.version>3.1</forbiddenapis.version>
         <frontend-maven-plugin.version>1.11.0</frontend-maven-plugin.version>
-        <gethostname4j.version>1.0.0</gethostname4j.version>
+        <gethostname4j.version>1.0.0</gethostname4j.version>  <!-- See here: https://github.com/mattsheppard/gethostname4j -->
         <glassfish-jaxb.version>2.3.3</glassfish-jaxb.version>
         <gson.version>2.8.9</gson.version>
         <groovy.version>3.0.7</groovy.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

As explained in [KNOX-3008](https://issues.apache.org/jira/browse/KNOX-3008), the following changes were implemented in this PR:
- the hostname where the Knox Gateway instance is running is added in the `General Proxy Information' section on the Knox Home page
- end-users can configure a custom banner text displayed on the top banner between the Knox logo and the logged-in user name. The new gateway-level configuration name is `gateway.ui.banner.text` and defaults to an `empty string`. Administrators can set this configuration to simple text, or they can also set HTML style elements to match their needs.

## How was this patch tested?

Manually tested with the following `gateway-site.xml` settings:
1. Simple text
```
    <property>
        <name>gateway.ui.banner.text</name>
        <value>Message of the day: give Knox a star on GitHub!</value>
    </property>
```
<img width="1776" alt="Screenshot 2024-02-23 at 14 13 14" src="https://github.com/apache/knox/assets/34065904/b573a52c-355b-456d-9175-ebbceb353617">
<img width="1786" alt="Screenshot 2024-02-23 at 14 13 23" src="https://github.com/apache/knox/assets/34065904/7cb4ca17-8c94-4c7a-897e-e85735b7474b">
<img width="1788" alt="Screenshot 2024-02-23 at 14 13 32" src="https://github.com/apache/knox/assets/34065904/c63a2b76-8701-42b1-9147-3228756d1fcd">
<img width="1780" alt="Screenshot 2024-02-23 at 14 13 47" src="https://github.com/apache/knox/assets/34065904/8712cb77-a69c-429a-9335-c10e5e00a7d8">

2. Message within a `span` with yellow color. Please note the XML-encoded entry in the `value` field:
```
    <property>
        <name>gateway.ui.banner.text</name>
        <value>&lt;span style=&quot;color: yellow&quot;&gt;This is a very long banner text without any meaningful content. This is a very long banner text without any meaningful content. This is a very long banner text without any meaningful content. This is a very long banner text without any meaningful content. This is a very long banner text without any meaningful content. This is a very long banner text without any meaningful content.&lt;/span&gt;</value>
    </property>
```
<img width="1783" alt="Screenshot 2024-02-23 at 14 15 52" src="https://github.com/apache/knox/assets/34065904/ec9fb063-919f-4516-9fbf-a614a4ef20ee">
<img width="1791" alt="Screenshot 2024-02-23 at 14 16 00" src="https://github.com/apache/knox/assets/34065904/79398786-9b90-459a-b4fc-f463914ccbf4">
<img width="1783" alt="Screenshot 2024-02-23 at 14 16 08" src="https://github.com/apache/knox/assets/34065904/9a45fe03-cd24-4d6c-a40d-afad01c162fd">
