### PR TITLE
KNOX-3055: Change MySQL connector dependency scope to provided

### DIFF
--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -426,6 +426,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2240,6 +2240,7 @@
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${mysql.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.mariadb.jdbc</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the scope for the MySQL Connector dependency to provided.

## How was this patch tested?

Ran tests locally
