### PR TITLE
KNOX-3009 - KNOX-SESSION missing from Manager Topology and Admin UI

### DIFF
--- a/gateway-release/home/conf/topologies/manager.xml
+++ b/gateway-release/home/conf/topologies/manager.xml
@@ -81,6 +81,9 @@
       </provider>
    </gateway>
    <service>
+      <role>KNOX-SESSION</role>
+   </service>
+   <service>
       <role>KNOX</role>
    </service>
    <application>


### PR DESCRIPTION
Adds KNOX-SESSION to manager.xml for out of the box functionality of the Admin UI and displaying the logged in username.

## How was this patch tested?

Manually tested the Admin UI and ran all unit tests.
