### PR TITLE
KNOX-3033 Add option to set the correct path for sticky session cookies

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServiceConfig.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/HaServiceConfig.java
@@ -67,4 +67,8 @@ public interface HaServiceConfig {
 
   void setFailoverNonIdempotentRequestEnabled(boolean failoverNonIdempotentRequestEnabled);
 
+  boolean isUseRoutesForStickyCookiePath();
+
+  void setUseRoutesForStickyCookiePath(boolean useRoutesForStickyCookiePath);
+
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/DefaultHaServiceConfig.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/DefaultHaServiceConfig.java
@@ -45,6 +45,8 @@ public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigC
 
   private String disableStickySessionForUserAgents;
 
+  private boolean useRoutesForStickyCookiePath = DEFAULT_USE_ROUTES_FOR_STICKY_COOKIE_PATH;
+
   public DefaultHaServiceConfig(String name) {
     this.name = name;
   }
@@ -168,5 +170,15 @@ public class DefaultHaServiceConfig implements HaServiceConfig, HaServiceConfigC
   public void setFailoverNonIdempotentRequestEnabled(
       boolean failoverNonIdempotentRequestEnabled) {
     this.failoverNonIdempotentRequestEnabled = failoverNonIdempotentRequestEnabled;
+  }
+
+  @Override
+  public boolean isUseRoutesForStickyCookiePath() {
+    return this.useRoutesForStickyCookiePath;
+  }
+
+  @Override
+  public void setUseRoutesForStickyCookiePath(boolean useRoutesForStickyCookiePath) {
+    this.useRoutesForStickyCookiePath = useRoutesForStickyCookiePath;
   }
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorConstants.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorConstants.java
@@ -61,4 +61,6 @@ public interface HaDescriptorConstants {
     * default is false (no).
     */
    String FAILOVER_NON_IDEMPOTENT = "failoverNonIdempotentRequestEnabled";
+
+   String USE_ROUTES_FOR_STICKY_COOKIE_PATH = "useRoutesForStickyCookiePath";
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactory.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorFactory.java
@@ -42,10 +42,11 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
     final boolean loadBalancingEnabled = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_LOAD_BALANCING_ENABLED, Boolean.toString(DEFAULT_LOAD_BALANCING_ENABLED)));
     final boolean noFallbackEnabled = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_NO_FALLBACK_ENABLED, Boolean.toString(DEFAULT_NO_FALLBACK_ENABLED)));
     final String stickySessionCookieName = configMap.getOrDefault(STICKY_SESSION_COOKIE_NAME, DEFAULT_STICKY_SESSION_COOKIE_NAME);
+    final boolean useRoutesForStickyCookiePath = Boolean.parseBoolean(configMap.getOrDefault(CONFIG_USE_ROUTES_FOR_STICKY_COOKIE_PATH, Boolean.toString(DEFAULT_USE_ROUTES_FOR_STICKY_COOKIE_PATH)));
     final boolean failoverNonIdempotentRequestEnabled = Boolean.parseBoolean(configMap.getOrDefault(FAILOVER_NON_IDEMPOTENT, Boolean.toString(DEFAULT_FAILOVER_NON_IDEMPOTENT)));
     final String disableLoadBalancingForUserAgentsConfig = configMap.getOrDefault(DISABLE_LB_USER_AGENTS, DEFAULT_DISABLE_LB_USER_AGENTS);
     return createServiceConfig(serviceName, enabled, maxFailoverAttempts, failoverSleep, zookeeperEnsemble, zookeeperNamespace, stickySessionsEnabled, loadBalancingEnabled,
-            stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgentsConfig, failoverNonIdempotentRequestEnabled);
+            stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgentsConfig, failoverNonIdempotentRequestEnabled, useRoutesForStickyCookiePath);
   }
 
   public static HaServiceConfig createServiceConfig(String serviceName, String enabledValue,
@@ -53,7 +54,8 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
       String zookeeperEnsemble, String zookeeperNamespace,
       String loadBalancingEnabledValue, String stickySessionsEnabledValue,
       String stickySessionCookieNameValue, String noFallbackEnabledValue,
-      String disableLoadBalancingForUserAgentsValue, String failoverNonIdempotentRequestEnabledValue) {
+      String disableLoadBalancingForUserAgentsValue, String failoverNonIdempotentRequestEnabledValue,
+      String useRoutesForStickyCookiePathValue) {
 
     boolean enabled = DEFAULT_ENABLED;
     int maxFailoverAttempts = DEFAULT_MAX_FAILOVER_ATTEMPTS;
@@ -64,6 +66,7 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
     String stickySessionCookieName = DEFAULT_STICKY_SESSION_COOKIE_NAME;
     String disableLoadBalancingForUserAgentsConfig = DEFAULT_DISABLE_LB_USER_AGENTS;
     boolean failoverNonIdempotentRequestEnabled = DEFAULT_FAILOVER_NON_IDEMPOTENT;
+    boolean useRoutesForStickyCookiePath = DEFAULT_USE_ROUTES_FOR_STICKY_COOKIE_PATH;
 
     if (enabledValue != null && !enabledValue.trim().isEmpty()) {
       enabled = Boolean.parseBoolean(enabledValue);
@@ -94,8 +97,12 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
       failoverNonIdempotentRequestEnabled = Boolean.parseBoolean(failoverNonIdempotentRequestEnabledValue);
     }
 
+    if (useRoutesForStickyCookiePathValue != null && !useRoutesForStickyCookiePathValue.trim().isEmpty()) {
+      useRoutesForStickyCookiePath = Boolean.parseBoolean(useRoutesForStickyCookiePathValue);
+    }
+
     return createServiceConfig(serviceName, enabled, maxFailoverAttempts, failoverSleep, zookeeperEnsemble, zookeeperNamespace, stickySessionsEnabled, loadBalancingEnabled,
-        stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgentsConfig, failoverNonIdempotentRequestEnabled);
+        stickySessionCookieName, noFallbackEnabled, disableLoadBalancingForUserAgentsConfig, failoverNonIdempotentRequestEnabled, useRoutesForStickyCookiePath);
 
 
   }
@@ -124,7 +131,7 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
                                                      String disableLoadBalancingForUserAgentsValue) {
 
      return createServiceConfig(serviceName, enabledValue, maxFailoverAttemptsValue, failoverSleepValue, zookeeperEnsemble, zookeeperNamespace, loadBalancingEnabledValue, stickySessionsEnabledValue,
-         stickySessionCookieNameValue, noFallbackEnabledValue, disableLoadBalancingForUserAgentsValue, Boolean.toString(DEFAULT_FAILOVER_NON_IDEMPOTENT));
+         stickySessionCookieNameValue, noFallbackEnabledValue, disableLoadBalancingForUserAgentsValue, Boolean.toString(DEFAULT_FAILOVER_NON_IDEMPOTENT), Boolean.toString(DEFAULT_USE_ROUTES_FOR_STICKY_COOKIE_PATH));
    }
 
   public static DefaultHaServiceConfig createServiceConfig(final String serviceName, final boolean enabled,
@@ -133,7 +140,8 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
           final boolean stickySessionsEnabled, final boolean loadBalancingEnabled,
           final String stickySessionCookieName,
           final boolean noFallbackEnabled, final String disableStickySessionForUserAgents,
-          final boolean failoverNonIdempotentRequestEnabled) {
+          final boolean failoverNonIdempotentRequestEnabled,
+          final boolean useRoutesForStickyCookiePath) {
     DefaultHaServiceConfig serviceConfig = new DefaultHaServiceConfig(serviceName);
     serviceConfig.setEnabled(enabled);
     serviceConfig.setMaxFailoverAttempts(maxFailoverAttempts);
@@ -146,6 +154,7 @@ public abstract class HaDescriptorFactory implements HaServiceConfigConstants {
     serviceConfig.setNoFallbackEnabled(noFallbackEnabled);
     serviceConfig.setDisableStickySessionForUserAgents(disableStickySessionForUserAgents);
     serviceConfig.setFailoverNonIdempotentRequestEnabled(failoverNonIdempotentRequestEnabled);
+    serviceConfig.setUseRoutesForStickyCookiePath(useRoutesForStickyCookiePath);
     return serviceConfig;
   }
 

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManager.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManager.java
@@ -67,9 +67,10 @@ public class HaDescriptorManager implements HaDescriptorConstants {
                  serviceElement.setAttribute(STICKY_SESSION_COOKIE_NAME, config.getStickySessionCookieName());
                }
                if(config.getStickySessionDisabledUserAgents() != null && !config.getStickySessionDisabledUserAgents().isEmpty()) {
-                  serviceElement.setAttribute(DISABLE_LB_USER_AGENTS, config.getStickySessionDisabledUserAgents());
+                 serviceElement.setAttribute(DISABLE_LB_USER_AGENTS, config.getStickySessionDisabledUserAgents());
                }
                serviceElement.setAttribute(FAILOVER_NON_IDEMPOTENT, Boolean.toString(config.isFailoverNonIdempotentRequestEnabled()));
+               serviceElement.setAttribute(USE_ROUTES_FOR_STICKY_COOKIE_PATH, Boolean.toString(config.isUseRoutesForStickyCookiePath()));
                root.appendChild(serviceElement);
             }
          }
@@ -101,7 +102,8 @@ public class HaDescriptorManager implements HaDescriptorConstants {
                      element.getAttribute(STICKY_SESSION_COOKIE_NAME),
                      element.getAttribute(ENABLE_NO_FALLBACK),
                      element.getAttribute(DISABLE_LB_USER_AGENTS),
-                     element.getAttribute(FAILOVER_NON_IDEMPOTENT));
+                     element.getAttribute(FAILOVER_NON_IDEMPOTENT),
+                     element.getAttribute(USE_ROUTES_FOR_STICKY_COOKIE_PATH));
                descriptor.addServiceConfig(config);
             }
          }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaServiceConfigConstants.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/provider/impl/HaServiceConfigConstants.java
@@ -40,6 +40,8 @@ public interface HaServiceConfigConstants {
 
    String STICKY_SESSION_COOKIE_NAME = "stickySessionCookieName";
 
+   String CONFIG_USE_ROUTES_FOR_STICKY_COOKIE_PATH = "useRoutesForStickyCookiePath";
+
    /**
     * For non-idempotent requests such as
     * POST, PATCH, CONNECT
@@ -71,4 +73,7 @@ public interface HaServiceConfigConstants {
    String DEFAULT_STICKY_SESSION_COOKIE_NAME = "KNOX_BACKEND";
 
    String DEFAULT_DISABLE_LB_USER_AGENTS = "ClouderaODBCDriverforApacheHive";
+
+   boolean DEFAULT_USE_ROUTES_FOR_STICKY_COOKIE_PATH = false;
+
 }

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManagerTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/provider/impl/HaDescriptorManagerTest.java
@@ -105,14 +105,16 @@ public class HaDescriptorManagerTest {
   @Test
   public void testDescriptorStoringLoadBalancerConfig() throws IOException {
     HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", "true", "false", null, null,null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, "true", null, null, null,null));
-    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("abc", "true", "3", "5000", null, null, null, "true", "abc", null,null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("foo", "false", "42", "1000", "foo:2181,bar:2181", "hiveserver2", "true", "false", null, null,null, null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("bar", "true", "3", "5000", null, null, "true", null, null, null,null, null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("abc", "true", "3", "5000", null, null, null, "true", "abc", null,null, null, null));
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig("def", "true", "3", "5000", null, null, null, "true", "abc", null,null, null, "true"));
     StringWriter writer = new StringWriter();
     HaDescriptorManager.store(descriptor, writer);
     String xml = writer.toString();
     assertThat( the( xml ), hasXPath( "/ha//service[@enabled='false' and @failoverSleep='1000' and @maxFailoverAttempts='42' and @name='foo' and @zookeeperEnsemble='foo:2181,bar:2181' and @zookeeperNamespace='hiveserver2' and @enableLoadBalancing='true' and @enableStickySession='false']" ) );
     assertThat( the( xml ), hasXPath( "/ha//service[@enabled='true' and @failoverSleep='5000' and @maxFailoverAttempts='3' and @name='bar' and @enableLoadBalancing='true' and @enableStickySession='false']" ) );
     assertThat( the( xml ), hasXPath( "/ha//service[@enabled='true' and @failoverSleep='5000' and @maxFailoverAttempts='3' and @name='abc' and @enableLoadBalancing='false' and @enableStickySession='true' and @stickySessionCookieName='abc']" ) );
+    assertThat( the( xml ), hasXPath( "/ha//service[@enabled='true' and @failoverSleep='5000' and @maxFailoverAttempts='3' and @name='def' and @enableLoadBalancing='false' and @enableStickySession='true' and @stickySessionCookieName='abc' and @useRoutesForStickyCookiePath='true']" ) );
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -82,6 +82,10 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
   @Configure
   private String serviceRole;
 
+  @Optional
+  @Configure
+  private String stickyCookiePath;
+
   //Buffer size in bytes
   private int replayBufferSize = -1;
 
@@ -102,6 +106,14 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
 
   public void setServiceRole(String serviceRole) {
     this.serviceRole = serviceRole;
+  }
+
+  public String getStickyCookiePath() {
+    return stickyCookiePath;
+  }
+
+  public void setStickyCookiePath(String stickyCookiePath) {
+    this.stickyCookiePath = stickyCookiePath;
   }
 
   @Configure

--- a/gateway-test/src/test/resources/org/apache/knox/gateway/GatewayAppFuncTest/test-svcs-and-apps-topology.xml
+++ b/gateway-test/src/test/resources/org/apache/knox/gateway/GatewayAppFuncTest/test-svcs-and-apps-topology.xml
@@ -48,6 +48,7 @@
         </provider>
     </gateway>
     <service>
+        <name>webhdfs</name>
         <role>WEBHDFS</role>
         <url>$WEBHDFS_URL</url>
     </service>


### PR DESCRIPTION
… instead of appending the role name

## What changes were proposed in this pull request?

Add a new dispatch property to generate the sticky session cookie path from the service routes, and use a default or configured sticky session cookie name without appending the service role to it.

This is expected to be necessary for integration with external load balancers like the AWS Application load balancer which expect a single sticky cookie name.

## How was this patch tested?

Deployed the changes on a live cluster, set the new parameter and checked the cookie name and path set by Knox.
Also added some unit tests.
