### PR TITLE
KNOX-3026 - End-users can exclude certain services or roles from CM service discovery

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -48,6 +48,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.INFO, text = "Discovering service role: {0} ({1}) ...")
   void discoveringServiceRole(String roleName, String roleType);
 
+  @Message(level = MessageLevel.INFO, text = "Skipping role discovery: {0} ({1})")
+  void skipRoleDiscovery(String roleName, String roleType);
+
   @Message(level = MessageLevel.INFO, text = "Discovered service role: {0} ({1})")
   void discoveredServiceRole(String roleName, String roleType);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -297,6 +297,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.connect.timeout.ms";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.read.timeout.ms";
   private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.write.timeout.ms";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_EXCLUDED_SERVICE_TYPES = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.excluded.service.types";
+  private static final String CLOUDERA_MANAGER_SERVICE_DISCOVERY_EXCLUDED_ROLE_TYPES = GATEWAY_CONFIG_FILE_PREFIX + ".cloudera.manager.service.discovery.excluded.role.types";
 
   private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_CONNECT_TIMEOUT_DEFAULT = 10000;
   private static final long CLOUDERA_MANAGER_SERVICE_DISCOVERY_READ_TIMEOUT_DEFAULT = 10000;
@@ -1299,6 +1301,16 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public int getClouderaManagerServiceDiscoveryMaximumRetryAttempts() {
     return getInt(CLOUDERA_MANAGER_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPS, DEFAULT_CM_SERVICE_DISCOVERY_MAX_RETRY_ATTEMPTS);
+  }
+
+  @Override
+  public Collection<String> getClouderaManagerServiceDiscoveryExcludedServiceTypes() {
+    return getTrimmedStringCollection(CLOUDERA_MANAGER_SERVICE_DISCOVERY_EXCLUDED_SERVICE_TYPES);
+  }
+
+  @Override
+  public Collection<String> getClouderaManagerServiceDiscoveryExcludedRoleTypes() {
+    return getTrimmedStringCollection(CLOUDERA_MANAGER_SERVICE_DISCOVERY_EXCLUDED_ROLE_TYPES);
   }
 
   @Override

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -872,6 +872,16 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public Collection<String> getClouderaManagerServiceDiscoveryExcludedServiceTypes() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<String> getClouderaManagerServiceDiscoveryExcludedRoleTypes() {
+    return Collections.emptySet();
+  }
+
+  @Override
   public boolean isServerManagedTokenStateEnabled() {
     return false;
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -751,6 +751,18 @@ public interface GatewayConfig {
   int getClouderaManagerServiceDiscoveryMaximumRetryAttempts();
 
   /**
+   * @return a collection of comma separated service types that should be excluded
+   *         from CM service discovery (e.g. HDFS, KNOX, RANGER, HIVE, etc...)
+   */
+  Collection<String> getClouderaManagerServiceDiscoveryExcludedServiceTypes();
+
+  /**
+   * @return a collection of comma separated role types that should be excluded
+   *         from CM service discovery (e.g. KNOX_GATEWAY, IDBROKER, DATANODE, HIVEMETASTORE, etc...)
+   */
+  Collection<String> getClouderaManagerServiceDiscoveryExcludedRoleTypes();
+
+  /**
    * @return true, if state for tokens issued by the Knox Token service should be managed by Knox.
    */
   boolean isServerManagedTokenStateEnabled();


### PR DESCRIPTION
## What changes were proposed in this pull request?

I added two new gateway-level configurations:
- `gateway.cloudera.manager.service.discovery.excluded.service.types`
- `gateway.cloudera.manager.service.discovery.excluded.role.types`

Both configurations can store a collection of comma-separated Cloudera Manager service or role types that should be excluded from CM service discovery. They both default to an empty set, meaning full CM discovery.
During a CM service discovery attempt, those configurations are checked and based on the supplied values the discovery logic skips the given service(s) or role(s) discovery.

## How was this patch tested?

I added and updated existing JUnit tests.
Tested on a live CM cluster:

<img width="1203" alt="Screenshot 2024-03-28 at 13 14 01" src="https://github.com/apache/knox/assets/34065904/7595e5ca-637d-4da3-bd73-451c8b40a133">

After restarting Knox, I exported discovery-related logs into [cm_discovery.txt](https://github.com/apache/knox/files/14789431/cm_discovery.txt)
```
grep "discovery.cm" /var/log/knox/gateway/gateway.log > cm_discovery.txt
```
Here is the list of relevant log entries for this PR:
```
$ grep -i skipping cm_discovery.txt 
2024-03-28 12:15:25,967 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$2(352)) - Skipping service discovery: CORE_SETTINGS-1 (CORE_SETTINGS)
2024-03-28 12:15:25,968 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$2(352)) - Skipping service discovery: KUDU-1 (KUDU)
2024-03-28 12:15:25,968 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$2(352)) - Skipping service discovery: YARN-1 (YARN)
2024-03-28 12:15:25,968 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$2(352)) - Skipping service discovery: IMPALA-1 (IMPALA)
2024-03-28 12:15:26,313 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HDFS-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:27,117 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HBASE-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:28,326 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HIVE-1-GATEWAY-6b773e2d140b3c8597330125d17829ce (GATEWAY)
2024-03-28 12:15:28,326 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HIVE-1-GATEWAY-962722fbc5dd79be35fd4c71f50d9db4 (GATEWAY)
2024-03-28 12:15:28,326 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HIVE-1-GATEWAY-70be993d2303e6d7523ef15597ea5a1c (GATEWAY)
2024-03-28 12:15:30,067 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:30,068 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:30,068 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:30,170 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SPARK_ON_YARN-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:30,170 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SPARK_ON_YARN-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:30,170 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SPARK_ON_YARN-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:30,538 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: KAFKA-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:31,943 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HIVE_ON_TEZ-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:31,943 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HIVE_ON_TEZ-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:31,943 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: HIVE_ON_TEZ-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:32,550 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: LIVY-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:32,551 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: LIVY-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:32,551 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: LIVY-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:32,974 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: OZONE-1-GATEWAY-70be993d2303e6d7523ef15597ea5a1c (GATEWAY)
2024-03-28 12:15:32,974 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: OZONE-1-GATEWAY-962722fbc5dd79be35fd4c71f50d9db4 (GATEWAY)
2024-03-28 12:15:32,974 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: OZONE-1-GATEWAY-6b773e2d140b3c8597330125d17829ce (GATEWAY)
2024-03-28 12:15:34,801 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-962722fbc5dd79be35fd4c71f50d9db4 (GATEWAY)
2024-03-28 12:15:34,801 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-6b773e2d140b3c8597330125d17829ce (GATEWAY)
2024-03-28 12:15:34,801 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-70be993d2303e6d7523ef15597ea5a1c (GATEWAY)
2024-03-28 12:15:38,121 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:38,121 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:38,121 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:38,187 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-962722fbc5dd79be35fd4c71f50d9db4 (GATEWAY)
2024-03-28 12:15:38,187 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-6b773e2d140b3c8597330125d17829ce (GATEWAY)
2024-03-28 12:15:38,187 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-70be993d2303e6d7523ef15597ea5a1c (GATEWAY)
2024-03-28 12:15:40,426 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:40,426 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:40,426 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:40,490 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-962722fbc5dd79be35fd4c71f50d9db4 (GATEWAY)
2024-03-28 12:15:40,490 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-6b773e2d140b3c8597330125d17829ce (GATEWAY)
2024-03-28 12:15:40,490 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-70be993d2303e6d7523ef15597ea5a1c (GATEWAY)
2024-03-28 12:15:46,313 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-2 (GATEWAY)
2024-03-28 12:15:46,313 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-3 (GATEWAY)
2024-03-28 12:15:46,313 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: SQOOPCLIENT-GATEWAY-1 (GATEWAY)
2024-03-28 12:15:46,377 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-962722fbc5dd79be35fd4c71f50d9db4 (GATEWAY)
2024-03-28 12:15:46,377 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-6b773e2d140b3c8597330125d17829ce (GATEWAY)
2024-03-28 12:15:46,377 INFO  discovery.cm (ClouderaManagerServiceDiscovery.java:lambda$4(431)) - Skipping role discovery: TEZ-1-GATEWAY-70be993d2303e6d7523ef15597ea5a1c (GATEWAY)
```
