### PR TITLE
KNOX-3037 - Client credentials flow accepts essential parameters in the request body only

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -82,12 +82,10 @@ public interface JWTMessages {
   @Message( level = MessageLevel.WARN, text = "Unable to derive authentication provider URL: {0}" )
   void failedToDeriveAuthenticationProviderUrl(@StackTrace( level = MessageLevel.ERROR) Exception e);
 
-  @Message( level = MessageLevel.ERROR,
-            text = "The configuration value ({0}) for maximum token verification cache is invalid; Using the default value." )
+  @Message( level = MessageLevel.ERROR, text = "The configuration value ({0}) for maximum token verification cache is invalid; Using the default value." )
   void invalidVerificationCacheMaxConfiguration(String value);
 
-  @Message( level = MessageLevel.ERROR,
-            text = "Missing token passcode." )
+  @Message( level = MessageLevel.ERROR, text = "Missing token passcode." )
   void missingTokenPasscode();
 
   @Message( level = MessageLevel.INFO, text = "Initialized token signature verification cache for the {0} topology." )
@@ -113,5 +111,8 @@ public interface JWTMessages {
 
   @Message( level = MessageLevel.INFO, text = "Idle timeout has been configured to {0} seconds in {1}" )
   void configuredIdleTimeout(long idleTimeout, String topology);
+
+  @Message(level = MessageLevel.ERROR, text = "Error while fetching grant type and client secret from the request: {0}")
+  void errorFetchingClientSecret(String errorMessage, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
 }

--- a/gateway-util-common/pom.xml
+++ b/gateway-util-common/pom.xml
@@ -94,5 +94,10 @@
             <artifactId>gateway-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/RequestBodyUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/RequestBodyUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletRequest;
+
+public class RequestBodyUtils {
+
+  public static String getRequestBodyParameter(ServletRequest request, String parameter) throws IOException {
+    return getRequestBodyParameter(request, parameter, false);
+  }
+
+  public static String getRequestBodyParameter(ServletRequest request, String parameter, boolean decode) throws IOException {
+    return getRequestBodyParameter(request.getInputStream(), parameter, decode);
+  }
+
+  public static String getRequestBodyParameter(InputStream inputStream, String parameter) throws IOException {
+    return getRequestBodyParameter(inputStream, parameter, false);
+  }
+
+  public static String getRequestBodyParameter(InputStream inputStream, String parameter, boolean decode) throws IOException {
+    return getRequestBodyParameter(new InputStreamReader(inputStream, StandardCharsets.UTF_8), parameter, decode);
+  }
+
+  public static String getRequestBodyParameter(Reader reader, String parameter) throws IOException {
+    return getRequestBodyParameter(reader, parameter, false);
+  }
+
+  public static String getRequestBodyParameter(Reader reader, String parameter, boolean decode) throws IOException {
+    final BufferedReader bufferedReader = new BufferedReader(reader);
+    final StringBuilder requestBodyBuilder = new StringBuilder();
+    String line;
+    while ((line = bufferedReader.readLine()) != null) {
+      requestBodyBuilder.append(line);
+    }
+
+    final String requestBodyString = decode ? URLDecoder.decode(requestBodyBuilder.toString(), StandardCharsets.UTF_8.name()) : requestBodyBuilder.toString();
+    return getRequestBodyParameter(requestBodyString, parameter);
+  }
+
+  public static String getRequestBodyParameter(String requestBodyString, String parameter) {
+    if (requestBodyString != null) {
+      final String[] requestBodyParams = requestBodyString.split("&");
+      for (String requestBodyParam : requestBodyParams) {
+        String[] keyValue = requestBodyParam.split("=", 2);
+        if (parameter.equals(keyValue[0])) {
+          return keyValue[1];
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/RequestBodyUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/RequestBodyUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.knox.test.mock.MockServletInputStream;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class RequestBodyUtilsTest {
+
+  private static final String REQUEST_BODY_PARAM_NAME = "myParam";
+  private static final String REQUEST_BODY_PARAM_VALUE_RAW = "This-is_my sample text!";
+  private static final String REQUEST_BODY_PARAM_VALUE_ENCODED = "This-is_my%20sample%20text%21";
+
+  @Test
+  public void testGetRequestBodyParameterEncoded() throws Exception {
+    testGetRequestBodyParameter(true);
+  }
+
+  @Test
+  public void testGetRequestBodyParameterRaw() throws Exception {
+    testGetRequestBodyParameter(false);
+  }
+
+  private void testGetRequestBodyParameter(boolean decode) throws Exception {
+    final ServletRequest request = EasyMock.createNiceMock(ServletRequest.class);
+    EasyMock.expect(request.getInputStream()).andReturn(produceServletInputStream(decode)).anyTimes();
+
+    EasyMock.replay(request);
+
+    final String requestBodyParam = RequestBodyUtils.getRequestBodyParameter(request, REQUEST_BODY_PARAM_NAME, decode);
+    assertEquals(REQUEST_BODY_PARAM_VALUE_RAW, requestBodyParam);
+  }
+
+  private ServletInputStream produceServletInputStream(boolean encode) {
+    final String requestBody = REQUEST_BODY_PARAM_NAME + "=" + (encode ? REQUEST_BODY_PARAM_VALUE_ENCODED : REQUEST_BODY_PARAM_VALUE_RAW);
+    final InputStream inputStream = IOUtils.toInputStream(requestBody, StandardCharsets.UTF_8);
+    return new MockServletInputStream(inputStream);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in the [corresponding JIRA](https://issues.apache.org/jira/browse/KNOX-3037), Knox no longer accepts the `grant_type` and `client_secret` as query parameters. Instead, they should be passed in the request body.

For reviewers: I'm not satisfied with the `WARN` message I added in case the client secret is passed as a query param.  I'm hoping for a better sentence from someone :)

## How was this patch tested?

Added JUnit tests and conducted manual testing:

1. Using the request body:
```
$ curl -ik -X GET -H "Content-Type: application/x-www-form-urlencoded" --data "grant_type=client_credentials" --data "client_id=$CLIENT_ID" --data-urlencode "client_secret=$CLIENT_SECRET" https://localhost:8443/gateway/tokenbased/oauth/v1/token
HTTP/1.1 200 OK
Date: Wed, 08 May 2024 11:19:06 GMT
Content-Type: application/json
Content-Length: 1061

{"access_token":"eyJqa3UiOiJodHRwczpcL1wvbG9jYWxob3N0Ojg0NDNcL2dhdGV3YXlcL3Rva2VuYmFzZWRcL29hdXRoXC92MVwvandrcy5qc29uIiwia2lkIjoiQ2t3dkZFY1VBbkpUbGtyWWhjazk1RHdIYU5GeGkzdER4S2JxQ2VTWE8yOCIsInR5cCI6IkpXVCIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiJhZG1pbiIsImprdSI6Imh0dHBzOlwvXC9sb2NhbGhvc3Q6ODQ0M1wvZ2F0ZXdheVwvdG9rZW5iYXNlZFwvb2F1dGhcL3YxXC9qd2tzLmpzb24iLCJraWQiOiJDa3d2RkVjVUFuSlRsa3JZaGNrOTVEd0hhTkZ4aTN0RHhLYnFDZVNYTzI4IiwiaXNzIjoiS05PWFNTTyIsImV4cCI6MTAzNjgsIm1hbmFnZWQudG9rZW4iOiJ0cnVlIiwia25veC5pZCI6ImNlNzA2MDZlLTk1OWQtNDQ5NC1hOWFiLWU3OGEyY2IwYzQ4YyJ9.fVa9Uy2UwXzl-kTJcVCaSBpXpUbs9pK5GZyU3BjyZPkkqAruo-eGJIHnkP8TP5bbiGQh2eNjKiaIUd32apXt-164IcwU3QSg7f95pYCC6XCY8g5Lcsk3rFfs-o55oaV8Uo21CJ4N762taC2sC8xKUXDWaOxttcc2uIufy_VBebCR1S2itlCgGREqL-amxeUtKs3_UQ-7ZcBTxDLO_iC5T1tlFSqdQuvW0puWTsjc8iUQ19WgvDiMqOO2MBt9aE96fUNZN41h9Vy3Y6eNWuQVv_qptRgi_Ib8G76ktjMB_PGcft4M9FuUwLyofbAKWqVVsDKUlcWoBakJ5cfRjzpK3Q","refresh_token":"b8987378-b016-4a78-99d8-5b73fcf59449","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":10368000}
```

2. Using query params (achieved by adding the `-G` option in the `curl` command:
```
$ curl -G -ik -X POST -H "Content-Type: application/x-www-form-urlencoded" --data "grant_type=client_credentials" --data "client_id=$CLIENT_ID" --data-urlencode "client_secret=$CLIENT_SECRET" https://localhost:8443/gateway/tokenbased/oauth/v1/token
HTTP/1.1 400 Bad Request
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: text/html;charset=iso-8859-1
Content-Length: 426
Connection: close

<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 400 Bad Request</title>
</head>
<body><h2>HTTP ERROR 400 Bad Request</h2>
<table>
<tr><th>URI:</th><td>/gateway/tokenbased/oauth/v1/token</td></tr>
<tr><th>STATUS:</th><td>400</td></tr>
<tr><th>MESSAGE:</th><td>Bad Request</td></tr>
<tr><th>SERVLET:</th><td>tokenbased-knox-gateway-servlet</td></tr>
</table>

</body>
</html>
```
Relevant gateway.log:
```
2024-05-09 09:28:59,694 778970b4-7973-4e3d-ab8d-b37980f082c1 ERROR knox.gateway (AbstractGatewayFilter.java:doFilter(64)) - Failed to execute filter: java.lang.SecurityException
2024-05-09 09:28:59,695 778970b4-7973-4e3d-ab8d-b37980f082c1 ERROR knox.gateway (GatewayFilter.java:doFilter(193)) - Gateway processing failed: javax.servlet.ServletException: java.lang.SecurityException
javax.servlet.ServletException: java.lang.SecurityException
	at org.apache.knox.gateway.filter.AbstractGatewayFilter.doFilter(AbstractGatewayFilter.java:65) ~[gateway-spi-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
...
Caused by: java.lang.SecurityException
	at org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter.parseFromClientCredentialsFlow(JWTFederationFilter.java:282) ~[gateway-provider-security-jwt-2.1.0-SNAPSHOT.jar:2.1.0-SNAPSHOT]
```