### PR TITLE
KNOX-3069 - Fix Flakey Test - TokenServiceResourceTest

### DIFF
--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1136,8 +1136,13 @@ public class TokenServiceResourceTest {
       tss.addMetadata(tokenId, tokenMetadata);
     }
 
+    ArrayList<String> tokenIDs = new ArrayList<>();
     for (int i = 0; i < numberOfTokens; i++) {
-      acquireToken(tr);
+      final Response tokenResponse = acquireToken(tr);
+      final String tokenId = getTagValue(tokenResponse.getEntity().toString(), "token_id");
+      assertNotNull("TokenID should not be null", tokenId);
+      assertFalse("TokenID must be unique", tokenIDs.contains(tokenId));
+      tokenIDs.add(tokenId);
     }
     final Response getKnoxTokensResponse = getUserTokensResponse(tr);
     final Collection<String> tokens = ((Map<String, Collection<String>>) JsonUtils.getObjectFromJsonString(getKnoxTokensResponse.getEntity().toString()))


### PR DESCRIPTION
## What changes were proposed in this pull request?

TokenServiceResourceTest - testLimitingTokensPerUser method acquires many tokens within a tight for loop and does not insure that the tokenIds are unique.

This results in test failures for the unlimited tokens per user on certain machines.

This may also point to a larger concurrency problem which needs investigation. Will file a separate JIRA for this. This may be an issue with the test or the UUID use for the tokenID in general. In the meantime, we can't have builds failing on certain machines.

This change interrogates the response and adds an assertion to ensure that the tokenId is unique. It seems the time spent in doing the check "fixes" the failures. The same "fix" was accomplished with a sleep of 1ms between token acquisitions.

## How was this patch tested?

Prior to this fix the following test failure was encountered for every run on my local machine:

[ERROR] Tests run: 60, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.113 s <<< FAILURE! - in org.apache.knox.gateway.service.knoxtoken.TokenServiceResourceTest
[ERROR] testUnlimitedTokensPerUser(org.apache.knox.gateway.service.knoxtoken.TokenServiceResourceTest)  Time elapsed: 0.118 s  <<< FAILURE!
java.lang.AssertionError: expected:<94> but was:<105>
	at org.apache.knox.gateway.service.knoxtoken.TokenServiceResourceTest.testLimitingTokensPerUser(TokenServiceResourceTest.java:1145)
	at org.apache.knox.gateway.service.knoxtoken.TokenServiceResourceTest.testLimitingTokensPerUser(TokenServiceResourceTest.java:1110)
	at org.apache.knox.gateway.service.knoxtoken.TokenServiceResourceTest.testUnlimitedTokensPerUser(TokenServiceResourceTest.java:1046)

This change looks for the root cause of the failure but also introduces a time lag between token acquisitions such that the tokenIDs are indeed unique.

