### PR TITLE
KNOX-3050 - Add support for HTTP verbs for pre endpoint.

### DIFF
--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/PATCH.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/PATCH.java
@@ -1,0 +1,13 @@
+package org.apache.knox.gateway.service.auth;
+import javax.ws.rs.HttpMethod;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH {
+}

--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/PreAuthResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/PreAuthResource.java
@@ -20,8 +20,7 @@ package org.apache.knox.gateway.service.auth;
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
@@ -54,4 +53,25 @@ public class PreAuthResource extends AbstractAuthResource {
   public Response doGet() {
     return doGetImpl();
   }
+
+  @PUT
+  public Response doPut() {
+    return doGetImpl();
+  }
+
+  @POST
+  public Response doPost() {
+    return doGetImpl();
+  }
+
+  @PATCH
+  public Response doPatch() {
+    return doGetImpl();
+  }
+
+  @DELETE
+  public Response doDelete() {
+    return doGetImpl();
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
`auth/api/v1/pre` endpoint was only supporting GET, with this patch other http verbs such as DELETE, PATCH, POST, PUT are now supported.

NOTE: There is no change in functionality, calling new verbs will return the exact same information as GET. 

## How was this patch tested?
This patch was tested locally.