### PR TITLE
KNOX-3058: Avoid 404 When Topology Is Being Redeployed

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -62,11 +62,13 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.NetworkConnector;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -84,6 +86,8 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.servlet.SessionCookieConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.File;
@@ -147,6 +151,8 @@ public class GatewayServer {
   private Map<String, WebAppContext> deployments;
   private AtomicBoolean stopped = new AtomicBoolean(false);
   private GatewayStatusService gatewayStatusService;
+
+  private final Set<String> inactiveTopologies = new HashSet<>();
 
   public static void main( String[] args ) {
     try {
@@ -717,6 +723,22 @@ public class GatewayServer {
     jetty.setAttribute(ContextHandler.MAX_FORM_KEYS_KEY, config.getJettyMaxFormKeys());
     log.setMaxFormKeys(config.getJettyMaxFormKeys());
 
+    // Add a handler for the 404 responses when a topology is being redeployed (i.e., is inactive)
+//    jetty.setErrorHandler(new ErrorHandler() {
+//      @Override
+//      public void doError(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+//        final int gatewayPrefixLength = ("/" + config.getGatewayPath() + "/").length();
+//        String pathInfo = baseRequest.getPathInfo();
+//        String topologyName = pathInfo.substring(gatewayPrefixLength, pathInfo.indexOf('/', gatewayPrefixLength));
+//        if (isInactiveTopology(topologyName) && (response.getStatus() == HttpServletResponse.SC_NOT_FOUND)) {
+//          request.setAttribute("javax.servlet.error.message", "Service Unavailable"); // The default ErrorHandler references this attribute
+//          response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+//        }
+//        super.doError(target, baseRequest, request, response);
+//      }
+//    });
+    jetty.setErrorHandler(new Http404ErrorHandler(this, config.getGatewayPath()));
+
     /* topologyName is null because all topology listen on this port */
     List<Connector> connectors = createConnector( jetty, config, config.getGatewayPort(), null);
     for (Connector connector : connectors) {
@@ -915,13 +937,21 @@ public class GatewayServer {
   }
 
   private synchronized void internalActivateTopology( Topology topology, File topoDir ) {
-    log.activatingTopology( topology.getName() );
+    final String name = topology.getName();
+
+    // Add the topology to the inactive set until it has been activated
+    addInactiveTopology(name);
+
+    log.activatingTopology(name);
     File[] files = topoDir.listFiles( new RegexFilenameFilter( "%.*" ) );
     if( files != null ) {
       for( File file : files ) {
         internalActivateArchive( topology, file );
       }
     }
+
+    // Remove the topology from the inactive set
+    removeInactiveTopology(name);
   }
 
   private synchronized void internalActivateArchive( Topology topology, File warDir ) {
@@ -962,9 +992,31 @@ public class GatewayServer {
     });
   }
 
+  private void addInactiveTopology(final String topologyName) {
+    synchronized (inactiveTopologies) {
+      inactiveTopologies.add(topologyName);
+    }
+  }
+
+  private void removeInactiveTopology(final String topologyName) {
+    synchronized (inactiveTopologies) {
+      inactiveTopologies.remove(topologyName);
+    }
+  }
+
+  private boolean isInactiveTopology(final String topologyName) {
+    boolean result = false;
+    synchronized (inactiveTopologies) {
+      result = inactiveTopologies.contains(topologyName);
+    }
+    return result;
+  }
+
   private synchronized void internalDeactivateTopology( Topology topology ) {
 
     log.deactivatingTopology( topology.getName() );
+
+    addInactiveTopology(topology.getName());
 
     String topoName = topology.getName();
     String topoPath = "/" + Urls.trimLeadingAndTrailingSlashJoin( config.getGatewayPath(), topoName );
@@ -1026,6 +1078,10 @@ public class GatewayServer {
         auditor.audit(Action.UNDEPLOY, topology.getName(), ResourceType.TOPOLOGY,
           ActionOutcome.UNAVAILABLE);
         internalDeactivateTopology( topology );
+
+        // Since it is being deleted, then no longer consider it as only inactive
+        removeInactiveTopology(topology.getName());
+
         for( File file : files ) {
           log.deletingDeployment( file.getAbsolutePath() );
           FileUtils.deleteQuietly( file );
@@ -1164,4 +1220,30 @@ public class GatewayServer {
       return Long.compare(rightTime, leftTime);
     }
   }
+
+  /**
+   * Jetty ErrorHandler extension for handling 404 responses when topologies are inactive.
+   */
+  private static class Http404ErrorHandler extends ErrorHandler {
+    private final GatewayServer gs;
+    private final String gatewayPath;
+
+    Http404ErrorHandler(final GatewayServer gs, final String gatewayPath) {
+      this.gs = gs;
+      this.gatewayPath = gatewayPath;
+    }
+
+    @Override
+    public void doError(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+      final int gatewayPrefixLength = ("/" + gatewayPath + "/").length();
+      String pathInfo = baseRequest.getPathInfo();
+      String topologyName = pathInfo.substring(gatewayPrefixLength, pathInfo.indexOf('/', gatewayPrefixLength));
+      if (gs.isInactiveTopology(topologyName) && (response.getStatus() == HttpServletResponse.SC_NOT_FOUND)) {
+        request.setAttribute("javax.servlet.error.message", "Service Unavailable"); // The default ErrorHandler references this attribute
+        response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+      }
+      super.doError(target, baseRequest, request, response);
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified error handling when a topology is being redeployed, such that the response is not HTTP 404 'Not Found', but rather HTTP 503 'Service Unavailable'. The 503 response is much more likely to be retried by clients than is a 404 response.

Added a Jetty ErrorHandler that checks whether or not the topology being requested is in a Set marked as inactive. Topology names are add to this inactive set when the associated topology is deactivated, and removed from this set when the topology is reactivated. In the case of topology deletion, the topology is marked as inactive, but then removed from the inactive set because we know it's being deleted.

## How was this patch tested?

I deployed a test topology with a demo LDAP provider and the Knox Token service.

I then ran the following script with 'https://localhost:8443/gateway/demo/knoxtoken/api/v2/token' and one of the demo LDAP username/pwd combinations, and piped the output to a file. This script outputs only the HTTP response status code for each invocation.
```
#!/bin/sh
#
#

ENDPOINT=$1
echo "Endpoint: $ENDPOINT"

if [ ! -z "$2" ] ; then
  USER=$2
fi

if [ ! -z "$3" ] ; then
  PWD=$3
fi

for i in {1..100000}
do
  curl -o /dev/null -s -w "%{http_code}\n" -ku ${USER}:${PWD} ${ENDPOINT}
done

```
Example:
`~/bin/resp-test.sh 'https://localhost:8443/gateway/demo/knoxtoken/api/v2/token' sam sam-password > ~/response-code-test.txt &
`
While this script is running, I copied the test topology to the conf/topologies directory, then subsequently "touched" the test topology to trigger redeployment many times over several minutes. Finally, I deleted the test topology.

Following this, I reviewed the output to verify that there were initially 404 responses, followed by some 503 responses while the topology was being activated. Then, I verified that there were no additional 404 responses until that time at which I deleted the topology. I also verified the periodic 503 responses which are expected, and the normal 200 responses in between.

