### PR TITLE
KNOX-3113: Changed the default HSTS header for global config, skips c…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -361,7 +361,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   //Strict-Transport Option
   public static final boolean DEFAULT_STRICT_TRANSPORT_ENABLED = false;
-  public static final String DEFAULT_STRICT_TRANSPORT_OPTION = "max-age=31536000";
+  public static final String DEFAULT_STRICT_TRANSPORT_OPTION = "max-age=31536000; includeSubDomains";
 
   public static final String STRICT_TRANSPORT_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".strict.transport.enabled";
   public static final String STRICT_TRANSPORT_OPTION = GATEWAY_CONFIG_FILE_PREFIX + ".strict.transport.option";

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayGlobalConfigTest.java
@@ -213,6 +213,6 @@ public class GatewayGlobalConfigTest {
     System.setProperty( GatewayConfigImpl.GATEWAY_HOME_VAR, getHomeDirName( "conf-demo/conf/gateway-site.xml" ) );
     GatewayConfig config = new GatewayConfigImpl();
     assertFalse(config.isStrictTransportEnabled());
-    assertEquals("max-age=31536000", config.getStrictTransportOption());
+    assertEquals("max-age=31536000; includeSubDomains", config.getStrictTransportOption());
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/dispatch/DefaultDispatch.java
@@ -68,6 +68,7 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
   /* list of cookies that should be blocked when set-cookie header is allowed */
   protected static final Set<String> EXCLUDE_SET_COOKIES_DEFAULT = new HashSet<>(Arrays.asList("hadoop.auth", "hive.server2.auth", "impala.auth"));
 
+  protected static final String STRICT_TRANSPORT_SECURITY = "Strict-Transport-Security";
 
   protected static final SpiGatewayMessages LOG = MessagesFactory.get(SpiGatewayMessages.class);
   protected static final SpiGatewayResources RES = ResourcesFactory.get(SpiGatewayResources.class);
@@ -359,6 +360,10 @@ public class DefaultDispatch extends AbstractGatewayDispatch {
     getOutboundResponseExcludeHeaders().stream().forEach(excludeHeader ->
         excludedHeaderDirectives.put(excludeHeader, Collections.singleton(EXCLUDE_ALL)));
     excludedHeaderDirectives.put(SET_COOKIE, getOutboundResponseExcludedSetCookieHeaderDirectives());
+    //If HSTS header is already present in the response we skip adding it to avoid any duplication
+    if(outboundResponse.containsHeader(STRICT_TRANSPORT_SECURITY)) {
+        excludedHeaderDirectives.put(STRICT_TRANSPORT_SECURITY, Collections.singleton(EXCLUDE_ALL));
+    }
 
     for (Header header : inboundResponse.getAllHeaders()) {
       boolean isBlockedAuthHeader = Arrays.stream(header.getElements()).anyMatch(h -> EXCLUDE_SET_COOKIES_DEFAULT.contains(h.getName()) && getOutboundResponseExcludedSetCookieHeaderDirectives().contains(h.getName()) );


### PR DESCRIPTION
…opying the HSTS header if its already set

## What changes were proposed in this pull request?

[KNOX-3111](https://issues.apache.org/jira/projects/KNOX/issues/KNOX-3111) introduced a bug. If the global settings for HSTS is set and the topology wide setting is disabled the HSTS header is duplicated in case the proxied service also adds its own header. This PR adds verification to the response header copy method that checks whether this header is already set or not.

Also added `includeSubDomains` to the default global setting.

## How was this patch tested?
New unit tests
Manually tests