### PR TITLE
KNOX-3112 - Add an API for CLIENT_ID and SECRET based on KNOXTOKEN API

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file to
+ * you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import org.apache.knox.gateway.services.security.token.TokenMetadata;
+import org.apache.knox.gateway.services.security.token.TokenMetadataType;
+import org.apache.knox.gateway.util.JsonUtils;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+
+@Path(ClientCredentialsResource.RESOURCE_PATH)
+@Singleton
+public class ClientCredentialsResource extends TokenResource {
+    private static final String TYPE = "type";
+    public static final String RESOURCE_PATH = "clientid/api/v1/oauth/credentials";
+    public static final String CLIENT_ID = "client_id";
+    public static final String CLIENT_SECRET = "client_secret";
+
+    @Override
+    @GET
+    @Produces({ APPLICATION_JSON, APPLICATION_XML })
+    public Response doGet() {
+        return super.doGet();
+    }
+
+    @Override
+    @POST
+    @Produces({ APPLICATION_JSON, APPLICATION_XML })
+    public Response doPost() {
+        return super.doPost();
+    }
+
+    @Override
+    protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
+        tokenMetadata.add(TYPE, TokenMetadataType.CLIENT_ID.name());
+        super.addArbitraryTokenMetadata(tokenMetadata);
+    }
+
+    @Override
+    public Response getAuthenticationToken() {
+        Response response = enforceClientCertIfRequired();
+        if (response != null) { return response; }
+
+        response = onlyAllowGroupsToBeAddedWhenEnabled();
+        if (response != null) { return response; }
+
+        UserContext context = buildUserContext(request);
+
+        response = enforceTokenLimitsAsRequired(context.userName);
+        if (response != null) { return response; }
+
+        TokenResponseContext resp = getTokenResponse(context);
+        if (resp.responseMap != null) {
+            String passcode = resp.responseMap.passcode;
+            String tokenId = resp.responseMap.tokenId;
+
+            final HashMap<String, Object> map = new HashMap<>();
+            map.put(CLIENT_ID, tokenId);
+            map.put(CLIENT_SECRET, passcode);
+            String jsonResponse = JsonUtils.renderAsJsonString(map);
+            return resp.responseBuilder.entity(jsonResponse).build();
+        }
+
+        if (resp.responseStr != null) {
+            return resp.responseBuilder.entity(resp.responseStr).build();
+        } else {
+            return resp.responseBuilder.build();
+        }
+    }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -1071,7 +1071,7 @@ public class TokenResource {
     return groups;
   }
 
-  private void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
+  protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
     final Enumeration<String> paramNames = request.getParameterNames();
     while (paramNames.hasMoreElements()) {
       final String paramName = paramNames.nextElement();

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/deploy/ClientCredentialsServiceDeploymentContributor.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/deploy/ClientCredentialsServiceDeploymentContributor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken.deploy;
+
+import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
+
+public class ClientCredentialsServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
+
+    public static final String ROLE = "CLIENTID";
+
+    @Override
+    public String getRole() {
+        return ROLE;
+    }
+
+    @Override
+    public String getName() {
+        return "ClientCredentialsService";
+    }
+
+    @Override
+    protected String[] getPackages() {
+      return new String[]{ "org.apache.knox.gateway.service.knoxtoken" };
+    }
+
+    @Override
+    protected String[] getPatterns() {
+       return new String[]{ "clientid/api/**?**" };
+    }
+}

--- a/gateway-service-knoxtoken/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ServiceDeploymentContributor
+++ b/gateway-service-knoxtoken/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ServiceDeploymentContributor
@@ -17,3 +17,4 @@
 ##########################################################################
 
 org.apache.knox.gateway.service.knoxtoken.deploy.TokenServiceDeploymentContributor
+org.apache.knox.gateway.service.knoxtoken.deploy.ClientCredentialsServiceDeploymentContributor

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1394,6 +1394,25 @@ public class TokenServiceResourceTest {
     assertFalse(payload.containsKey(KNOX_GROUPS_CLAIM));
   }
 
+  @Test
+  public void testClientCredentialsResponse() throws Exception {
+    Map<String, String> contextExpectations = new HashMap<>();
+    configureCommonExpectations(contextExpectations, Boolean.TRUE);
+
+    ClientCredentialsResource ccr = new ClientCredentialsResource();
+    ccr.request = request;
+    ccr.context = context;
+    ccr.init();
+
+    Response response = ccr.doPost();
+    assertEquals(200, response.getStatus());
+
+    String clientId = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_ID);
+    assertNotNull(clientId);
+    String clientSecret = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_SECRET);
+    assertNotNull(clientSecret);
+  }
+
   /**
    *
    * @param isTokenStateServerManaged true, if server-side token state management should be enabled; Otherwise, false or null.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a specialized extension of the KNOXTOKEN API to request CLIENT_ID and CLIENT_SECRET.
This requires the use of Passcode tokens as the CLIENT_SECRET and the TokenID as the CLIENT_ID.

One of the motivations for this is to provide this extension so that it can be deployed separately within the same topology as the KNOXTOKEN API. Another is to codify the conventions being used in order to use the pattern described above for CLIENT_ID and CLIENT_SECRET without having to leave it to the consumer to interpret how to do so.

## How was this patch tested?

New unit tests were added for the API extension and run along with all existing unit tests.
Manual testing of the use of CLIENT_ID and CLIENT_SECRET was done with the JWTProvider.