### PR TITLE
KNOX-3064: Set the private gatewayservices field to fix nullpointer e…

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -27,6 +27,7 @@ import static org.apache.knox.gateway.config.GatewayConfig.DEFAULT_IDENTITY_KEY_
 import com.mycila.xmltool.XMLDoc;
 import com.mycila.xmltool.XMLTag;
 import org.apache.commons.io.FileUtils;
+import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
@@ -55,6 +56,7 @@ import javax.websocket.WebSocketContainer;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -189,7 +191,7 @@ public class BadUrlTest {
    * Initialize the configs and components required for this test.
    */
   private static void setupGatewayConfig(final String backend)
-      throws IOException {
+      throws Exception {
     services = new DefaultGatewayServices();
 
     URL serviceUrl = ClassLoader.getSystemResource("websocket-services");
@@ -317,6 +319,8 @@ public class BadUrlTest {
 
     EasyMock.replay(gatewayConfig);
 
+    setGatewayServices(services);
+
     try {
       services.init(gatewayConfig, options);
     } catch (ServiceLifecycleException e) {
@@ -329,6 +333,17 @@ public class BadUrlTest {
     monitor.addTopologyChangeListener(topoListener);
     monitor.reloadTopologies();
 
+  }
+
+  /**
+   * Set the static GatewayServices field to the specified value.
+   *
+   * @param gws A GatewayServices object, or null.
+   */
+  private static void setGatewayServices(final GatewayServices gws) throws Exception {
+    Field gwsField = GatewayServer.class.getDeclaredField("services");
+    gwsField.setAccessible(true);
+    gwsField.set(null, gws);
   }
 
   private static File createDir() throws IOException {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.websockets;
 import com.mycila.xmltool.XMLDoc;
 import com.mycila.xmltool.XMLTag;
 import org.apache.commons.io.FileUtils;
+import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
@@ -41,6 +42,7 @@ import org.eclipse.jetty.websocket.server.WebSocketHandler;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -216,7 +218,7 @@ public class WebsocketEchoTestBase {
    * @param backend topology to use
    * @throws IOException exception on setting up the gateway
    */
-  public static void setupGatewayConfig(final String backend) throws IOException {
+  public static void setupGatewayConfig(final String backend) throws Exception {
     services = new DefaultGatewayServices();
 
     URL serviceUrl = ClassLoader.getSystemResource("websocket-services");
@@ -347,6 +349,8 @@ public class WebsocketEchoTestBase {
 
     EasyMock.replay(gatewayConfig);
 
+    setGatewayServices(services);
+
     try {
       services.init(gatewayConfig, options);
     } catch (ServiceLifecycleException e) {
@@ -358,6 +362,17 @@ public class WebsocketEchoTestBase {
         .getService(ServiceType.TOPOLOGY_SERVICE);
     monitor.addTopologyChangeListener(topoListener);
     monitor.reloadTopologies();
+  }
+
+  /**
+   * Set the static GatewayServices field to the specified value.
+   *
+   * @param gws A GatewayServices object, or null.
+   */
+  private static void setGatewayServices(final GatewayServices gws) throws Exception {
+    Field gwsField = GatewayServer.class.getDeclaredField("services");
+    gwsField.setAccessible(true);
+    gwsField.set(null, gws);
   }
 
   private static File createDir() throws IOException {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
@@ -27,6 +27,7 @@ import static org.apache.knox.gateway.config.GatewayConfig.DEFAULT_IDENTITY_KEY_
 import com.mycila.xmltool.XMLDoc;
 import com.mycila.xmltool.XMLTag;
 import org.apache.commons.io.FileUtils;
+import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
@@ -57,6 +58,7 @@ import javax.websocket.WebSocketContainer;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -249,7 +251,7 @@ public class WebsocketMultipleConnectionTest {
    * @param backend name of topology
    */
   private static void setupGatewayConfig(final String backend)
-      throws IOException {
+      throws Exception {
     services = new DefaultGatewayServices();
 
     URL serviceUrl = ClassLoader.getSystemResource("websocket-services");
@@ -380,6 +382,8 @@ public class WebsocketMultipleConnectionTest {
 
     EasyMock.replay(gatewayConfig);
 
+    setGatewayServices(services);
+
     try {
       services.init(gatewayConfig, options);
     } catch (ServiceLifecycleException e) {
@@ -391,6 +395,17 @@ public class WebsocketMultipleConnectionTest {
         .getService(ServiceType.TOPOLOGY_SERVICE);
     monitor.addTopologyChangeListener(topoListener);
     monitor.reloadTopologies();
+  }
+
+  /**
+   * Set the static GatewayServices field to the specified value.
+   *
+   * @param gws A GatewayServices object, or null.
+   */
+  private static void setGatewayServices(final GatewayServices gws) throws Exception {
+    Field gwsField = GatewayServer.class.getDeclaredField("services");
+    gwsField.setAccessible(true);
+    gwsField.set(null, gws);
   }
 
   private static File createDir() throws IOException {


### PR DESCRIPTION
…xceptions

## What changes were proposed in this pull request?

The below tests are failing with NullPointerException during the build

BadUrlTest.setUpBeforeClass:122->startGatewayServer:180->setupGatewayConfig:321 » NullPointer

WebsocketBackendUrlTest.setUpBeforeClass:59->WebsocketEchoTestBase.setupGatewayConfig:351 » NullPointer

WebsocketEchoHTTPServiceRoleTest.setUpBeforeClass:64->WebsocketEchoTestBase.startServers:116->WebsocketEchoTestBase.startServers:121->WebsocketEchoTestBase.startGatewayServer:206->WebsocketEchoTestBase.setupGatewayConfig:351 » NullPointer

WebsocketEchoTest.setUpBeforeClass:63->WebsocketEchoTestBase.startServers:116->WebsocketEchoTestBase.startServers:121->WebsocketEchoTestBase.startGatewayServer:206->WebsocketEchoTestBase.setupGatewayConfig:351 » NullPointer

WebsocketMultipleConnectionTest.startServers:131->startGatewayServer:239->setupGatewayConfig:384 » NullPointer

WebsocketServerInitiatedMessageTest.setUpBeforeClass:73->WebsocketEchoTestBase.startServers:116->WebsocketEchoTestBase.startServers:121->WebsocketEchoTestBase.startGatewayServer:206->WebsocketEchoTestBase.setupGatewayConfig:351 » NullPointer

WebsocketServerInitiatedPingTest.setUpBeforeClass:75->WebsocketEchoTestBase.startServers:116->WebsocketEchoTestBase.startServers:121->WebsocketEchoTestBase.startGatewayServer:206->WebsocketEchoTestBase.setupGatewayConfig:351 » NullPointer

The changes address these NullPointerExceptions thrown.

## How was this patch tested?

Ran tests locally
Github build also successfully completed with these changes in my repository
