### PR TITLE
Knox 3069

### DIFF
--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1136,8 +1136,13 @@ public class TokenServiceResourceTest {
       tss.addMetadata(tokenId, tokenMetadata);
     }
 
+    ArrayList<String> tokenIDs = new ArrayList<>();
     for (int i = 0; i < numberOfTokens; i++) {
-      acquireToken(tr);
+      final Response tokenResponse = acquireToken(tr);
+      final String tokenId = getTagValue(tokenResponse.getEntity().toString(), "token_id");
+      assertNotNull("TokenID should not be null", tokenId);
+      assertFalse("TokenID must be unique", tokenIDs.contains(tokenId));
+      tokenIDs.add(tokenId);
     }
     final Response getKnoxTokensResponse = getUserTokensResponse(tr);
     final Collection<String> tokens = ((Map<String, Collection<String>>) JsonUtils.getObjectFromJsonString(getKnoxTokensResponse.getEntity().toString()))

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1143,6 +1143,7 @@ public class TokenServiceResourceTest {
       assertNotNull("TokenID should not be null", tokenId);
       assertFalse("TokenID must be unique", tokenIDs.contains(tokenId));
       tokenIDs.add(tokenId);
+      Thread.sleep(5);
     }
     final Response getKnoxTokensResponse = getUserTokensResponse(tr);
     final Collection<String> tokens = ((Map<String, Collection<String>>) JsonUtils.getObjectFromJsonString(getKnoxTokensResponse.getEntity().toString()))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a sleep to the test to ensure uniqueness

## How was this patch tested?

Local jenkins job to build and test continued to fail after previous checks were added.
Testing with mutliple runs reproduced it locally.
Cannot reproduce with a sleep of 5 ms between tokens.

