### PR TITLE
KNOX-3082: Bump netty to 4.1.116.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <metrics.version>4.1.16</metrics.version>
         <mina.version>2.0.22</mina.version>
         <mockito.version>4.8.1</mockito.version>
-        <netty.version>4.1.77.Final</netty.version>
+        <netty.version>4.1.116.Final</netty.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>
         <nodejs.version>v14.15.0</nodejs.version>
         <okhttp.version>2.7.5</okhttp.version>


### PR DESCRIPTION

## What changes were proposed in this pull request?

Bumpup the netty-all to  4.1.116.Final
