### PR TITLE
KNOX-3043 - NullpointerException in calling loadBuildProperties

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -63,10 +63,10 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.INFO, text = "Loading configuration file {0}" )
   void loadingConfigurationFile( String file );
 
-  @Message( level = MessageLevel.INFO, text = "Failed to find configuration file {0}" )
+  @Message( level = MessageLevel.ERROR, text = "Failed to find configuration file {0}" )
   void failedToFindConfig( String path );
 
-  @Message( level = MessageLevel.INFO, text = "Failed to find configuration file {0}: {1}" )
+  @Message( level = MessageLevel.ERROR, text = "Failed to find configuration file {0}: {1}" )
   void failedToFindConfig( String path, @StackTrace( level = MessageLevel.INFO ) Exception e );
 
   @Message( level = MessageLevel.WARN, text = "Failed to load configuration file {0}: {1}" )

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -63,10 +63,10 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.INFO, text = "Loading configuration file {0}" )
   void loadingConfigurationFile( String file );
 
-  @Message( level = MessageLevel.ERROR, text = "Failed to find configuration file {0}" )
+  @Message( level = MessageLevel.INFO, text = "Failed to find configuration file {0}" )
   void failedToFindConfig( String path );
 
-  @Message( level = MessageLevel.ERROR, text = "Failed to find configuration file {0}: {1}" )
+  @Message( level = MessageLevel.INFO, text = "Failed to find configuration file {0}: {1}" )
   void failedToFindConfig( String path, @StackTrace( level = MessageLevel.INFO ) Exception e );
 
   @Message( level = MessageLevel.WARN, text = "Failed to load configuration file {0}: {1}" )

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -63,6 +63,12 @@ public interface GatewayMessages {
   @Message( level = MessageLevel.INFO, text = "Loading configuration file {0}" )
   void loadingConfigurationFile( String file );
 
+  @Message( level = MessageLevel.INFO, text = "Failed to find configuration file {0}" )
+  void failedToFindConfig( String path );
+
+  @Message( level = MessageLevel.INFO, text = "Failed to find configuration file {0}: {1}" )
+  void failedToFindConfig( String path, @StackTrace( level = MessageLevel.INFO ) Exception e );
+
   @Message( level = MessageLevel.WARN, text = "Failed to load configuration file {0}: {1}" )
   void failedToLoadConfig( String path, @StackTrace( level = MessageLevel.DEBUG ) Exception e );
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -304,10 +304,15 @@ public class GatewayServer {
 
   private static Properties loadBuildProperties() {
     Properties properties = new Properties();
-    try(InputStream inputStream = GatewayServer.class.getClassLoader().getResourceAsStream( "build.properties" )) {
-      properties.load( inputStream );
+    String BUILD_PROPERTY = "build.properties";
+    try(InputStream inputStream = GatewayServer.class.getClassLoader().getResourceAsStream( BUILD_PROPERTY )) {
+      if (inputStream != null) {
+        properties.load(inputStream);
+      } else {
+        log.failedToFindConfig( BUILD_PROPERTY);
+      }
     } catch( IOException e ) {
-      // Ignore.
+      log.failedToFindConfig( BUILD_PROPERTY, e );
     }
     return properties;
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -2570,10 +2570,16 @@ public class KnoxCLI extends Configured implements Tool {
 
   private static Properties loadBuildProperties() {
     Properties properties = new Properties();
-    try(InputStream inputStream = KnoxCLI.class.getClassLoader().getResourceAsStream( "build.properties" )) {
-      properties.load(inputStream);
+    String BUILD_PROPERTY = "build.properties";
+    PrintStream out = System.out;
+    try(InputStream inputStream = KnoxCLI.class.getClassLoader().getResourceAsStream( BUILD_PROPERTY )) {
+      if (inputStream != null) {
+        properties.load(inputStream);
+      } else {
+        out.println("Failed to find configuration file " + BUILD_PROPERTY);
+      }
     } catch( IOException e ) {
-      // Ignore.
+      out.println("Failed to find configuration file " + BUILD_PROPERTY + e.getMessage());
     }
     return properties;
   }


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?
Rootcause of this Issue:

Due to improper maven build, We were getting NullPointer Exception as Gatewayserver was not able to find 'build.properties' file (eventhough build.properties was part of gateway-server.jar file)

Error Messgae:
{{
SEVERE: Failed to start gateway: java.lang.NullPointerException
java.lang.NullPointerException
at java.util.Properties$LineReader.readLine(Properties.java:434)
at java.util.Properties.load0(Properties.java:353)
at java.util.Properties.load(Properties.java:341)
at org.apache.knox.gateway.GatewayServer.loadBuildProperties(GatewayServer.java:306)
at org.apache.knox.gateway.GatewayServer.main(GatewayServer.java:160)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
at org.apache.knox.gateway.launcher.Invoker.invokeMainMethod(Invoker.java:68)
at org.apache.knox.gateway.launcher.Invoker.invoke(Invoker.java:39)
at org.apache.knox.gateway.launcher.Command.run(Command.java:99)
at org.apache.knox.gateway.launcher.Launcher.run(Launcher.java:75)
at org.apache.knox.gateway.launcher.Launcher.main(Launcher.java:52)
}}

Changes : Added Exceptional handlings to handle NullPointerException thrown while calling loadBuildProperties method and also respective log messages


## How was this patch tested?

Tested  by adding exceptional handling and then tested, in local cluster, for better error messages.

Adding exeption handling helped to troubleshoot the issue sooner.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
