### PR TITLE
KNOX-3013 - Knox redirecting Yarn Node Manager URLs to http instead of https

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
@@ -220,13 +220,6 @@
     </content>
 </filter>
 
-<filter name="YARNUI/yarn/outbound/filter/nodes">
-    <content type="*/html">
-        <apply path="(?!http:)//[^/':,]+:[\d]+" rule="YARNUI/yarn/outbound/node3"/>
-    </content>
-</filter>
-
-
 <rule dir="OUT" name="YARNUI/yarn/outbound/apps/app">
     <rewrite template="{$frontend[url]}/yarn/cluster/app"/>
 </rule>
@@ -278,10 +271,6 @@ https://knox_host:knox_port/gateway/yarnui/yarn/nodemanager/node/containerlogs/c
 <rule dir="OUT" name="YARNUI/yarn/outbound/node2">
     <match pattern="{scheme}://{host}:{port}"/>
     <rewrite template="{$frontend[url]}/yarn/nodemanager/node?{scheme}?{host}?{port}"/>
-</rule>
-<rule dir="OUT" name="YARNUI/yarn/outbound/node3">
-    <match pattern="//{host}:{port}"/>
-    <rewrite template="{$frontend[url]}/yarn/nodemanager/node?scheme=http?{host}?{port}"/>
 </rule>
 
 <rule dir="OUT" name="YARNUI/yarn/outbound/node/containerlogs2" pattern="*://*:*/node/containerlogs/{**}?{**}">


### PR DESCRIPTION
## What changes were proposed in this pull request?

- YARNUI/yarn/outbound/node3 rule rewrites the https schemes to http
- To fix the issue we skip this rule in case if the schema is https

## How was this patch tested?

- unit tests
- manually deployed a cluster and verified the url stays https
   - run MapReduce job
   - after that i checked the ResourceManager UI behind Knox
   - verified the scheme stayed https which links to the NodeManager (befor the change it was http cause the node3 rule)
   
![knox](https://github.com/apache/knox/assets/109747532/34d702ee-042a-4c96-8d12-56ee0cf18db1)
