### PR TITLE
KNOX-3011 - Excluded logback-[core|classic] as transitive dependencies pulled in by Zookeeper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2084,6 +2084,14 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>ch.qos.logback</groupId>
+                        <artifactId>logback-classic</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before my change, any time I ran a KnoxCLI command I saw the following warning messages wrt. there are multiple SLF4J bindings on the classpath:
```
$ bin/knoxcli.sh create-master --master gateway
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/sandormolnar/test/knoxGateway/bin/../dep/log4j-slf4j-impl-2.17.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/sandormolnar/test/knoxGateway/bin/../dep/logback-classic-1.2.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.apache.logging.slf4j.Log4jLoggerFactory]
Master secret has been persisted to disk.
```

I also confirmed that we have had `ch.qos.logback:logback-[core-classic]:jar:1.2.10` on Maven's dependency tree multiple times.
```
$ mvn dependency:tree | grep '^.*logback.*1.2.10.*$' | wc -l
      66
```

## How was this patch tested?

1. Running the previous `mvn:dependencyTree` command:
```
$ mvn dependency:tree | grep '^.*logback.*1.2.10.*$' | wc -l
       0
```
2. Rebuilt and redeployed Knox, then ran the `create-master` command:
```
$ bin/knoxcli.sh create-master --master gateway
Master secret has been persisted to disk.
```
