### PR TITLE
KNOX-3039 Add error message sanitization to GatewayServlet

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -176,6 +176,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String CLUSTER_CONFIG_MONITOR_INTERVAL_SUFFIX = ".interval";
   public static final String CLUSTER_CONFIG_MONITOR_ENABLED_SUFFIX = ".enabled";
 
+  private static final String ERROR_MESSAGE_SANITIZATION_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".error.sanitization.enabled";
+  private static final boolean DEFAULT_ERROR_MESSAGE_SANITIZATION_ENABLED = true;
 
   // These config property names are not inline with the convention of using the
   // GATEWAY_CONFIG_FILE_PREFIX as is done by those above. These are left for
@@ -931,6 +933,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
       return Arrays.asList( value.trim().split("\\s*,\\s*") );
     }
     return DEFAULT_GLOBAL_RULES_SERVICES;
+  }
+
+  @Override
+  public boolean isErrorMessageSanitizationEnabled() {
+    return getBoolean(ERROR_MESSAGE_SANITIZATION_ENABLED, DEFAULT_ERROR_MESSAGE_SANITIZATION_ENABLED);
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServletTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServletTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.easymock.EasyMock;
+import org.easymock.IMocksControl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+public class GatewayServletTest {
+
+    @Parameterized.Parameters(name = "{index}: SanitizationEnabled={2}, Exception={0}, ExpectedMessage={1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { new IOException("Connection to 192.168.1.1 failed"), "Connection to [hidden] failed", true },
+                { new RuntimeException("Connection to 192.168.1.1 failed"), "Connection to [hidden] failed", true },
+                { new NullPointerException(), null, true },
+                { new IOException("General failure"), "General failure", true },
+                { new IOException("Connection to 192.168.1.1 failed"), "Connection to 192.168.1.1 failed", false },
+                { new RuntimeException("Connection to 192.168.1.1 failed"), "Connection to 192.168.1.1 failed", false },
+                { new NullPointerException(), null, false },
+                { new IOException("General failure"), "General failure", false }
+        });
+    }
+
+    private final Exception exception;
+    private final String expectedMessage;
+    private final boolean isSanitizationEnabled;
+
+    public GatewayServletTest(Exception exception, String expectedMessage, boolean isSanitizationEnabled) {
+        this.exception = exception;
+        this.expectedMessage = expectedMessage;
+        this.isSanitizationEnabled = isSanitizationEnabled;
+    }
+
+    private IMocksControl mockControl;
+    private ServletConfig servletConfig;
+    private ServletContext servletContext;
+    private GatewayConfig gatewayConfig;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private GatewayFilter filter;
+
+    @Before
+    public void setUp() throws ServletException {
+        mockControl = EasyMock.createControl();
+        servletConfig = mockControl.createMock(ServletConfig.class);
+        servletContext = mockControl.createMock(ServletContext.class);
+        gatewayConfig = mockControl.createMock(GatewayConfig.class);
+        request = mockControl.createMock(HttpServletRequest.class);
+        response = mockControl.createMock(HttpServletResponse.class);
+        filter = mockControl.createMock(GatewayFilter.class);
+
+        EasyMock.expect(servletConfig.getServletName()).andStubReturn("default");
+        EasyMock.expect(servletConfig.getServletContext()).andStubReturn(servletContext);
+        EasyMock.expect(servletContext.getAttribute("org.apache.knox.gateway.config")).andStubReturn(gatewayConfig);
+    }
+
+    @Test
+    public void testExceptionSanitization() throws ServletException, IOException {
+        GatewayServlet servlet = initializeServletWithSanitization(isSanitizationEnabled);
+
+        try {
+            servlet.service(request, response);
+        } catch (Exception e) {
+            if (expectedMessage != null) {
+                assertEquals(expectedMessage, e.getMessage());
+            } else {
+                assertNull(e.getMessage());
+            }
+        }
+
+        mockControl.verify();
+    }
+
+    private GatewayServlet initializeServletWithSanitization(boolean isErrorMessageSanitizationEnabled) throws ServletException, IOException {
+        EasyMock.expect(gatewayConfig.isErrorMessageSanitizationEnabled()).andStubReturn(isErrorMessageSanitizationEnabled);
+
+        filter.init(EasyMock.anyObject(FilterConfig.class));
+        EasyMock.expectLastCall().once();
+        filter.doFilter(EasyMock.eq(request), EasyMock.eq(response), EasyMock.isNull());
+        EasyMock.expectLastCall().andThrow(exception).once();
+
+        mockControl.replay();
+
+        GatewayServlet servlet = new GatewayServlet(filter);
+        servlet.init(servletConfig);
+        return servlet;
+    }
+}

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -620,6 +620,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public boolean isErrorMessageSanitizationEnabled() {
+    return true;
+  }
+
+  @Override
   public boolean isMetricsEnabled() {
     return false;
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -902,6 +902,11 @@ public interface GatewayConfig {
   boolean isAsyncSupported();
 
   /**
+   * @return true if error message sanitization is enabled; false otherwise (defaults to true)
+   */
+  boolean isErrorMessageSanitizationEnabled();
+
+  /**
    * @return <code>true</code> if the supplied user is allowed to see all tokens
    *         (i.e. not only tokens where userName or createdBy equals to the
    *         userName) on the Token Management page; <code>false</code> otherwise


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request introduces a mechanism to sanitize error messages in the `GatewayServlet` to improve security by hiding IP addresses from exception messages. The following changes were made:
- Added a `isErrorMessageSanitizationEnabled` flag to the `GatewayServlet` to control whether error messages should be sanitized.
- Implemented the `sanitizeException` and `sanitizeAndRethrow` methods in `GatewayServlet` to handle exception sanitization.
- Updated the `GatewayConfig` interface and its implementation `GatewayConfigImpl` to include a new method `isErrorMessageSanitizationEnabled`.
- Created the `GatewayServletTest` class to parameterize tests for scenarios where sanitization is enabled and disabled.

## How was this patch tested?

This patch was tested using the following methods:
- Parameterized unit tests were added to `GatewayServletTest` to cover both scenarios where error message sanitization is enabled and disabled.
- Manual review and inspection of the code changes to ensure accuracy and completeness.

Test steps:
1. Added unit tests in `GatewayServletTest` to check for sanitized and non-sanitized error messages.
2. Verified the new tests pass successfully, ensuring error messages are appropriately sanitized or left unchanged based on the configuration.