### PR TITLE
KNOX-3087 - Provide a way to validate JWT tokens that are missing typ header and Add letsencrypt staging cert to knox docker image

### DIFF
--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -43,7 +43,8 @@ ADD --chown=knox:knox \
     http://www.awstrust.com/repository/AmazonRootCA1.cer \
     http://www.awstrust.com/repository/AmazonRootCA2.cer \
     http://www.awstrust.com/repository/AmazonRootCA3.cer \
-    http://www.awstrust.com/repository/AmazonRootCA4.cer /home/knox/cacrts/
+    http://www.awstrust.com/repository/AmazonRootCA4.cer \
+    http://letsencrypt.org/certs/staging/letsencrypt-stg-root-x1.pem /home/knox/cacrts/
 
 WORKDIR /home/knox/knox
 

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -190,7 +190,15 @@ fi
   -storepass "${ALIAS_PASSPHRASE}" \
   -noprompt || true
 
-export KNOX_GATEWAY_DBG_OPTS="${KNOX_GATEWAY_DBG_OPTS}"
+# Add letsencrypt staging root CA
+/usr/bin/keytool -importcert \
+  -keystore ${KEYSTORE_DIR}/truststore.jks \
+  -alias letsencrypt-stg-root \
+  -file /home/knox/cacrts/letsencrypt-stg-root-x1.pem \
+  -storepass "${ALIAS_PASSPHRASE}" \
+  -noprompt || true
+
+export KNOX_GATEWAY_DBG_OPTS="${KNOX_GATEWAY_DBG_OPTS} -Djavax.net.ssl.trustStore=${KEYSTORE_DIR}/truststore.jks -Djavax.net.ssl.trustStorePassword=${ALIAS_PASSPHRASE}"
 
 echo "Starting Knox gateway ..."
 /home/knox/knox/bin/gateway.sh start

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -354,8 +354,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String GATEWAY_HEALTH_CHECK_TOPOLOGIES = GATEWAY_CONFIG_FILE_PREFIX + ".health.check.topologies";
 
-  private static final String JWKS_OUTAGE_CACHE_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".jwks.outage.cache.ttl";;
+  private static final String JWKS_OUTAGE_CACHE_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".jwks.outage.cache.ttl";
   private static final long JWKS_OUTAGE_CACHE_TTL_DEFAULT = TimeUnit.HOURS.toMillis(2);
+  private static final String ISSUER_IGNORE_TYPE_VALIDATION = GATEWAY_CONFIG_FILE_PREFIX + ".token.issuers.ignore.type.validation";
 
   public GatewayConfigImpl() {
     init();
@@ -1545,6 +1546,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public long getServiceDiscoveryWriteTimeoutMillis() {
     return getLong(CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT, CLOUDERA_MANAGER_SERVICE_DISCOVERY_WRITE_TIMEOUT_DEFAULT);
+  }
+
+  @Override
+  public Set<String> getIssuersWithIgnoredTypeHeader() {
+    final Collection<String> issuers = getTrimmedStringCollection(ISSUER_IGNORE_TYPE_VALIDATION);
+    return issuers == null ? Collections.emptySet() : new HashSet<>(issuers);
   }
 
   private Map<String, Collection<String>> getPathAliases(String qualifier) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -241,7 +241,13 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
         JWTClaimsSetVerifier<SecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>();
         jwtProcessor.setJWTClaimsSetVerifier(claimsVerifier);
         final JOSEObjectTypeVerifier<SecurityContext> objectTypeVerifier = new DefaultJOSEObjectTypeVerifier<>(allowedJwsTypes);
-        jwtProcessor.setJWSTypeVerifier(objectTypeVerifier);
+        /* See if we have a issuer for which we want to ignore type validation */
+        if(!config.getIssuersWithIgnoredTypeHeader().contains(token.getIssuer())) {
+          jwtProcessor.setJWSTypeVerifier(objectTypeVerifier);
+        } else {
+          /* no typ claim found in token, log and move on */
+          LOG.ignoreTypeHeaderVerification();
+        }
 
         // Process the token
         SecurityContext ctx = null; // optional context parameter, not required here

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenAuthorityServiceMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/TokenAuthorityServiceMessages.java
@@ -28,4 +28,7 @@ public interface TokenAuthorityServiceMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Failed to verify token using JWKS endpoint {0}, reason: {1}")
   void jwksVerificationFailed(String jwksUrl, String reason);
+
+  @Message(level = MessageLevel.WARN, text = "Ignoring typ header verification for token")
+  void ignoreTypeHeaderVerification();
 }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1133,4 +1133,9 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
 
+  @Override
+  public Set<String> getIssuersWithIgnoredTypeHeader() {
+    return Collections.emptySet();
+  }
+
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -961,4 +961,12 @@ public interface GatewayConfig {
    * @return jwks outage cache TTL
    */
   long getJwksOutageCacheTTL();
+
+  /**
+   * Some JWT tokens could be missing typ header.
+   * This config skips typ validation for tokens issued by
+   * configured Issuers.
+   * @return
+  */
+  Set<String> getIssuersWithIgnoredTypeHeader();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <xml-jaxb.version>2.3.0</xml-jaxb.version>
         <xml-matchers.version>0.10</xml-matchers.version>
         <zookeeper.version>3.8.4</zookeeper.version>
-        <docker-maven-plugin.version>0.43.4</docker-maven-plugin.version>
+        <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
     </properties>
     <repositories>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Ability to validate JWT tokens that are missing `typ` header for configured issuers.
    1.1. This is configured by gateway-site.xml property `gateway.token.issuers.ignore.type.validation`
3. Add letsencrypt staging cert to knox docker image

## How was this patch tested?

This patch was tested on a local cluster.