### PR TITLE
KNOX-3102 - Complete Auditing in RemoteAuthProvider

### DIFF
--- a/gateway-provider-security-authc-remote/pom.xml
+++ b/gateway-provider-security-authc-remote/pom.xml
@@ -54,6 +54,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.knox</groupId>
             <artifactId>gateway-test-utils</artifactId>
             <scope>test</scope>

--- a/gateway-provider-security-authc-remote/src/main/java/org/apache/knox/gateway/filter/RemoteAuthFilter.java
+++ b/gateway-provider-security-authc-remote/src/main/java/org/apache/knox/gateway/filter/RemoteAuthFilter.java
@@ -35,6 +35,7 @@ import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
+import org.apache.logging.log4j.ThreadContext;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -71,6 +72,8 @@ public class RemoteAuthFilter implements Filter {
   private static final String CONFIG_GROUP_HEADER = "remote.auth.group.header";
   private static final String DEFAULT_CONFIG_USER_HEADER = "X-Knox-Actor-ID";
   private static final String DEFAULT_CONFIG_GROUP_HEADER = "X-Knox-Actor-Groups-1";
+  static final String TRACE_ID = "trace_id";
+  static final String REQUEST_ID_HEADER_NAME = "X-Request-Id";
 
   private String remoteAuthUrl;
   private List<String> includeHeaders;
@@ -149,6 +152,12 @@ public class RemoteAuthFilter implements Filter {
         if (headerValue != null) {
           connection.addRequestProperty(header, headerValue);
         }
+      }
+
+      // Add trace ID to the outgoing request if it exists to correlate logs
+      String traceId = ThreadContext.get(TRACE_ID);
+      if (traceId != null) {
+        connection.addRequestProperty(REQUEST_ID_HEADER_NAME, ThreadContext.get(TRACE_ID));
       }
 
       int responseCode = connection.getResponseCode();

--- a/gateway-provider-security-authc-remote/src/main/java/org/apache/knox/gateway/filter/RemoteAuthFilter.java
+++ b/gateway-provider-security-authc-remote/src/main/java/org/apache/knox/gateway/filter/RemoteAuthFilter.java
@@ -71,7 +71,7 @@ public class RemoteAuthFilter implements Filter {
   private static final String CONFIG_USER_HEADER = "remote.auth.user.header";
   private static final String CONFIG_GROUP_HEADER = "remote.auth.group.header";
   private static final String DEFAULT_CONFIG_USER_HEADER = "X-Knox-Actor-ID";
-  private static final String DEFAULT_CONFIG_GROUP_HEADER = "X-Knox-Actor-Groups-1";
+  private static final String DEFAULT_CONFIG_GROUP_HEADER = "X-Knox-Actor-Groups-*";
   private static final String WILDCARD = "*";
   static final String TRACE_ID = "trace_id";
   static final String REQUEST_ID_HEADER_NAME = "X-Request-Id";

--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -247,7 +247,7 @@ public class RemoteAuthFilterTest {
             ThreadContext.remove(RemoteAuthFilter.TRACE_ID);
         }
     }
-  
+
     public void successfulAuthenticationWithMultipleGroups() throws Exception {
         EasyMock.expect(requestMock.getServletContext()).andReturn(new MockServletContext()).anyTimes();
         EasyMock.expect(requestMock.getHeader("Authorization")).andReturn(BEARER_VALID_TOKEN).anyTimes();

--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -254,6 +254,10 @@ public class RemoteAuthFilterTest {
         EasyMock.expect(responseMock.getStatus()).andReturn(200).anyTimes();
         responseMock.sendError(EasyMock.eq(HttpServletResponse.SC_UNAUTHORIZED), EasyMock.anyString());
         EasyMock.expectLastCall().andThrow(new AssertionError("Authentication should be successful, but was not.")).anyTimes();
+
+        EasyMock.replay(requestMock, responseMock);
+
+        try {
             MockHttpURLConnection mockConn = new MockHttpURLConnection(new URL(URL_SUCCESS));
             // Add groups from multiple headers
             mockConn.addHeader(X_AUTHENTICATED_GROUP, "admin,engineers");

--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -248,6 +248,7 @@ public class RemoteAuthFilterTest {
         }
     }
 
+    @Test
     public void successfulAuthenticationWithMultipleGroups() throws Exception {
         EasyMock.expect(requestMock.getServletContext()).andReturn(new MockServletContext()).anyTimes();
         EasyMock.expect(requestMock.getHeader("Authorization")).andReturn(BEARER_VALID_TOKEN).anyTimes();

--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -23,6 +23,7 @@ import org.apache.knox.test.mock.MockServletContext;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
+import org.apache.logging.log4j.ThreadContext;
 
 import javax.security.auth.Subject;
 import javax.servlet.FilterChain;
@@ -190,6 +191,54 @@ public class RemoteAuthFilterTest {
             }
         } catch (AssertionError e) {
             assert false : "Authentication failed unexpectedly";
+        }
+    }
+
+    @Test
+    public void testTraceIdPropagation() throws Exception {
+        String expectedTraceId = "test-trace-123";
+
+        // Set up mocks
+        EasyMock.expect(requestMock.getServletContext())
+            .andReturn(new MockServletContext())
+            .anyTimes();
+        EasyMock.expect(requestMock.getHeader("Authorization"))
+            .andReturn(BEARER_VALID_TOKEN)
+            .anyTimes();
+        EasyMock.expect(responseMock.getStatus())
+            .andReturn(200)
+            .anyTimes();
+
+        EasyMock.replay(requestMock, responseMock);
+
+        try {
+            // Set up the trace ID in ThreadContext
+            ThreadContext.put(RemoteAuthFilter.TRACE_ID, expectedTraceId);
+
+            MockHttpURLConnection mockConn = new MockHttpURLConnection(new URL(URL_SUCCESS)) {
+                private final Map<String, String> requestProperties = new HashMap<>();
+
+                @Override
+                public void addRequestProperty(String key, String value) {
+                    requestProperties.put(key, value);
+                }
+
+                @Override
+                public String getRequestProperty(String key) {
+                    return requestProperties.get(key);
+                }
+            };
+            filter.httpURLConnection = mockConn;
+
+            filter.doFilter(requestMock, responseMock, chainMock);
+
+            // Verify the trace ID was propagated with the correct header name
+            assertEquals("Trace ID should be propagated to outgoing request",
+                expectedTraceId,
+                mockConn.getRequestProperty(RemoteAuthFilter.REQUEST_ID_HEADER_NAME));
+        } finally {
+            // Clean up ThreadContext
+            ThreadContext.remove(RemoteAuthFilter.TRACE_ID);
         }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The initial implementation of the RemoteAuthProvider only has the initial access level audit. We need to add not only the result of the authentication attempt but also add the correlation id for the audit entries to the call to the remote auth service so that the audit logs can be correlated.

## How was this patch tested?

Added new unit tests and ran all existing tests.
Manually tested with a single instance and traced the call from through the initial topology and the "remote" endpoint. Note the correlation id is the same for all of the entries. This will follow across instances as well.


```
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN||||access|uri|/gateway/tokengen/knoxtoken/api/v1/token|unavailable|Request method: GET
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|127.0.0.1|KNOX-AUTH-SERVICE||||access|uri|/gateway/sandbox/auth/api/v1/pre|unavailable|Request method: GET
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|127.0.0.1|KNOX-AUTH-SERVICE|guest|||authentication|uri|/gateway/sandbox/auth/api/v1/pre|success|
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|127.0.0.1|KNOX-AUTH-SERVICE|guest|||authentication|uri|/gateway/sandbox/auth/api/v1/pre|success|Groups: []
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|127.0.0.1|KNOX-AUTH-SERVICE|guest|||identity-mapping|principal|guest|success|Groups: []
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|127.0.0.1|KNOX-AUTH-SERVICE|guest|||access|uri|/gateway/sandbox/auth/api/v1/pre|success|Response status: 200
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|guest|||authentication|uri|/gateway/tokengen/knoxtoken/api/v1/token|success|
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|guest|||identity-mapping|principal|guest|success|Groups: []
25/02/27 23:53:15 ||9f67555c-6561-40fb-ad39-6fa8ac4fa1f9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|guest|||access|uri|/gateway/tokengen/knoxtoken/api/v1/token|success|Response status: 200
```
