### PR TITLE
KNOX-3101 - hash key for RemoteAuthProvider cache

### DIFF
--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -160,7 +160,7 @@ public class RemoteAuthFilterTest {
         // Add groups to the principal if available
         Arrays.stream(groupNames.split(",")).forEach(groupName -> subject.getPrincipals()
                 .add(new GroupPrincipal(groupName)));
-        filter.authenticationCache.put(BEARER_VALID_TOKEN, subject);
+        filter.setCachedSubject(BEARER_VALID_TOKEN, subject);
 
         EasyMock.expect(requestMock.getHeader("Authorization")).andReturn(BEARER_VALID_TOKEN).anyTimes();
         EasyMock.expect(responseMock.getStatus()).andReturn(200).anyTimes();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The initial implementation of RemoteAuthProvider caches authenticated Subjects locally based on the header that contained the credentials. While the cache is designed to provide only a few mins of caching, it is less than ideal to use the credentials as keys. This needs to be strengthened to use a hash as to not inadvertently risk leaking the credentials.

This will require some overhead involved in the hashing so we may need to find something else but we shouldn't use the credentials themselves. We would normally have to do a hash for implementing authentication for things like RDMS or LDAP based passwords, etc.

## How was this patch tested?

Refactored and ran existing unit tests to ensure no regression was introduced.
