### PR TITLE
KNOX-3109 - Passcode Tokens to use as Bearer Token

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -279,7 +279,14 @@ public class JWTFederationFilter extends AbstractJWTFilter {
               // what follows the bearer designator should be the JWT token being used
               // to request or as an access token
               token = header.substring(BEARER.length());
-              parsed = Pair.of(TokenType.JWT, token);
+
+              // if this appears to be a JWT token then attempt to use it as such
+              // otherwise assume it is a passcode token
+              if (isJWT(token)) {
+                parsed = Pair.of(TokenType.JWT, token);
+              } else {
+                parsed = Pair.of(TokenType.Passcode, token);
+              }
           } else if (header.toLowerCase(Locale.ROOT).startsWith(BASIC.toLowerCase(Locale.ROOT))) {
               // what follows the Basic designator should be the JWT token or the unique token ID being used
               // to request or as an access token

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -43,6 +43,10 @@ import com.nimbusds.jwt.SignedJWT;
 
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class JWTFederationFilterTest extends AbstractJWTFilterTest {
+
+  private static final String BASIC_ = "Basic ";
+  private static final String BEARER_ = "Bearer ";
+
   @Before
   public void setUp() {
     handler = new TestJWTFederationFilter();
@@ -106,19 +110,33 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
 
   @Test
   public void testVerifyPasscodeTokens() throws Exception {
-    testVerifyPasscodeTokens(true);
+    testVerifyPasscodeTokens(BASIC_, true);
   }
 
   @Test
   public void testVerifyPasscodeTokensTssDisabled() throws Exception {
-    testVerifyPasscodeTokens(false);
+    testVerifyPasscodeTokens(BASIC_, false);
   }
 
-  private void testVerifyPasscodeTokens(boolean tssEnabled) throws Exception {
+  @Test
+  public void testVerifyPasscodeBearerTokens() throws Exception {
+    testVerifyPasscodeTokens(BEARER_, true);
+  }
+
+  @Test
+  public void testVerifyPasscodeBearerTokensTssDisabled() throws Exception {
+    testVerifyPasscodeTokens(BEARER_, false);
+  }
+
+  private void testVerifyPasscodeTokens(String authTokenType, boolean tssEnabled) throws Exception {
     final String topologyName = "jwt-topology";
     final String tokenId = "4e0c548b-6568-4061-a3dc-62908087650a";
     final String passcode = "0138aaed-ca2a-47f1-8ed8-e0c397596f95";
-    final String passcodeToken = "UGFzc2NvZGU6VGtkVmQxbDZWVEJQUjBsMFRtcFZNazlETURCTlJGbDRURmRGZWxwSFRYUk9ha2sxVFVSbmQwOUVZekpPVkVKb09qcE5SRVY2VDBkR2FGcFhVWFJaTWtWNVdWTXdNRTR5V1hoTVZHaHNXa1JuZEZwVVFtcE5lbXN6VGxSck1scHFhekU9";
+    final String passcodeBearerToken = "TkdVd1l6VTBPR0l0TmpVMk9DMDBNRFl4TFdFelpHTXROakk1TURnd09EYzJOVEJoOjpNREV6T0dGaFpXUXRZMkV5WVMwME4yWXhMVGhsWkRndFpUQmpNemszTlRrMlpqazE=";
+    String passcodeToken = "UGFzc2NvZGU6VGtkVmQxbDZWVEJQUjBsMFRtcFZNazlETURCTlJGbDRURmRGZWxwSFRYUk9ha2sxVFVSbmQwOUVZekpPVkVKb09qcE5SRVY2VDBkR2FGcFhVWFJaTWtWNVdWTXdNRTR5V1hoTVZHaHNXa1JuZEZwVVFtcE5lbXN6VGxSck1scHFhekU9";
+    if (authTokenType.equals(BEARER_)) {
+      passcodeToken = passcodeBearerToken;
+    }
 
     final TokenStateService tokenStateService = EasyMock.createNiceMock(TokenStateService.class);
     EasyMock.expect(tokenStateService.getTokenExpiration(tokenId)).andReturn(Long.MAX_VALUE).anyTimes();
@@ -136,7 +154,7 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
 
     final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
     EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
-    EasyMock.expect(request.getHeader("Authorization")).andReturn("Basic " + passcodeToken);
+    EasyMock.expect(request.getHeader("Authorization")).andReturn(authTokenType + passcodeToken);
 
     final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     if (!tssEnabled) {

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -44,9 +44,6 @@ import com.nimbusds.jwt.SignedJWT;
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
 public class JWTFederationFilterTest extends AbstractJWTFilterTest {
 
-  private static final String BASIC_ = "Basic ";
-  private static final String BEARER_ = "Bearer ";
-
   @Before
   public void setUp() {
     handler = new TestJWTFederationFilter();
@@ -110,22 +107,22 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
 
   @Test
   public void testVerifyPasscodeTokens() throws Exception {
-    testVerifyPasscodeTokens(BASIC_, true);
+    testVerifyPasscodeTokens(JWTFederationFilter.BASIC, true);
   }
 
   @Test
   public void testVerifyPasscodeTokensTssDisabled() throws Exception {
-    testVerifyPasscodeTokens(BASIC_, false);
+    testVerifyPasscodeTokens(JWTFederationFilter.BASIC, false);
   }
 
   @Test
   public void testVerifyPasscodeBearerTokens() throws Exception {
-    testVerifyPasscodeTokens(BEARER_, true);
+    testVerifyPasscodeTokens(JWTFederationFilter.BEARER, true);
   }
 
   @Test
   public void testVerifyPasscodeBearerTokensTssDisabled() throws Exception {
-    testVerifyPasscodeTokens(BEARER_, false);
+    testVerifyPasscodeTokens(JWTFederationFilter.BEARER, false);
   }
 
   private void testVerifyPasscodeTokens(String authTokenType, boolean tssEnabled) throws Exception {
@@ -134,7 +131,7 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
     final String passcode = "0138aaed-ca2a-47f1-8ed8-e0c397596f95";
     final String passcodeBearerToken = "TkdVd1l6VTBPR0l0TmpVMk9DMDBNRFl4TFdFelpHTXROakk1TURnd09EYzJOVEJoOjpNREV6T0dGaFpXUXRZMkV5WVMwME4yWXhMVGhsWkRndFpUQmpNemszTlRrMlpqazE=";
     String passcodeToken = "UGFzc2NvZGU6VGtkVmQxbDZWVEJQUjBsMFRtcFZNazlETURCTlJGbDRURmRGZWxwSFRYUk9ha2sxVFVSbmQwOUVZekpPVkVKb09qcE5SRVY2VDBkR2FGcFhVWFJaTWtWNVdWTXdNRTR5V1hoTVZHaHNXa1JuZEZwVVFtcE5lbXN6VGxSck1scHFhekU9";
-    if (authTokenType.equals(BEARER_)) {
+    if (authTokenType.equals(JWTFederationFilter.BEARER)) {
       passcodeToken = passcodeBearerToken;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, passcode tokens can only be used as passwords with HTTP Basic authentication headers.
This change will enable them to be accepted as Authorization: Bearer tokens.

Will need to be able to distinguish between a JWT and a Passcode token when presented as a Bearer token.
This will allow Passcode tokens to be used as API_KEYs.

## How was this patch tested?

Manually tested, added new unit tests and ran all existing unit tests.

`curl -ivk -H "Authorization: Bearer TWpNMFlUTTNZamN0WVdaa09DM...U5XVXdabVF4OjpORFptTnpReU9URXROREUyWlMwMFpETXhMVGt6TnpRdE9HRXlZemt3WW1Rek5XRm0=" -X POST https://localhost:8444/gateway/tokengen/knoxtoken/api/v1/token`

To a topology protected with RemoteAuthProvider which makes a remote auth call to a separate topology configured with the JWTProvider and server managed tokens.

Results

```
* Host localhost:8444 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8444...
* Connected to localhost (::1) port 8444
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (OUT), TLS handshake, Client hello (1):
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: C=US; ST=Test; L=Test; O=Hadoop; OU=Test; CN=localhost
*  start date: Mar 19 19:06:18 2025 GMT
*  expire date: Mar 19 19:06:18 2026 GMT
*  issuer: C=US; ST=Test; L=Test; O=Hadoop; OU=Test; CN=localhost
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* using HTTP/1.x
> POST /gateway/tokengen/knoxtoken/api/v1/token HTTP/1.1
> Host: localhost:8444
> User-Agent: curl/8.7.1
> Accept: */*
> Authorization: Bearer TWpNMFlUTTNZamN0WVdaa09DMDBZMkV3TFR....4OjpORFptTnpReU9URXROREUyWlMwMFpETXhMVGt6TnpRdE9HRXlZemt3WW1Rek5XRm0=
> 
* Request completely sent off
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Thu, 20 Mar 2025 00:00:26 GMT
Date: Thu, 20 Mar 2025 00:00:26 GMT
< Content-Type: application/json
Content-Type: application/json
< Content-Length: 2301
Content-Length: 2301
< 

* Connection #0 to host localhost left intact
{"access_token":"eyJqa3UiOiJodHRwczovL2xvY2FsaG9zdDo4NDQ0L2dhdGV3YXkvdG9rZW5nZW4va25veHRva2VuL2FwaS92MS9qd2tzLmpzb24iLCJraWQiOiJ6RG5sYUFGTmVDRHdoQkRkYnZMUjVNd01nSVhmc3ZnV3RKaFFLTUY1RjEwIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.ey....WhlE690POuZbAB_7FZjL_Q79vXAxM_5YrbGIH1L2ESTj7TMjNP8M0wFnWS9v4Y0vFYXIqzeAK7tcRYci_ZQ6hxhiZsQB6d8N6BcGmnayALZIJIgWGJHHP5KosJOe19_lkrU-w1-r6lhDMp69ZRC_DRfQJMMLoxm3YWtmu3zbj5idTGnXnVSVVJyHw_BP6HQYZ1BP8kGDREQSztbfKC0JH3TXA-LYzt9Eq91AznrMbBy7ptO_aOiHrce02PQqmqpB3A5WOpfRSlopOdbR-TPwxacCyEkB4yrsZj7TXPzIF4RoCsaRlOeW_A3HvnHlU_6OO2gR9fzgnrbrDL2knpug","token_id":"6f2e9179-46c9-44e1-aca2-131e16550b0b","managed":"true","endpoint_public_cert":"MIIDWDCCAkCgAwIBAgIIWc41/P+e4oQwDQYJKoZIhvcNAQEFBQAwXzELMAkGA1UEBhMCVVMxDTALBgNVBAgTBFRlc3QxDTALBgNVBAcTBFRlc3QxDzANBgNVBAoTBkhhZG9vcDENMAsGA1UECxMEVGVzdDESMBAGA1UEAxMJbG9jYWxob3N0MB4XDTI1MDMxOTE5MDYxOFoXDTI2MDMxOTE5MDYxOFowXzELMAkGA1UEBhMCVVMxDTALBgNVBAg...7NHvGyFUuFcDRFgOHzOP0D8dXsctm1mXx8xlRWsJT+gWcq0KKsvG+ia5niFRmlA7dWSkJ55wWVk9jzeyNq3av/4UW3fpq9B6BJa2FYLoC+JZC0YL1sE21gqH/4zrPRlnQo6I4BQOmuZZpNcxr+n6z6gCbZHSlEsgsggLbbvxYmr1odLLwL1/HXGCKlGLOkLw+uxTud115GppjHIZyhBBlc1R/ubxKGN2CsKkBKyayxll+2X9tBbq3BiTxg6jv3Let8OpEL/XNE4d64Le2Q7wIDAQABoxgwFjAUBgNVHREEDTALgglsb2NhbGhvc3QwDQYJKoZIhvcNAQEFBQADggEBAE5hNf5YTazdV5uueucgDynnxZQr359er0q7mewFl3fGGv3UDuwnWAyXdKNH4TLeCH8B1483m0DiYIEXiBO2MHHg1gTAXtMG2tUs/ZcoVbQn1j7l0Jux9dpcQ5ivPp1SEW+l44FwefVpE6xeT9ydfebO6kDJXl9D7EgtgtEYAj/jXOnQeX/oYWOTOaiKiTYIgFgCbKOGJTZxPFRn6fjA9ro//92/1bGd1RvGnQMG6yl2wQtiUr01dvhUbASGF0y+o4v70Fum/Turi07L2Aqs7b6kFxSYwz1xXWV1J+sjNnYex3UfAxNs/iUFvKqToXsBKEAvY6S2jUnmxnA/RhfPBxc=","token_type":"Bearer","expires_in":-1,"passcode":"Tm1ZeVpUa3hOemt0...V0k1TlRFeE56SXRaalptWXkwME5ESXpMV0kzTVRBdFpqSTNNRFV4WldWbE9UZ3k="}% 
```