### PR TITLE
KNOX-3017 - Avoid showing lifetime adjustment popup when TTL is set to -1

### DIFF
--- a/knox-token-generation-ui/token-generation/app/token-generation.component.html
+++ b/knox-token-generation-ui/token-generation/app/token-generation.component.html
@@ -29,7 +29,7 @@
             <label *ngIf="comment.invalid" style="color: red;"><i class="icon-warning"></i>Invalid comment!</label>
 
             <label><i class="icon-info"></i> Configured maximum lifetime: </label>
-            <label>{{tssStatus.maximumLifetimeText}}</label>
+            <label>{{tssStatus.maximumLifetimeText}} <i class="icon-exclamation" *ngIf="'Unlimited lifetime' === tssStatus.maximumLifetimeText"></i></label>
             <div *ngIf="tssStatus.lifespanInputEnabled">
                 <label><i class="icon-time"></i> Lifetime (days, hours, mins):</label>
                 <table>

--- a/knox-token-generation-ui/token-generation/app/token-generation.service.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.service.ts
@@ -53,7 +53,8 @@ export class TokenGenService {
                 return {
                     tokenManagementEnabled: responseData.tokenManagementEnabled === 'true',
                     maximumLifetimeText: responseData.maximumLifetimeText,
-                    maximumLifetimeSeconds: responseData.maximumLifetimeSeconds,
+                    // the '+' character at the beginning converts the incoming string to a number
+                    maximumLifetimeSeconds: +responseData.maximumLifetimeSeconds,
                     lifespanInputEnabled: responseData.lifespanInputEnabled === 'true',
                     impersonationEnabled: responseData.impersonationEnabled === 'true',
                     configuredTssBackend: responseData.configuredTssBackend,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two changes on the `Token Generation UI`:
- if the `homepage` topology is configured with `Unlimited token lifetime`, the lifetime adjustment popup will not shown. The logic was there before, this was a casting issue between strings and numbers in the JS code.
- added an `exclamation` icon to better emphasize the `Unlimited lifetime` setting on the UI.

## How was this patch tested?

Manually tested and confirmed that the popup is no longer displayed when creating a 1-year token with `Unlimited lifetime` settings. The new exclamation mark is shown as expected (tested with and without the `-1` TTL).

<img width="1747" alt="Screenshot 2024-03-11 at 14 13 13" src="https://github.com/apache/knox/assets/34065904/79a33228-617b-4afe-9503-590112b98e83">

