### PR TITLE
KNOX-3038 - The expires_in field in OAuthResource response returns the configured token TTL.

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/OAuthResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/OAuthResource.java
@@ -79,14 +79,13 @@ public class OAuthResource extends TokenResource {
             // let's get the subset of the KnoxToken Response needed for OAuth
             String accessToken = resp.responseMap.accessToken;
             String passcode = resp.responseMap.passcode;
-            long expires = (long) resp.responseMap.map.get(EXPIRES_IN);
             String tokenType = (String) resp.responseMap.map.get(TOKEN_TYPE);
 
             // build and return the expected OAuth response
             final HashMap<String, Object> map = new HashMap<>();
             map.put(ACCESS_TOKEN, accessToken);
             map.put(TOKEN_TYPE, tokenType);
-            map.put(EXPIRES_IN, expires);
+            map.put(EXPIRES_IN, getTokenLifetimeInSeconds());
             map.put(ISSUED_TOKEN_TYPE, ISSUED_TOKEN_TYPE_ACCESS_TOKEN_VALUE);
             // let's use the passcode as the refresh token
             map.put(REFRESH_TOKEN, passcode);
@@ -103,8 +102,7 @@ public class OAuthResource extends TokenResource {
         }
     }
 
-    @Override
-    protected long getExpiry() {
+    private long getTokenLifetimeInSeconds() {
         long secs = tokenTTL/1000;
 
         String lifetimeStr = request.getParameter(LIFESPAN);

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1657,21 +1657,8 @@ public class TokenServiceResourceTest {
 
 
   private String getTagValue(String token, String tagName) {
-    if (!token.contains(tagName)) {
-      return null;
-    }
-    String searchString = "\"" + tagName + "\":";
-    String value = token.substring(token.indexOf(searchString) + searchString.length());
-    if (value.startsWith("\"")) {
-      value = value.substring(1);
-    }
-    if (value.contains("\"")) {
-      return value.substring(0, value.indexOf('\"'));
-    } else if (value.contains(",")) {
-      return value.substring(0, value.indexOf(','));
-    } else {
-      return value.substring(0, value.length() - 1);
-    }
+    final Map<String, String> tokenMap = JsonUtils.getMapFromJsonString(token);
+    return tokenMap == null ? null : tokenMap.get(tagName);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

To honor the contract of the existing expiration time in the database for Knox Tokens, I removed the override in the new `OAuthResource` class. Thus, everything that depends on this field will be the same as in the case of our "regular" tokens (token eviction is the most important piece here).
To indicate the actual OAuth token lifetime, I changed the meaning of the `expires_in` field in the JSON response: that's the configured TTL in seconds.

## How was this patch tested?

Updated JUnit tests and executed manual testing:
```
$ curl -ik -X POST -H "Content-Type: application/x-www-form-urlencoded" --data "grant_type=client_credentials" --data "client_id=$CLIENT_ID" --data-urlencode "client_secret=$CLIENT_SECRET" https://localhost:8443/gateway/tokenbased/oauth/v1/token
HTTP/1.1 200 OK
Date: Thu, 10 May 2024 23:46:18 GMT
Content-Type: application/json
Content-Length: 1098

{"access_token":"eyJqa...0ijh_g","refresh_token":"a36bafd4...9491-7e17e710a004","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":10368000}
```
The `tokenabased` topology was configured with `knox.token.ttl = 10368000000`. As you can see, the `expires_in` field in the response was populated as expected (converted the given TTL milliseconds to seconds).
