### PR TITLE
Revert KNOX-3006

### DIFF
--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.main.libpam4j</groupId>
+            <groupId>org.kohsuke</groupId>
             <artifactId>libpam4j</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <json-smart.version>2.4.9</json-smart.version>
         <junit.version>4.13.2</junit.version>
         <lang-tag.version>1.5</lang-tag.version>
-        <libpam4j.version>5.1.0</libpam4j.version>
+        <libpam4j.version>1.11</libpam4j.version>
         <log4j2.version>2.17.1</log4j2.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -2094,7 +2094,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.glassfish.main.libpam4j</groupId>
+                <groupId>org.kohsuke</groupId>
                 <artifactId>libpam4j</artifactId>
                 <version>${libpam4j.version}</version>
             </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change reverts KNOX-3006, which replaced the libpam4j implementation in an attempt to resolve the intermittent garbage group names issue. However, this change apparently does not completely resolve that issue AND it introduces intermittent authentication failures.

## How was this patch tested?

Unit and manual testing.