### PR TITLE
KNOX-3071: New ability in list-alias to list for multiple clusters. N…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -136,8 +136,7 @@ public class KnoxCLI extends Configured implements Tool {
       "   [" + TopologyConverter.USAGE + "]\n" +
       "   [" + JWKGenerator.USAGE  + "]\n" +
       "   [" + GenerateDescriptorCommand.USAGE + "]\n" +
-      "   [" + TokenMigration.USAGE  + "]\n" +
-      "   [" + CreateListAliasesCommand.USAGE + "]\n";
+      "   [" + TokenMigration.USAGE  + "]\n";
   private static final String CLUSTER_STRING_SEPARATOR = ",";
 
   /** allows stdout to be captured if necessary */
@@ -164,6 +163,7 @@ public class KnoxCLI extends Configured implements Tool {
   private boolean migrateExpiredTokens;
   private boolean verbose;
   private String alias;
+  private boolean listAliases;
 
   private String remoteRegistryClient;
   private String remoteRegistryEntryName;
@@ -277,12 +277,6 @@ public class KnoxCLI extends Configured implements Tool {
           printKnoxShellUsage();
           return -1;
         }
-      } else if (args[i].equals("create-list-aliases")) {
-        command = new CreateListAliasesCommand();
-        if (args.length < 3 || "--help".equals(alias)) {
-          printKnoxShellUsage();
-          return -1;
-        }
       } else if (args[i].equals("create-cert")) {
         command = new CertCreateCommand();
         if ((args.length > i + 1) && args[i + 1].equals("--help")) {
@@ -351,8 +345,8 @@ public class KnoxCLI extends Configured implements Tool {
           return -1;
         }
         this.cluster = args[++i];
-        if(command instanceof CreateListAliasesCommand) {
-          ((CreateListAliasesCommand) command).toMap(this.cluster);
+        if(command instanceof BatchAliasCreateCommand) {
+          ((BatchAliasCreateCommand) command).toMap(this.cluster);
         }
       } else if (args[i].equals("service-test")) {
         if( i + 1 >= args.length) {
@@ -462,6 +456,8 @@ public class KnoxCLI extends Configured implements Tool {
         this.master = args[++i];
       } else if (args[i].equals("--force")) {
         this.force = true;
+      } else if (args[i].equals("--list")) {
+        this.listAliases = true;
       } else if (args[i].equals("--help")) {
         printKnoxShellUsage();
         return -1;
@@ -675,9 +671,6 @@ public class KnoxCLI extends Configured implements Tool {
       out.println();
       out.println( div );
       out.println(BatchAliasCreateCommand.USAGE + "\n\n" + BatchAliasCreateCommand.DESC);
-      out.println();
-      out.println( div );
-      out.println(CreateListAliasesCommand.USAGE + "\n\n" + CreateListAliasesCommand.DESC);
       out.println();
       out.println( div );
     }
@@ -1048,17 +1041,22 @@ public class KnoxCLI extends Configured implements Tool {
             "--alias alias1 [--value value1] " +
             "--alias alias2 [--value value2] " +
             "--alias aliasN [--value valueN] ... " +
-            "[--cluster clustername] " +
-            "[--generate]";
+            "--cluster cluster1 " +
+            "--alias aliasN [--value valueN] ..." +
+            "--cluster clusterN " +
+            "[--generate] " +
+            "[--list]";
     public static final String DESC = "The create-aliases command will create multiple aliases\n"
             + "and secret pairs within the same credential store for the\n"
-            + "indicated --cluster otherwise within the gateway\n"
+            + "indicated --cluster(s) otherwise within the gateway\n"
             + "credential store. The actual secret may be specified via\n"
             + "the --value option or --generate (will create a random secret\n"
-            + "for you) or user will be prompt to provide password.";
+            + "for you) or user will be prompt to provide password.\n"
+            + "Optionally the aliases for the clusters can be listed with --list.";
 
-    protected List<String> names = new ArrayList<>();
-    protected List<String> values = new ArrayList<>();
+    private final List<String> names = new ArrayList<>();
+    private final List<String> values = new ArrayList<>();
+    private final Map<String, Map<String, String>> aliasMap = new LinkedHashMap<>();
 
     public void addName(String alias) {
       if (names.contains(alias)) {
@@ -1075,18 +1073,25 @@ public class KnoxCLI extends Configured implements Tool {
 
     @Override
     public void execute() throws Exception {
-      Map<String, String> aliases = toMap();
-      List<String> generated = new ArrayList<>();
-      AliasService as = getAliasService();
-      if (cluster == null) {
+      if (cluster == null || !names.isEmpty()) {
         cluster = "__gateway";
+        this.toMap(cluster);
       }
-      fillMissingValues(aliases, generated);
-      as.addAliasesForCluster(cluster, aliases);
-      printResults(generated, aliases);
+
+      AliasService aliasService = getAliasService();
+
+      for (Map.Entry<String, Map<String, String>> aliasesMapEntry : aliasMap.entrySet()) {
+        List<String> generated = new ArrayList<>();
+        fillMissingValues(aliasesMapEntry.getValue(), generated);
+        aliasService.addAliasesForCluster(aliasesMapEntry.getKey(), aliasesMapEntry.getValue());
+        printResults(generated, aliasesMapEntry.getValue());
+        if(listAliases) {
+          listAliasesForCluster(aliasesMapEntry.getKey(), aliasService);
+        }
+      }
     }
 
-    protected void printResults(List<String> generated, Map<String, String> aliases) {
+    private void printResults(List<String> generated, Map<String, String> aliases) {
       if (!generated.isEmpty()) {
         out.println(generated.size() + " alias(es) have been successfully generated: " + generated);
       }
@@ -1097,7 +1102,7 @@ public class KnoxCLI extends Configured implements Tool {
       }
     }
 
-    protected void fillMissingValues(Map<String, String> aliases, List<String> generated) {
+    private void fillMissingValues(Map<String, String> aliases, List<String> generated) {
       for (Map.Entry<String, String> entry : aliases.entrySet()) {
         if (entry.getValue() == null) {
           if (Boolean.parseBoolean(generate)) {
@@ -1110,59 +1115,9 @@ public class KnoxCLI extends Configured implements Tool {
       }
     }
 
-    private Map<String, String> toMap() {
-      Map<String,String> aliases = new LinkedHashMap<>();
-      for (int i = 0; i < names.size(); i++) {
-        aliases.put(names.get(i), values.get(i));
-      }
-      return aliases;
-    }
-
-    @Override
-    public String getUsage() {
-      return USAGE + ":\n\n" + DESC;
-    }
-  }
-
-  public class CreateListAliasesCommand extends BatchAliasCreateCommand {
-    public static final String USAGE = "create-list-aliases " +
-            "--alias alias1 [--value value1] " +
-            "--alias alias2 [--value value2] " +
-            "--alias aliasN [--value valueN] ... " +
-            "--cluster cluster1 " +
-            "--alias aliasN [--value valueN] ..." +
-            "--cluster clusterN " +
-            "[--generate]";
-    public static final String DESC = "The create-list-aliases command will create multiple aliases\n"
-            + "and secret pairs within the same credential store for the\n"
-            + "indicated --cluster(s) otherwise within the gateway\n"
-            + "credential store. The actual secret may be specified via\n"
-            + "the --value option or --generate (will create a random secret\n"
-            + "for you) or user will be prompt to provide password.";
-
-    private final Map<String, Map<String, String>> aliasMap = new LinkedHashMap<>();
-
-    @Override
-    public void execute() throws Exception {
-      if (cluster == null || !names.isEmpty()) {
-        cluster = "__gateway";
-        this.toMap(cluster);
-      }
-
-      AliasService aliasService = getAliasService();
-
-      for (Map.Entry<String, Map<String, String>> aliasesMapEntry : aliasMap.entrySet()) {
-        List<String> generated = new ArrayList<>();
-        this.fillMissingValues(aliasesMapEntry.getValue(), generated);
-        aliasService.addAliasesForCluster(aliasesMapEntry.getKey(), aliasesMapEntry.getValue());
-        this.printResults(generated, aliasesMapEntry.getValue());
-        this.listAliasesForCluster(aliasesMapEntry.getKey(), aliasService);
-      }
-    }
-
-    private void listAliasesForCluster(String cluster, AliasService as) throws AliasServiceException {
+    private void listAliasesForCluster(String cluster, AliasService aliasService) throws AliasServiceException {
       out.println("Listing aliases for: " + cluster);
-      List<String> aliases = as.getAliasesForCluster(cluster);
+      List<String> aliases = aliasService.getAliasesForCluster(cluster);
       for (String alias : aliases) {
         out.println(alias);
       }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -1379,9 +1379,9 @@ public class KnoxCLITest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     outContent.reset();
-    String[] args1 = {"create-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
+    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
             "--alias", "alias2", "--value", "value2", "--alias", "alias1", "--value", "value1", "--cluster", "cluster2",
-            "--master", "master", "--list"};
+            "--master", "master"};
     int rc;
     KnoxCLI cli = new KnoxCLI();
     cli.setConf(config);
@@ -1407,9 +1407,9 @@ public class KnoxCLITest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     outContent.reset();
-    String[] args1 = {"create-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
+    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
             "alias2", "--value", "value2", "--alias", "alias3", "--cluster", "cluster2",
-            "--master", "master", "--generate", "--list"};
+            "--master", "master", "--generate"};
     int rc;
     KnoxCLI cli = new KnoxCLI();
     cli.setConf(config);
@@ -1437,9 +1437,9 @@ public class KnoxCLITest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     outContent.reset();
-    String[] args1 = {"create-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
+    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
             "alias2", "--value", "value2", "--alias", "alias3",
-            "--master", "master", "--generate", "--list"};
+            "--master", "master", "--generate"};
     int rc;
     KnoxCLI cli = new KnoxCLI();
     cli.setConf(config);
@@ -1460,30 +1460,6 @@ public class KnoxCLITest {
             outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: __gateway"));
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
             outContent.toString(StandardCharsets.UTF_8.name()).contains("alias3"));
-  }
-
-  @Test
-  public void testCreateAndListForMultipleClustersNoListing() throws Exception {
-    GatewayConfigImpl config = new GatewayConfigImpl();
-
-    outContent.reset();
-    String[] args1 = {"create-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
-            "--alias", "alias2", "--value", "value2", "--alias", "alias1", "--value", "value1", "--cluster", "cluster2",
-            "--master", "master"};
-    int rc;
-    KnoxCLI cli = new KnoxCLI();
-    cli.setConf(config);
-    rc = cli.run(args1);
-    assertEquals(0, rc);
-    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
-            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully created: [alias1]"));
-    assertFalse(outContent.toString(StandardCharsets.UTF_8.name()),
-            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster1"));
-
-    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
-            outContent.toString(StandardCharsets.UTF_8.name()).contains("2 alias(es) have been successfully created: [alias2, alias1]"));
-    assertFalse(outContent.toString(StandardCharsets.UTF_8.name()),
-            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster2"));
   }
 
   private void testGeneratingJWK(JWSAlgorithm jwkAlgorithm) throws Exception {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -1379,9 +1379,9 @@ public class KnoxCLITest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     outContent.reset();
-    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
+    String[] args1 = {"create-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
             "--alias", "alias2", "--value", "value2", "--alias", "alias1", "--value", "value1", "--cluster", "cluster2",
-            "--master", "master"};
+            "--master", "master", "--list"};
     int rc;
     KnoxCLI cli = new KnoxCLI();
     cli.setConf(config);
@@ -1407,9 +1407,9 @@ public class KnoxCLITest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     outContent.reset();
-    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
+    String[] args1 = {"create-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
             "alias2", "--value", "value2", "--alias", "alias3", "--cluster", "cluster2",
-            "--master", "master", "--generate"};
+            "--master", "master", "--generate", "--list"};
     int rc;
     KnoxCLI cli = new KnoxCLI();
     cli.setConf(config);
@@ -1437,9 +1437,9 @@ public class KnoxCLITest {
     GatewayConfigImpl config = new GatewayConfigImpl();
 
     outContent.reset();
-    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
+    String[] args1 = {"create-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
             "alias2", "--value", "value2", "--alias", "alias3",
-            "--master", "master", "--generate"};
+            "--master", "master", "--generate", "--list"};
     int rc;
     KnoxCLI cli = new KnoxCLI();
     cli.setConf(config);
@@ -1460,6 +1460,30 @@ public class KnoxCLITest {
             outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: __gateway"));
     assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
             outContent.toString(StandardCharsets.UTF_8.name()).contains("alias3"));
+  }
+
+  @Test
+  public void testCreateAndListForMultipleClustersNoListing() throws Exception {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    outContent.reset();
+    String[] args1 = {"create-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
+            "--alias", "alias2", "--value", "value2", "--alias", "alias1", "--value", "value1", "--cluster", "cluster2",
+            "--master", "master"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(config);
+    rc = cli.run(args1);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully created: [alias1]"));
+    assertFalse(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster1"));
+
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("2 alias(es) have been successfully created: [alias2, alias1]"));
+    assertFalse(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster2"));
   }
 
   private void testGeneratingJWK(JWSAlgorithm jwkAlgorithm) throws Exception {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/util/KnoxCLITest.java
@@ -1309,6 +1309,159 @@ public class KnoxCLITest {
     testGeneratingJWK(JWSAlgorithm.HS512);
   }
 
+  @Test
+  public void testListingAliasesForMultipleClusters() throws Exception {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    outContent.reset();
+    String[] args1 = {"create-alias", "multiplealias", "--value", "multiplealias", "--cluster", "cluster1", "--master", "master"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(config);
+    rc = cli.run(args1);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias has been successfully " +
+                    "created."));
+
+    outContent.reset();
+    String[] args2 = {"create-alias", "multiplealias2", "--value", "multiplealias2", "--cluster", "test",
+            "--master", "master"};
+    cli = new KnoxCLI();
+    cli.setConf( config );
+    rc = cli.run(args2);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias2 has been successfully " +
+            "created."));
+
+    outContent.reset();
+    String[] args3 = { "list-alias", "--cluster", "cluster1,test", "--master", "master" };
+    rc = cli.run(args3);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias2"));
+
+    outContent.reset();
+    String[] args4 = { "list-alias", "--cluster", "cluster1,test,invalidcluster", "--master", "master" };
+    rc = cli.run(args4);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias2"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Invalid cluster name provided: invalidcluster"));
+
+    outContent.reset();
+    String[] args5 = {"delete-alias", "multiplealias", "--cluster", "cluster1", "--master", "master"};
+    rc = cli.run(args5);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias has been successfully " +
+            "deleted."));
+
+    outContent.reset();
+    String[] args6 = {"delete-alias", "multiplealias2", "--cluster", "test", "--master", "master"};
+    rc = cli.run(args6);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias2 has been successfully " +
+            "deleted."));
+
+    outContent.reset();
+    rc = cli.run(args3);
+    assertEquals(0, rc);
+    assertFalse(outContent.toString(StandardCharsets.UTF_8.name()), outContent.toString(StandardCharsets.UTF_8.name()).contains("multiplealias2"));
+  }
+
+  @Test
+  public void testCreateAndListForMultipleClusters() throws Exception {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    outContent.reset();
+    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--value", "value1", "--cluster", "cluster1",
+            "--alias", "alias2", "--value", "value2", "--alias", "alias1", "--value", "value1", "--cluster", "cluster2",
+            "--master", "master"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(config);
+    rc = cli.run(args1);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully created: [alias1]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster1"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("alias1"));
+
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("2 alias(es) have been successfully created: [alias2, alias1]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster2"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("alias2"));
+  }
+
+  @Test
+  public void testCreateAndListForMultipleClustersWithGenerate() throws Exception {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    outContent.reset();
+    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
+            "alias2", "--value", "value2", "--alias", "alias3", "--cluster", "cluster2",
+            "--master", "master", "--generate"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(config);
+    rc = cli.run(args1);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully generated: [alias1]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster1"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("alias1"));
+
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully created: [alias2]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully generated: [alias3]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster2"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("alias3"));
+  }
+
+  @Test
+  public void testCreateAndListForMultipleClustersNoCLuster() throws Exception {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+
+    outContent.reset();
+    String[] args1 = {"create-list-aliases", "--alias", "alias1", "--cluster", "cluster1", "--alias",
+            "alias2", "--value", "value2", "--alias", "alias3",
+            "--master", "master", "--generate"};
+    int rc;
+    KnoxCLI cli = new KnoxCLI();
+    cli.setConf(config);
+    rc = cli.run(args1);
+    assertEquals(0, rc);
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully generated: [alias1]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: cluster1"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("alias1"));
+
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully created: [alias2]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("1 alias(es) have been successfully generated: [alias3]"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("Listing aliases for: __gateway"));
+    assertTrue(outContent.toString(StandardCharsets.UTF_8.name()),
+            outContent.toString(StandardCharsets.UTF_8.name()).contains("alias3"));
+  }
+
   private void testGeneratingJWK(JWSAlgorithm jwkAlgorithm) throws Exception {
     testGeneratingJWK(jwkAlgorithm, null);
   }


### PR DESCRIPTION
…ew create-list-alias command to create multiple aliases for multiple clusters and also list them.

## What changes were proposed in this pull request?

This PR proposes a few changes to the KnoxCLI list-alias and the create-aliases commands. Usage was missing for BatchAliasCreateCommand in printKnoxShellUsage so I added that as well.

With this change the list-alias command will be able to list for multiple clusters. The cluster names have to be concatenated by ','. It is backward compatible with the current usage so it is able to list for a single cluster as well.
Usage: list-alias --cluster1,cluster2,clusterN

New create-list-aliases command that creates aliases on multiple clusters and list them at the end.

create-list-aliases --alias alias1 --value value1 --cluster cluster1 --alias alias2 --value value2 --cluster2 --alias aliasN --value valueN --cluster clusterN

When there is a --cluster args every alias before it will be added to that cluster.

## How was this patch tested?

I wrote new unit tests to cover the new functionalities and tested manually on my local computer.

