### PR TITLE
KNOX-3059: Upgrade Commons-configuration2 to 2.10.1

### DIFF
--- a/gateway-shell/pom.xml
+++ b/gateway-shell/pom.xml
@@ -103,8 +103,8 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
         </dependency>
         <dependency>
             <groupId>de.thetaphi</groupId>

--- a/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ClientContext.java
+++ b/gateway-shell/src/main/java/org/apache/knox/gateway/shell/ClientContext.java
@@ -17,9 +17,9 @@
  */
 package org.apache.knox.gateway.shell;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.MapConfiguration;
-import org.apache.commons.configuration.SubsetConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.MapConfiguration;
+import org.apache.commons.configuration2.SubsetConfiguration;
 import org.apache.commons.lang3.StringUtils;
 
 import java.security.KeyStore;

--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-compress.version>1.26.0</commons-compress.version>
-        <commons-configuration.version>1.10</commons-configuration.version>
+        <commons-configuration2.version>2.10.1</commons-configuration2.version>
         <commons-digester3.version>3.2</commons-digester3.version>
         <commons-io.version>2.8.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
@@ -1857,9 +1857,9 @@
                 <version>${commons-compress.version}</version>
             </dependency>
             <dependency>
-                <groupId>commons-configuration</groupId>
-                <artifactId>commons-configuration</artifactId>
-                <version>${commons-configuration.version}</version>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>${commons-configuration2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed commons-configuration 1.10 and 2.1 and upgraded them to commons-configuration2 2.10.1

## How was this patch tested?

Ran tests locally
