### PR TITLE
KNOX-3077 - Add pac4j.cookie.max.age param

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -122,6 +122,12 @@ public class Pac4jDispatcherFilter implements Filter, SessionInvalidator {
 
   private static final String PAC4J_OIDC_TYPE = "oidc.type";
 
+  /* property for specifying pac4j cookies ttl */
+  public static final String PAC4J_COOKIE_MAX_AGE = "pac4j.cookie.max.age";
+
+  /* default value is same is KNOXSSO token ttl default */
+  public static final int PAC4J_COOKIE_MAX_AGE_DEFAULT = -1;
+
   private CallbackFilter callbackFilter;
 
   private SecurityFilter securityFilter;
@@ -216,6 +222,8 @@ public class Pac4jDispatcherFilter implements Filter, SessionInvalidator {
       setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS, PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS_DEFAULT);
       /* do we need to exclude custom attributes? */
       setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT);
+      /* add cookie expiry */
+      setSessionStoreConfig(filterConfig, PAC4J_COOKIE_MAX_AGE, Long.toString(PAC4J_COOKIE_MAX_AGE_DEFAULT));
       //decorating client configuration (if needed)
       PAC4J_CLIENT_CONFIGURATION_DECORATOR.decorateClients(clients, properties);
     }

--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStore.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStore.java
@@ -56,6 +56,7 @@ import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_S
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_PERMISSIONS_DEFAULT;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_ROLES;
 import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_SESSION_STORE_EXCLUDE_ROLES_DEFAULT;
+import static org.apache.knox.gateway.pac4j.filter.Pac4jDispatcherFilter.PAC4J_COOKIE_MAX_AGE;
 
 /**
  * Specific session store where data are saved into cookies (and not in memory).
@@ -200,6 +201,11 @@ public class KnoxSessionStore<C extends WebContext> implements SessionStore<C> {
 
             cookie.setPath(parts[0]);
 
+        }
+
+        /* Set cookie max age */
+        if(sessionStoreConfigs != null && sessionStoreConfigs.containsKey(PAC4J_COOKIE_MAX_AGE)) {
+            cookie.setMaxAge(Integer.parseInt(sessionStoreConfigs.get(PAC4J_COOKIE_MAX_AGE)));
         }
         context.addResponseCookie(cookie);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR introduces a new parameter `pac4j.cookie.max.age` for the Pac4J provider that enforces cookie age on the cookies created by the pac4j provider. 
e.g. 
```
         <provider>
                  <role>federation</role>
                  <name>pac4j</name>
                  <enabled>true</enabled>
                  <param>
                      <name>pac4j.callbackUrl</name>
                      <value>https://www.local.com:8443/gateway/knoxsso/api/v1/websso</value>
                  </param>

                 <!-- Unit is seconds -->
                  <param>
                      <name>pac4j.cookie.max.age</name>
                      <value>180</value>
                  </param>
            .........

```
Note that these value needs to be same as `knoxsso.cookie.max.age` if  you want Knox session to expire at the same time.

## How was this patch tested?

This patch was tested locally.