### PR TITLE
KNOX-3072: Fix for GatewayBasicFuncTest.testEncodedForwardSlash fail

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/deploy/impl/ShiroConfig.java
@@ -37,6 +37,7 @@ public class ShiroConfig {
     params.putIfAbsent("main.invalidRequest.blockSemicolon", "false");
     params.putIfAbsent("main.invalidRequest.blockBackslash", "false");
     params.putIfAbsent("main.invalidRequest.blockNonAscii", "false");
+    params.putIfAbsent("main.invalidRequest.blockEncodedForwardSlash", "false");
 
     for(Entry<String, String> entry : params.entrySet()) {
       int sectionDot = entry.getKey().indexOf('.');


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shiro was upgraded from 1.10.0 to 1.13.0 in a previous [PR](https://github.com/apache/knox/pull/853). Due to this the GatewayBasicFuncTest.testEncodedForwardSlash is failing. This fix is addressing that.

## How was this patch tested?

Unit tests
