### PR TITLE
KNOX-3049 Fix startup for JDK17

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -177,7 +177,7 @@ function buildAppJavaOpts {
     fi
 
     # Add properties to enable Knox to run on JDK 17
-    JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    JAVA_VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
     CHECK_VERSION_17="17"
     if [[ "$JAVA_VERSION" == *"$CHECK_VERSION_17"* ]]; then
         echo "Java version is $CHECK_VERSION_17. Adding properties to enable Knox to run on JDK 17"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix an issue where `java -version` is not evaluated when java is not set.

## How was this patch tested?

Patch was tested locally.