### PR TITLE
KNOX-3016 - add support for client credentials flow

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -306,7 +306,7 @@ public abstract class AbstractJWTFilter implements Filter {
     if (metadata != null) {
       String type =  metadata.getMetadata(TYPE);
       // using tokenID and passcode as CLIENT_ID and CLIENT_SECRET will
-      // result in a metadata item called "type". If the valid is set
+      // result in a metadata item called "type". If the value is set
       // to CLIENT_ID then it will be assumed to be a CLIENT_ID and we
       // will use the token id as the username. Since we don't know the
       // token id until it is created, the username is always the same

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -241,7 +241,9 @@ public class JWTFederationFilter extends AbstractJWTFilter {
           }
       }
 
-      parsed = parseFromClientCredentialsFlow(request);
+      if (parsed == null) {
+        parsed = parseFromClientCredentialsFlow(request);
+      }
 
       if (parsed == null) {
         token = request.getParameter(this.paramName);

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -58,6 +58,9 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   private static final JWTMessages LOGGER = MessagesFactory.get( JWTMessages.class );
   /* A semicolon separated list of paths that need to bypass authentication */
   public static final String JWT_UNAUTHENTICATED_PATHS_PARAM = "jwt.unauthenticated.path.list";
+  public static final String GRANT_TYPE = "grant_type";
+  public static final String CLIENT_CREDENTIALS = "client_credentials";
+  public static final String CLIENT_SECRET = "client_secret";
 
   public enum TokenType {
     JWT, Passcode;
@@ -238,10 +241,33 @@ public class JWTFederationFilter extends AbstractJWTFilter {
           }
       }
 
+      /*
+      POST /{tenant}/oauth2/v2.0/token HTTP/1.1
+      Host: login.microsoftonline.com:443
+      Content-Type: application/x-www-form-urlencoded
+
+      client_id=535fb089-9ff3-47b6-9bfb-4f1264799865
+      &scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
+      &client_secret=sampleCredentials
+      &grant_type=client_credentials
+       */
+
+      // Let's check whether this is a client credentials oauth request or whether
+      // the token has been configured for another usecase specific header
       if (parsed == null) {
-          token = request.getParameter(this.paramName);
-          if (token != null) {
-            parsed = Pair.of(TokenType.JWT, token);
+          String grantType = request.getParameter(GRANT_TYPE);
+          if (CLIENT_CREDENTIALS.equals(grantType)) {
+            // this is indeed a client credentials flow client_id and
+            // client_secret are expected now the client_id will be in
+            // the token as the token_id so we will get that later
+            token = request.getParameter(CLIENT_SECRET);
+            parsed = Pair.of(TokenType.Passcode, token);
+          }
+          else {
+            token = request.getParameter(this.paramName);
+            if (token != null) {
+              parsed = Pair.of(TokenType.JWT, token);
+            }
           }
       }
 

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -241,38 +241,43 @@ public class JWTFederationFilter extends AbstractJWTFilter {
           }
       }
 
-      /*
-      POST /{tenant}/oauth2/v2.0/token HTTP/1.1
-      Host: login.microsoftonline.com:443
-      Content-Type: application/x-www-form-urlencoded
+      parsed = parseFromClientCredentialsFlow(request);
 
-      client_id=535fb089-9ff3-47b6-9bfb-4f1264799865
-      &scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
-      &client_secret=sampleCredentials
-      &grant_type=client_credentials
-       */
-
-      // Let's check whether this is a client credentials oauth request or whether
-      // the token has been configured for another usecase specific header
       if (parsed == null) {
-          String grantType = request.getParameter(GRANT_TYPE);
-          if (CLIENT_CREDENTIALS.equals(grantType)) {
-            // this is indeed a client credentials flow client_id and
-            // client_secret are expected now the client_id will be in
-            // the token as the token_id so we will get that later
-            token = request.getParameter(CLIENT_SECRET);
-            parsed = Pair.of(TokenType.Passcode, token);
-          }
-          else {
-            token = request.getParameter(this.paramName);
-            if (token != null) {
-              parsed = Pair.of(TokenType.JWT, token);
-            }
-          }
+        token = request.getParameter(this.paramName);
+        if (token != null) {
+          parsed = Pair.of(TokenType.JWT, token);
+        }
       }
 
       return parsed;
   }
+
+    private Pair<TokenType, String> parseFromClientCredentialsFlow(ServletRequest request) {
+      Pair<TokenType, String> parsed = null;
+      String token = null;
+
+      /*
+        POST /{tenant}/oauth2/v2.0/token HTTP/1.1
+        Host: login.microsoftonline.com:443
+        Content-Type: application/x-www-form-urlencoded
+
+        client_id=535fb089-9ff3-47b6-9bfb-4f1264799865
+        &scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
+        &client_secret=sampleCredentials
+        &grant_type=client_credentials
+       */
+
+      String grantType = request.getParameter(GRANT_TYPE);
+      if (CLIENT_CREDENTIALS.equals(grantType)) {
+        // this is indeed a client credentials flow client_id and
+        // client_secret are expected now the client_id will be in
+        // the token as the token_id so we will get that later
+        token = request.getParameter(CLIENT_SECRET);
+        parsed = Pair.of(TokenType.Passcode, token);
+      }
+      return parsed;
+    }
 
     private Pair<TokenType, String> parseFromHTTPBasicCredentials(final String header) {
       Pair<TokenType, String> parsed = null;

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/ClientIdAndClientSecretFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/ClientIdAndClientSecretFederationFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.knox.gateway.provider.federation;
 
 
 import org.easymock.EasyMock;
+import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -32,6 +33,7 @@ public class ClientIdAndClientSecretFederationFilterTest extends TokenIDAsHTTPBa
     }
 
     @Override
+    @Test
     public void testInvalidUsername() throws Exception {
         // there is no way to specify an invalid username for
         // client credentials flow or at least no meaningful way
@@ -41,6 +43,7 @@ public class ClientIdAndClientSecretFederationFilterTest extends TokenIDAsHTTPBa
     }
 
     @Override
+    @Test
     public void testInvalidJWTForPasscode() throws Exception {
         // there is no way to specify an invalid username for
         // client credentials flow or at least no meaningful way

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/ClientIdAndClientSecretFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/ClientIdAndClientSecretFederationFilterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.provider.federation;
+
+
+import org.easymock.EasyMock;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+public class ClientIdAndClientSecretFederationFilterTest extends TokenIDAsHTTPBasicCredsFederationFilterTest {
+    @Override
+    protected void setTokenOnRequest(HttpServletRequest request, String authUsername, String authPassword) {
+        EasyMock.expect((Object)request.getHeader("Authorization")).andReturn("");
+        EasyMock.expect((Object)request.getParameter("grant_type")).andReturn("client_credentials");
+        EasyMock.expect((Object)request.getParameter("client_id")).andReturn(authUsername);
+        EasyMock.expect((Object)request.getParameter("client_secret")).andReturn(authPassword);
+    }
+
+    @Override
+    public void testInvalidUsername() throws Exception {
+        // there is no way to specify an invalid username for
+        // client credentials flow or at least no meaningful way
+        // to do so for our implementation. The client id is
+        // actually encoded in the client secret and that is used
+        // for the actual authentication with passcodes.
+    }
+
+    @Override
+    public void testInvalidJWTForPasscode() throws Exception {
+        // there is no way to specify an invalid username for
+        // client credentials flow or at least no meaningful way
+        // to do so for our implementation. The username is actually
+        // set by the JWTProvider when determining that the request
+        // is a client credentials flow.
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding support for integrations to Knox proxied services and APIs via OAuth style cllient credentials flow. This allows an integration that is provided a CLIENT_ID and CLIENT_SECRET to authenticate to Knox and directly access proxied services with those or exchange those credentials for short lived JWT based access, id and refresh tokens.

This change introduces only the acceptance of the Knox TokenID and Passcode tokens as CLIENT_ID and CLIENT_SECRET in a standard OAuth 2.0 client credentials flow request body. This body will contain the following params:

1. grant_type and it will be "client_credentials"
2. client_id which will be the KnoxToken tokenId or KnoxID
3. client_secret which will be the passcode token for which we store the hash

Authentication using this flow will result in the effective user being what is provided as the CLIENT_ID.

## How was this patch tested?

Ran existing tests and added new unit tests

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
