### PR TITLE
KNOX-3052 - Allow Multiple Issuers and with some and no Audience

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.security.auth.Subject;
 import javax.servlet.Filter;
@@ -112,7 +113,7 @@ public abstract class AbstractJWTFilter implements Filter {
   protected JWTokenAuthority authority;
   protected RSAPublicKey publicKey;
   protected SignatureVerificationCache signatureVerificationCache;
-  private String expectedIssuer;
+  private List<String> expectedIssuers;
   private String expectedSigAlg;
   protected String expectedPrincipalClaim;
   protected String expectedJWKSUrl;
@@ -160,15 +161,28 @@ public abstract class AbstractJWTFilter implements Filter {
   }
 
   protected void configureExpectedParameters(FilterConfig filterConfig) {
-    expectedIssuer = filterConfig.getInitParameter(JWT_EXPECTED_ISSUER);
-    if (expectedIssuer == null) {
-      expectedIssuer = JWT_DEFAULT_ISSUER;
+    String expectedIssuersParam = filterConfig.getInitParameter(JWT_EXPECTED_ISSUER);
+    if (expectedIssuersParam == null) {
+      expectedIssuersParam = JWT_DEFAULT_ISSUER;
     }
+    expectedIssuers = parseToListOfStrings(expectedIssuersParam);
 
     expectedSigAlg = filterConfig.getInitParameter(JWT_EXPECTED_SIGALG);
     if(StringUtils.isBlank(expectedSigAlg)) {
       expectedSigAlg = JWT_DEFAULT_SIGALG;
     }
+  }
+
+  /**
+   * Helper function to extract a List<String> from a comma separated
+   * String param.
+   * @param commaSeparatedList string to parse into a List<String>
+   */
+  protected List<String> parseToListOfStrings(final String commaSeparatedList) {
+      return Arrays.stream(
+                    commaSeparatedList.split(","))
+            .map(String::trim)
+            .collect(Collectors.toList());
   }
 
   protected List<String> parseExpectedAudiences(String expectedAudiences) {
@@ -240,6 +254,9 @@ public abstract class AbstractJWTFilter implements Filter {
             break;
           }
         }
+      } else if (audiences.contains("NONE")) {
+        log.jwtAudienceValidated();
+        valid = true;
       }
     }
     return valid;
@@ -350,7 +367,7 @@ public abstract class AbstractJWTFilter implements Filter {
     final String displayableTokenId = Tokens.getTokenIDDisplayText(tokenId);
     final String displayableToken = Tokens.getTokenDisplayText(token.toString());
     // confirm that issuer matches the intended target
-    if (expectedIssuer.equals(token.getIssuer())) {
+    if (expectedIssuers.contains(token.getIssuer())) {
       // if there is no expiration data then the lifecycle is tied entirely to
       // the cookie validity - otherwise ensure that the current time is before
       // the designated expiration time

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -231,6 +231,96 @@ public abstract class AbstractJWTFilterTest  {
   }
 
   @Test
+  public void testValidAudienceJWTWithNONEAllowed() throws Exception {
+    try {
+      Properties props = getProperties();
+      props.put(getAudienceProperty(), "bar, NONE");
+      handler.init(new TestFilterConfig(props));
+
+      SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "alice",
+              null, new Date(new Date().getTime() + 5000));
+      HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+      setTokenOnRequest(request, jwt);
+
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+      EasyMock.expect(request.getQueryString()).andReturn(null);
+      HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+      EasyMock.replay(request, response);
+
+      TestFilterChain chain = new TestFilterChain();
+      handler.doFilter(request, response, chain);
+      Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
+      Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
+      Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
+    } catch (ServletException se) {
+      fail("Should NOT have thrown a ServletException.");
+    }
+  }
+
+  @Test
+  public void testValidAudienceJWTWithNONEAllowedButWithBar() throws Exception {
+    try {
+      Properties props = getProperties();
+      props.put(getAudienceProperty(), "bar, NONE");
+      handler.init(new TestFilterConfig(props));
+
+      SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "alice",
+              "bar", new Date(new Date().getTime() + 5000));
+      HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+      setTokenOnRequest(request, jwt);
+
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+      EasyMock.expect(request.getQueryString()).andReturn(null);
+      HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+      EasyMock.replay(request, response);
+
+      TestFilterChain chain = new TestFilterChain();
+      handler.doFilter(request, response, chain);
+      Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
+      Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
+      Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
+    } catch (ServletException se) {
+      fail("Should NOT have thrown a ServletException.");
+    }
+  }
+
+  @Test
+  public void testInvalidAudienceJWTWithNONENotAllowed() throws Exception {
+    try {
+      Properties props = getProperties();
+      props.put(getAudienceProperty(), "bar");
+      handler.init(new TestFilterConfig(props));
+
+      SignedJWT jwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "alice",
+              null, new Date(new Date().getTime() + 5000));
+      HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+      setTokenOnRequest(request, jwt);
+
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+      EasyMock.expect(request.getQueryString()).andReturn(null);
+      HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+      EasyMock.replay(request, response);
+
+      TestFilterChain chain = new TestFilterChain();
+      handler.doFilter(request, response, chain);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled );
+    } catch (ServletException se) {
+      fail("Should NOT have thrown a ServletException.");
+    }
+  }
+
+  @Test
   public void testInvalidAudienceJWT() throws Exception {
     try {
       Properties props = getProperties();
@@ -767,6 +857,65 @@ public abstract class AbstractJWTFilterTest  {
   }
 
   @Test
+  public void testValidIssuerViaConfigWithTwoIssuers() throws Exception {
+    try {
+      Properties props = getProperties();
+      props.setProperty(AbstractJWTFilter.JWT_EXPECTED_ISSUER, "new-issuer, KNOXSSO");
+      handler.init(new TestFilterConfig(props));
+
+      SignedJWT jwt = getJWT("KNOXSSO", "alice", new Date(new Date().getTime() + 5000), privateKey);
+
+      HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+      setTokenOnRequest(request, jwt);
+
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+      EasyMock.expect(request.getQueryString()).andReturn(null);
+      HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+      EasyMock.replay(request, response);
+
+      TestFilterChain chain = new TestFilterChain();
+      handler.doFilter(request, response, chain);
+      Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled);
+      Set<PrimaryPrincipal> principals = chain.subject.getPrincipals(PrimaryPrincipal.class);
+      Assert.assertFalse("No PrimaryPrincipal", principals.isEmpty());
+      Assert.assertEquals("Not the expected principal", "alice", ((Principal)principals.toArray()[0]).getName());
+    } catch (ServletException se) {
+      fail("Should NOT have thrown a ServletException.");
+    }
+  }
+
+  @Test
+  public void testInvalidIssuerViaConfigWithTwoIssuers() throws Exception {
+    try {
+      Properties props = getProperties();
+      props.setProperty(AbstractJWTFilter.JWT_EXPECTED_ISSUER, "new-issuer, KNOXSSO");
+      handler.init(new TestFilterConfig(props));
+
+      SignedJWT jwt = getJWT("fake-issuer", "alice", new Date(new Date().getTime() + 5000), privateKey);
+
+      HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+      setTokenOnRequest(request, jwt);
+
+      EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+      EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+      EasyMock.expect(request.getQueryString()).andReturn(null);
+      HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+      EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
+      EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+      EasyMock.replay(request, response);
+
+      TestFilterChain chain = new TestFilterChain();
+      handler.doFilter(request, response, chain);
+      Assert.assertFalse("doFilterCalled should not be true.", chain.doFilterCalled);
+    } catch (ServletException se) {
+      fail("Should NOT have thrown a ServletException.");
+    }
+  }
+
+  @Test
   public void testRS512SignatureAlgorithm() throws Exception {
     try {
       Properties props = getProperties();
@@ -1101,6 +1250,10 @@ public abstract class AbstractJWTFilterTest  {
 
   protected SignedJWT getJWT(String issuer, String sub, Date expires) throws Exception {
     return getJWT(issuer, sub, expires, privateKey);
+  }
+
+  protected SignedJWT getJWT(String issuer, String sub, String aud, Date expires) throws Exception {
+    return getJWT(issuer, sub, aud, expires, null, privateKey, JWSAlgorithm.RS256.getName());
   }
 
   protected SignedJWT getJWT(String issuer, String sub, Date expires, RSAPrivateKey privateKey)


### PR DESCRIPTION
## What changes were proposed in this pull request?

While we have a change to introduce the ability to use multiple JWKS Urls to verify a token signature, without this change any tokens would need to have the same Issuer. This isn't ideal and limits the flexibility that we are looking for.

This change is only an iteration beyond that approach but still not ideal. We will want to have a better isolation of the expected claims, algorithms, etc - per token. This will suffice for now but we will revisit it in the near future for better isolation.

Here we will simply change the expectedIssuers param to be a List of Strings from a comma separated list and introduce a keyword "NONE" to indicate even though there are expected audiences for some tokens, it is also possible to accept a token with no audience as well. This is an opt-in only feature that requires the admin to configure "NONE" as an acceptable audience claim. This will pass when there are no audiences in the token or even if there is one called "NONE". Again, this will be revisited in the future and done better.

## How was this patch tested?
New unit tests were added and existing tests run along with the new tests.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
