### PR TITLE
KNOX-3105 - Add Topology Level Config for Truststore to RemoteAuthProvider

### DIFF
--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -84,10 +84,10 @@ public class RemoteAuthFilterTest {
     private void setUp(String trustStorePath, String trustStorePass, String trustStoreType) {
         // Reset existing mocks
         EasyMock.reset(requestMock, responseMock);
-        
+
         FilterConfig filterConfigMock = EasyMock.createNiceMock(FilterConfig.class);
         chainMock = new TestFilterChain();
-        
+
         // Create and configure Gateway Services mocks
         gatewayServicesMock = EasyMock.createNiceMock(GatewayServices.class);
         keystoreServiceMock = EasyMock.createNiceMock(KeystoreService.class);

--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("PMD.JUnit4TestShouldUseBeforeAnnotation")
 public class RemoteAuthFilterTest {
 
     public static final String BEARER_INVALID_TOKEN = "Bearer invalid-token";

--- a/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
+++ b/gateway-provider-security-authc-remote/src/test/java/org/apache/knox/gateway/filter/RemoteAuthFilterTest.java
@@ -103,18 +103,18 @@ public class RemoteAuthFilterTest {
                .anyTimes();
 
         // Basic config
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.url")).andReturn("https://example.com/auth").anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.include.headers")).andReturn("Authorization").anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.cache.key")).andReturn("Authorization").anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.expire.after")).andReturn("5").anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.user.header")).andReturn(X_AUTHENTICATED_USER).anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.group.header"))
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_REMOTE_AUTH_URL)).andReturn("https://example.com/auth").anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_INCLUDE_HEADERS)).andReturn("Authorization").anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.DEFAULT_CACHE_KEY_HEADER)).andReturn("Authorization").anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_EXPIRE_AFTER)).andReturn("5").anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_USER_HEADER)).andReturn(X_AUTHENTICATED_USER).anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_GROUP_HEADER))
                .andReturn(X_AUTHENTICATED_GROUP + "," + X_AUTHENTICATED_GROUP_2 + ",X-Custom-Group-*").anyTimes();
 
         // Trust store config
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.truststore.path")).andReturn(trustStorePath).anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.truststore.password")).andReturn(trustStorePass).anyTimes();
-        EasyMock.expect(filterConfigMock.getInitParameter("remote.auth.truststore.type")).andReturn(trustStoreType).anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_TRUSTSTORE_PATH)).andReturn(trustStorePath).anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_TRUSTSTORE_PASSWORD)).andReturn(trustStorePass).anyTimes();
+        EasyMock.expect(filterConfigMock.getInitParameter(RemoteAuthFilter.CONFIG_TRUSTSTORE_TYPE)).andReturn(trustStoreType).anyTimes();
 
         // Only replay the mocks that won't need additional expectations
         EasyMock.replay(filterConfigMock, gatewayServicesMock, servletContextMock);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -46,6 +46,7 @@ import java.net.InetAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -560,6 +561,26 @@ public class DefaultKeystoreService implements KeystoreService {
       LOG.failedToLoadKeystore(keyStoreFilePath.toString(), storeType, e);
       throw new KeystoreServiceException(e);
     }
+  }
+
+  @Override
+  public synchronized KeyStore loadKeyStore(String path, String keystoreType, String password)
+          throws KeystoreServiceException {
+      try {
+          return createKeyStore(FileSystems.getDefault().getPath(path), keystoreType, password.toCharArray());
+      } catch (Exception e) {
+          throw new KeystoreServiceException(e);
+      }
+  }
+
+  @Override
+  public synchronized KeyStore loadTruststore(String path,  String keystoreType, String password)
+          throws KeystoreServiceException {
+      try {
+          return loadKeyStore(FileSystems.getDefault().getPath(path), keystoreType, password.toCharArray());
+      } catch (Exception e) {
+          throw new KeystoreServiceException(e);
+      }
   }
 
   // Package private for unit test access

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/KeystoreService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/KeystoreService.java
@@ -79,4 +79,26 @@ public interface KeystoreService extends Service {
   char[] getCredentialForCluster(String clusterName, String alias, KeyStore ks) throws KeystoreServiceException;
 
   String getKeystorePath();
+
+      /**
+     * Load a keystore from the specified path with the given password.
+     *
+     * @param path The path to the keystore file
+     * @param password The password for the keystore
+     * @return The loaded KeyStore instance
+     * @throws KeystoreServiceException if loading fails
+     */
+    KeyStore loadKeyStore(String path, String keystoreType, String password)
+        throws KeystoreServiceException;
+
+    /**
+     * Load a truststore from the specified path with the given password.
+     *
+     * @param path The path to the truststore file
+     * @param password The password for the truststore
+     * @return The loaded KeyStore instance
+     * @throws KeystoreServiceException if loading fails
+     */
+    KeyStore loadTruststore(String path, String keystoreType, String password)
+        throws KeystoreServiceException;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I originally had this topology level config only for the truststore and password but decided that it should be configured at the gateway level. However, it is much easier to use specific truststores for dev and testing environments than adding a cert from one Knox to another's truststore which may have other certs, etc.

This change will add the params for location and password with alias service support of the password.

## How was this patch tested?

Added new unit tests, ran all existing tests and manually tested with another knox instance.

`curl -ivku admin:admin-password https://localhost:8444/gateway/tokengen/knoxtoken/api/v1/token`

Audit logs for each instance are below to show the correlation ID across instances:

Local instance:

```
25/03/03 23:21:10 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN||||access|uri|/gateway/tokengen/knoxtoken/api/v1/token|unavailable|Request method: GET
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|admin|||authentication|uri|/gateway/tokengen/knoxtoken/api/v1/token|success|Groups: []
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|admin|||identity-mapping|principal|admin|success|Groups: []
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|[0:0:0:0:0:0:0:1]|KNOXTOKEN|admin|||access|uri|/gateway/tokengen/knoxtoken/api/v1/token|success|Response status: 200
```

remote instance:

```
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|127.0.0.1|KNOX-AUTH-SERVICE||||access|uri|/gateway/sandbox/auth/api/v1/pre|unavailable|Request method: GET
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||authentication|uri|/gateway/sandbox/auth/api/v1/pre|success|
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||authentication|uri|/gateway/sandbox/auth/api/v1/pre|success|Groups: []
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||identity-mapping|principal|admin|success|Groups: []
25/03/03 23:21:21 ||878975c9-de91-4da3-94e8-f716ce5b337a|audit|127.0.0.1|KNOX-AUTH-SERVICE|admin|||access|uri|/gateway/sandbox/auth/api/v1/pre|success|Response status: 200
```

The local instance above is running on port 8444 and the remote instance on 8443.

