### PR TITLE
KNOX-3012 - Fix the DN links on the Ozone SCM UI

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -76,7 +76,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
             <apply path="/docs" rule="OZONE-SCM/ozone-scm/outbound/filter/docs"/>
             <apply path="logLevel" rule="OZONE-SCM/ozone-scm/outbound/filter/logLevel"/>
             <apply path="stacks" rule="OZONE-SCM/ozone-scm/outbound/filter/stacks"/>
-            <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
+            <apply path="\{\{typestat\.protocol\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.port\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
         </content>
         <content type="*/javascript">
             <apply path="main\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/main"/>

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.2.0/rewrite.xml
@@ -117,8 +117,8 @@ Licensed to the Apache Software Foundation (ASF) under one or more
     <!-- outbound rule for the datanode links on SCM UI -->
 
     <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/datanode/address">
-        <match pattern="{{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}"/>
-        <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host={{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}} "/>
+        <match pattern="{{typestat.protocol}}://{{typestat.hostname}}:{{typestat.port}}"/>
+        <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host={{typestat.protocol}}://{{typestat.hostname}}:{{typestat.port}} "/>
     </rule>
 
     <!-- datanode inbound rules -->

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.4.0/rewrite.xml
@@ -76,7 +76,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more
             <apply path="/docs" rule="OZONE-SCM/ozone-scm/outbound/filter/docs"/>
             <apply path="logLevel" rule="OZONE-SCM/ozone-scm/outbound/filter/logLevel"/>
             <apply path="stacks" rule="OZONE-SCM/ozone-scm/outbound/filter/stacks"/>
-            <apply path="\{\{typestat\.portval\.toLowerCase\(\)\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.portno\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
+            <apply path="\{\{typestat\.protocol\}\}\:\/\/\{\{typestat\.hostname\}\}\:\{\{typestat\.port\}\}" rule="OZONE-SCM/ozone-scm/outbound/datanode/address"/>
         </content>
         <content type="*/javascript">
             <apply path="main\.html" rule="OZONE-SCM/ozone-scm/outbound/filter/main"/>
@@ -117,8 +117,8 @@ Licensed to the Apache Software Foundation (ASF) under one or more
     <!-- outbound rule for the datanode links on SCM UI -->
 
     <rule dir="OUT" name="OZONE-SCM/ozone-scm/outbound/datanode/address">
-        <match pattern="{{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}}"/>
-        <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host={{typestat.portval.toLowerCase()}}://{{typestat.hostname}}:{{typestat.portno}} "/>
+        <match pattern="{{typestat.protocol}}://{{typestat.hostname}}:{{typestat.port}}"/>
+        <rewrite template="{gateway.url}/ozone-scm/datanode/index.html?host={{typestat.protocol}}://{{typestat.hostname}}:{{typestat.port}} "/>
     </rule>
 
     <!-- datanode inbound rules -->

--- a/gateway-service-definitions/src/main/resources/services/ozone-scm/1.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ozone-scm/1.4.0/service.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ -->
+<service role="OZONE-SCM" name="ozone-scm" version="1.2.0">
+	<metadata>
+		<type>UI</type>
+		<context>/ozone-scm/index.html?host={{BACKEND_HOST}}</context>
+		<shortDesc>OZONE SCM UI</shortDesc>
+	</metadata>
+	<routes>
+			<!-- SCM routes -->
+			<route path="/ozone-scm/">
+				<rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
+			</route>
+      <route path="/ozone-scm/**">
+				 <rewrite apply="OZONE-SCM/ozone-scm/inbound/request" to="request.url"/>
+				 <rewrite apply="OZONE-SCM/ozone-scm/outbound/response" to="response.body"/>
+			</route>
+			<!-- datanode routes -->
+			<route path="/ozone-scm/datanode/">
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/outbound/response" to="response.body"/>
+			</route>
+			<route path="/ozone-scm/datanode/**">
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/datanode/outbound/response" to="response.body"/>	 
+			</route>
+			<!-- documentation route -->
+			<route path="/ozone-scm/documentation/**">
+				<rewrite apply="OZONE-SCM/ozone-scm/documentation/inbound/request" to="request.url"/>
+				<rewrite apply="OZONE-SCM/ozone-scm/documentation/outbound/response" to="response.body"/>
+			</route>
+	</routes>
+	<dispatch classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch" ha-classname="org.apache.knox.gateway.dispatch.URLDecodingDispatch"/>
+</service>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In Ozone in [HDDS-9732](https://issues.apache.org/jira/browse/HDDS-9732) the datanode links were changed on the SCM UI. We need to reflect these changes in Knox. As Ozone is 1.4.0 since the last changes in Knox, I added a new folder for the `ozone-scm` service with the changes and left the 1.2.0 folder as it was. 

## How was this patch tested?

Tested the changes in a cluster. Before my changes it was redirecting to the DN UI without Knox, so the link was not rewritten:

<img width="1726" alt="before_change" src="https://github.com/apache/knox/assets/50611074/05f4f03e-2cc5-4f06-a396-c20784ed8fea">

With the changes Knox rewrites the link to the correct url:

<img width="1724" alt="after_change" src="https://github.com/apache/knox/assets/50611074/62fed34a-0e86-41a8-a3b4-69092ae508bf">

