### PR TITLE
KNOX-2998 - Path based authorization provider

### DIFF
--- a/gateway-provider-security-authz-path-acls/pom.xml
+++ b/gateway-provider-security-authz-path-acls/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.knox</groupId>
+        <artifactId>gateway</artifactId>
+        <version>2.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>gateway-provider-security-authz-path-acls</artifactId>
+    <name>gateway-provider-security-authz-path-acls</name>
+    <description>Provides authorization ACL support based on request path.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-i18n</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-provider-security-authz-acls</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-urltemplate</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/deploy/impl/PathAclsAuthzDeploymentContributor.java
+++ b/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/deploy/impl/PathAclsAuthzDeploymentContributor.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.deploy.impl;
+
+import org.apache.knox.gateway.deploy.DeploymentContext;
+import org.apache.knox.gateway.deploy.ProviderDeploymentContributorBase;
+import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
+import org.apache.knox.gateway.descriptor.ResourceDescriptor;
+import org.apache.knox.gateway.topology.Provider;
+import org.apache.knox.gateway.topology.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class PathAclsAuthzDeploymentContributor
+    extends ProviderDeploymentContributorBase {
+
+  private static final String FILTER_CLASSNAME = "org.apache.knox.gateway.filter.PathAclsAuthorizationFilter";
+
+  @Override
+  public String getRole() {
+    return "authorization";
+  }
+
+  @Override
+  public String getName() {
+    return "PathAclsAuthz";
+  }
+
+  @Override
+  public void initializeContribution(DeploymentContext context) {
+    super.initializeContribution(context);
+  }
+
+  @Override
+  public void contributeProvider(DeploymentContext context, Provider provider) {
+  }
+
+  @Override
+  public void contributeFilter(DeploymentContext context, Provider provider,
+      Service service, ResourceDescriptor resource,
+      List<FilterParamDescriptor> params) {
+    if (params == null) {
+      params = new ArrayList<>();
+    }
+    // add resource role to params so that we can determine the acls to enforce at runtime
+    params.add(resource.createFilterParam().name("resource.role")
+        .value(resource.role()));
+
+    // the following are used within the PathAclsAuthz provider to replace
+    // placeholders within the acls KNOX_ADMIN_GROUPS and KNOX_ADMIN_USERS
+    String adminGroups = context.getGatewayConfig().getKnoxAdminGroups();
+    params.add(resource.createFilterParam().name("knox.admin.groups")
+        .value(adminGroups));
+
+    String adminUsers = context.getGatewayConfig().getKnoxAdminUsers();
+    params.add(resource.createFilterParam().name("knox.admin.users")
+        .value(adminUsers));
+
+    // blindly add all the provider params as filter init params
+    Map<String, String> providerParams = provider.getParams();
+    for (Entry<String, String> entry : providerParams.entrySet()) {
+      params.add(resource.createFilterParam()
+          .name(entry.getKey().toLowerCase(Locale.ROOT))
+          .value(entry.getValue()));
+    }
+
+    resource.addFilter().name(getName()).role(getRole()).impl(FILTER_CLASSNAME)
+        .params(params);
+  }
+}

--- a/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/AclsAuthorizationResources.java
+++ b/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/AclsAuthorizationResources.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import org.apache.knox.gateway.i18n.resources.Resource;
+import org.apache.knox.gateway.i18n.resources.Resources;
+
+@Resources
+public interface AclsAuthorizationResources {
+  @Resource( text = "Response status: {0}" )
+  String responseStatus( int status );
+}

--- a/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/InvalidACLException.java
+++ b/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/InvalidACLException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+/**
+ * invalid ACL configuration item
+ */
+public class InvalidACLException extends RuntimeException {
+
+  private static final long serialVersionUID = -4284269372393774095L;
+
+  public InvalidACLException(String message) {
+    super(message);
+  }
+
+}

--- a/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/PathAclParser.java
+++ b/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/PathAclParser.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.util.urltemplate.Matcher;
+import org.apache.knox.gateway.util.urltemplate.Parser;
+import org.apache.knox.gateway.util.urltemplate.Template;
+
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PathAclParser {
+  private static PathAclsAuthorizationMessages log = MessagesFactory.get(
+      PathAclsAuthorizationMessages.class);
+  /* A Map of path to ACLs (users, groups, ips) to match */
+  public Map<Matcher, AclParser> rulesMap = new HashMap<>();
+  public PathAclParser() {
+    super();
+  }
+
+  public void parsePathAcls(final String resourceRole,
+      Map<String, String> rawRules) throws InvalidACLException {
+    if (rawRules != null && !rawRules.isEmpty()) {
+      for (final Map.Entry<String, String> rules : rawRules.entrySet()) {
+        final String acls = rules.getValue();
+        final Matcher urlMatcher = new Matcher();
+        final AclParser aclParser = new AclParser();
+        final Template urlPatternTemplate;
+        if (acls != null) {
+          final String path = acls.substring(0, acls.indexOf(';'));
+          final String aclRules = acls.substring(acls.indexOf(';') + 1);
+
+          log.aclsFoundForResource(rules.getKey());
+          if (StringUtils.isBlank(path) || StringUtils.isBlank(aclRules)) {
+            log.invalidAclsFoundForResource(rules.getKey());
+            throw new InvalidACLException(
+                "Invalid Path ACLs specified for rule: " + rules.getKey());
+          }
+          log.aclsFoundForResource(rules.getKey());
+
+          try {
+            urlPatternTemplate = Parser.parseTemplate(path);
+          } catch (URISyntaxException e) {
+            log.invalidURLPattern(rules.getKey());
+            throw new InvalidACLException(
+                "Invalid URL pattern for rule: " + rules.getKey());
+          }
+
+          urlMatcher.add(urlPatternTemplate, rules.getKey());
+          /* Reuse the code that parses users, groups and ips*/
+          aclParser.parseAcls(resourceRole, aclRules);
+          /* Save our rule and the parsed path */
+          rulesMap.put(urlMatcher, aclParser);
+        }
+
+      }
+    } else {
+      log.noAclsFoundForResource(resourceRole);
+    }
+  }
+
+  public Map getRulesMap() {
+    return Collections.unmodifiableMap(rulesMap);
+  }
+
+}

--- a/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/PathAclsAuthorizationFilter.java
+++ b/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/PathAclsAuthorizationFilter.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.knox.gateway.audit.api.Action;
+import org.apache.knox.gateway.audit.api.ActionOutcome;
+import org.apache.knox.gateway.audit.api.AuditServiceFactory;
+import org.apache.knox.gateway.audit.api.Auditor;
+import org.apache.knox.gateway.audit.api.ResourceType;
+import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.security.GroupPrincipal;
+import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.knox.gateway.util.urltemplate.Matcher;
+import org.apache.knox.gateway.util.urltemplate.Parser;
+import org.apache.knox.gateway.util.urltemplate.Template;
+
+import javax.security.auth.Subject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class PathAclsAuthorizationFilter implements Filter {
+  private static PathAclsAuthorizationMessages log = MessagesFactory.get(
+      PathAclsAuthorizationMessages.class);
+  private static Auditor auditor = AuditServiceFactory.getAuditService()
+      .getAuditor(AuditConstants.DEFAULT_AUDITOR_NAME,
+          AuditConstants.KNOX_SERVICE_NAME, AuditConstants.KNOX_COMPONENT_NAME);
+  private static String PATH_ACL_POSTFIX = ".path.acl";
+  private String resourceRole;
+  private String aclProcessingMode;
+  private PathAclParser pathAclParser = new PathAclParser();
+  private List<String> adminGroups = new ArrayList<>();
+  private List<String> adminUsers = new ArrayList<>();
+  private Map<String, String> rawRules = new HashMap<>();
+
+  @Override
+  public void init(FilterConfig filterConfig) {
+    resourceRole = getInitParameter(filterConfig, "resource.role");
+    log.initializingForResourceRole(resourceRole);
+
+    String adminGroups = filterConfig.getInitParameter("knox.admin.groups");
+    if (adminGroups != null) {
+      parseAdminGroupConfig(adminGroups);
+    }
+
+    String adminUsers = filterConfig.getInitParameter("knox.admin.users");
+    if (adminUsers != null) {
+      parseAdminUserConfig(adminUsers);
+    }
+
+    /* Get the path rules defined for this services */
+    final Enumeration<String> rules = filterConfig.getInitParameterNames();
+    while (rules.hasMoreElements()) {
+      String rule = rules.nextElement();
+      if (StringUtils.endsWithIgnoreCase(rule, PATH_ACL_POSTFIX)
+          && StringUtils.containsIgnoreCase(rule, resourceRole)) {
+        rawRules.put(rule, filterConfig.getInitParameter(rule));
+      }
+    }
+
+    /* in case there is a super rule for all services `path.acl` add that too */
+    final String pathAcls = getInitParameter(filterConfig, "path.acl");
+    if (pathAcls != null) {
+      rawRules.put("path.acl", pathAcls);
+    }
+
+    /* in case there is a resource rule for the services `{service}.path.acl` add that too */
+    final String pathResourceAcls = getInitParameter(filterConfig,
+        resourceRole + ".path.acl");
+    if (pathResourceAcls != null) {
+      rawRules.put(resourceRole + ".path.acl", pathResourceAcls);
+    }
+
+    aclProcessingMode = getInitParameter(filterConfig,
+        resourceRole + ".path.acl.mode");
+    if (aclProcessingMode == null) {
+      aclProcessingMode = getInitParameter(filterConfig, "path.acl.mode");
+      if (aclProcessingMode == null) {
+        aclProcessingMode = "AND";
+      }
+    }
+    log.aclProcessingMode(aclProcessingMode);
+    /* Rules for services */
+    pathAclParser.parsePathAcls(resourceRole, rawRules);
+  }
+
+  private String getInitParameter(FilterConfig filterConfig, String paramName) {
+    return filterConfig.getInitParameter(paramName.toLowerCase(Locale.ROOT));
+  }
+
+  private void parseAdminGroupConfig(String groups) {
+    Collections.addAll(adminGroups, groups.split(","));
+  }
+
+  private void parseAdminUserConfig(String users) {
+    Collections.addAll(adminUsers, users.split(","));
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response,
+      FilterChain chain) throws IOException, ServletException {
+
+    boolean accessGranted = enforceAclAuthorizationPolicy(request);
+    log.accessGranted(accessGranted);
+    String sourceUrl = (String) request.getAttribute(
+        AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME);
+    if (accessGranted) {
+      auditor.audit(Action.AUTHORIZATION, sourceUrl, ResourceType.URI,
+          ActionOutcome.SUCCESS);
+      chain.doFilter(request, response);
+    } else {
+      auditor.audit(Action.AUTHORIZATION, sourceUrl, ResourceType.URI,
+          ActionOutcome.FAILURE);
+      sendForbidden((HttpServletResponse) response);
+    }
+  }
+
+  protected boolean enforceAclAuthorizationPolicy(final ServletRequest request)
+      throws IOException {
+    /*
+       Before enforcing acls check whether there are no acls defined
+       which would mean that there are no restrictions
+    */
+    if (rawRules.isEmpty()) {
+      /* no rules defined, free to go */
+      return true;
+    }
+    try {
+      String requestURL = ((HttpServletRequest) request).getRequestURL().toString();
+      if (((HttpServletRequest) request).getQueryString() != null
+          && StringUtils.isNotBlank(
+          ((HttpServletRequest) request).getQueryString())) {
+        requestURL = requestURL + "?"
+            + (((HttpServletRequest) request).getQueryString());
+      }
+
+      final Template requestUrlTemplate = Parser.parseLiteral(requestURL);
+      final Map<Matcher, AclParser> rulesMap = pathAclParser.getRulesMap();
+
+      /**
+       *
+       * TODO NOTE: Important thing here is that we have the ability to capture the path or
+       * query parameters of incoming request. This gives us an ability to rewrite
+       * them based on rules or simply inspect them conditionally based on their values.
+       * I don't have a use case in mind but it would be a nice feature if we have a
+       * use case in the future.
+       */
+      /* See if we have any path match */
+      for (final Map.Entry<Matcher, AclParser> e : rulesMap.entrySet()) {
+        final Matcher<String>.Match match = e.getKey()
+            .match(requestUrlTemplate);
+        if (match != null) {
+          /* we have a path match, now check ACLs */
+          return checkACLs(e.getValue(), request);
+        }
+      }
+
+    } catch (URISyntaxException e) {
+      log.errorParsingUrl(e.toString());
+      throw new IOException(e);
+    }
+    return false;
+  }
+
+  /* This helper function check whether the user has proper permissions */
+  private boolean checkACLs(final AclParser aclParser,
+      final ServletRequest request) {
+
+    if (aclParser.users.isEmpty() && aclParser.groups.isEmpty()
+        && aclParser.ipv.getIPAddresses().isEmpty()) {
+      return true;
+    }
+
+    boolean groupAccess = false;
+    boolean ipAddrAccess;
+
+    final Subject subject = SubjectUtils.getCurrentSubject();
+    final String effectivePrincipalName = SubjectUtils.getEffectivePrincipalName(
+        subject);
+    log.effectivePrincipal(effectivePrincipalName);
+    boolean userAccess = checkUserAcls(effectivePrincipalName, aclParser);
+    log.effectivePrincipalHasAccess(userAccess);
+
+    Object[] groups = subject.getPrincipals(GroupPrincipal.class).toArray();
+    if (groups.length > 0) {
+      groupAccess = checkGroupAcls(groups, aclParser);
+      log.groupPrincipalHasAccess(groupAccess);
+    } else {
+      // if we have no groups in the subject then make
+      // it true if there is an anyGroup acl
+      // for AND mode and acls like *;*;127.0.0.* we need to
+      // make it pass
+      if (aclParser.anyGroup && "AND".equals(aclProcessingMode)) {
+        groupAccess = true;
+      }
+    }
+    log.remoteIPAddress(((HttpServletRequest) request).getRemoteAddr());
+    ipAddrAccess = checkRemoteIpAcls(
+        ((HttpServletRequest) request).getRemoteAddr(), aclParser);
+    log.remoteIPAddressHasAccess(ipAddrAccess);
+
+    if ("OR".equals(aclProcessingMode)) {
+      // need to interpret '*' as excluded for OR semantics
+      // to make sense and not grant access to everyone by mistake.
+      // exclusion in OR is equivalent to denied
+      // so, let's set each one that contains '*' to false.
+      if (aclParser.anyUser) {
+        userAccess = false;
+      }
+      if (aclParser.anyGroup) {
+        groupAccess = false;
+      }
+      if (aclParser.ipv.allowsAnyIP()) {
+        ipAddrAccess = false;
+      }
+
+      return (userAccess || groupAccess || ipAddrAccess);
+    } else if ("AND".equals(aclProcessingMode)) {
+      return (userAccess && groupAccess && ipAddrAccess);
+    }
+    return false;
+  }
+
+  private boolean checkRemoteIpAcls(final String remoteAddr,
+      final AclParser aclParser) {
+    boolean allowed;
+    if (remoteAddr == null) {
+      return false;
+    }
+    allowed = aclParser.ipv.validateIpAddress(remoteAddr);
+    return allowed;
+  }
+
+  boolean checkUserAcls(final String userName, final AclParser aclParser) {
+    boolean allowed = false;
+    if (userName == null) {
+      return false;
+    }
+    if (aclParser.anyUser) {
+      allowed = true;
+    } else {
+      if (aclParser.users.contains(userName)) {
+        allowed = true;
+      } else if (aclParser.users.contains("KNOX_ADMIN_USERS")
+          && adminUsers.contains(userName)) {
+        allowed = true;
+      }
+    }
+    return allowed;
+  }
+
+  boolean checkGroupAcls(final Object[] userGroups, final AclParser aclParser) {
+    boolean allowed;
+    if (userGroups == null) {
+      return false;
+    }
+    if (aclParser.anyGroup) {
+      allowed = true;
+    } else {
+      allowed = hasAllowedPrincipal(aclParser.groups, userGroups);
+      if (!allowed && aclParser.groups.contains("KNOX_ADMIN_GROUPS")) {
+        allowed = hasAllowedPrincipal(adminGroups, userGroups);
+      }
+    }
+    return allowed;
+  }
+
+  private boolean hasAllowedPrincipal(List<String> allowed,
+      Object[] userGroups) {
+    boolean rc = false;
+    for (Object userGroup : userGroups) {
+      if (allowed.contains(((Principal) userGroup).getName())) {
+        rc = true;
+        break;
+      }
+    }
+    return rc;
+  }
+
+  private void sendForbidden(HttpServletResponse res) {
+    sendErrorCode(res, 403);
+  }
+
+  private void sendErrorCode(HttpServletResponse res, int code) {
+    try {
+      res.sendError(code);
+    } catch (final IOException e) {
+      log.errorSendCode(e.toString());
+    }
+  }
+}

--- a/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/PathAclsAuthorizationMessages.java
+++ b/gateway-provider-security-authz-path-acls/src/main/java/org/apache/knox/gateway/filter/PathAclsAuthorizationMessages.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import org.apache.knox.gateway.i18n.messages.Message;
+import org.apache.knox.gateway.i18n.messages.MessageLevel;
+import org.apache.knox.gateway.i18n.messages.Messages;
+
+@Messages(logger="org.apache.knox.gateway")
+public interface PathAclsAuthorizationMessages {
+
+  @Message( level = MessageLevel.INFO, text = "Initializing PathAclsAuthz Provider for: {0}" )
+  void initializingForResourceRole(String resourceRole);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACL Processing Mode is: {0}" )
+  void aclProcessingMode(String aclProcessingMode);
+
+  @Message( level = MessageLevel.WARN, text = "Invalid Path ACLs found for rule: {0}" )
+  void invalidAclsFoundForResource(String resourceRole);
+
+  @Message( level = MessageLevel.WARN, text = "Invalid URL pattern for rule: {0}" )
+  void invalidURLPattern(String rule);
+
+  @Message( level = MessageLevel.INFO, text = "Path ACLs found for: {0}" )
+  void aclsFoundForResource(String resourceRole);
+
+  @Message( level = MessageLevel.DEBUG, text = "No Path ACLs found for: {0}" )
+  void noAclsFoundForResource(String resourceRole);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACLs Access Granted: {0}" )
+  void accessGranted(boolean accessGranted);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACLs Effective principal: {0}" )
+  void effectivePrincipal(String name);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACLs Effective principal has access: {0}" )
+  void effectivePrincipalHasAccess(boolean userAccess);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACLs GroupPrincipal has access: {0}" )
+  void groupPrincipalHasAccess(boolean groupAccess);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACLs Remote IP Address: {0}" )
+  void remoteIPAddress(String remoteAddr);
+
+  @Message( level = MessageLevel.DEBUG, text = "Path ACLs Remote IP Address has access: {0}" )
+  void remoteIPAddressHasAccess(boolean remoteIpAccess);
+
+  @Message( level = MessageLevel.ERROR, text = "Path ACLs, error parsing URL: {0}" )
+  void errorParsingUrl(String reason);
+
+  @Message( level = MessageLevel.ERROR, text = "Path ACLs, error sending error code: {0}" )
+  void errorSendCode(String reason);
+}

--- a/gateway-provider-security-authz-path-acls/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ProviderDeploymentContributor
+++ b/gateway-provider-security-authz-path-acls/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ProviderDeploymentContributor
@@ -1,0 +1,18 @@
+##########################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##########################################################################
+org.apache.knox.gateway.deploy.impl.PathAclsAuthzDeploymentContributor

--- a/gateway-provider-security-authz-path-acls/src/test/java/org/apache/knox/gateway/filter/PathAclParserTest.java
+++ b/gateway-provider-security-authz-path-acls/src/test/java/org/apache/knox/gateway/filter/PathAclParserTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test paring of path ACLs rules
+ */
+@Ignore
+public class PathAclParserTest {
+  final Map<String, String> rawRules = new HashMap<>();
+
+  @Before
+  public void setUp() {
+    rawRules.put("rule_user", "/foo/user/*;hdfs,admin;*;*");
+    rawRules.put("rule_group", "/foo/groups/*;*;admin-group;*");
+    rawRules.put("rule_ip", "/foo/groups/*;*;*;67.54.12.11");
+    rawRules.put("rule_allow_all", "/foo/groups/*;*;*;*");
+    rawRules.put("rule_deny_all", "/foo/groups/*; ; ; ;");
+  }
+
+  @Test
+  public void testParseACLs() {
+    PathAclParser pathAclParser = new PathAclParser();
+    pathAclParser.parsePathAcls("test", rawRules);
+    Map rulesMap = pathAclParser.getRulesMap();
+    assertNotNull("Rules map should not be null", rulesMap);
+    assertEquals(5, rulesMap.size());
+  }
+
+  @Test(expected = InvalidACLException.class)
+  public void testInvalidACLs() {
+    final Map<String, String> rawRules1 = new HashMap<>();
+    rawRules1.put("rule_user", "/foo/user/*;hdfs,admin;*");
+
+    PathAclParser pathAclParser = new PathAclParser();
+    pathAclParser.parsePathAcls("test", rawRules1);
+  }
+}

--- a/gateway-provider-security-authz-path-acls/src/test/java/org/apache/knox/gateway/filter/PathAclsAuthzFilterTest.java
+++ b/gateway-provider-security-authz-path-acls/src/test/java/org/apache/knox/gateway/filter/PathAclsAuthzFilterTest.java
@@ -1,0 +1,769 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import org.apache.knox.gateway.security.GroupPrincipal;
+import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import javax.security.auth.Subject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class PathAclsAuthzFilterTest {
+  private AtomicBoolean accessGranted;
+  private Filter filter;
+
+  @Before
+  public void setUp() {
+    filter = new PathAclsAuthorizationFilter() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response,
+          FilterChain chain) throws IOException, ServletException {
+        boolean accessGranted = enforceAclAuthorizationPolicy(request);
+        if (accessGranted) {
+          chain.doFilter(request, response);
+        }
+      }
+
+      @Override
+      protected boolean enforceAclAuthorizationPolicy(ServletRequest request)
+          throws IOException {
+        accessGranted = new AtomicBoolean(
+            super.enforceAclAuthorizationPolicy(request));
+        return accessGranted.get();
+      }
+    };
+  }
+
+  @After
+  public void tearDown() {
+    accessGranted = null;
+    filter = null;
+  }
+
+  @Test
+  public void testValidPathAcls() throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+            Collections.enumeration(
+                Arrays.asList("knox.admin.users", "knox.admin.groups",
+                    "resource.role", "knox.acl.mode", "knox.rule_group.path.acl")))
+        .anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.path.acl.mode"))
+        .andReturn("OR");
+    EasyMock.expect(config.getInitParameter("knox.rule_group.path.acl"))
+        .andReturn("https://*:*/foo/group/*;*;KNOX_ADMIN_GROUPS;*");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * Test to make sure `path.acl` property is applied to ALL services
+   */
+  @Test
+  public void testDefaultPathAcls() throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+        Collections.enumeration(
+            Arrays.asList("knox.admin.users", "knox.admin.groups",
+                "resource.role", "knox.acl.mode"))).anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.path.acl.mode"))
+        .andReturn("OR");
+    EasyMock.expect(config.getInitParameter("path.acl"))
+        .andReturn("https://*:*/foo/group/*;*;KNOX_ADMIN_GROUPS;*");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * Test to make sure `{service}.path.acl` property is applied only to provided
+   * services. In this test we apply path ACLs to `test` service and use AND
+   * mode. Access should be granted because knox service does not have any ALCs
+   * defined.
+   */
+  @Test
+  public void testDefaultResourcePathAcls()
+      throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+        Collections.enumeration(
+            Arrays.asList("knox.admin.users", "knox.admin.groups",
+                "resource.role", "test.acl.mode", "test.path.acl"))).anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("test.path.acl.mode"))
+        .andReturn("AND");
+    EasyMock.expect(config.getInitParameter("test.path.acl"))
+        .andReturn("https://*:*/foo/group/*;random_user;random_group;*");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * Test to make sure AND acls work.
+   */
+  @Test
+  public void testANDAclsMode() throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+            Collections.enumeration(
+                Arrays.asList("knox.admin.users", "knox.admin.groups",
+                    "resource.role", "knox.acl.mode", "knox.rule_group.path.acl")))
+        .anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.path.acl.mode"))
+        .andReturn("AND");
+    EasyMock.expect(config.getInitParameter("knox.rule_group.path.acl"))
+        .andReturn(
+            "https://*:*/foo/group/*;more;KNOX_ADMIN_GROUPS;127.1.97.24");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * Test to make sure AND acls work (AND evaluates to false) Note: user is
+   * `more` so user `knox` should not grant access
+   */
+  @Test
+  public void testNegativeANDAclsMode() throws ServletException, IOException {
+
+    final TestPathAclsAuthorizationFilter testFilter = new TestPathAclsAuthorizationFilter();
+
+    final FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+        Collections.enumeration(
+            Arrays.asList("knox.admin.users", "knox.admin.groups",
+                "resource.role", "path.acl.mode",
+                "knox.rule_group_1.path.acl"))).anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("path.acl.mode")).andReturn("AND");
+    /* Note: user is `more` so user `knox` should not grant access */
+    EasyMock.expect(config.getInitParameter("knox.rule_group_1.path.acl"))
+        .andReturn(
+            "https://*:*/foo/group/*;knox;KNOX_ADMIN_GROUPS;127.1.97.24");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(request, response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    testFilter.init(config);
+
+    final Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          testFilter.doFilter(request, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+
+    assertFalse(testFilter.access.get());
+  }
+
+  /**
+   * Test to make sure OR acls work. Note: user is `more` so user `knox` should
+   * not match ACLs but ALCs mode is OR so access should be granted
+   */
+  @Test
+  public void testORAclsMode() throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+            Collections.enumeration(
+                Arrays.asList("knox.admin.users", "knox.admin.groups",
+                    "resource.role", "knox.acl.mode", "knox.rule_group.path.acl")))
+        .anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.path.acl.mode"))
+        .andReturn("OR");
+    /* Note: user is `more` so user `knox` should not match ACLs but ALCs mode is OR so access should be granted  */
+    EasyMock.expect(config.getInitParameter("knox.rule_group.path.acl"))
+        .andReturn(
+            "https://*:*/foo/group/*;knox;KNOX_ADMIN_GROUPS;127.1.97.24");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * THest the case where multiple paths are defined with different ACL
+   * conditions
+   *
+   * @throws ServletException
+   * @throws IOException
+   */
+  @Test
+  public void testMultiplePathPathAcls_1()
+      throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+            Collections.enumeration(
+                Arrays.asList("knox.admin.users", "knox.admin.groups",
+                    "resource.role", "knox.acl.mode", "knox.rule_group.path.acl",
+                    "knox.user_group.path.acl", "knox.user_query_group.path.acl")))
+        .anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.rule_group.path.acl"))
+        .andReturn("https://*:*/foo/group/*;*;KNOX_ADMIN_GROUPS;*");
+    EasyMock.expect(config.getInitParameter("knox.user_group.path.acl"))
+        .andReturn("https://*:*/foo/user/*;more;*;*");
+    EasyMock.expect(config.getInitParameter("knox.user_query_group.path.acl"))
+        .andReturn("https://*:*/foo/bar/{**}?{**};more;*;*");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request_group = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request_group.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request_group).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request_group);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request_group, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * THest the case where multiple paths are defined with different ACL
+   * conditions
+   *
+   * @throws ServletException
+   * @throws IOException
+   */
+  @Test
+  public void testMultiplePathPathAcls_2()
+      throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+            Collections.enumeration(
+                Arrays.asList("knox.admin.users", "knox.admin.groups",
+                    "resource.role", "knox.acl.mode", "knox.rule_group.path.acl",
+                    "knox.user_group.path.acl", "knox.user_query_group.path.acl")))
+        .anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.rule_group.path.acl"))
+        .andReturn("https://*:*/foo/group/*;*;KNOX_ADMIN_GROUPS;*");
+    EasyMock.expect(config.getInitParameter("knox.user_group.path.acl"))
+        .andReturn("https://*:*/foo/user/*;more;*;*");
+    EasyMock.expect(config.getInitParameter("knox.user_query_group.path.acl"))
+        .andReturn("https://*:*/foo/bar/{**}?{**};more;*;*");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request_user = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request_user.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request_user).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request_user);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+
+    // check for request_user
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request_user, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  /**
+   * THest the case where multiple paths are defined with different ACL
+   * conditions
+   *
+   * @throws ServletException
+   * @throws IOException
+   */
+  @Test
+  public void testMultiplePathPathAcls_3()
+      throws ServletException, IOException {
+    FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+    EasyMock.expect(config.getInitParameterNames()).andReturn(
+            Collections.enumeration(
+                Arrays.asList("knox.admin.users", "knox.admin.groups",
+                    "resource.role", "knox.acl.mode", "knox.rule_group.path.acl",
+                    "knox.user_group.path.acl", "knox.user_query_group.path.acl")))
+        .anyTimes();
+    EasyMock.expect(config.getInitParameter("knox.admin.users"))
+        .andReturn(null);
+    EasyMock.expect(config.getInitParameter("knox.admin.groups"))
+        .andReturn("admin");
+    EasyMock.expect(config.getInitParameter("resource.role")).andReturn("KNOX");
+    EasyMock.expect(config.getInitParameter("knox.rule_group.path.acl"))
+        .andReturn("https://*:*/foo/group/*;*;KNOX_ADMIN_GROUPS;*");
+    EasyMock.expect(config.getInitParameter("knox.user_group.path.acl"))
+        .andReturn("https://*:*/foo/user/*;more;*;*");
+    EasyMock.expect(config.getInitParameter("knox.user_query_group.path.acl"))
+        .andReturn("https://*:*/foo/bar/{**}?{**};more;*;*");
+    EasyMock.replay(config);
+
+    final HttpServletRequest request_user_query = EasyMock.createNiceMock(
+        HttpServletRequest.class);
+    EasyMock.expect(request_user_query.getRequestURL())
+        .andReturn(new StringBuffer("https://example.com/foo/group/bar"));
+    EasyMock.expect(((HttpServletRequest) request_user_query).getQueryString())
+        .andReturn("foz=baz");
+    EasyMock.expect(((HttpServletRequest) request_user_query).getRemoteAddr())
+        .andReturn("127.1.97.24").anyTimes();
+
+    EasyMock.replay(request_user_query);
+
+    final HttpServletResponse response = EasyMock.createNiceMock(
+        HttpServletResponse.class);
+    EasyMock.replay(response);
+
+    final FilterChain chain = new FilterChain() {
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response)
+          throws IOException, ServletException {
+      }
+    };
+
+    filter.init(config);
+    Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal("more"));
+    subject.getPrincipals().add(new GroupPrincipal("users"));
+    subject.getPrincipals().add(new GroupPrincipal("admin"));
+
+    /* check for request_user_query */
+    try {
+      Subject.doAs(subject, new PrivilegedExceptionAction<Object>() {
+        @Override
+        public Object run() throws Exception {
+          filter.doFilter(request_user_query, response, chain);
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      Throwable t = e.getCause();
+      if (t instanceof IOException) {
+        throw (IOException) t;
+      } else if (t instanceof ServletException) {
+        throw (ServletException) t;
+      } else {
+        throw new ServletException(t);
+      }
+    }
+    assertTrue(accessGranted.get());
+  }
+
+  class TestPathAclsAuthorizationFilter extends PathAclsAuthorizationFilter {
+
+    private AtomicBoolean access;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+        FilterChain chain) throws IOException, ServletException {
+      boolean accessGranted = enforceAclAuthorizationPolicy(request);
+      if (accessGranted) {
+        chain.doFilter(request, response);
+      }
+    }
+
+    @Override
+    protected boolean enforceAclAuthorizationPolicy(ServletRequest request)
+        throws IOException {
+      access = new AtomicBoolean(super.enforceAclAuthorizationPolicy(request));
+      return access.get();
+    }
+  }
+
+}

--- a/gateway-release/pom.xml
+++ b/gateway-release/pom.xml
@@ -360,6 +360,10 @@
         </dependency>
         <dependency>
             <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-provider-security-authz-path-acls</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
             <artifactId>gateway-provider-security-authz-composite</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <module>gateway-provider-security-shiro</module>
         <module>gateway-provider-security-pac4j</module>
         <module>gateway-provider-security-authz-acls</module>
+        <module>gateway-provider-security-authz-path-acls</module>
         <module>gateway-provider-security-authz-composite</module>
         <module>gateway-provider-security-authc-anon</module>
         <module>gateway-provider-identity-assertion-common</module>
@@ -982,6 +983,11 @@
             <dependency>
                 <groupId>org.apache.knox</groupId>
                 <artifactId>gateway-provider-security-authz-acls</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.knox</groupId>
+                <artifactId>gateway-provider-security-authz-path-acls</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change proposes a new authorization provider `PathAclsAuthz` that authorized based on request path. Authorization is done based on path matching similar to rewrite rules.

Format is very similar to  AclsAuthz provider with an addition of path. The format is 
`{path};{users};{groups}:{ips}`
One important thing to note here is that the path is not plural, there has to be one and only one path defined. 

In case one wants multiple paths they can define multiple rules with rule name as a parameter e.g. 
KNOXTOKEN.{rule_name}.path.acl

_These are special cases for rule names_
This rule will be applied to ALL services defined in the topology
```
           <param>
                <name>path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
```

This rule will be applied to only the service {service_name}
```
           <param>
                <name>{service_name}.path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
```

ALL of these rules will be applied to service {service_name}. 
_NOTE_: {rule_1} and {rule_2} can be any unique names.
```
           <param>
                <name>{service_name}.{rule_1}.path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
            <param>
                <name>{service_name}.{rule_2}.path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
```

Following are concrete examples of the the above rules:

1. This rule will be applied to ALL services defined in the topology

```
       <provider>
            <role>authorization</role>
            <name>PathAclsAuthz</name>
            <enabled>true</enabled>
            <param>
                <name>path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
        </provider>
```

2. This rule will be applied to only to KNOXTOKEN service

```
       <provider>
            <role>authorization</role>
            <name>PathAclsAuthz</name>
            <enabled>true</enabled>
            <param>
                <name>KNOXTOKEN.path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
        </provider>
```

3. All of these rules will be applied to only to KNOXTOKEN service

```
       <provider>
            <role>authorization</role>
            <name>PathAclsAuthz</name>
            <enabled>true</enabled>
            <param>
                <name>KNOXTOKEN.rule_1.path.acl</name>
                <value>https://*:*/**/knoxtoken/api/**;admin;*;*</value> 
            </param>
            <param>
                <name>KNOXTOKEN.rule_2.path.acl</name>
                <value>https://*:*/**/knoxtoken/foo/**;knox;*;*</value> 
            </param>
            <param>
                <name>KNOXTOKEN.rule_3.path.acl</name>
                <value>https://*:*/**/knoxtoken/bar/**;sam;admin;*</value> 
            </param>
        </provider>
```

## How was this patch tested?
This patch was tested locally

```
curl -ivku admin:admin-password https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/token
*   Trying 127.0.0.1:8443...
* Connected to localhost (127.0.0.1) port 8443 (#0)
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=Test; L=Test; O=Hadoop; OU=Test; CN=localhost
*  start date: Mar  5 19:59:57 2024 GMT
*  expire date: Mar  5 19:59:57 2025 GMT
*  issuer: C=US; ST=Test; L=Test; O=Hadoop; OU=Test; CN=localhost
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/1.x
* Server auth using Basic with user 'admin'
> GET /gateway/sandbox/knoxtoken/api/v1/token HTTP/1.1
> Host: localhost:8443
> Authorization: Basic YWRtaW46YWRtaW4tcGFzc3dvcmQ=
> User-Agent: curl/7.88.1
> Accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Tue, 05 Mar 2024 20:30:59 GMT
Date: Tue, 05 Mar 2024 20:30:59 GMT
< Set-Cookie: KNOXSESSIONID=node0nt5x5i2yaz2dhj3vyicmwp2k5.node0; Path=/gateway/sandbox; Secure; HttpOnly
Set-Cookie: KNOXSESSIONID=node0nt5x5i2yaz2dhj3vyicmwp2k5.node0; Path=/gateway/sandbox; Secure; HttpOnly
< Expires: Thu, 01 Jan 1970 00:00:00 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
< Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Mon, 04-Mar-2024 20:30:59 GMT; SameSite=lax
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Mon, 04-Mar-2024 20:30:59 GMT; SameSite=lax
< Content-Type: application/json
Content-Type: application/json
< Content-Length: 2300
Content-Length: 2300

.......             
```
