### PR TITLE
KNOX-3067: Upgrade ehcache to 3.3.1

### DIFF
--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -73,12 +73,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.shiro</groupId>
-            <artifactId>shiro-ehcache</artifactId>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache-core</artifactId>
+            <groupId>org.ehcache.integrations.shiro</groupId>
+            <artifactId>shiro-ehcache3</artifactId>
         </dependency>
 
         <dependency>

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
@@ -20,12 +20,28 @@ package org.apache.knox.gateway;
 import org.apache.knox.gateway.i18n.messages.Message;
 import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
+import org.apache.knox.gateway.i18n.messages.StackTrace;
 
 @Messages(logger="org.apache.knox.gateway")
 public interface ShiroMessages {
-  @Message(level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path configured in topology, letting it through" )
+  @Message( level = MessageLevel.INFO, text = "Request {0} matches unauthenticated path configured in topology, letting it through" )
   void unauthenticatedPathBypass(String uri);
 
   @Message( level = MessageLevel.WARN, text = "Invalid URL pattern for rule: {0}" )
   void invalidURLPattern(String rule);
+
+  @Message( level = MessageLevel.TRACE, text = "Acquiring EhcacheShiro instance named {0}" )
+  void acquireEhcacheShiro(String name);
+
+  @Message( level = MessageLevel.INFO, text = "Cache with name {0} does not yet exist.  Creating now." )
+  void noCacheFound(String name);
+
+  @Message( level = MessageLevel.INFO, text = "Added EhcacheShiro named {0}" )
+  void ehcacheShiroAdded(String name);
+
+  @Message( level = MessageLevel.INFO, text = "Using existing EhcacheShiro named {0}" )
+  void usingExistingEhcacheShiro(String name);
+
+  @Message( level = MessageLevel.WARN, text = "The Shiro managed CacheManager threw an Exception while closing: {0}" )
+  void errorClosingManagedCacheManager(@StackTrace(level=MessageLevel.WARN) Exception e);
 }

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ShiroMessages.java
@@ -33,7 +33,7 @@ public interface ShiroMessages {
   @Message( level = MessageLevel.TRACE, text = "Acquiring EhcacheShiro instance named {0}" )
   void acquireEhcacheShiro(String name);
 
-  @Message( level = MessageLevel.INFO, text = "Cache with name {0} does not yet exist.  Creating now." )
+  @Message( level = MessageLevel.INFO, text = "Cache with name {0} does not exist yet.  Creating now." )
   void noCacheFound(String name);
 
   @Message( level = MessageLevel.INFO, text = "Added EhcacheShiro named {0}" )
@@ -42,6 +42,6 @@ public interface ShiroMessages {
   @Message( level = MessageLevel.INFO, text = "Using existing EhcacheShiro named {0}" )
   void usingExistingEhcacheShiro(String name);
 
-  @Message( level = MessageLevel.WARN, text = "The Shiro managed CacheManager threw an Exception while closing: {0}" )
+  @Message( level = MessageLevel.WARN, text = "There was an error closing the CacheManager, reason: {0}" )
   void errorClosingManagedCacheManager(@StackTrace(level=MessageLevel.WARN) Exception e);
 }

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxCacheManager.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxCacheManager.java
@@ -17,11 +17,136 @@
  */
 package org.apache.knox.gateway.shirorealm;
 
-import org.apache.shiro.cache.ehcache.EhCacheManager;
+import org.apache.knox.gateway.ShiroMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.cache.Cache;
+import org.apache.shiro.cache.CacheException;
+import org.apache.shiro.io.ResourceUtils;
+import org.apache.shiro.util.Destroyable;
+import org.apache.shiro.util.Initializable;
+import org.ehcache.CacheManager;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.CacheManagerBuilder;
+import org.ehcache.integrations.shiro.EhcacheShiro;
+import org.ehcache.xml.XmlConfiguration;
 
-public class KnoxCacheManager extends EhCacheManager {
+import java.net.MalformedURLException;
+import java.net.URL;
 
-  public KnoxCacheManager() {
-    setCacheManager(net.sf.ehcache.CacheManager.create());
+public class KnoxCacheManager implements org.apache.shiro.cache.CacheManager, Initializable, Destroyable {
+  private static final ShiroMessages LOG = MessagesFactory.get(ShiroMessages.class);
+
+  private org.ehcache.CacheManager manager;
+  private String cacheManagerConfigFile = "classpath:org/ehcache/integrations/shiro/ehcache.xml";
+  private boolean cacheManagerImplicitlyCreated;
+  private XmlConfiguration cacheConfiguration;
+
+  public CacheManager getCacheManager() {
+    return manager;
+  }
+
+  public void setCacheManager(CacheManager cacheManager) {
+    try {
+      destroy();
+    } catch (Exception e) {
+      LOG.errorClosingManagedCacheManager(e);
+    }
+    manager = cacheManager;
+    cacheManagerImplicitlyCreated = false;
+  }
+
+  public String getCacheManagerConfigFile() {
+    return cacheManagerConfigFile;
+  }
+
+  public void setCacheManagerConfigFile(String cacheManagerConfigFile) {
+    this.cacheManagerConfigFile = cacheManagerConfigFile;
+  }
+
+  @Override
+  public <K, V> Cache<K, V> getCache(String name) throws CacheException {
+    LOG.acquireEhcacheShiro(name);
+    try {
+      org.ehcache.Cache<Object, Object> cache = ensureCacheManager().getCache(name, Object.class, Object.class);
+
+      if (cache == null) {
+        LOG.noCacheFound(name);
+        cache = createCache(name);
+        LOG.ehcacheShiroAdded(name);
+      } else {
+        LOG.usingExistingEhcacheShiro(name);
+      }
+      return new EhcacheShiro<>(cache);
+    } catch (MalformedURLException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new CacheException(e);
+    }
+  }
+
+  private synchronized org.ehcache.Cache<Object, Object> createCache(String name)
+          throws MalformedURLException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+    org.ehcache.Cache<Object, Object> cache = ensureCacheManager().getCache(name, Object.class, Object.class);
+    if (cache == null) {
+      XmlConfiguration xmlConfiguration = getConfiguration();
+      CacheConfigurationBuilder<Object, Object> configurationBuilder = xmlConfiguration.newCacheConfigurationBuilderFromTemplate(
+              "defaultCacheConfiguration", Object.class, Object.class);
+      CacheConfiguration<Object, Object> cacheConfiguration = configurationBuilder.build();
+      cache = ensureCacheManager().createCache(name, cacheConfiguration);
+    }
+    return cache;
+  }
+
+  private org.ehcache.CacheManager ensureCacheManager() throws MalformedURLException {
+    if (manager == null) {
+      manager = CacheManagerBuilder.newCacheManager(getConfiguration());
+      manager.init();
+
+      cacheManagerImplicitlyCreated = true;
+    }
+
+    return manager;
+  }
+
+  private URL getResource() {
+    String URL = ResourceUtils.hasResourcePrefix(this.cacheManagerConfigFile) ?
+            stripPrefix(this.cacheManagerConfigFile) : this.cacheManagerConfigFile;
+
+    ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    if (loader == null) {
+      loader = this.getClass().getClassLoader();
+    }
+
+    return loader.getResource(URL);
+  }
+
+
+  private static String stripPrefix(String resourcePath) {
+    return resourcePath.substring(resourcePath.indexOf(':') + 1);
+  }
+
+  private XmlConfiguration getConfiguration() throws MalformedURLException {
+    if (cacheConfiguration == null) {
+      cacheConfiguration = new XmlConfiguration(getResource());
+    }
+
+    return cacheConfiguration;
+  }
+
+  @Override
+  public void destroy() {
+    if (cacheManagerImplicitlyCreated && manager != null) {
+      manager.close();
+      manager = null;
+    }
+  }
+
+  @Override
+  public void init() throws ShiroException {
+    try {
+      ensureCacheManager();
+    } catch (MalformedURLException e) {
+      throw new ShiroException(e);
+    }
   }
 }

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxCacheManagerTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxCacheManagerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shirorealm;
+
+import org.apache.shiro.cache.Cache;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KnoxCacheManagerTest {
+
+    @Test
+    public void testConfigFileManipulation() {
+        KnoxCacheManager cacheManager = new KnoxCacheManager();
+        cacheManager.setCacheManagerConfigFile("config.xml");
+
+        assertEquals("config.xml", cacheManager.getCacheManagerConfigFile());
+    }
+
+    @Test
+    public void testGetCache() throws Exception {
+        KnoxCacheManager cacheManager = new KnoxCacheManager();
+        Cache<Object, Object> cache = cacheManager.getCache("cache");
+
+        cache.put("testK", "testV");
+        assertEquals("testV", cache.get("testK"));
+
+        cacheManager.destroy();
+        assertNull(cacheManager.getCacheManager());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <dom4j.version>2.1.3</dom4j.version>
         <easymock.version>4.3</easymock.version>
         <eclipselink.version>2.7.8</eclipselink.version>
-        <ehcache.version>2.6.11</ehcache.version>
+        <ehcache.version>3.3.1</ehcache.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <fastinfoset.version>1.2.18</fastinfoset.version>
         <findsecbugs-plugin.version>1.11.0</findsecbugs-plugin.version>
@@ -267,6 +267,7 @@
         <pty4j.version>0.11.4</pty4j.version>
         <rest-assured.version>4.3.3</rest-assured.version>
         <shiro.version>1.10.0</shiro.version>
+        <shiro-ehcache3.version>1.0.0</shiro-ehcache3.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
         <slf4j.version>1.7.30</slf4j.version>
@@ -2042,19 +2043,30 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.shiro</groupId>
-                <artifactId>shiro-ehcache</artifactId>
-                <version>${shiro.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-web</artifactId>
                 <version>${shiro.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>net.sf.ehcache</groupId>
-                <artifactId>ehcache-core</artifactId>
+                <groupId>org.ehcache</groupId>
+                <artifactId>ehcache</artifactId>
                 <version>${ehcache.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.ehcache.integrations.shiro</groupId>
+                <artifactId>shiro-ehcache3</artifactId>
+                <version>${shiro-ehcache3.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.ehcache</groupId>
+                        <artifactId>ehcache</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.shiro</groupId>
+                        <artifactId>shiro-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade ehcache from 2.x to 3.x

Currently with 2.x the CacheManager is a Singleton therefore every cache will be stored in the same CacheManager. Due to this caches with the same name will be created only once and different topologies are using the same cache. For example if a user authenticates in the sandbox topology the same user and password can be used for other topologies as well where ehcache is enabled and the cache name is the same. This could cause issues if the ldap configuration is different. 

With Ehcache 3.x creating the CacheManager is our responsibility. Different topologies will have different configurations and caches even with the same name. Every topology that enables ehcache needs a different configuration file. The persistence attribute has to be unique.

<persistence directory="${java.io.tmpdir}/TOPOLOGY_NAME"/>

## How was this patch tested?

Unit tests and manually on local setup
