### PR TITLE
KNOX-3040 - Followup patch. Support for multiple JWKS endpoints + code cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,5 +39,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: maven
       - name: 'Build and Test'
         run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Dshellcheck=true -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,5 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: 'Build and Test'
-        run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Dshellcheck=true -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V
+        run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Dshellcheck=true -Djavax.net.ssl.trustStorePassword=changeit -Dhttp.keepAlive=false -B -V
+        # run: mvn -T.75C clean verify -U -Dsurefire.useFile=false -Dshellcheck=true -Djavax.net.ssl.trustStorePassword=changeit -Dmaven.wagon.http.retryHandler.count=5 -Dmaven.wagon.http.retryHandler.class=default -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.InterruptedIOException -Dhttp.keepAlive=false -B -V

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,9 @@ jobs:
       fail-fast: false
     name: CI - Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Setup Java'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
       - name: 'Build and Test'

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -582,6 +582,7 @@ public class HadoopAuthFilterTest {
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_AUDIENCES)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_QUERY_PARAM_NAME)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.JWKS_URL)).andReturn(null).anyTimes();
+      expect(filterConfig.getInitParameter(JWTFederationFilter.JWKS_URLS)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.TOKEN_PRINCIPAL_CLAIM)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.TOKEN_VERIFICATION_PEM)).andReturn(null).anyTimes();
       expect(filterConfig.getInitParameter(JWTFederationFilter.JWT_UNAUTHENTICATED_PATHS_PARAM)).andReturn(null).anyTimes();

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -125,5 +125,5 @@ public interface JWTMessages {
   void signingKeyVerificationResultMessage(boolean verified);
 
   @Message(level = MessageLevel.ERROR, text = "Invalid URL ignored. Not a valid JWKS url {0}")
-  void notValidJwksUrl(String jwksUrl);
+  void invalidJwksUrl(String jwksUrl);
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -123,4 +123,7 @@ public interface JWTMessages {
 
   @Message( level = MessageLevel.INFO, text = "Token verification result using knox signing cert, verified: {0}" )
   void signingKeyVerificationResultMessage(boolean verified);
+
+  @Message(level = MessageLevel.ERROR, text = "Invalid URL ignored. Not a valid JWKS url {0}")
+  void notValidJwksUrl(String jwksUrl);
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -116,7 +116,7 @@ public abstract class AbstractJWTFilter implements Filter {
   private String expectedIssuer;
   private String expectedSigAlg;
   protected String expectedPrincipalClaim;
-  protected Set<URI> expectedJWKSUrl = new HashSet();
+  protected Set<URI> expectedJWKSUrls = new HashSet();
   protected Set<JOSEObjectType> allowedJwsTypes;
 
   private TokenStateService tokenStateService;
@@ -517,8 +517,8 @@ public abstract class AbstractJWTFilter implements Filter {
           log.pemVerificationResultMessage(verified);
         }
 
-        if (!verified && expectedJWKSUrl != null && !expectedJWKSUrl.isEmpty()) {
-          verified = authority.verifyToken(token, expectedJWKSUrl, expectedSigAlg, allowedJwsTypes);
+        if (!verified && expectedJWKSUrls != null && !expectedJWKSUrls.isEmpty()) {
+          verified = authority.verifyToken(token, expectedJWKSUrls, expectedSigAlg, allowedJwsTypes);
           log.jwksVerificationResultMessage(verified);
         }
 

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.provider.federation.jwt.filter;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
+import java.net.URI;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -115,7 +116,7 @@ public abstract class AbstractJWTFilter implements Filter {
   private String expectedIssuer;
   private String expectedSigAlg;
   protected String expectedPrincipalClaim;
-  protected String expectedJWKSUrl;
+  protected Set<URI> expectedJWKSUrl = new HashSet();
   protected Set<JOSEObjectType> allowedJwsTypes;
 
   private TokenStateService tokenStateService;
@@ -516,7 +517,7 @@ public abstract class AbstractJWTFilter implements Filter {
           log.pemVerificationResultMessage(verified);
         }
 
-        if (!verified && expectedJWKSUrl != null) {
+        if (!verified && expectedJWKSUrl != null && !expectedJWKSUrl.isEmpty()) {
           verified = authority.verifyToken(token, expectedJWKSUrl, expectedSigAlg, allowedJwsTypes);
           log.jwksVerificationResultMessage(verified);
         }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -33,6 +33,7 @@ import org.apache.knox.gateway.provider.federation.jwt.filter.SignatureVerificat
 import org.apache.knox.gateway.security.PrimaryPrincipal;
 import org.apache.knox.gateway.services.security.token.JWTokenAttributes;
 import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
+import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 import org.apache.knox.gateway.util.X509CertificateUtil;
@@ -55,6 +56,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.KeyPair;
@@ -1179,6 +1181,11 @@ public abstract class AbstractJWTFilterTest  {
     @Override
     public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) {
      return false;
+    }
+
+    @Override
+    public boolean verifyToken(JWT token, Set<URI> jwksurls, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException {
+      return false;
     }
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -166,7 +166,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String WEBSHELL_READ_BUFFER_SIZE = GATEWAY_CONFIG_FILE_PREFIX + ".webshell.read.buffer.size";
 
   /**
-   * Properties for for gateway port mapping feature
+   * Properties for gateway port mapping feature
    */
   public static final String GATEWAY_PORT_MAPPING_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".port.mapping.";
   public static final String GATEWAY_PORT_MAPPING_REGEX = GATEWAY_CONFIG_FILE_PREFIX + "\\.port\\.mapping\\..*";
@@ -353,6 +353,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final boolean GATEWAY_SERVLET_ASYNC_SUPPORTED_DEFAULT = false;
 
   private static final String GATEWAY_HEALTH_CHECK_TOPOLOGIES = GATEWAY_CONFIG_FILE_PREFIX + ".health.check.topologies";
+
+  private static final String JWKS_OUTAGE_CACHE_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".jwks.outage.cache.ttl";;
+  private static final long JWKS_OUTAGE_CACHE_TTL_DEFAULT = TimeUnit.HOURS.toMillis(2);
 
   public GatewayConfigImpl() {
     init();
@@ -1588,6 +1591,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getBannerText() {
     return get(UI_BANNER_TEXT, "");
+  }
+
+  @Override
+  public long getJwksOutageCacheTTL() {
+    return getLong(JWKS_OUTAGE_CACHE_TTL, JWKS_OUTAGE_CACHE_TTL_DEFAULT);
   }
 
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenAuthorityServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenAuthorityServiceMessages.java
@@ -25,4 +25,7 @@ import org.apache.knox.gateway.i18n.messages.Messages;
 public interface TokenAuthorityServiceMessages {
   @Message(level = MessageLevel.ERROR, text = "There was an error getting kid, cause: {0}")
   void errorGettingKid(String message);
+
+  @Message(level = MessageLevel.ERROR, text = "Failed to verify token using JWKS endpoint {0}, reason: {1}")
+  void jwksVerificationFailed(String jwksUrl, String reason);
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -646,10 +646,7 @@ public class DefaultTopologyServiceTest {
       EasyMock.replay(config);
 
       TopologyService ts = new DefaultTopologyService();
-      ts.init(config, Collections.emptyMap());
-
       ClusterConfigurationMonitorService ccms = new DefaultClusterConfigurationMonitorService();
-      ccms.init(config, Collections.emptyMap());
 
       // GatewayServices mock
       GatewayServices gws = EasyMock.createNiceMock(GatewayServices.class);
@@ -657,6 +654,9 @@ public class DefaultTopologyServiceTest {
       EasyMock.expect(gws.getService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE)).andReturn(ccms).anyTimes();
       EasyMock.replay(gws);
       setGatewayServices(gws);
+
+      ts.init(config, Collections.emptyMap());
+      ccms.init(config, Collections.emptyMap());
 
       // Write out the referenced provider config first
       createFile(sharedProvidersDir,

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 import java.lang.reflect.Field;
 import java.net.HttpCookie;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
@@ -1004,6 +1005,11 @@ public class WebSSOResourceTest {
     @Override
     public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) {
      return false;
+    }
+
+    @Override
+    public boolean verifyToken(JWT token, Set<URI> jwksurls, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException {
+      return false;
     }
   }
 }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.net.URI;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Principal;
@@ -95,6 +96,7 @@ import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
 import org.apache.knox.gateway.services.security.token.KnoxToken;
 import org.apache.knox.gateway.services.security.token.PersistentTokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.apache.knox.gateway.services.security.token.TokenUtils;
 import org.apache.knox.gateway.services.security.token.UnknownTokenException;
@@ -1898,6 +1900,11 @@ public class TokenServiceResourceTest {
     @Override
     public boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) {
      return false;
+    }
+
+    @Override
+    public boolean verifyToken(JWT token, Set<URI> jwksurls, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException {
+      return false;
     }
   }
 }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -32,6 +32,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -1125,5 +1126,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   public String getBannerText() {
     return null;
   }
+
+  @Override
+  public long getJwksOutageCacheTTL() {
+    return TimeUnit.HOURS.toMillis(2);
+  }
+
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -956,4 +956,9 @@ public interface GatewayConfig {
    */
   String getBannerText();
 
+  /**
+   * The time to live of the cached JWK set to cover outages, in milliseconds.
+   * @return jwks outage cache TTL
+   */
+  long getJwksOutageCacheTTL();
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAuthority.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAuthority.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.services.security.token;
 
+import java.net.URI;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Set;
 
@@ -33,4 +34,7 @@ public interface JWTokenAuthority {
   boolean verifyToken(JWT token, RSAPublicKey publicKey) throws TokenServiceException;
 
   boolean verifyToken(JWT token, String jwksurl, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException;
+
+  boolean verifyToken(JWT token, Set<URI> jwksurls, String algorithm, Set<JOSEObjectType> allowedJwsTypes) throws TokenServiceException;
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -63,26 +63,26 @@ public class JWTToken implements JWT {
     try {
       header = new JWSHeader(new JWSAlgorithm(jwtAttributes.getAlgorithm()),
               jwtAttributes.getType() == null ? null : new JOSEObjectType(jwtAttributes.getType()),
-      null,
-      null,
-      jwtAttributes.getJkuUri(),
-      null,
-      null,
-      null,
-      null,
-      null,
-      jwtAttributes.getKid(),
-      null,
-      null);
+              null,
+              null,
+              jwtAttributes.getJkuUri(),
+              null,
+              null,
+              null,
+              null,
+              null,
+              jwtAttributes.getKid(),
+              null,
+              null);
     } catch (URISyntaxException e) {
       /* in event of bad URI exception fall back to using just algo in header */
       header = new JWSHeader(new JWSAlgorithm(jwtAttributes.getAlgorithm()));
     }
     JWTClaimsSet claims;
     JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
-      .issuer(jwtAttributes.getIssuer())
-      .subject(jwtAttributes.getUserName())
-      .audience(jwtAttributes.getAudiences());
+            .issuer(jwtAttributes.getIssuer())
+            .subject(jwtAttributes.getUserName())
+            .audience(jwtAttributes.getAudiences());
     if(jwtAttributes.getExpiresDate() != null) {
       builder = builder.expirationTime(jwtAttributes.getExpiresDate());
     }
@@ -127,7 +127,7 @@ public class JWTToken implements JWT {
     JWTClaimsSet claims;
     try {
       claims = jwt.getJWTClaimsSet();
-      c = claims.toJSONObject().toJSONString();
+      c = claims.toJSONObject().toString();
     } catch (ParseException e) {
       log.unableToParseToken(e);
     }
@@ -195,7 +195,7 @@ public class JWTToken implements JWT {
     String c = null;
 
     claim = getAudienceClaims();
-    if (claim != null) {
+    if (claim != null && claim.length > 0) {
       c = claim[0];
     }
 
@@ -217,7 +217,7 @@ public class JWTToken implements JWT {
 
   @Override
   public String getExpires() {
-      Date expires = getExpiresDate();
+    Date expires = getExpiresDate();
     if (expires != null) {
       return String.valueOf(expires.getTime());
     }

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
@@ -19,7 +19,6 @@ package org.apache.knox.gateway.services.security.token.impl;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -143,7 +142,7 @@ public class JWTTokenTest {
     assertEquals("KNOXSSO", token.getIssuer());
     assertEquals("john.doe@example.com", token.getSubject());
     assertNull(token.getAudience());
-    assertArrayEquals(null, token.getAudienceClaims());
+    assertEquals(0, token.getAudienceClaims().length);
   }
 
   @Test
@@ -205,15 +204,14 @@ public class JWTTokenTest {
   @Test
   public void testUnsignedToken() throws Exception {
     String unsignedToken = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJhbGljZSIsImp0aSI6ImY2YmNj"
-                               + "MDVjLWI4MTktNGM0Mi1iMGMyLWJlYmY1MDE4YWFiZiJ9.";
+            + "MDVjLWI4MTktNGM0Mi1iMGMyLWJlYmY1MDE4YWFiZiJ9.";
 
     try {
       new JWTToken(unsignedToken);
       fail("Failure expected on an unsigned token");
     } catch (ParseException ex) {
       // expected
-      assertEquals("Invalid JWS header: The algorithm \"alg\" header parameter must be for signatures",
-          ex.getMessage());
+      assertEquals("Invalid JWS header: Not a JWS header", ex.getMessage());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <mina.version>2.0.22</mina.version>
         <mockito.version>4.8.1</mockito.version>
         <netty.version>4.1.77.Final</netty.version>
-        <nimbus-jose-jwt.version>8.14.1</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
         <nodejs.version>v14.15.0</nodejs.version>
         <okhttp.version>2.7.5</okhttp.version>
         <opensaml.version>3.4.5</opensaml.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR is a followup to KNOX-3040 and adds support for multiple JWKS endpoints. Users can specify one JWKS endpoint or multiple comma separated JWKS endpoints as shown in following example.

```
           <param>
                <name>knox.token.jwks.url</name>
                <value>https://example.com/oauth2/keys?accountId=1234567890, https://www.googleapis.com/oauth2/v3/certs</value>
            </param>
``` 
Note that the parameter name `knox.token.jwks.url` did not change. 

This PR also fixes some deprecated classes and adds supports for JWKS caching and retries (just one retry). 
TTL for JWKS caching is set to 2 hours. 


Two parameters were added one topology level `knox.token.jwks.urls` indicating support for multiple jwks urls (this is in addition to previous param which also supports multiple jwks urls but differs in name only) and one gateway level `gateway.jwks.outage.cache.ttl` where we can now configure JWKS outage TTL value.


## How was this patch tested?

Following is the log snippet of token verification from one valid and one invalid JWKS endpoints (https://example.com/oauth2/keys?accountId=1234567890, https://www.googleapis.com/oauth2/v3/certs)

```
2024-07-08 23:06:08,004 bfc003e6-5d86-4b09-bf0d-a9f1565e0d60 ERROR token.state (DefaultTokenAuthorityService.java:verifyToken(270)) - Failed to verify token using JWKS endpoint https://www.googleapis.com/oauth2/v3/certs, reason: org.apache.knox.gateway.services.security.token.TokenServiceException: Cannot verify token.
2024-07-08 23:06:13,977 bfc003e6-5d86-4b09-bf0d-a9f1565e0d60 INFO  federation.jwt (AbstractJWTFilter.java:verifyTokenSignature(514)) - Token verification result using provided JWKS Url, verified: true
```

