### PR TITLE
KNOX-3030 - Make TopologyUtils.parse thread safe

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -69,7 +69,6 @@ import javax.xml.bind.Marshaller;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -149,19 +148,17 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
   }
 
   @Override
-  public Topology parse(final InputStream content) throws IOException, SAXException {
+  public Topology parse(final String content) throws IOException, SAXException {
     return TopologyUtils.parse(content);
   }
 
   private Topology loadTopologyAttempt(File file) throws IOException, SAXException {
-    Topology topology;
-    try (InputStream in = FileUtils.openInputStream(file)) {
-      topology = parse(in);
-      if (topology != null) {
-        topology.setUri(file.toURI());
-        topology.setName(FilenameUtils.removeExtension(file.getName()));
-        topology.setTimestamp(file.lastModified());
-      }
+    final String topologyContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+    final Topology topology = parse(topologyContent);
+    if (topology != null) {
+      topology.setUri(file.toURI());
+      topology.setName(FilenameUtils.removeExtension(file.getName()));
+      topology.setTimestamp(file.lastModified());
     }
     return topology;
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/TopologyUtils.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/TopologyUtils.java
@@ -35,7 +35,7 @@ public final class TopologyUtils {
                                                                  new AmbariFormatXmlTopologyRules());
 
 
-  public static Topology parse(final String content) throws IOException, SAXException {
+  public static synchronized Topology parse(final String content) throws IOException, SAXException {
     Topology result;
 
     TopologyBuilder builder = digesterLoader.newDigester().parse(new StringReader(content));
@@ -44,7 +44,7 @@ public final class TopologyUtils {
     return result;
   }
 
-  public static Topology parse(final InputStream content) throws IOException, SAXException {
+  public static synchronized Topology parse(final InputStream content) throws IOException, SAXException {
     Topology result;
 
     TopologyBuilder builder = digesterLoader.newDigester().parse(content);

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/topology/TopologyService.java
@@ -26,7 +26,6 @@ import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +77,6 @@ public interface TopologyService extends Service, ServiceDefinitionChangeListene
    * @throws IOException Exception thrown parsing input stream.
    * @throws SAXException Exception thrown parsing xml.
    */
-  Topology parse(InputStream content) throws IOException, SAXException;
+  Topology parse(String content) throws IOException, SAXException;
 
 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -31,12 +31,11 @@ import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.topology.discovery.DefaultServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryFactory;
+import org.xml.sax.SAXParseException;
 
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
@@ -677,11 +676,14 @@ public class SimpleDescriptorHandler {
             }
 
             if (existing != null) {
-                try (InputStream in = new ByteArrayInputStream(generatedContent.getBytes(StandardCharsets.UTF_8))) {
-                    Topology generatedTopology = topologyService.parse(in);
+                try {
+                    Topology generatedTopology = topologyService.parse(generatedContent);
                     generatedTopology.setName(topologyName);
                     // If the generated topology is different from the existing, then it should be persisted
                     result = !existing.equals(generatedTopology);
+                } catch (SAXParseException e) {
+                    log.errorComparingGeneratedTopology(topologyName, e);
+                    log.faultyGeneratedContent(generatedContent);
                 } catch (Exception e) {
                     log.errorComparingGeneratedTopology(topologyName, e);
                 }

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorMessages.java
@@ -70,6 +70,10 @@ public interface SimpleDescriptorMessages {
     void errorComparingGeneratedTopology(String topologyName,
                                          @StackTrace( level = MessageLevel.DEBUG) Exception e);
 
+    @Message(level = MessageLevel.ERROR,
+        text = "Faulty generated content: {0}" )
+    void faultyGeneratedContent(String generatedContent);
+
     @Message(level = MessageLevel.INFO,
             text = "Persisting the generated {0} topology because it either does not exist or it has changed." )
     void persistingGeneratedTopology(String topologyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change makes the `TopologyUtils.parse(...)` methods thread safe by synchronizing them. Another update is that occurrences of `SAXParseException` are handled separately and logged properly.

## How was this patch tested?

Multiple automated tests were executed parallel to challenge Knox (more than 50 at a time). These tests were capable of reproducing the issue constantly. After repeating the same tests 3 times, we found no problems.
