### PR TITLE
KNOX-3053 - Fix DefaultTopologyService - Mock setup moved before meth…

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -646,10 +646,7 @@ public class DefaultTopologyServiceTest {
       EasyMock.replay(config);
 
       TopologyService ts = new DefaultTopologyService();
-      ts.init(config, Collections.emptyMap());
-
       ClusterConfigurationMonitorService ccms = new DefaultClusterConfigurationMonitorService();
-      ccms.init(config, Collections.emptyMap());
 
       // GatewayServices mock
       GatewayServices gws = EasyMock.createNiceMock(GatewayServices.class);
@@ -657,6 +654,9 @@ public class DefaultTopologyServiceTest {
       EasyMock.expect(gws.getService(ServiceType.CLUSTER_CONFIGURATION_MONITOR_SERVICE)).andReturn(ccms).anyTimes();
       EasyMock.replay(gws);
       setGatewayServices(gws);
+
+      ts.init(config, Collections.emptyMap());
+      ccms.init(config, Collections.emptyMap());
 
       // Write out the referenced provider config first
       createFile(sharedProvidersDir,


### PR DESCRIPTION
…od call

## What changes were proposed in this pull request?

Moved the mock setup before the actual method call in testTopologyDiscoveryTriggerHandlesInvalidDescriptorContent(org.apache.knox.gateway.services.topology.DefaultTopologyServiceTest).

## How was this patch tested?

Tests are passing locally.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
