### PR TITLE
KNOX-3044 - Port numbers are written with ',' format in logs

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -46,7 +46,7 @@ public interface GatewayMessages {
   void failedToStartGateway( @StackTrace( level = MessageLevel.FATAL ) Exception e );
 
   @Message( level = MessageLevel.INFO, text = "Started gateway on port {0}." )
-  void startedGateway( int port );
+  void startedGateway( String port );
 
   @Message( level = MessageLevel.INFO, text = "Stopping gateway..." )
   void stoppingGateway();
@@ -466,7 +466,7 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR,
            text = "No topology mapped to port: {0}")
-  void noTopologyMappedToPort(int port);
+  void noTopologyMappedToPort(String port);
 
   @Message(level = MessageLevel.ERROR,
            text = "Could not find topology {0} specified in port mapping config")
@@ -474,7 +474,7 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.DEBUG,
            text = "Creating a connector for topology {0} listening on port {1}.")
-  void createJettyConnector(String topology, int port);
+  void createJettyConnector(String topology, String port);
 
   @Message(level = MessageLevel.DEBUG,
            text = "Creating a handler for topology {0}.")
@@ -492,26 +492,26 @@ public interface GatewayMessages {
 
   @Message(level = MessageLevel.ERROR,
            text = "Port {0} configured for Topology - {1} is already in use.")
-  void portAlreadyInUse(int port, String topology);
+  void portAlreadyInUse(String port, String topology);
 
   @Message(level = MessageLevel.ERROR,
            text = "Port {0} is already in use.")
-  void portAlreadyInUse(int port);
+  void portAlreadyInUse(String port);
 
   @Message(level = MessageLevel.INFO,
            text = "Started gateway, topology \"{0}\" listening on port \"{1}\".")
-  void startedGateway(String topology, int port);
+  void startedGateway(String topology, String port);
 
   @Message(level = MessageLevel.ERROR,
            text = "Topology \"{0}\" failed to start listening on port \"{1}\".")
-  void startedGatewayPortConflict(String topology, int port);
+  void startedGatewayPortConflict(String topology, String port);
 
   @Message(level = MessageLevel.ERROR,
            text =
                " Could not find topology \"{0}\" mapped to port \"{1}\" configured in gateway-config.xml. "
                    + "This invalid topology mapping will be ignored by the gateway. "
                    + "Gateway restart will be required if in the future \"{0}\" topology is added.")
-  void topologyPortMappingCannotFindTopology(String topology, int port);
+  void topologyPortMappingCannotFindTopology(String topology, String port);
 
   @Message(level = MessageLevel.ERROR,
            text = "Port mapped topology {0} cannot be configured as default topology")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -375,9 +375,9 @@ public class GatewayServer {
             }
           }
           if (networkConnector.getName() == null) {
-            log.startedGateway(networkConnector.getLocalPort());
+            log.startedGateway(convertPortToString(networkConnector.getLocalPort()));
           } else {
-            log.startedGateway(networkConnector.getName(), networkConnector.getLocalPort());
+            log.startedGateway(networkConnector.getName(), convertPortToString(networkConnector.getLocalPort()));
           }
         }
       }
@@ -543,9 +543,9 @@ public class GatewayServer {
     // Throw an exception if port in use
     if (isPortInUse(port)) {
       if (topologyName == null) {
-        log.portAlreadyInUse(port);
+        log.portAlreadyInUse(convertPortToString(port));
       } else {
-        log.portAlreadyInUse(port, topologyName);
+        log.portAlreadyInUse(convertPortToString(port), topologyName);
       }
       throw new IOException(String.format(Locale.ROOT, "Port %d already in use.", port));
     }
@@ -555,7 +555,7 @@ public class GatewayServer {
       // If we have Default Topology old and new configuration (Port Mapping) throw error.
       if (config.getGatewayPortMappings().containsValue(port)
           && !StringUtils.isBlank(config.getDefaultTopologyName())) {
-        log.portAlreadyInUse(port);
+        log.portAlreadyInUse(convertPortToString(port));
         throw new IOException(String.format(Locale.ROOT,
             " Please map port %d using either \"gateway.port.mapping.sandbox\" or "
                 + "\"default.app.topology.name\" property, "
@@ -568,7 +568,7 @@ public class GatewayServer {
       for (Connector connector : connectors) {
         if (connector instanceof ServerConnector
                 && ((ServerConnector) connector).getPort() == port) {
-          log.portAlreadyInUse(port, topologyName);
+          log.portAlreadyInUse(convertPortToString(port), topologyName);
           throw new IOException(String.format(Locale.ROOT,
               " Port %d used by topology %s is used by other topology, ports for topologies (if defined) have to be unique. ",
               port, topologyName));
@@ -668,7 +668,7 @@ public class GatewayServer {
         // Add connector for only valid topologies, i.e. deployed topologies.
         // and NOT for Default Topology listening on standard gateway port.
         if(deployedTopologyList.contains(entry.getKey()) && (entry.getValue() != config.getGatewayPort()) ) {
-          log.createJettyConnector(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+          log.createJettyConnector(entry.getKey().toLowerCase(Locale.ROOT), convertPortToString(entry.getValue()));
           try {
             connectors = createConnector(jetty, config, entry.getValue(), entry.getKey().toLowerCase(Locale.ROOT));
             for (Connector connector : connectors) {
@@ -677,7 +677,7 @@ public class GatewayServer {
           } catch(final IOException e) {
             /* in case of port conflict we log error and move on */
             if( e.toString().contains("ports for topologies (if defined) have to be unique.") ) {
-              log.startedGatewayPortConflict(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+              log.startedGatewayPortConflict(entry.getKey().toLowerCase(Locale.ROOT), convertPortToString(entry.getValue()));
             } else {
               throw e;
             }
@@ -752,6 +752,16 @@ public class GatewayServer {
   }
 
   /**
+   * Check whether a port is free
+   *
+   * @param port port to convert
+   * @return value of port in String
+   */
+  private static String convertPortToString(int port) {
+    return String.valueOf(port);
+  }
+
+  /**
    * Checks whether the topologies defined in gateway-xml as part of Topology
    * Port mapping feature exists. If it does not Log a message and move on.
    */
@@ -761,7 +771,7 @@ public class GatewayServer {
     for(final Map.Entry<String, Integer> entry : configTopologies.entrySet()) {
       // If the topologies defined in gateway-config.xml are not found in gateway
       if (!topologies.contains(entry.getKey())) {
-        log.topologyPortMappingCannotFindTopology(entry.getKey(), entry.getValue());
+        log.topologyPortMappingCannotFindTopology(entry.getKey(), convertPortToString(entry.getValue()));
       }
     }
   }


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Modified GatewayMessages, GatewayServer such that port number will be written without ',' character.

Log message before change :  Port 1,243 is already in use.

Log message after change :  Port 1243 is already in use.

## How was this patch tested?

Tested with Existing GatewayPortMappingConfigTest testsuite.


