### PR TITLE
KNOX-3036 - Add Primary Group Virtual Group

### DIFF
--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
@@ -32,6 +32,7 @@ import org.apache.knox.gateway.plang.AbstractSyntaxTree;
 import org.apache.knox.gateway.plang.Interpreter;
 
 public class VirtualGroupMapper {
+    public static final String PRIMARY_GROUP = "$PRIMARY_GROUP";
     private final IdentityAsserterMessages LOG = MessagesFactory.get(IdentityAsserterMessages.class);
     private final Map<String, AbstractSyntaxTree> virtualGroupToPredicateMap;
 
@@ -46,6 +47,9 @@ public class VirtualGroupMapper {
         Set<String> virtualGroups = new HashSet<>();
         for (Map.Entry<String, AbstractSyntaxTree> each : virtualGroupToPredicateMap.entrySet()) {
             String virtualGroupName = each.getKey();
+            // check for logical virtual groups - names to be dynamically created
+            virtualGroupName = resolveLogicalGroupName(username, groups, virtualGroupName);
+
             AbstractSyntaxTree predicate = each.getValue();
             if (evalPredicate(virtualGroupName, username, groups, predicate, request)) {
                 virtualGroups.add(virtualGroupName);
@@ -54,6 +58,13 @@ public class VirtualGroupMapper {
         }
         LOG.virtualGroups(username, groups, virtualGroups);
         return virtualGroups;
+    }
+
+    private String resolveLogicalGroupName(String username, Set<String> groups, String virtualGroupName) {
+        if (PRIMARY_GROUP.equalsIgnoreCase(virtualGroupName)) {
+            virtualGroupName = username;
+        }
+        return virtualGroupName;
     }
 
     /**

--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/VirtualGroupMapper.java
@@ -48,7 +48,7 @@ public class VirtualGroupMapper {
         for (Map.Entry<String, AbstractSyntaxTree> each : virtualGroupToPredicateMap.entrySet()) {
             String virtualGroupName = each.getKey();
             // check for logical virtual groups - names to be dynamically created
-            virtualGroupName = resolveLogicalGroupName(username, groups, virtualGroupName);
+            virtualGroupName = resolveLogicalGroupName(username, virtualGroupName);
 
             AbstractSyntaxTree predicate = each.getValue();
             if (evalPredicate(virtualGroupName, username, groups, predicate, request)) {
@@ -60,7 +60,7 @@ public class VirtualGroupMapper {
         return virtualGroups;
     }
 
-    private String resolveLogicalGroupName(String username, Set<String> groups, String virtualGroupName) {
+    private String resolveLogicalGroupName(String username, String virtualGroupName) {
         if (PRIMARY_GROUP.equalsIgnoreCase(virtualGroupName)) {
             virtualGroupName = username;
         }

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/InterpreterTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/plang/InterpreterTest.java
@@ -268,6 +268,17 @@ public class InterpreterTest {
         assertFalse((boolean)eval("(empty groups)"));
     }
 
+    /**
+     * Adding the ability to create a primary group
+     * (group with same name as username) when it is missing
+     */
+    @Test
+    public void testPrimaryGroup() {
+        interpreter.addConstant("username", "user1");
+        interpreter.addConstant("groups", singletonList("grp1"));
+        assertTrue((boolean)eval("(not (member username))"));
+    }
+
     @Test
     public void testLowerUpper() {
         assertEquals("apple", eval("(lowercase 'APPLE')"));


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

The virtual groups through predicate evaluations should include a means to dynamically add a group principal with the same name as the username.

This will require intercepting the configured mapping key name which usually ends with the literal virtual group name that will be added upon matching of the predicate logic.

For this, we will add an optional Logical Virtual Group which will need to be resolved rather than used as a literal. For this specific usecase, we can use syntax such as:

```
<param>
    <name>group.mapping.$PRIMARY_GROUP</name>
    <value>(not (member username))</value>
</param>
```

This will add a primary group for all authenticated users that don't already have one in the current groups list.

## How was this patch tested?

Existing unit tests were run and a new one added to prove existing capability to determine that a user is not a member of a group with the username.

curl command used to test it manually

curl -ivku guest:guest-password https://localhost:8443/gateway/sandbox/knoxtoken/v1/oauth/tokens

Audit entries show group added to match the name:

24/05/04 19:58:36 ||142cc739-e70e-494e-926c-0c0f6df64171|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|guest|||authentication|uri|/gateway/sandbox/knoxtoken/v1/oauth/tokens|success|Groups: []
24/05/04 19:58:36 ||142cc739-e70e-494e-926c-0c0f6df64171|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|guest|||identity-mapping|principal|guest|success|Groups: [guest]

