### PR TITLE
KNOX-3024 - Fixed Java finding issues

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -50,6 +50,17 @@ DEFAULT_APP_STATUS_TEST_RETRY_SLEEP=2
 ##### common functions #####
 ############################
 
+function setVerbose() {
+  export VERBOSE=false
+  for arg in "$@"; do
+    # Check if the argument contains the search string
+    if [[ $arg == *"--verbose"* ]]; then
+      export VERBOSE=true
+      break
+    fi
+  done
+}
+
 JAVA_VERSION_PATTERNS=( "1.6.0_31/bin/java$" "1.6.0_.*/bin/java$" "1.6.0.*/bin/java$" "1.6\..*/bin/java$" "/bin/java$" )
 
 function findJava() {
@@ -72,7 +83,7 @@ function findJava() {
 
   # Try to find java on PATH.
   if [ "$JAVA" == "" ]; then
-    JAVA=$(command -v java 2>/dev/null)
+    JAVA=$(which java 2>/dev/null)
     if [ ! -x "$JAVA" ]; then
       JAVA=""
     fi
@@ -82,9 +93,8 @@ function findJava() {
   if [ "$JAVA" == "" ]; then
     for pattern in "${JAVA_VERSION_PATTERNS[@]}"; do
       # shellcheck disable=SC2207
-      JAVAS=( $(find /usr -executable -name java -print 2> /dev/null | grep "$pattern" | head -n 1 ) )
+      JAVA=$(find /usr -executable -name java -print 2> /dev/null | grep "$pattern" | head -n 1 )
       if [ -x "$JAVA" ]; then
-        JAVA=${JAVAS[1]}
         break
       else
         JAVA=""
@@ -98,6 +108,8 @@ function checkJava() {
 
   if [[ -z $JAVA ]]; then
     echo "Warning: JAVA is not set and could not be found." 1>&2
+  elif [[ "$VERBOSE" = "true" ]]; then
+    echo "Found Java at $JAVA"
   fi
 }
 

--- a/gateway-release/home/bin/gateway.sh
+++ b/gateway-release/home/bin/gateway.sh
@@ -26,9 +26,11 @@ APP_NAME=gateway
 # Start/stop script location
 APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# shellcheck disable=SC1091
 # Setup the common environment
 . "$APP_BIN_DIR"/knox-env.sh
 
+# shellcheck disable=SC1091
 # Source common functions
 . "$APP_BIN_DIR"/knox-functions.sh
 
@@ -103,6 +105,7 @@ function startGateway() {
 }
 
 function main {
+   setVerbose "$@"
    checkJava
 
    case "$1" in

--- a/gateway-release/home/bin/knoxcli.sh
+++ b/gateway-release/home/bin/knoxcli.sh
@@ -26,9 +26,11 @@ APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # The app's jar name
 APP_JAR="$APP_BIN_DIR/knoxcli.jar"
 
+# shellcheck disable=SC1091
 # Setup the common environment
 . "$APP_BIN_DIR"/knox-env.sh
 
+# shellcheck disable=SC1091
 # Source common functions
 . "$APP_BIN_DIR"/knox-functions.sh
 
@@ -72,6 +74,7 @@ function buildAppJavaOpts {
 }
 
 function main {
+   setVerbose "$@"
    checkJava
    buildAppJavaOpts
    $JAVA "${APP_JAVA_OPTS[@]}" -jar "$APP_JAR" "$@" || exit 1

--- a/gateway-release/home/bin/ldap.sh
+++ b/gateway-release/home/bin/ldap.sh
@@ -29,9 +29,11 @@ APP_BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # The app's JAR name
 export APP_JAR="$APP_BIN_DIR/ldap.jar"
 
+# shellcheck disable=SC1091
 # Setup the common environment
 . "$APP_BIN_DIR"/knox-env.sh
 
+# shellcheck disable=SC1091
 # Source common functions
 . "${APP_BIN_DIR}"/knox-functions.sh
 
@@ -65,6 +67,7 @@ DEFAULT_APP_RUNNING_IN_FOREGROUND="$LDAP_SERVER_RUN_IN_FOREGROUND"
 export APP_RUNNING_IN_FOREGROUND=${KNOX_LDAP_RUNNING_IN_FOREGROUND:-$DEFAULT_APP_RUNNING_IN_FOREGROUND}
 
 function main {
+   setVerbose "$@"
    checkJava
 
    case "$1" in


### PR DESCRIPTION
## What changes were proposed in this pull request?

I updated the existing login in `knox-functions.sh` to successfully check Java executables under `/usr` if no `JAVA_HOME` is set or Java is not available on the path.
In addition to fixing the issue, I added an option to display the Java with the `--verbose` option (when using KnoxCLI, `--verbose true` should be used.

## How was this patch tested?

Checked the updated scripts on [shellcheck.net](https://www.shellcheck.net/) and tested them manually:
- `gateway.sh`
```
$ bin/gateway.sh restart --verbose
Found Java at /usr/local/opt/openjdk@8/bin/java
Stopping Gateway with PID 12173 succeeded.
Starting Gateway succeeded with PID 12346.

$ bin/gateway.sh restart
Stopping Gateway with PID 12346 succeeded.
Starting Gateway succeeded with PID 12419.
```
- `knoxcli.sh`
```
$ bin/knoxcli.sh export-cert --type JKS --verbose true
Found Java at /usr/local/opt/openjdk@8/bin/java
Certificate gateway-identity has been successfully exported to: /Users/sandormolnar/test/knoxGateway/data/security/keystores/gateway-client-trust.jks

$ bin/knoxcli.sh export-cert --type JKS
Certificate gateway-identity has been successfully exported to: /Users/sandormolnar/test/knoxGateway/data/security/keystores/gateway-client-trust.jks
```
- `ldap.sh`
```
$ bin/ldap.sh start --verbose
Found Java at /usr/local/opt/openjdk@8/bin/java
Starting LDAP succeeded with PID 12531.

$ bin/ldap.sh stop
Stopping LDAP with PID 12531 succeeded.

$ bin/ldap.sh start
Starting LDAP succeeded with PID 12573.
```