### PR TITLE
KNOX-3063: Added monitorInterval to log4j2 configuration file

### DIFF
--- a/gateway-release/home/conf/gateway-log4j2.xml
+++ b/gateway-release/home/conf/gateway-log4j2.xml
@@ -15,7 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<Configuration>
+<Configuration monitorInterval="15">
     <Properties>
         <Property name="app.log.dir">${sys:launcher.dir}/../logs</Property>
         <Property name="app.log.file">${sys:launcher.name}.log</Property>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added monitorInterval property to the Configuration tag in the log4j2 configuration file. With this change Knox can change log level at runtime there is no need to restart the service.

## How was this patch tested?

Ran existing tests locally.
Tested the new behaviour locally by changing the knox.gateway log level to TRACE and checking the gateway.log file for DEBUG and TRACE level logs.

