### PR TITLE
KNOX-3073 - Token verification fallback to Knox keys behavior should be configurable

### DIFF
--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.hadoopauth.filter;
 
+import static org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter.JWT_INSTANCE_KEY_FALLBACK;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.captureInt;
@@ -577,6 +578,7 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn(supportJwt).anyTimes();
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(JWT_INSTANCE_KEY_FALLBACK)).andReturn("false").anyTimes();
     final boolean isJwtSupported = Boolean.parseBoolean(supportJwt);
     if (isJwtSupported) {
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_AUDIENCES)).andReturn(null).anyTimes();

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTAsHTTPBasicCredsFederationFilterTest.java
@@ -111,5 +111,39 @@ public class JWTAsHTTPBasicCredsFederationFilterTest extends AbstractJWTFilterTe
         }
     }
 
+    @Override
+    @Test
+    public void testNoPEMInvalidJwksWithoutFallback() throws Exception {
+        // No-op: This filter does not appear to support the JWKS URL(s) config like the
+        // JWTFederationFilter does, so this test does not apply
+    }
+
+    @Override
+    @Test
+    public void testNoPEMInvalidJwksWithFallback() throws Exception {
+        // No-op: This filter does not appear to support the JWKS URL(s) config like the
+        // JWTFederationFilter does, so this test does not apply
+    }
+
+    @Override
+    @Test
+    public void testInvalidPEMNoJwksWithoutFallback() throws Exception {
+        // No-op: This filter does not appear to support the JWKS URL(s) config like the
+        // JWTFederationFilter does, so this test does not apply
+    }
+
+    @Override
+    @Test
+    public void testInvalidPEMInvalidJwksWithoutFallback() throws Exception {
+        // No-op: This filter does not appear to support the JWKS URL(s) config like the
+        // JWTFederationFilter does, so this test does not apply
+    }
+
+    @Override
+    @Test
+    public void testInvalidPEMInvalidJwksWithFallback() throws Exception {
+        // No-op: This filter does not appear to support the JWKS URL(s) config like the
+        // JWTFederationFilter does, so this test does not apply
+    }
 }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/SSOCookieProviderTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/SSOCookieProviderTest.java
@@ -330,6 +330,34 @@ public class SSOCookieProviderTest extends AbstractJWTFilterTest {
     Assert.assertEquals(loginURL, "https://remotehost/notgateway/knoxsso/api/v1/websso?originalUrl=" + "https://remotehost/resource");
   }
 
+  @Override
+  @Test
+  public void testNoPEMInvalidJwksWithoutFallback() throws Exception {
+    // No-op: The SSOCookieProvider does not appear to support the JWKS URL(s) config like the
+    // JWTFederationFilter does, so this test does not apply
+  }
+
+  @Override
+  @Test
+  public void testNoPEMInvalidJwksWithFallback() throws Exception {
+    // No-op: The SSOCookieProvider does not appear to support the JWKS URL(s) config like the
+    // JWTFederationFilter does, so this test does not apply
+  }
+
+  @Override
+  @Test
+  public void testInvalidPEMInvalidJwksWithoutFallback() throws Exception {
+    // No-op: The SSOCookieProvider does not appear to support the JWKS URL(s) config like the
+    // JWTFederationFilter does, so this test does not apply
+  }
+
+  @Override
+  @Test
+  public void testInvalidPEMInvalidJwksWithFallback() throws Exception {
+    // No-op: The SSOCookieProvider does not appear to support the JWKS URL(s) config like the
+    // JWTFederationFilter does, so this test does not apply
+  }
+
   @Test
   public void testIdleTimoutExceeded() throws Exception {
     final TokenStateService tokenStateService = EasyMock.createNiceMock(TokenStateService.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a topology-level JWTProvider param for enabling token signature verification fallback to Knox's key(s) when a PEM and/or JWKS URL(s) are explicitly configured for the verification. By default, if one or both of those explicit methods is configured, the verification will not fallback to Knox's key(s).

## How was this patch tested?

Unit tests and manual testing was performed to validate the flow and conditions.
