### PR TITLE
KNOX-3111: Gobal config for HSTS headers

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -809,4 +809,7 @@ public interface GatewayMessages {
 
   @Message( level = MessageLevel.INFO, text = "Excluded \"{0}\" topology from client auth" )
   void topologyExcludedFromClientAuth( String topologyName );
+
+  @Message( level = MessageLevel.DEBUG, text = "Strict-Transport-Security header enabled with \"{0}\" option" )
+  void strictTransportHeaderEnabled(String option);
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -33,6 +33,7 @@ import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentException;
 import org.apache.knox.gateway.deploy.DeploymentFactory;
 import org.apache.knox.gateway.filter.CorrelationHandler;
+import org.apache.knox.gateway.filter.HSTSHandler;
 import org.apache.knox.gateway.filter.PortMappingHelperHandler;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.i18n.resources.ResourcesFactory;
@@ -524,6 +525,12 @@ public class GatewayServer {
     }
 
     handlers.addHandler(logHandler);
+
+    if(config.isStrictTransportEnabled()) {
+      final String strictTransportOption = config.getStrictTransportOption();
+      handlers.addHandler(new HSTSHandler(strictTransportOption));
+      log.strictTransportHeaderEnabled(strictTransportOption);
+    }
 
     if (config.isWebsocketEnabled()) {
       final GatewayWebsocketHandler websocketHandler = new GatewayWebsocketHandler(

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -359,6 +359,13 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final long JWKS_OUTAGE_CACHE_TTL_DEFAULT = TimeUnit.HOURS.toMillis(2);
   private static final String ISSUER_IGNORE_TYPE_VALIDATION = GATEWAY_CONFIG_FILE_PREFIX + ".token.issuers.ignore.type.validation";
 
+  //Strict-Transport Option
+  public static final boolean DEFAULT_STRICT_TRANSPORT_ENABLED = false;
+  public static final String DEFAULT_STRICT_TRANSPORT_OPTION = "max-age=31536000";
+
+  public static final String STRICT_TRANSPORT_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".strict.transport.enabled";
+  public static final String STRICT_TRANSPORT_OPTION = GATEWAY_CONFIG_FILE_PREFIX + ".strict.transport.option";
+
   public GatewayConfigImpl() {
     init();
   }
@@ -1615,4 +1622,13 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     return getLong(JWKS_OUTAGE_CACHE_TTL, JWKS_OUTAGE_CACHE_TTL_DEFAULT);
   }
 
+  @Override
+  public boolean isStrictTransportEnabled() {
+    return getBoolean(STRICT_TRANSPORT_ENABLED, DEFAULT_STRICT_TRANSPORT_ENABLED);
+  }
+
+  @Override
+  public String getStrictTransportOption() {
+    return get(STRICT_TRANSPORT_OPTION, DEFAULT_STRICT_TRANSPORT_OPTION);
+  }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/filter/HSTSHandler.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/filter/HSTSHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import com.google.common.net.HttpHeaders;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HSTSHandler extends HandlerWrapper {
+
+    private final String option;
+
+    public HSTSHandler(String option) {
+        this.option = option;
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        response.setHeader(HttpHeaders.STRICT_TRANSPORT_SECURITY, option);
+        super.handle(target, baseRequest, request, response);
+    }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
@@ -79,7 +79,7 @@ public class GatewayGlobalConfigTest {
   public void testSiteConfigWithDifferentTopologyExcluded() {
     System.setProperty( GatewayConfigImpl.GATEWAY_HOME_VAR, getHomeDirName( "conf-site/conf/gateway-site.xml" ) );
     GatewayConfig config = new GatewayConfigImpl();
-    assertThat( config.isClientAuthNeeded(), is( true ) );
+    assertTrue( config.isClientAuthNeeded() );
     assertFalse( config.isTopologyExcludedFromClientAuth("different"));
   }
 
@@ -198,5 +198,21 @@ public class GatewayGlobalConfigTest {
     System.setProperty(GatewayConfigImpl.GATEWAY_HOME_VAR, homeDirName);
     config = new GatewayConfigImpl();
     assertEquals("target/test", config.getGatewayServicesDir());
+  }
+
+  @Test
+  public void testSiteConfigWithStrictTransportEnabled() {
+    System.setProperty( GatewayConfigImpl.GATEWAY_HOME_VAR, getHomeDirName( "conf-site/conf/gateway-site.xml" ) );
+    GatewayConfig config = new GatewayConfigImpl();
+    assertTrue(config.isStrictTransportEnabled());
+    assertEquals("max-age=3000", config.getStrictTransportOption());
+  }
+
+  @Test
+  public void testSiteConfigWithStrictTransportDisabled() {
+    System.setProperty( GatewayConfigImpl.GATEWAY_HOME_VAR, getHomeDirName( "conf-demo/conf/gateway-site.xml" ) );
+    GatewayConfig config = new GatewayConfigImpl();
+    assertFalse(config.isStrictTransportEnabled());
+    assertEquals("max-age=31536000", config.getStrictTransportOption());
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/filter/HSTSHandlerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/filter/HSTSHandlerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.filter;
+
+import junit.framework.TestCase;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HSTSHandlerTest extends TestCase {
+
+    @Test
+    public void testHandle() throws ServletException, IOException {
+        HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+        response.setHeader("Strict-Transport-Security", "max-age=1000");
+        EasyMock.expectLastCall().once();
+        EasyMock.replay(response);
+
+        HSTSHandler hstsHandler = new HSTSHandler("max-age=1000");
+        hstsHandler.handle("", null, null, response);
+
+        EasyMock.verify(response);
+    }
+}

--- a/gateway-server/src/test/resources/conf-site/conf/gateway-site.xml
+++ b/gateway-server/src/test/resources/conf-site/conf/gateway-site.xml
@@ -72,4 +72,14 @@ limitations under the License.
         <value>PKCS12</value>
         <description>type of truststore</description>
     </property>
+
+    <property>
+        <name>gateway.strict.transport.enabled</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>gateway.strict.transport.option</name>
+        <value>max-age=3000</value>
+    </property>
 </configuration>

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1143,4 +1143,13 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return Collections.emptySet();
   }
 
+  @Override
+  public boolean isStrictTransportEnabled() {
+    return false;
+  }
+
+  @Override
+  public String getStrictTransportOption() {
+    return "max-age=3001";
+  }
 }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1145,7 +1145,7 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
 
   @Override
   public boolean isStrictTransportEnabled() {
-    return false;
+    return true;
   }
 
   @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -971,4 +971,14 @@ public interface GatewayConfig {
    * @return
   */
   Set<String> getIssuersWithIgnoredTypeHeader();
+
+  /**
+   * @return true if the strict transport is enabled; otherwise false
+   */
+  boolean isStrictTransportEnabled();
+
+  /**
+   * @return the strict transport option if set; otherwise return the default value 'max-age=31536000'
+   */
+  String getStrictTransportOption();
 }

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayHSTSTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayHSTSTest.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import com.mycila.xmltool.XMLDoc;
+import com.mycila.xmltool.XMLTag;
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.http.HttpStatus;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.security.ldap.SimpleLdapDirectoryServer;
+import org.apache.knox.gateway.services.DefaultGatewayServices;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.test.TestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hamcrest.MatcherAssert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.notNullValue;
+
+public class GatewayHSTSTest {
+    private static final Logger LOG = LogManager.getLogger(GatewayHSTSTest.class);
+
+    public static GatewayConfig config;
+    public static GatewayServer gateway;
+    public static String gatewayUrl;
+    public static SimpleLdapDirectoryServer ldap;
+    public static TcpTransport ldapTransport;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        TestUtils.LOG_ENTER();
+        setupLdap();
+        setupGateway();
+        TestUtils.LOG_EXIT();
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        TestUtils.LOG_ENTER();
+        gateway.stop();
+        ldap.stop(true);
+        TestUtils.LOG_EXIT();
+    }
+
+    public static void setupLdap() throws Exception {
+        String basedir = System.getProperty("basedir");
+        if (basedir == null) {
+            basedir = new File(".").getCanonicalPath();
+        }
+
+        final Path path = FileSystems
+                .getDefault().getPath(basedir, "/src/test/resources/users.ldif");
+
+        ldapTransport = new TcpTransport(0);
+        ldap = new SimpleLdapDirectoryServer("dc=hadoop,dc=apache,dc=org", path.toFile(), ldapTransport);
+        ldap.start();
+        LOG.info("LDAP port = " + ldapTransport.getPort());
+    }
+
+    public static void setupGateway() throws Exception {
+
+        File targetDir = new File(System.getProperty("user.dir"), "target");
+        File gatewayDir = new File(targetDir, "gateway-home-" + UUID.randomUUID());
+        gatewayDir.mkdirs();
+
+        GatewayTestConfig testConfig = new GatewayTestConfig();
+        config = testConfig;
+        testConfig.setGatewayHomeDir(gatewayDir.getAbsolutePath());
+
+        File topoDir = new File(testConfig.getGatewayTopologyDir());
+        topoDir.mkdirs();
+
+        File descDir = new File(testConfig.getGatewayDescriptorsDir());
+        descDir.mkdirs();
+
+        File provConfDir = new File(testConfig.getGatewayProvidersConfigDir());
+        provConfDir.mkdirs();
+
+        File deployDir = new File(testConfig.getGatewayDeploymentDir());
+        deployDir.mkdirs();
+
+        File strictDescriptor = new File(topoDir, "strict-cluster.xml");
+        try (OutputStream stream = Files.newOutputStream(strictDescriptor.toPath())) {
+            createTopology(true).toStream(stream);
+        }
+
+        File nonStrictDescriptor = new File(topoDir, "non-strict-cluster.xml");
+        try (OutputStream stream = Files.newOutputStream(nonStrictDescriptor.toPath())) {
+            createTopology(false).toStream(stream);
+        }
+
+        DefaultGatewayServices srvcs = new DefaultGatewayServices();
+        Map<String, String> options = new HashMap<>();
+        options.put("persist-master", "false");
+        options.put("master", "password");
+        try {
+            srvcs.init(testConfig, options);
+        } catch (ServiceLifecycleException e) {
+            e.printStackTrace(); // I18N not required.
+        }
+        gateway = GatewayServer.startGateway(testConfig, srvcs);
+        MatcherAssert.assertThat("Failed to start gateway.", gateway, notNullValue());
+
+        LOG.info("Gateway port = " + gateway.getAddresses()[0].getPort());
+
+        gatewayUrl = "http://localhost:" + gateway.getAddresses()[0].getPort() + "/" + config.getGatewayPath();
+    }
+
+    private static XMLTag createTopology(boolean strictTransport) {
+        return XMLDoc.newDocument(true)
+                .addRoot("topology")
+                .addTag("gateway")
+                .addTag("provider")
+                .addTag("role").addText("authentication")
+                .addTag("name").addText("ShiroProvider")
+                .addTag("enabled").addText("true")
+                .addTag("param")
+                .addTag("name").addText("main.ldapRealm")
+                .addTag("value").addText("org.apache.knox.gateway.shirorealm.KnoxLdapRealm").gotoParent()
+                .addTag("param")
+                .addTag("name").addText("main.ldapRealm.userDnTemplate")
+                .addTag("value").addText("uid={0},ou=people,dc=hadoop,dc=apache,dc=org").gotoParent()
+                .addTag("param")
+                .addTag("name").addText("main.ldapRealm.contextFactory.url")
+                .addTag("value").addText("ldap://localhost:" + ldapTransport.getAcceptor().getLocalAddress().getPort()).gotoParent()
+                .addTag("param")
+                .addTag("name").addText("main.ldapRealm.contextFactory.authenticationMechanism")
+                .addTag("value").addText("simple").gotoParent()
+                .addTag("param")
+                .addTag("name").addText("urls./**")
+                .addTag("value").addText("authcBasic").gotoParent().gotoParent()
+                .addTag("provider")
+                .addTag("role").addText("identity-assertion")
+                .addTag("enabled").addText("true")
+                .addTag("name").addText("Default").gotoParent()
+                .addTag("provider")
+                .addTag("role").addText("webappsec")
+                .addTag("name").addText("WebAppSec")
+                .addTag("enabled").addText("true")
+                .addTag("param")
+                .addTag("name").addText("strict.transport.enabled")
+                .addTag("value").addText(String.valueOf(strictTransport)).gotoParent()
+                .addTag("param")
+                .addTag("name").addText("strict.transport")
+                .addTag("value").addText("max-age=444; includeSubDomains").gotoParent()
+                .gotoRoot()
+                .addTag("service")
+                .addTag("role").addText("HEALTH")
+                .gotoRoot();
+    }
+
+    @Test(timeout = TestUtils.MEDIUM_TIMEOUT)
+    public void testTopologyHSTSHeader404() {
+        TestUtils.LOG_ENTER();
+        String username = "guest";
+        String password = "guest-password";
+        String serviceUrl = gatewayUrl + "/strict-cluster/v1/not-exist";
+        given()
+                .auth().preemptive().basic(username, password)
+                .header("Accept", MediaType.TEXT_PLAIN)
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .header("Strict-Transport-Security", "max-age=444; includeSubDomains")
+                .contentType(MediaType.TEXT_PLAIN)
+                .when().get(serviceUrl);
+        TestUtils.LOG_EXIT();
+    }
+
+    @Test(timeout = TestUtils.MEDIUM_TIMEOUT)
+    public void testTopologyHSTSHeader200() {
+        TestUtils.LOG_ENTER();
+        String username = "guest";
+        String password = "guest-password";
+        String serviceUrl = gatewayUrl + "/strict-cluster/v1/ping";
+        given()
+                .auth().preemptive().basic(username, password)
+                .header("Accept", MediaType.TEXT_PLAIN)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .header("Strict-Transport-Security", "max-age=444; includeSubDomains")
+                .contentType(MediaType.TEXT_PLAIN)
+                .when().get(serviceUrl);
+        TestUtils.LOG_EXIT();
+    }
+
+    @Test(timeout = TestUtils.MEDIUM_TIMEOUT)
+    public void testGlobalHSTSHeader200() {
+        TestUtils.LOG_ENTER();
+        String username = "guest";
+        String password = "guest-password";
+        String serviceUrl = gatewayUrl + "/non-strict-cluster/v1/ping";
+        given()
+                .auth().preemptive().basic(username, password)
+                .header("Accept", MediaType.TEXT_PLAIN)
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .header("Strict-Transport-Security", "max-age=3001")
+                .contentType(MediaType.TEXT_PLAIN)
+                .when().get(serviceUrl);
+        TestUtils.LOG_EXIT();
+    }
+
+    @Test(timeout = TestUtils.MEDIUM_TIMEOUT)
+    public void testGlobalHSTSHeader404() {
+        TestUtils.LOG_ENTER();
+        String username = "guest";
+        String password = "guest-password";
+        String serviceUrl = gatewayUrl + "/non-strict-cluster/v1/not-exist";
+        given()
+                .auth().preemptive().basic(username, password)
+                .header("Accept", MediaType.TEXT_PLAIN)
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .header("Strict-Transport-Security", "max-age=3001")
+                .contentType(MediaType.TEXT_PLAIN)
+                .when().get(serviceUrl);
+        TestUtils.LOG_EXIT();
+    }
+
+    @Test(timeout = TestUtils.MEDIUM_TIMEOUT)
+    public void testGlobalHSTSHeaderTopologyNotExist() {
+        TestUtils.LOG_ENTER();
+        String username = "guest";
+        String password = "guest-password";
+        String serviceUrl = gatewayUrl + "/not-exist/v1/not-exist";
+        given()
+                .auth().preemptive().basic(username, password)
+                .header("Accept", MediaType.TEXT_PLAIN)
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .header("Strict-Transport-Security", "max-age=3001")
+                .contentType(MediaType.TEXT_PLAIN)
+                .when().get(serviceUrl);
+        TestUtils.LOG_EXIT();
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR introduces the ability to enable `Strict-Transport-Security` header globally for all responses (even 404). Currently there is a topology wide configuration in the WebAppSec provider. The users now can enable it for only specific topologies or globally as well. If both is enabled and there is a request for that specific topology the WebAppSec configuration will take precedence. 

To enable the global configuration the below is required in the gateway-site.xml configuration file. The `option` config is optional, the default value is `max-age=31536000` (Its the same for the WebAppSec provider as well).

```
<property>
    <name>gateway.strict.transport.enabled</name>
    <value>true</value>
</property>
<property>
    <name>gateway.strict.transport.option</name>
    <value>max-age=31</value>
</property>
```

## How was this patch tested?

Unit tests.
Manual tests locally. 
