### PR TITLE
KNOX-3018 - Tokens that never expire should not be evicted automatically and their expiration should be displayed properly

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenStateService.java
@@ -392,9 +392,10 @@ public class DefaultTokenStateService implements TokenStateService {
    * @return true, if the associated token state can be evicted; Otherwise, false.
    */
   protected boolean needsEviction(final String tokenId) throws UnknownTokenException {
+    final long tokenExpiration = getTokenExpiration(tokenId, false);
     // If the expiration time(+ grace period) has already passed, it should be considered expired
-    long expirationWithGrace = getTokenExpiration(tokenId, false) + TimeUnit.SECONDS.toMillis(tokenEvictionGracePeriod);
-    return (expirationWithGrace <= System.currentTimeMillis());
+    long expirationWithGrace = tokenExpiration + TimeUnit.SECONDS.toMillis(tokenEvictionGracePeriod);
+    return tokenExpiration > 0 && (expirationWithGrace <= System.currentTimeMillis());
   }
 
   /**

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
@@ -43,8 +43,8 @@ public class TokenStateDatabase {
   static final String TOKEN_METADATA_TABLE_NAME = "KNOX_TOKEN_METADATA";
   private static final String ADD_TOKEN_SQL = "INSERT INTO " + TOKENS_TABLE_NAME + "(token_id, issue_time, expiration, max_lifetime) VALUES(?, ?, ?, ?)";
   private static final String REMOVE_TOKEN_SQL = "DELETE FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
-  private static final String GET_EXPIRED_TOKENS_SQL = "SELECT token_id FROM " + TOKENS_TABLE_NAME + " WHERE expiration < ?";
-  private static final String REMOVE_EXPIRED_TOKENS_SQL = "DELETE FROM " + TOKENS_TABLE_NAME + " WHERE expiration < ?";
+  private static final String GET_EXPIRED_TOKENS_SQL = "SELECT token_id FROM " + TOKENS_TABLE_NAME + " WHERE expiration < ? AND expiration > 0";
+  private static final String REMOVE_EXPIRED_TOKENS_SQL = "DELETE FROM " + TOKENS_TABLE_NAME + " WHERE expiration < ? AND expiration > 0";
   static final String GET_TOKEN_ISSUE_TIME_SQL = "SELECT issue_time FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
   static final String GET_TOKEN_EXPIRATION_SQL = "SELECT expiration FROM " + TOKENS_TABLE_NAME + " WHERE token_id = ?";
   private static final String UPDATE_TOKEN_EXPIRATION_SQL = "UPDATE " + TOKENS_TABLE_NAME + " SET expiration = ? WHERE token_id = ?";

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateServiceTest.java
@@ -260,9 +260,13 @@ public class JDBCTokenStateServiceTest {
       final String tokenId = UUID.randomUUID().toString();
       jdbcTokenStateService.addToken(tokenId, 1, 1, 1);
     }
-    assertEquals(tokenCount, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
+
+    //add another token that never expires
+    jdbcTokenStateService.addToken(UUID.randomUUID().toString(), 1, -1, 1);
+
+    assertEquals(tokenCount + 1, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
     jdbcTokenStateService.evictExpiredTokens();
-    assertEquals(0, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));
+    assertEquals(1, getLongTokenAttributeFromDatabase(null, GET_TOKENS_COUNT_SQL));  //the one that never expires should remain
   }
 
   private long getLongTokenAttributeFromDatabase(String tokenId, String sql) throws SQLException {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/KnoxToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/KnoxToken.java
@@ -60,7 +60,7 @@ public class KnoxToken implements Comparable<KnoxToken>{
   }
 
   public String getExpiration() {
-    return KNOX_TOKEN_TS_FORMAT.get().format(new Date(expiration));
+    return expiration < 0 ? "Never" : KNOX_TOKEN_TS_FORMAT.get().format(new Date(expiration));
   }
 
   public long getExpirationLong() {

--- a/knox-token-generation-ui/token-generation/app/token-generation.service.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.service.ts
@@ -113,7 +113,7 @@ export class TokenGenService {
                 accessToken: tokenData.access_token,
                 user: jwtJson.sub,
                 accessPasscode: tokenData.passcode,
-                expiry: new Date(tokenData.expires_in).toLocaleString(),
+                expiry: tokenData.expires_in < 0 ? 'Never expires' : new Date(tokenData.expires_in).toLocaleString(),
                 homepageURL: this.baseURL + tokenData.homepage_url,
                 targetURL: window.location.protocol + '//' + window.location.host + this.baseURL + tokenData.target_url
             };

--- a/knox-token-management-ui/token-management/app/token.management.component.ts
+++ b/knox-token-management-ui/token-management/app/token.management.component.ts
@@ -196,11 +196,11 @@ export class TokenManagementComponent implements OnInit {
     }
 
     formatDateTime(dateTime: number) {
-        return new Date(dateTime).toLocaleString();
+        return dateTime < 0 ? 'Never' : new Date(dateTime).toLocaleString();
     }
 
     isTokenExpired(expiration: number): boolean {
-        return Date.now() > expiration;
+        return expiration < 0 ? false : Date.now() > expiration;
     }
 
     getExpirationColor(expiration: number): string {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `Token Management` and `Token Generation` UIs are updated in a way such that they display `Never expires` in case a token never expires (that is, if the token's expiration is set to a negative number).
Moreover, the automated token eviction logic is modified to never remove those tokens from the underlying token state backend.

## How was this patch tested?

Updated existing unit tests to cover the token eviction logic change and ran manual testing on the UI.

<img width="1776" alt="Screenshot 2024-03-11 at 16 39 33" src="https://github.com/apache/knox/assets/34065904/fe510492-25f8-4ab8-993e-2936af93a001">
<img width="1777" alt="Screenshot 2024-03-11 at 17 14 10" src="https://github.com/apache/knox/assets/34065904/74304b4f-dce9-42c9-aaea-2b4223f72c41">
<img width="1781" alt="Screenshot 2024-03-11 at 17 14 41" src="https://github.com/apache/knox/assets/34065904/db8a6b11-84ba-4c9e-b94e-c8c13f46093d">
<img width="1778" alt="Screenshot 2024-03-11 at 17 17 46" src="https://github.com/apache/knox/assets/34065904/af1876ff-d884-4ca1-9bf2-6ab28052cba2">

