### PR TITLE
KNOX-3022 - Handling the case when previously persisted CM cluster config file is empty

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -184,6 +184,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   void failedToLoadClusterMonitorServiceConfigurations(String monitor,
                                                        @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.WARN, text = "Previously saved cluster configuration file {0} is empty.")
+  void emptyClusterConfiguration(String clusterConfigurationFile);
+
   @Message(level = MessageLevel.ERROR,
       text = "Failed to remove persisted data for cluster configuration monitor {0} {1}")
   void failedToRemovPersistedClusterMonitorData(String monitor, String filename);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClusterConfigurationFileStore.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClusterConfigurationFileStore.java
@@ -79,7 +79,10 @@ public class ClusterConfigurationFileStore extends AbstractConfigurationStore
     if (persistenceDir != null && Files.exists(persistenceDir)) {
       Collection<File> persistedConfigs = FileUtils.listFiles(persistenceDir.toFile(), new String[]{"ver"}, false);
       for (File persisted : persistedConfigs) {
-        result.add(get(persisted));
+        ServiceConfigurationRecord serviceConfiguration = get(persisted);
+        if (serviceConfiguration != null) {
+          result.add(serviceConfiguration);
+        }
       }
     }
 
@@ -100,10 +103,14 @@ public class ClusterConfigurationFileStore extends AbstractConfigurationStore
     ServiceConfigurationRecord result = null;
 
     if (persisted != null && persisted.exists()) {
-      try (InputStream in = Files.newInputStream(persisted.toPath())) {
-        result = mapper.readValue(in, ServiceConfigurationRecord.class);
-      } catch (Exception e) {
-        log.failedToLoadClusterMonitorServiceConfigurations(getMonitorType(), e);
+      if (persisted.length() == 0) {
+        log.emptyClusterConfiguration(persisted.getAbsolutePath());
+      } else {
+        try (InputStream in = Files.newInputStream(persisted.toPath())) {
+          result = mapper.readValue(in, ServiceConfigurationRecord.class);
+        } catch (Exception e) {
+          log.failedToLoadClusterMonitorServiceConfigurations(getMonitorType(), e);
+        }
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in the corresponding KNOX-3022 JIRA, it might happen - due to various IO reasons - that the CM cluster configuration file is empty at Knox startup time. This could prevent the Knox Gateway from starting.
In this PR we fix this issue.

## How was this patch tested?

Added a new JUnit test case as well as ran manual testing on a real cluster using CM discovery. Once my patch was applied, the Knox Gateway started properly, and the empty file log entry appeared as expected:
```
grep "is empty" /var/log/knox/gateway/gateway.log 
2024-03-19 02:56:57,434 WARN  discovery.cm (ClusterConfigurationFileStore.java:get(107)) - Previously saved cluster configuration file /var/lib/knox/gateway/data/cm-clusters/https___CM-HOST_CM-PORT-Cluster_1.ver is empty.
```
