### PR TITLE
KNOX-3099: Ability to exclude topologies form client auth needed policy

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -806,4 +806,7 @@ public interface GatewayMessages {
   @Message(level = MessageLevel.INFO,
           text = "Starting gateway status service. Topologies to check: {0}")
   void startingStatusMonitor(Set<String> topologyNames);
+
+  @Message( level = MessageLevel.INFO, text = "Excluded \"{0}\" topology from client auth" )
+  void topologyExcludedFromClientAuth( String topologyName );
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -440,6 +440,7 @@ public class GatewayServer {
         httpsConfig.addCustomizer( new SecureRequestCustomizer() );
         SSLService ssl = services.getService(ServiceType.SSL_SERVICE);
         SslContextFactory sslContextFactory = (SslContextFactory)ssl.buildSslContextFactory( config );
+        ssl.excludeTopologyFromClientAuth(sslContextFactory, config, topologyName);
         connector = new ServerConnector( server, sslContextFactory, new HttpConnectionFactory( httpsConfig ) );
       } else {
         connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -692,8 +692,12 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public String getClientAuthExclude() {
-    return get( CLIENT_AUTH_EXCLUDE, null );
+  public boolean isTopologyExcludedFromClientAuth(String topologyName) {
+    String clientAuthExcludeConfig = get(CLIENT_AUTH_EXCLUDE, null);
+    if(clientAuthExcludeConfig == null || topologyName == null) {
+      return false;
+    }
+    return clientAuthExcludeConfig.contains(topologyName);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -117,6 +117,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   public static final String FRONTEND_URL = GATEWAY_CONFIG_FILE_PREFIX + ".frontend.url";
   private static final String TRUST_ALL_CERTS = GATEWAY_CONFIG_FILE_PREFIX + ".trust.all.certs";
   private static final String CLIENT_AUTH_NEEDED = GATEWAY_CONFIG_FILE_PREFIX + ".client.auth.needed";
+  private static final String CLIENT_AUTH_EXCLUDE = GATEWAY_CONFIG_FILE_PREFIX + ".client.auth.exclude";
   private static final String CLIENT_AUTH_WANTED = GATEWAY_CONFIG_FILE_PREFIX + ".client.auth.wanted";
   private static final String KEYSTORE_TYPE = GATEWAY_CONFIG_FILE_PREFIX + ".keystore.type";
   private static final String KEYSTORE_CACHE_LIMIT = GATEWAY_CONFIG_FILE_PREFIX + ".keystore.cache.size.limit";
@@ -688,6 +689,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public boolean isClientAuthNeeded() {
     return Boolean.parseBoolean(get( CLIENT_AUTH_NEEDED, "false" ));
+  }
+
+  @Override
+  public String getClientAuthExclude() {
+    return get( CLIENT_AUTH_EXCLUDE, null );
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
@@ -237,6 +237,17 @@ public class JettySSLService implements SSLService {
   }
 
   @Override
+  public void excludeTopologyFromClientAuth(SslContextFactory sslContextFactory, GatewayConfig config, String topologyName) {
+    if(config.getClientAuthExclude() != null && topologyName != null
+            && config.isClientAuthNeeded() && config.getClientAuthExclude().contains(topologyName)) {
+      SslContextFactory.Server sslContextFactoryServer = (SslContextFactory.Server) sslContextFactory;
+      sslContextFactoryServer.setNeedClientAuth(false);
+      sslContextFactoryServer.setWantClientAuth(true);
+      log.topologyExcludedFromClientAuth(topologyName);
+    }
+  }
+
+  @Override
   public void start() throws ServiceLifecycleException {
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/JettySSLService.java
@@ -238,8 +238,7 @@ public class JettySSLService implements SSLService {
 
   @Override
   public void excludeTopologyFromClientAuth(SslContextFactory sslContextFactory, GatewayConfig config, String topologyName) {
-    if(config.getClientAuthExclude() != null && topologyName != null
-            && config.isClientAuthNeeded() && config.getClientAuthExclude().contains(topologyName)) {
+    if(config.isClientAuthNeeded() && config.isTopologyExcludedFromClientAuth(topologyName)) {
       SslContextFactory.Server sslContextFactoryServer = (SslContextFactory.Server) sslContextFactory;
       sslContextFactoryServer.setNeedClientAuth(false);
       sslContextFactoryServer.setWantClientAuth(true);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
@@ -30,6 +30,7 @@ import java.security.KeyStore;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -48,7 +49,7 @@ public class GatewayGlobalConfigTest {
     GatewayConfig config = new GatewayConfigImpl();
     assertThat( config.getGatewayPort(), is( 7777 ) );
     assertThat( config.isClientAuthNeeded(), is( false ) );
-    assertNull( "gateway.client.auth.exclude should be null", config.getClientAuthExclude());
+    assertFalse( config.isTopologyExcludedFromClientAuth("health"));
     assertNull("ssl.exclude.protocols should be null.", config.getExcludedSSLProtocols());
     //assertThat( config.getShiroConfigFile(), is( "full-shiro.ini") );
   }
@@ -68,10 +69,18 @@ public class GatewayGlobalConfigTest {
     GatewayConfig config = new GatewayConfigImpl();
     assertThat( config.getGatewayPort(), is( 5555 ) );
     assertThat( config.isClientAuthNeeded(), is( true ) );
-    assertThat( config.getClientAuthExclude(), is( "health" ) );
+    assertTrue( config.isTopologyExcludedFromClientAuth("health"));
     assertThat( config.getTruststorePath(), is("./gateway-trust.jks"));
     assertThat( config.getTruststoreType(), is( "PKCS12" ) );
     assertThat( config.getKeystoreType(), is(KeyStore.getDefaultType()) );
+  }
+
+  @Test
+  public void testSiteConfigWithDifferentTopologyExcluded() {
+    System.setProperty( GatewayConfigImpl.GATEWAY_HOME_VAR, getHomeDirName( "conf-site/conf/gateway-site.xml" ) );
+    GatewayConfig config = new GatewayConfigImpl();
+    assertThat( config.isClientAuthNeeded(), is( true ) );
+    assertFalse( config.isTopologyExcludedFromClientAuth("different"));
   }
 
   @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
@@ -48,6 +48,7 @@ public class GatewayGlobalConfigTest {
     GatewayConfig config = new GatewayConfigImpl();
     assertThat( config.getGatewayPort(), is( 7777 ) );
     assertThat( config.isClientAuthNeeded(), is( false ) );
+    assertNull( "gateway.client.auth.exclude should be null", config.getClientAuthExclude());
     assertNull("ssl.exclude.protocols should be null.", config.getExcludedSSLProtocols());
     //assertThat( config.getShiroConfigFile(), is( "full-shiro.ini") );
   }
@@ -67,6 +68,7 @@ public class GatewayGlobalConfigTest {
     GatewayConfig config = new GatewayConfigImpl();
     assertThat( config.getGatewayPort(), is( 5555 ) );
     assertThat( config.isClientAuthNeeded(), is( true ) );
+    assertThat( config.getClientAuthExclude(), is( "health" ) );
     assertThat( config.getTruststorePath(), is("./gateway-trust.jks"));
     assertThat( config.getTruststoreType(), is( "PKCS12" ) );
     assertThat( config.getKeystoreType(), is(KeyStore.getDefaultType()) );

--- a/gateway-server/src/test/resources/conf-site/conf/gateway-site.xml
+++ b/gateway-server/src/test/resources/conf-site/conf/gateway-site.xml
@@ -56,6 +56,12 @@ limitations under the License.
     </property>
 
     <property>
+        <name>gateway.client.auth.exclude</name>
+        <value>health</value>
+        <description>topologies to be excluded from client auth needed policy</description>
+    </property>
+
+    <property>
         <name>gateway.truststore.path</name>
         <value>./gateway-trust.jks</value>
         <description>path to truststore</description>

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -345,8 +345,8 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public String getClientAuthExclude() {
-    return null;
+  public boolean isTopologyExcludedFromClientAuth(String topology) {
+    return false;
   }
 
   @Override

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -345,6 +345,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getClientAuthExclude() {
+    return null;
+  }
+
+  @Override
   public String getTruststorePath() {
     return null;
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -207,7 +207,7 @@ public interface GatewayConfig {
 
   boolean isClientAuthNeeded();
 
-  String getClientAuthExclude();
+  boolean isTopologyExcludedFromClientAuth(String topologyName);
 
   boolean isClientAuthWanted();
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -207,6 +207,8 @@ public interface GatewayConfig {
 
   boolean isClientAuthNeeded();
 
+  String getClientAuthExclude();
+
   boolean isClientAuthWanted();
 
   String getTruststorePath();

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/SSLService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/SSLService.java
@@ -19,7 +19,10 @@ package org.apache.knox.gateway.services.security;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.Service;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 public interface SSLService extends Service {
   Object buildSslContextFactory(GatewayConfig config) throws AliasServiceException;
+
+  void excludeTopologyFromClientAuth(SslContextFactory sslContextFactory, GatewayConfig config, String topologyName);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently if the user adds `gateway.client.auth.needed` as true to the gateway-site.xml every topology will enforce this. There is no option to exclude from this policy. The user can also specify gateway.client.auth.wanted as true however the policy is not enforced in this case.

We need the ability to be able to exclude topologies in case the client auth is needed.

Example setup:

By adding the below to the gateway-site.xml we enable the client auth needed policy. To be able to exclude a topology from this we have to define a port mapping for that topology and add it to the `gateway.client.auth.exclude` as well.

    <property>
        <name>gateway.client.auth.needed</name>
        <value>true</value>
    </property>
    <property>
        <name>gateway.port.mapping.health</name>
        <value>9443</value>
    </property>
    <property>
        <name>gateway.client.auth.exclude</name>
        <value>health</value>
    </property>

## How was this patch tested?

Unit tests
Tested manually on my local setup
