### PR TITLE
KNOX-3046 - Yarn REST API should support query parameters

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
@@ -23,8 +23,8 @@
      e.g. http://host.com:8088
 -->
 
-<rule dir="IN" name="YARNUI/yarn/inbound/ws" pattern="*://*:*/**/yarn/ws/v1/{**}">
-    <rewrite template="{$serviceUrl[YARNUI]}/ws/v1/{**}"/>
+<rule dir="IN" name="YARNUI/yarn/inbound/ws" pattern="*://*:*/**/yarn/ws/v1/{**}?{**}">
+    <rewrite template="{$serviceUrl[YARNUI]}/ws/v1/{**}?{**}"/>
 </rule>
 <rule dir="IN" name="YARNUI/yarn/inbound/root" pattern="*://*:*/**/yarn/">
     <rewrite template="{$serviceUrl[YARNUI]}/cluster"/>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Knox Gateway for Yarn ResourceManager REST API should respect query parameters.

The conclusion is: `{**}?{**}` works and `{**}` will ignore query params.

## How was this patch tested?

There is already one can prove that patten `{**}?{**}` works with query parameters and without parameters.

https://github.com/apache/knox/blob/d21cf8f63944afdd5d4ffa0236a16cd788d9a14a/gateway-provider-rewrite/src/test/java/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest.java#L274-L303

and rewrite.xml :

https://github.com/apache/knox/blob/d21cf8f63944afdd5d4ffa0236a16cd788d9a14a/gateway-provider-rewrite/src/test/resources/org/apache/knox/gateway/filter/rewrite/api/UrlRewriteProcessorTest/rewrite.xml#L22-L25

