### PR TITLE
KNOX-3023 - Include groups in a header in ConfigurableDispatch

### DIFF
--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -120,4 +120,7 @@ public interface SpiGatewayMessages {
 
   @Message( level = MessageLevel.DEBUG, text = "Malformed dispatch URL: {0}" )
   void malformedDispatchUrl(String url);
+
+  @Message( level = MessageLevel.ERROR, text = "No valid principal found" )
+  void noPrincipalFound();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR extends configurable dispatch to optionally add authenticated principal and groups to the outbound request as headers (header names are configurable). By default this feature is turned off and will only be enabled if users update the dispatch config in service defition with param `shouldIncludePrincipalAndGroups` (demonstrated below)

Following properties are configurable on dispatch

- `shouldIncludePrincipalAndGroups` Should the principal and groups be passed to the dispatched request as request params.
- `actorIdHeaderName` Header name for the principal, default value is X-Knox-Actor-ID
- `actorGroupsHeaderPrefix` Prefix for header containing groups, default value is X-Knox-Actor-Groups. Note: header names are assigned as X-Knox-Actor-Groups-1, X-Knox-Actor-Groups-2, depending on number of groups. Each header i.e. X-Knox-Actor-Groups-1 can have max 1000 groups, next set of groups will be part of X-Knox-Actor-Groups-2 header and so on.
- `groupFilterPattern` Regex patten to filter groups on, default value is `.*`. This is useful when you only want specific groups to flow through dispatch. 

Complete service definition example:
```
<service role="WEATHER" name="weather" version="0.0.1">
  <routes>
    <route path="/weather/**"/>
  </routes>
  <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch">
          <param>
              <name>shouldIncludePrincipalAndGroups</name>
              <value>true</value>
          </param>
         <param>
              <name>actorIdHeaderName</name>
              <value>X-Apache-Actor-ID</value>
          </param>
  </dispatch>
</service>
```

Example of dispatched request headers.

```
GET /data/2.5/forecast/city?id=524901&APPID=54557732afcfe106bfc955b9da04fb14&user.name=sam HTTP/1.1
X-Request-Id: 39df3e87-f0ee-4dbd-bece-795186bf7be4
X-Forwarded-For: [0:0:0:0:0:0:0:1]
X-Forwarded-Proto: https
X-Forwarded-Port: 8443
X-Forwarded-Host: localhost:8443
X-Forwarded-Server: localhost
X-Forwarded-Context: /gateway/sandbox2
Accept: */*
User-Agent: curl/8.4.0
X-Apache-Actor-ID: sam
X-Knox-Actor-Groups-1: users
Host: localhost:50070
Connection: Keep-Alive
```


## How was this patch tested?
This patch was tested locally.