### PR TITLE
KNOX-3075 - Handling unlimited token expiration in JDBC TSS properly

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/JDBCTokenStateService.java
@@ -158,21 +158,21 @@ public class JDBCTokenStateService extends AbstractPersistentTokenStateService i
       validateToken(tokenId);
     }
 
-    long expiration = 0;
     try {
-      expiration = tokenDatabase.getTokenExpiration(tokenId);
-      if (expiration > 0) {
+      final Long expiration = tokenDatabase.getTokenExpiration(tokenId);
+      if (expiration != null) {
         log.fetchedExpirationFromDatabase(Tokens.getTokenIDDisplayText(tokenId), expiration);
 
         // Update the in-memory cache to avoid subsequent DB look-ups for the same state
         super.updateExpiration(tokenId, expiration);
+        return expiration;
       } else {
         throw new UnknownTokenException(tokenId);
       }
     } catch (SQLException e) {
       log.errorFetchingExpirationFromDatabase(Tokens.getTokenIDDisplayText(tokenId), e.getMessage(), e);
+      throw new TokenStateServiceException("An error occurred while fetching expiration for " + Tokens.getTokenIDDisplayText(tokenId) + " from the database", e);
     }
-    return expiration;
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenStateDatabase.java
@@ -99,11 +99,11 @@ public class TokenStateDatabase {
     }
   }
 
-  long getTokenExpiration(String tokenId) throws SQLException {
+  Long getTokenExpiration(String tokenId) throws SQLException {
     try (Connection connection = dataSource.getConnection(); PreparedStatement getTokenExpirationStatement = connection.prepareStatement(GET_TOKEN_EXPIRATION_SQL)) {
       getTokenExpirationStatement.setString(1, tokenId);
       try (ResultSet rs = getTokenExpirationStatement.executeQuery()) {
-        return rs.next() ? rs.getLong(1) : -1;
+        return rs.next() ? rs.getLong(1) : null;
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in KNOX-3075, when the token TTL was set to -1 (which allows creating never-expiring tokens), JDBC TSS threw an `UnknownTokenException`. This is wrong. It should have returned the configured `-1` value.

## How was this patch tested?

I updated existing JUnit tests to handle the path when fetching tokens for a user. I also added 2 new test cases to ensure this issue never occurs again.