### PR TITLE
KNOX-3032 - Passcode use without token state service returns 401

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -55,6 +55,9 @@ public interface JWTMessages {
   @Message( level = MessageLevel.WARN, text = "Unable to verify token expiration: {0}" )
   void unableToVerifyExpiration(@StackTrace( level = MessageLevel.DEBUG) Exception e);
 
+  @Message( level = MessageLevel.WARN, text = "Unable to verify passcode token ({0}) due to missing or incorrect token state service configuration.")
+  void unableToVerifyPasscodeToken(String tokenId);
+
   @Message( level = MessageLevel.ERROR, text = "Unable to issue token: {0}" )
   void unableToIssueToken(@StackTrace( level = MessageLevel.DEBUG) Exception e);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I updated the passcode verification logic in a way such that it returns an HTTP error response with 401 error code if clients want to verify a passcode token without properly configured token state service.


## How was this patch tested?

I added the missing JUnit test cases and re-run the `curl` command I used for reproducing the issue:
```
$ curl -iku Passcode:TkdVd1l6VTBPR0l0TmpVMk9DMDBNRFl4TFdFelpHTXROakk1TURnd09EYzJOVEJoOjpNREV6T0dGaFpXUXRZMkV5WVMwME4yWXhMVGhsWkRndFpUQmpNemszTlRrMlpqazE= https://localhost:8443/gateway/proxy-token/v1/gateway-status
HTTP/1.1 401 Unauthorized
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: text/html;charset=iso-8859-1
Content-Length: 684

<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 401 Error in token provider config: passcode use with knox.token.exp.server-managed set to false.</title>
</head>
<body><h2>HTTP ERROR 401 Error in token provider config: passcode use with knox.token.exp.server-managed set to false.</h2>
<table>
<tr><th>URI:</th><td>/gateway/proxy-token/health/v1/gateway-status</td></tr>
<tr><th>STATUS:</th><td>401</td></tr>
<tr><th>MESSAGE:</th><td>Error in token provider config: passcode use with knox.token.exp.server-managed set to false.</td></tr>
<tr><th>SERVLET:</th><td>proxy-token-knox-gateway-servlet</td></tr>
</table>

</body>
</html>
```

I also covered the happy path too. After I set `knox.token.exp.server-managed=true`, I re-executed the command:
```
$ curl -iku "Passcode:WkdKak1qVTNZalF0TjJFNE1TMDBORGMxTFdGbU5qa3ROVEJtWlRnek1UZzFNVGhsOjpNV1JtWTJZeVpXVXRNbVV6TlMwME1UUTNMV0UwT1RZdE1URTFOakprTlRBNE5XSmk=" https://localhost:8443/gateway/proxy-token/v1/gateway-status
HTTP/1.1 200 OK
Date: Mon, 29 Apr 2024 12:29:25 GMT
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: text/plain;charset=iso-8859-1
Content-Length: 3

OK

```
