### PR TITLE
KNOX-3088: Fix Ranger plug-in group lookup with Java 17

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -181,7 +181,7 @@ function buildAppJavaOpts {
     CHECK_VERSION_17="17"
     if [[ "$JAVA_VERSION" == *"$CHECK_VERSION_17"* ]]; then
         echo "Java version is $CHECK_VERSION_17. Adding properties to enable Knox to run on JDK 17"
-        addAppJavaOpts " --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.pkcs=ALL-UNNAMED --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED"
+        addAppJavaOpts " --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.pkcs=ALL-UNNAMED --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens java.base/sun.security.util=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-exports java.base/sun.net.util=ALL-UNNAMED --add-exports java.base/sun.net.dns=ALL-UNNAMED"
     fi
 
     # echo "APP_JAVA_OPTS =" "${APP_JAVA_OPTS[@]}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added explicit JVM exports to fix broken Ranger plug-in group lookups with Java 17

## How was this patch tested?

Unit and manual testing.