### PR TITLE
KNOX-3104 - Add groups to the RemoteAuthProvider audit entry

### DIFF
--- a/gateway-provider-security-authc-remote/src/main/java/org/apache/knox/gateway/filter/RemoteAuthFilter.java
+++ b/gateway-provider-security-authc-remote/src/main/java/org/apache/knox/gateway/filter/RemoteAuthFilter.java
@@ -178,7 +178,11 @@ public class RemoteAuthFilter implements Filter {
           context.setUsername( principalName );
           auditService.attachContext(context);
           String sourceUri = (String)request.getAttribute( AbstractGatewayFilter.SOURCE_REQUEST_CONTEXT_URL_ATTRIBUTE_NAME );
-          auditor.audit( Action.AUTHENTICATION , sourceUri, ResourceType.URI, ActionOutcome.SUCCESS );
+          auditor.audit(Action.AUTHENTICATION, sourceUri, ResourceType.URI,
+                  ActionOutcome.SUCCESS, "Groups: " + Arrays.toString(subject.getPrincipals(GroupPrincipal.class)
+                          .stream()
+                          .map(GroupPrincipal::getName)
+                          .toArray(String[]::new)));
         }
 
         continueWithEstablishedSecurityContext(subject, httpRequest, httpResponse, filterChain);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The audit log entry for the RemoteAuthProvider currently doesn't include groups that have been returned by the remote authentication service via the groups header.

This change will add them to the audit log from the established Java Subject's GroupPrincipals.

## How was this patch tested?

Existing unit tests to ensure no regression

Manually tested and observed the change in the audit log with the added groups array listed

```
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN||||access|uri|/gateway/tokengen/knoxtoken/api/v1/token|unavailable|Request method: GET
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|127.0.0.1|KNOX-AUTH-SERVICE||||access|uri|/gateway/sandbox/auth/api/v1/pre|unavailable|Request method: GET
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||authentication|uri|/gateway/sandbox/auth/api/v1/pre|success|
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||authentication|uri|/gateway/sandbox/auth/api/v1/pre|success|Groups: []
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||identity-mapping|principal|admin|success|Groups: [admin]
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||access|uri|/gateway/sandbox/auth/api/v1/pre|success|Response status: 200
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|admin|||authentication|uri|/gateway/tokengen/knoxtoken/api/v1/token|success|Groups: [admin]
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|admin|||identity-mapping|principal|admin|success|Groups: []
25/03/01 17:16:49 ||62d338e7-32fe-48a4-b174-ed9c5977c8e9|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|admin|||access|uri|/gateway/tokengen/knoxtoken/api/v1/token|success|Response status: 200
```