### PR TITLE
KNOX-3014 - Fix a bug where unauthenticated path configured in shiro provider throw exception

### DIFF
--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -45,6 +45,10 @@
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-util-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.knox</groupId>
+            <artifactId>gateway-util-urltemplate</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -85,6 +89,11 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import org.apache.knox.gateway.i18n.messages.Message;
+import org.apache.knox.gateway.i18n.messages.MessageLevel;
+import org.apache.knox.gateway.i18n.messages.Messages;
+
+@Messages(logger="org.apache.knox.gateway")
+public interface ShiroMessages {
+  @Message(level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path configured in topology, letting it through" )
+  void unauthenticatedPathBypass(String uri);
+}

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
@@ -25,4 +25,7 @@ import org.apache.knox.gateway.i18n.messages.Messages;
 public interface ShiroMessages {
   @Message(level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path configured in topology, letting it through" )
   void unauthenticatedPathBypass(String uri);
+
+  @Message( level = MessageLevel.WARN, text = "Invalid URL pattern for rule: {0}" )
+  void invalidURLPattern(String rule);
 }

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroDeploymentContributor.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroDeploymentContributor.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.descriptor.api.webcommon30.SessionConfigType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ShiroDeploymentContributor extends ProviderDeploymentContributorBase {
 
@@ -43,7 +44,9 @@ public class ShiroDeploymentContributor extends ProviderDeploymentContributorBas
   private static final String SESSION_TIMEOUT = "sessionTimeout";
   private static final String REMEMBER_ME = "rememberme";
   private static final String SHRIO_CONFIG_FILE_NAME = "shiro.ini";
+  private static final String SHIRO_URL_CONFIG = "urls";
   private static final int DEFAULT_SESSION_TIMEOUT = 30; // 30min
+
 
   @Override
   public String getRole() {
@@ -132,6 +135,17 @@ public class ShiroDeploymentContributor extends ProviderDeploymentContributorBas
 
     resource.addFilter().name( getName() ).role(
         getRole() ).impl( SHIRO_FILTER_CLASSNAME ).params( params );
+
+    /* Collect all shiro `urls.` params and them as filter params to POST_FILTER_CLASSNAME  */
+    Map<String, String> shiroURLs = providerParams.entrySet().stream().filter(e -> e.getKey().startsWith(SHIRO_URL_CONFIG)).collect(
+        Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+   for(final Map.Entry<String, String> m: shiroURLs.entrySet()) {
+     params.add( resource.createFilterParam()
+         .name( m.getKey() )
+         .value( m.getValue() ) );
+   }
+
     resource.addFilter().name( "Post" + getName() ).role(
         getRole() ).impl( POST_FILTER_CLASSNAME ).params( params );
   }

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/filter/ShiroSubjectIdentityAdapter.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/filter/ShiroSubjectIdentityAdapter.java
@@ -31,7 +31,9 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 
+import org.apache.knox.gateway.ShiroMessages;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
 import org.apache.knox.gateway.audit.api.AuditContext;
@@ -40,12 +42,14 @@ import org.apache.knox.gateway.audit.api.AuditServiceFactory;
 import org.apache.knox.gateway.audit.api.Auditor;
 import org.apache.knox.gateway.audit.api.ResourceType;
 import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.security.GroupPrincipal;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
 
 public class ShiroSubjectIdentityAdapter implements Filter {
+  private static final ShiroMessages LOG = MessagesFactory.get(ShiroMessages.class);
   private static final String SUBJECT_USER_GROUPS = "subject.userGroups";
   private static AuditService auditService = AuditServiceFactory.getAuditService();
   private static Auditor auditor = auditService.getAuditor(
@@ -96,54 +100,71 @@ public class ShiroSubjectIdentityAdapter implements Filter {
       };
       Subject shiroSubject = SecurityUtils.getSubject();
 
+      /**
+       * For cases when we want anonymous authentication to urls in shiro.
+       * This is when do not want authentication for jwks endpoints using
+       * shiro.
+       */
       if (shiroSubject == null || shiroSubject.getPrincipal() == null) {
-        throw new IllegalStateException("Unable to determine authenticated user from Shiro, please check that your Knox Shiro configuration is correct");
-      }
+        LOG.unauthenticatedPathBypass(((HttpServletRequest) request).getRequestURI());
+        final String principal = "anonymous";
+        javax.security.auth.Subject subject = new javax.security.auth.Subject();
+        subject.getPrincipals().add(new PrimaryPrincipal(principal));
+        AuditContext context = auditService.getContext();
+        context.setUsername( principal );
+        auditService.attachContext(context);
+        javax.security.auth.Subject.doAs( subject, action );
+    } else {
 
-      final String principal = shiroSubject.getPrincipal().toString();
-      Set<Principal> principals = new HashSet<>();
-      Principal p = new PrimaryPrincipal(principal);
-      principals.add(p);
-      AuditContext context = auditService.getContext();
-      context.setUsername( principal );
-      auditService.attachContext(context);
-      String sourceUri = (String)request.getAttribute( AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME );
-      auditor.audit( Action.AUTHENTICATION , sourceUri, ResourceType.URI, ActionOutcome.SUCCESS );
+        final String principal = shiroSubject.getPrincipal().toString();
+        Set<Principal> principals = new HashSet<>();
+        Principal p = new PrimaryPrincipal(principal);
+        principals.add(p);
+        AuditContext context = auditService.getContext();
+        context.setUsername(principal);
+        auditService.attachContext(context);
+        String sourceUri = (String) request.getAttribute(AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME);
+        auditor.audit(Action.AUTHENTICATION, sourceUri, ResourceType.URI,
+            ActionOutcome.SUCCESS);
 
-      Set<String> userGroups;
-      // map ldap groups saved in session to Java Subject GroupPrincipal(s)
-      if (SecurityUtils.getSubject().getSession().getAttribute(SUBJECT_USER_GROUPS) != null) {
-        userGroups = (Set<String>)SecurityUtils.getSubject().getSession().getAttribute(SUBJECT_USER_GROUPS);
-      } else { // KnoxLdapRealm case
-        if(  shiroSubject.getPrincipal() instanceof String ) {
-           userGroups = new HashSet<>(shiroSubject.getPrincipals().asSet());
-           userGroups.remove(principal);
-        } else { // KnoxPamRealm case
-           Set<Principal> shiroPrincipals = new HashSet<>(shiroSubject.getPrincipals().asSet());
-           userGroups = new HashSet<>(); // Here we are creating a new UserGroup
-                                               // so we don't need to remove a Principal
-                                               // In the case of LDAP the userGroup may have already Principal
-                                               // added to the list of groups, so it is not needed.
-           for( Principal shiroPrincipal: shiroPrincipals ) {
-                userGroups.add(shiroPrincipal.toString() );
-           }
+        Set<String> userGroups;
+        // map ldap groups saved in session to Java Subject GroupPrincipal(s)
+        if (SecurityUtils.getSubject().getSession().getAttribute(SUBJECT_USER_GROUPS) != null) {
+          userGroups = (Set<String>) SecurityUtils.getSubject().getSession().getAttribute(SUBJECT_USER_GROUPS);
+        } else { // KnoxLdapRealm case
+          if (shiroSubject.getPrincipal() instanceof String) {
+            userGroups = new HashSet<>(shiroSubject.getPrincipals().asSet());
+            userGroups.remove(principal);
+          } else { // KnoxPamRealm case
+            Set<Principal> shiroPrincipals = new HashSet<>(
+                shiroSubject.getPrincipals().asSet());
+            userGroups = new HashSet<>(); // Here we are creating a new UserGroup
+            // so we don't need to remove a Principal
+            // In the case of LDAP the userGroup may have already Principal
+            // added to the list of groups, so it is not needed.
+            for (Principal shiroPrincipal : shiroPrincipals) {
+              userGroups.add(shiroPrincipal.toString());
+            }
+          }
         }
-      }
-      for (String userGroup : userGroups) {
-        Principal gp = new GroupPrincipal(userGroup);
-        principals.add(gp);
-      }
-      auditor.audit( Action.AUTHENTICATION , sourceUri, ResourceType.URI, ActionOutcome.SUCCESS, "Groups: " + userGroups );
+        for (String userGroup : userGroups) {
+          Principal gp = new GroupPrincipal(userGroup);
+          principals.add(gp);
+        }
+        auditor.audit(Action.AUTHENTICATION, sourceUri, ResourceType.URI,
+            ActionOutcome.SUCCESS, "Groups: " + userGroups);
 
-      // The newly constructed Sets check whether this Subject has been set read-only
-      // before permitting subsequent modifications. The newly created Sets also prevent
-      // illegal modifications by ensuring that callers have sufficient permissions.
-      //
-      // To modify the Principals Set, the caller must have AuthPermission("modifyPrincipals").
-      // To modify the public credential Set, the caller must have AuthPermission("modifyPublicCredentials").
-      // To modify the private credential Set, the caller must have AuthPermission("modifyPrivateCredentials").
-      javax.security.auth.Subject subject = new javax.security.auth.Subject(true, principals, Collections.emptySet(), Collections.emptySet());
-      javax.security.auth.Subject.doAs( subject, action );
+        // The newly constructed Sets check whether this Subject has been set read-only
+        // before permitting subsequent modifications. The newly created Sets also prevent
+        // illegal modifications by ensuring that callers have sufficient permissions.
+        //
+        // To modify the Principals Set, the caller must have AuthPermission("modifyPrincipals").
+        // To modify the public credential Set, the caller must have AuthPermission("modifyPublicCredentials").
+        // To modify the private credential Set, the caller must have AuthPermission("modifyPrivateCredentials").
+        javax.security.auth.Subject subject = new javax.security.auth.Subject(
+            true, principals, Collections.emptySet(), Collections.emptySet());
+        javax.security.auth.Subject.doAs(subject, action);
+      }
 
       return null;
     }

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/filter/ShiroSubjectIdentityAdapter.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/filter/ShiroSubjectIdentityAdapter.java
@@ -17,22 +17,6 @@
  */
 package org.apache.knox.gateway.filter;
 
-import java.io.IOException;
-import java.security.Principal;
-import java.security.PrivilegedExceptionAction;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.Callable;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.knox.gateway.ShiroMessages;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
@@ -47,6 +31,21 @@ import org.apache.knox.gateway.security.GroupPrincipal;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.security.Principal;
+import java.security.PrivilegedExceptionAction;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
 
 public class ShiroSubjectIdentityAdapter implements Filter {
   private static final ShiroMessages LOG = MessagesFactory.get(ShiroMessages.class);
@@ -106,15 +105,16 @@ public class ShiroSubjectIdentityAdapter implements Filter {
        * shiro.
        */
       if (shiroSubject == null || shiroSubject.getPrincipal() == null) {
-        LOG.unauthenticatedPathBypass(((HttpServletRequest) request).getRequestURI());
+        LOG.unauthenticatedPathBypass(
+            ((HttpServletRequest) request).getRequestURI());
         final String principal = "anonymous";
         javax.security.auth.Subject subject = new javax.security.auth.Subject();
         subject.getPrincipals().add(new PrimaryPrincipal(principal));
         AuditContext context = auditService.getContext();
-        context.setUsername( principal );
+        context.setUsername(principal);
         auditService.attachContext(context);
-        javax.security.auth.Subject.doAs( subject, action );
-    } else {
+        javax.security.auth.Subject.doAs(subject, action);
+      } else {
 
         final String principal = shiroSubject.getPrincipal().toString();
         Set<Principal> principals = new HashSet<>();
@@ -123,14 +123,17 @@ public class ShiroSubjectIdentityAdapter implements Filter {
         AuditContext context = auditService.getContext();
         context.setUsername(principal);
         auditService.attachContext(context);
-        String sourceUri = (String) request.getAttribute(AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME);
+        String sourceUri = (String) request.getAttribute(
+            AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME);
         auditor.audit(Action.AUTHENTICATION, sourceUri, ResourceType.URI,
             ActionOutcome.SUCCESS);
 
         Set<String> userGroups;
         // map ldap groups saved in session to Java Subject GroupPrincipal(s)
-        if (SecurityUtils.getSubject().getSession().getAttribute(SUBJECT_USER_GROUPS) != null) {
-          userGroups = (Set<String>) SecurityUtils.getSubject().getSession().getAttribute(SUBJECT_USER_GROUPS);
+        if (SecurityUtils.getSubject().getSession()
+            .getAttribute(SUBJECT_USER_GROUPS) != null) {
+          userGroups = (Set<String>) SecurityUtils.getSubject().getSession()
+              .getAttribute(SUBJECT_USER_GROUPS);
         } else { // KnoxLdapRealm case
           if (shiroSubject.getPrincipal() instanceof String) {
             userGroups = new HashSet<>(shiroSubject.getPrincipals().asSet());

--- a/gateway-release/home/conf/topologies/sandbox.xml
+++ b/gateway-release/home/conf/topologies/sandbox.xml
@@ -57,6 +57,10 @@
                 <value>simple</value>
             </param>
             <param>
+                <name>urls./knoxtoken/api/v1/jwks.json</name>
+                <value>anon</value>
+            </param>
+            <param>
                 <name>urls./**</name>
                 <value>authcBasic</value>
             </param>

--- a/gateway-release/home/conf/topologies/sandbox.xml
+++ b/gateway-release/home/conf/topologies/sandbox.xml
@@ -57,6 +57,10 @@
                 <value>simple</value>
             </param>
             <param>
+                <name>urls./knoxtoken/api/v2/jwks.json</name>
+                <value>anon</value>
+            </param>
+            <param>
                 <name>urls./knoxtoken/api/v1/jwks.json</name>
                 <value>anon</value>
             </param>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Support `anon` in Shiro provider i.e. support for following param in shiro provider
```
           <param>
                <name>urls./knoxtoken/api/v1/jwks.json</name>
                <value>anon</value>
            </param>
```
- Add `/knoxtoken/api/v1/jwks.json` to unauthenticated path list in Shiro provider example in sandbox.xml


## How was this patch tested?

Tested locally

```
curl -v -k GET https://localhost:8443/gateway/sandbox/knoxtoken/api/v1/jwks.json
*   Trying 127.0.0.1:8443...
* Connected to localhost (127.0.0.1) port 8443 (#0)
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=Test; L=Test; O=Hadoop; OU=Test; CN=localhost
*  start date: Mar 11 17:19:27 2024 GMT
*  expire date: Mar 11 17:19:27 2025 GMT
*  issuer: C=US; ST=Test; L=Test; O=Hadoop; OU=Test; CN=localhost
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/1.x
> GET /gateway/sandbox/knoxtoken/api/v1/jwks.json HTTP/1.1
> Host: localhost:8443
> User-Agent: curl/7.88.1
> Accept: */*
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
< HTTP/1.1 200 OK
< Date: Tue, 12 Mar 2024 14:24:25 GMT
< Content-Type: application/json
< Content-Length: 462
<
* Connection #0 to host localhost left intact
{"keys":[{"kty":"RSA","e":"AQAB","use":"sig","kid":"milmJraf-UtaM9Bt1jmzRHAwyIc-8ivgXtwF_-k-SHY","alg":"RS256","n":"gp1GHeqEN3rYqTq-E0yrpelr_sKrrTSCCL7MsBQ2r9NUY8kYl1TOukW0Dw4ruF85z2NxgOj864zjaqmOzN1quyuNPNNuxFCYnBsAPV0nhQIgSSuRgTzkihfuosmB3vEvxFJYx1FfF-TOGEjyfBNiDRuj_tTK3b7Y77n9bQnc_Juv5xC7KdGbNaYaIPVZmhycEeSzIGHK7QeeFF5XLg5NX1UH4KRrr4Bk60s23IygWLz5z9GK_VeSRcrFDB3ELe6y_VUMrxAWtO9QdJD-ize6AIvKhgSK3nao1NzuQoTCgSNNwzoTk2hN-YyruyE6W3kTHffdxDUTAtR_3G6gl5BO5Q"}]}   
```