### PR TITLE
KNOX-3047 - Classpath extension for optional dependencies

### DIFF
--- a/gateway-server-launcher/src/main/resources/META-INF/launcher.cfg
+++ b/gateway-server-launcher/src/main/resources/META-INF/launcher.cfg
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 main.class = org.apache.knox.gateway.GatewayServer
-class.path = ../conf;../lib/*.jar;../dep/*.jar;../ext;../ext/*.jar
+class.path = ../conf;../lib/*.jar;../dep/*.jar;../ext;../ext/*.jar;/usr/share/java/*.jar
 GATEWAY_HOME=${launcher.dir}/..
 log4j.configurationFile=${GATEWAY_HOME}/conf/${launcher.name}-log4j2.xml

--- a/gateway-util-launcher/src/main/java/org/apache/knox/gateway/launcher/Command.java
+++ b/gateway-util-launcher/src/main/java/org/apache/knox/gateway/launcher/Command.java
@@ -115,7 +115,7 @@ class Command {
     StringTokenizer parser = new StringTokenizer( classPath, CLASS_PATH_DELIM, false );
     while( parser.hasMoreTokens() ) {
       String libPath = parser.nextToken().trim();
-      File libFile = new File( base, libPath );
+      File libFile = loadFileByPath( base, libPath );
       if( libFile.canRead() && ( libFile.isFile() || libFile.isDirectory() ) ) {
         urls.add( libFile.toURI().toURL() );
       } else if( libPath.endsWith( "*" ) || libPath.endsWith( "*.jar" ) ) {
@@ -129,6 +129,17 @@ class Command {
       }
     }
     return urls;
+  }
+
+  /* KNOX-3047 */
+  private static File loadFileByPath( File base, String libPath ) {
+    File file;
+    if( libPath.startsWith( "/" ) ) {
+      file = new File( libPath );
+    } else {
+      file = new File( base, libPath );
+    }
+    return file;
   }
 
   private static class WildcardFilenameFilter implements FilenameFilter {


### PR DESCRIPTION
## What changes were proposed in this pull request?

A new path /usr/share/java/*.jar is added on the classpath which is located outside of the Knox installation folder. Users can place 3rd-party JARs in /usr/share/java and those will be included on the classpath.

## How was this patch tested?

Changes were tested locally with test servers.
- Removed dependency from /dep/ folder so gateway fails to start.
- Placed missing dependency on the new path that is now included on the classpath.
- Verified with memory dump that the necessary class is indeed loaded. Also gateway successfully starts.
