### PR TITLE
KNOX-3081 - Upgrade commons-compress to fix CVE-2024-25710 and CVE-2024-26308

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <commons-cli.version>1.4</commons-cli.version>
         <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-compress.version>1.21</commons-compress.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
         <commons-configuration.version>1.10</commons-configuration.version>
         <commons-digester3.version>3.2</commons-digester3.version>
         <commons-io.version>2.8.0</commons-io.version>


### PR DESCRIPTION

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Upgrade commons-compress to 1.27.1 version 

## How was this patch tested?

Existing test suites

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
