### PR TITLE
KNOX-3118 - Use SHA256 as Knox Default Self-Signing algorithem for SSL…

### DIFF
--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -27,6 +27,7 @@ import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.SSOCookieFederationFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.SignatureVerificationCache;
@@ -107,7 +108,7 @@ public abstract class AbstractJWTFilterTest  {
     kpg.initialize(2048);
     KeyPair KPair = kpg.generateKeyPair();
     String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
     byte[] data = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     pem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -655,7 +656,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG );
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -711,7 +712,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -770,7 +771,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -865,7 +866,7 @@ public abstract class AbstractJWTFilterTest  {
 
     KeyPair KPair = kpg.generateKeyPair();
     String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
     byte[] data = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     return new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -107,7 +107,7 @@ public abstract class AbstractJWTFilterTest  {
     kpg.initialize(2048);
     KeyPair KPair = kpg.generateKeyPair();
     String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
     byte[] data = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     pem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -655,7 +655,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -711,7 +711,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -770,7 +770,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -865,7 +865,7 @@ public abstract class AbstractJWTFilterTest  {
 
     KeyPair KPair = kpg.generateKeyPair();
     String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
     byte[] data = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     return new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -108,7 +108,7 @@ public abstract class AbstractJWTFilterTest  {
     kpg.initialize(2048);
     KeyPair KPair = kpg.generateKeyPair();
     String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG);
     byte[] data = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     pem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -656,7 +656,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG );
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG );
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -712,7 +712,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG);
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -771,7 +771,7 @@ public abstract class AbstractJWTFilterTest  {
 
       KeyPair KPair = kpg.generateKeyPair();
       String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+      Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG);
       byte[] data = cert.getEncoded();
       Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
       String failingPem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();
@@ -866,7 +866,7 @@ public abstract class AbstractJWTFilterTest  {
 
     KeyPair KPair = kpg.generateKeyPair();
     String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+    Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG);
     byte[] data = cert.getEncoded();
     Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
     return new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -801,8 +801,8 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public String getCredentialSelfSigningAlgorithm() {
-    return get(CREDENTIAL_SELF_SIGNING_ALG, DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+  public String getSelfSigningCertificateAlgorithm() {
+    return get(SELF_SIGNING_CERT_ALG, DEFAULT_SELF_SIGNING_CERT_ALG);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -801,6 +801,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getCredentialSelfSigningAlgorithm() {
+    return get(CREDENTIAL_SELF_SIGNING_ALG, DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+  }
+
+  @Override
   public String getCredentialStoreType() {
     return get(CREDENTIAL_STORE_TYPE, DEFAULT_CREDENTIAL_STORE_TYPE);
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -196,11 +196,11 @@ public class DefaultKeystoreService implements KeystoreService {
       X509Certificate cert;
       if(hostname.equals(CERT_GEN_MODE_HOSTNAME)) {
         String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
       }
       else {
         String dn = buildDistinguishedName(hostname);
-        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
       }
 
       KeyStore privateKS = getKeystoreForGateway();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -89,9 +89,9 @@ public class DefaultKeystoreService implements KeystoreService {
   private Path keyStoreDirPath;
 
   private String credentialStoreAlgorithm;
-  private String credentialSelfSigningAlgorithm;
   private String credentialStoreType;
   private String credentialsSuffix;
+  private String selfSigningCertificateAlgorithm;
 
   public void setMasterService(MasterService ms) {
     this.masterService = ms;
@@ -118,9 +118,9 @@ public class DefaultKeystoreService implements KeystoreService {
     }
 
     this.credentialStoreAlgorithm = config.getCredentialStoreAlgorithm();
-    this.credentialSelfSigningAlgorithm = config.getCredentialSelfSigningAlgorithm();
     this.credentialStoreType = config.getCredentialStoreType();
     this.credentialsSuffix = CREDENTIALS_SUFFIX + this.credentialStoreType.toLowerCase(Locale.ROOT);
+    this.selfSigningCertificateAlgorithm = config.getSelfSigningCertificateAlgorithm();
   }
 
   @Override
@@ -198,11 +198,11 @@ public class DefaultKeystoreService implements KeystoreService {
       X509Certificate cert;
       if(hostname.equals(CERT_GEN_MODE_HOSTNAME)) {
         String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, this.credentialSelfSigningAlgorithm);
+        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, this.selfSigningCertificateAlgorithm);
       }
       else {
         String dn = buildDistinguishedName(hostname);
-        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, this.credentialSelfSigningAlgorithm);
+        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, this.selfSigningCertificateAlgorithm);
       }
 
       KeyStore privateKS = getKeystoreForGateway();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreService.java
@@ -89,6 +89,7 @@ public class DefaultKeystoreService implements KeystoreService {
   private Path keyStoreDirPath;
 
   private String credentialStoreAlgorithm;
+  private String credentialSelfSigningAlgorithm;
   private String credentialStoreType;
   private String credentialsSuffix;
 
@@ -117,6 +118,7 @@ public class DefaultKeystoreService implements KeystoreService {
     }
 
     this.credentialStoreAlgorithm = config.getCredentialStoreAlgorithm();
+    this.credentialSelfSigningAlgorithm = config.getCredentialSelfSigningAlgorithm();
     this.credentialStoreType = config.getCredentialStoreType();
     this.credentialsSuffix = CREDENTIALS_SUFFIX + this.credentialStoreType.toLowerCase(Locale.ROOT);
   }
@@ -196,11 +198,11 @@ public class DefaultKeystoreService implements KeystoreService {
       X509Certificate cert;
       if(hostname.equals(CERT_GEN_MODE_HOSTNAME)) {
         String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, this.credentialSelfSigningAlgorithm);
       }
       else {
         String dn = buildDistinguishedName(hostname);
-        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+        cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, this.credentialSelfSigningAlgorithm);
       }
 
       KeyStore privateKS = getKeystoreForGateway();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
@@ -298,6 +298,7 @@ public class DefaultKeystoreServiceTest {
 
     Path baseDir = testFolder.newFolder().toPath();
     GatewayConfigImpl config = createGatewayConfig(baseDir);
+    String selfSigningAlgorithm = config.getCredentialSelfSigningAlgorithm();
 
     /* *******************
      * Test Defaults
@@ -314,7 +315,7 @@ public class DefaultKeystoreServiceTest {
       fail("Not expecting ServiceLifecycleException due to missing signing keystore file since a custom one is not specified");
     }
 
-    createKeystore(keystoreService, defaultFile, defaultAlias, masterPassword);
+    createKeystore(keystoreService, defaultFile, defaultAlias, masterPassword, selfSigningAlgorithm);
 
     keystoreService.init(config, Collections.emptyMap());
 
@@ -333,7 +334,7 @@ public class DefaultKeystoreServiceTest {
     keystoreServiceAlt.setMasterService(masterService);
 
     // Ensure the signing keystore exists before init-ing the keystore service
-    createKeystore(keystoreService, customFile, customKeyAlias, masterPassword);
+    createKeystore(keystoreService, customFile, customKeyAlias, masterPassword, selfSigningAlgorithm);
 
     keystoreServiceAlt.init(config, Collections.emptyMap());
 
@@ -371,7 +372,7 @@ public class DefaultKeystoreServiceTest {
     keystoreServiceSymlink.setMasterService(masterService);
 
     // Ensure the signing keystore exists before init-ing the keystore service
-    createKeystore(keystoreService, symlinkFile, symlinkKeyAlias, masterPassword);
+    createKeystore(keystoreService, symlinkFile, symlinkKeyAlias, masterPassword, selfSigningAlgorithm);
 
     keystoreServiceSymlink.init(config, Collections.emptyMap());
 
@@ -531,7 +532,7 @@ public class DefaultKeystoreServiceTest {
     keystoreService.setMasterService(masterService);
     keystoreService.init(config, Collections.emptyMap());
 
-    createKeystore(keystoreService, Paths.get(config.getIdentityKeystorePath()), config.getIdentityKeyAlias(), masterPassword);
+    createKeystore(keystoreService, Paths.get(config.getIdentityKeystorePath()), config.getIdentityKeyAlias(), masterPassword, config.getCredentialSelfSigningAlgorithm());
 
     assertNull(keystoreService.getKeyForGateway("wrongpassword".toCharArray()));
     assertNotNull(keystoreService.getKeyForGateway(masterPassword));
@@ -814,7 +815,7 @@ public class DefaultKeystoreServiceTest {
 
   }
 
-  private void createKeystore(DefaultKeystoreService keystoreService, Path keystoreFilePath, String alias, char[] password)
+  private void createKeystore(DefaultKeystoreService keystoreService, Path keystoreFilePath, String alias, char[] password, String selfSigningAlgorithm)
       throws KeystoreServiceException, KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
     KeyStore keystore = keystoreService.createKeyStore(keystoreFilePath, "JKS", password);
 
@@ -827,7 +828,7 @@ public class DefaultKeystoreServiceTest {
         String.format(Locale.ROOT, "CN=%s,OU=Test,O=Hadoop,L=Test,ST=Test,C=US", this.getClass().getName()),
         keyPair,
         365,
-        "SHA256withRSA");
+        selfSigningAlgorithm);
 
     keystore.setKeyEntry(alias, keyPair.getPrivate(),
         password,

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
@@ -298,13 +298,16 @@ public class DefaultKeystoreServiceTest {
 
     Path baseDir = testFolder.newFolder().toPath();
     GatewayConfigImpl config = createGatewayConfig(baseDir);
-    String selfSigningAlgorithm = config.getCredentialSelfSigningAlgorithm();
 
     /* *******************
      * Test Defaults
      */
     Path defaultFile = baseDir.resolve("security").resolve("keystores").resolve("gateway.jks");
     String defaultAlias = "gateway-identity";
+
+    config.set(SIGNING_KEYSTORE_NAME, defaultFile.getFileName().toString());
+    config.set(IDENTITY_KEYSTORE_PATH, defaultFile.toAbsolutePath().toString());
+    config.set(IDENTITY_KEY_ALIAS, defaultAlias);
 
     DefaultKeystoreService keystoreService = new DefaultKeystoreService();
     keystoreService.setMasterService(masterService);
@@ -315,11 +318,11 @@ public class DefaultKeystoreServiceTest {
       fail("Not expecting ServiceLifecycleException due to missing signing keystore file since a custom one is not specified");
     }
 
-    createKeystore(keystoreService, defaultFile, defaultAlias, masterPassword, selfSigningAlgorithm);
+    createKeystore(keystoreService, masterPassword, config);
 
     keystoreService.init(config, Collections.emptyMap());
 
-    testSigningKeystore(keystoreService, defaultFile, defaultAlias, masterPassword);
+    testSigningKeystore(keystoreService, masterPassword, config);
 
     /* *******************
      * Test Custom Values
@@ -329,16 +332,17 @@ public class DefaultKeystoreServiceTest {
     String customKeyAlias = "custom_alias";
 
     config.set(SIGNING_KEYSTORE_NAME, customFileName);
+    config.set(IDENTITY_KEYSTORE_PATH, customFile.toAbsolutePath().toString());
     config.set(SIGNING_KEY_ALIAS, customKeyAlias);
 
     keystoreServiceAlt.setMasterService(masterService);
 
     // Ensure the signing keystore exists before init-ing the keystore service
-    createKeystore(keystoreService, customFile, customKeyAlias, masterPassword, selfSigningAlgorithm);
+    createKeystore(keystoreService, masterPassword, config);
 
     keystoreServiceAlt.init(config, Collections.emptyMap());
 
-    testSigningKeystore(keystoreServiceAlt, customFile, customKeyAlias, masterPassword);
+    testSigningKeystore(keystoreServiceAlt, masterPassword, config);
 
     /* *******************
      * Test Symlink Parent
@@ -366,17 +370,18 @@ public class DefaultKeystoreServiceTest {
     String symlinkKeyAlias = "symlink_alias";
 
     config.set(SIGNING_KEYSTORE_NAME, symlinkFileName);
+    config.set(IDENTITY_KEYSTORE_PATH, symlinkFile.toAbsolutePath().toString());
     config.set(SIGNING_KEY_ALIAS, symlinkKeyAlias);
     config.set(GatewayConfigImpl.SECURITY_DIR, symlinkSecurityDir.toString());
 
     keystoreServiceSymlink.setMasterService(masterService);
 
     // Ensure the signing keystore exists before init-ing the keystore service
-    createKeystore(keystoreService, symlinkFile, symlinkKeyAlias, masterPassword, selfSigningAlgorithm);
+    createKeystore(keystoreService, masterPassword, config);
 
     keystoreServiceSymlink.init(config, Collections.emptyMap());
 
-    testSigningKeystore(keystoreServiceSymlink, symlinkFile, symlinkKeyAlias, masterPassword);
+    testSigningKeystore(keystoreServiceSymlink, masterPassword, config);
 
 
     // Verify the keystore passwords are set properly...
@@ -532,7 +537,7 @@ public class DefaultKeystoreServiceTest {
     keystoreService.setMasterService(masterService);
     keystoreService.init(config, Collections.emptyMap());
 
-    createKeystore(keystoreService, Paths.get(config.getIdentityKeystorePath()), config.getIdentityKeyAlias(), masterPassword, config.getCredentialSelfSigningAlgorithm());
+    createKeystore(keystoreService, masterPassword, config);
 
     assertNull(keystoreService.getKeyForGateway("wrongpassword".toCharArray()));
     assertNotNull(keystoreService.getKeyForGateway(masterPassword));
@@ -799,12 +804,11 @@ public class DefaultKeystoreServiceTest {
   }
 
   private void testSigningKeystore(KeystoreService keystoreService,
-                                   Path expectedKeystoreFilePath,
-                                   String keyAlias,
-                                   char[] masterPassword) throws Exception {
-    assertTrue(Files.exists(expectedKeystoreFilePath));
+                                   char[] masterPassword,
+                                   GatewayConfig config) throws Exception {
+    assertTrue(Files.exists(Paths.get(config.getIdentityKeystorePath())));
     assertNotNull(keystoreService.getSigningKeystore());
-    assertNotNull(keystoreService.getSigningKey(keyAlias, masterPassword));
+    assertNotNull(keystoreService.getSigningKey(config.getIdentityKeyAlias(), masterPassword));
   }
 
   private GatewayConfigImpl createGatewayConfig(Path baseDir) {
@@ -815,8 +819,9 @@ public class DefaultKeystoreServiceTest {
 
   }
 
-  private void createKeystore(DefaultKeystoreService keystoreService, Path keystoreFilePath, String alias, char[] password, String selfSigningAlgorithm)
+  private void createKeystore(DefaultKeystoreService keystoreService, char[] password, final GatewayConfig config)
       throws KeystoreServiceException, KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+    Path keystoreFilePath = Paths.get(config.getIdentityKeystorePath());
     KeyStore keystore = keystoreService.createKeyStore(keystoreFilePath, "JKS", password);
 
     KeyPairGenerator keyPairGenerator;
@@ -828,9 +833,9 @@ public class DefaultKeystoreServiceTest {
         String.format(Locale.ROOT, "CN=%s,OU=Test,O=Hadoop,L=Test,ST=Test,C=US", this.getClass().getName()),
         keyPair,
         365,
-        selfSigningAlgorithm);
+        config.getSelfSigningCertificateAlgorithm());
 
-    keystore.setKeyEntry(alias, keyPair.getPrivate(),
+    keystore.setKeyEntry(config.getIdentityKeyAlias(), keyPair.getPrivate(),
         password,
         new java.security.cert.Certificate[]{cert});
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/security/impl/DefaultKeystoreServiceTest.java
@@ -827,7 +827,7 @@ public class DefaultKeystoreServiceTest {
         String.format(Locale.ROOT, "CN=%s,OU=Test,O=Hadoop,L=Test,ST=Test,C=US", this.getClass().getName()),
         keyPair,
         365,
-        "SHA1withRSA");
+        "SHA256withRSA");
 
     keystore.setKeyEntry(alias, keyPair.getPrivate(),
         password,

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
@@ -66,6 +66,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -115,6 +116,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -165,6 +167,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -213,6 +216,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -262,6 +266,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -316,6 +321,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
 
@@ -371,6 +377,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -414,6 +421,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -462,6 +470,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("invalid_password".toCharArray()).atLeastOnce();
@@ -510,6 +519,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -558,6 +568,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -606,6 +617,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityServiceTest.java
@@ -66,7 +66,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -116,7 +116,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -167,7 +167,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -216,7 +216,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -266,7 +266,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());
@@ -321,7 +321,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
 
@@ -377,7 +377,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -421,7 +421,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -470,7 +470,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("invalid_password".toCharArray()).atLeastOnce();
@@ -519,7 +519,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -568,7 +568,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getKeystoreCacheSizeLimit()).andReturn(0L).anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray()).atLeastOnce();
@@ -617,7 +617,7 @@ public class DefaultTokenAuthorityServiceTest {
     EasyMock.expect(config.getSigningKeyAlias()).andReturn("server").anyTimes();
     EasyMock.expect(config.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(config.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(config.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(config.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     MasterService ms = EasyMock.createNiceMock(MasterService.class);
     EasyMock.expect(ms.getMasterSecret()).andReturn("horton".toCharArray());

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -316,7 +316,7 @@ public class BadUrlTest {
 
     EasyMock.expect(gatewayConfig.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(gatewayConfig.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(gatewayConfig.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -316,6 +316,7 @@ public class BadUrlTest {
 
     EasyMock.expect(gatewayConfig.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(gatewayConfig.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/JWTValidatorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/JWTValidatorTest.java
@@ -91,7 +91,7 @@ public class JWTValidatorTest {
         kpg.initialize(2048);
         KeyPair KPair = kpg.generateKeyPair();
         String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-        Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
+        Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG);
         byte[] data = cert.getEncoded();
         Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
         pem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/JWTValidatorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/JWTValidatorTest.java
@@ -91,7 +91,7 @@ public class JWTValidatorTest {
         kpg.initialize(2048);
         KeyPair KPair = kpg.generateKeyPair();
         String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-        Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA1withRSA");
+        Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
         byte[] data = cert.getEncoded();
         Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
         pem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/JWTValidatorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/JWTValidatorTest.java
@@ -91,7 +91,7 @@ public class JWTValidatorTest {
         kpg.initialize(2048);
         KeyPair KPair = kpg.generateKeyPair();
         String dn = buildDistinguishedName(InetAddress.getLocalHost().getHostName());
-        Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, "SHA256withRSA");
+        Certificate cert = X509CertificateUtil.generateCertificate(dn, KPair, 365, GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG);
         byte[] data = cert.getEncoded();
         Base64 encoder = new Base64( 76, "\n".getBytes( StandardCharsets.US_ASCII ) );
         pem = new String(encoder.encodeToString( data ).getBytes( StandardCharsets.US_ASCII ), StandardCharsets.US_ASCII).trim();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
@@ -346,7 +346,7 @@ public class WebsocketEchoTestBase {
 
     EasyMock.expect(gatewayConfig.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(gatewayConfig.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(gatewayConfig.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketEchoTestBase.java
@@ -346,6 +346,7 @@ public class WebsocketEchoTestBase {
 
     EasyMock.expect(gatewayConfig.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(gatewayConfig.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
@@ -379,6 +379,7 @@ public class WebsocketMultipleConnectionTest {
 
     EasyMock.expect(gatewayConfig.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
+    EasyMock.expect(gatewayConfig.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketMultipleConnectionTest.java
@@ -379,7 +379,7 @@ public class WebsocketMultipleConnectionTest {
 
     EasyMock.expect(gatewayConfig.getCredentialStoreType()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_TYPE).anyTimes();
     EasyMock.expect(gatewayConfig.getCredentialStoreAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_STORE_ALG).anyTimes();
-    EasyMock.expect(gatewayConfig.getCredentialSelfSigningAlgorithm()).andReturn(GatewayConfig.DEFAULT_CREDENTIAL_SELF_SIGNING_ALG).anyTimes();
+    EasyMock.expect(gatewayConfig.getSelfSigningCertificateAlgorithm()).andReturn(GatewayConfig.DEFAULT_SELF_SIGNING_CERT_ALG).anyTimes();
 
     EasyMock.replay(gatewayConfig);
 

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -462,6 +462,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getCredentialSelfSigningAlgorithm() {
+    return DEFAULT_CREDENTIAL_SELF_SIGNING_ALG;
+  }
+
+  @Override
   public String getCredentialStoreType() {
     return DEFAULT_CREDENTIAL_STORE_TYPE;
   }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -462,8 +462,8 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
-  public String getCredentialSelfSigningAlgorithm() {
-    return DEFAULT_CREDENTIAL_SELF_SIGNING_ALG;
+  public String getSelfSigningCertificateAlgorithm() {
+    return DEFAULT_SELF_SIGNING_CERT_ALG;
   }
 
   @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -92,6 +92,8 @@ public interface GatewayConfig {
 
   String CREDENTIAL_STORE_ALG = "gateway.credential.store.alg";
   String DEFAULT_CREDENTIAL_STORE_ALG = "AES";
+  String CREDENTIAL_SELF_SIGNING_ALG = "gateway.credential.self-signing.alg";
+  String DEFAULT_CREDENTIAL_SELF_SIGNING_ALG = "SHA256withRSA";
   String CREDENTIAL_STORE_TYPE = "gateway.credential.store.type";
   String DEFAULT_CREDENTIAL_STORE_TYPE = "JCEKS";
 
@@ -265,6 +267,11 @@ public interface GatewayConfig {
    *         alias into a credential store
    */
   String getCredentialStoreAlgorithm();
+
+  /**
+   * @return the algorithm that is used when generating a self-signing certificate.
+   */
+  String getCredentialSelfSigningAlgorithm();
 
   /**
    * @return the type of the credential store used by AliasService

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -92,8 +92,8 @@ public interface GatewayConfig {
 
   String CREDENTIAL_STORE_ALG = "gateway.credential.store.alg";
   String DEFAULT_CREDENTIAL_STORE_ALG = "AES";
-  String CREDENTIAL_SELF_SIGNING_ALG = "gateway.credential.self-signing.alg";
-  String DEFAULT_CREDENTIAL_SELF_SIGNING_ALG = "SHA256withRSA";
+  String SELF_SIGNING_CERT_ALG = "gateway.self.signing.cert.alg";
+  String DEFAULT_SELF_SIGNING_CERT_ALG = "SHA256withRSA";
   String CREDENTIAL_STORE_TYPE = "gateway.credential.store.type";
   String DEFAULT_CREDENTIAL_STORE_TYPE = "JCEKS";
 
@@ -271,7 +271,7 @@ public interface GatewayConfig {
   /**
    * @return the algorithm that is used when generating a self-signing certificate.
    */
-  String getCredentialSelfSigningAlgorithm();
+  String getSelfSigningCertificateAlgorithm();
 
   /**
    * @return the type of the credential store used by AliasService

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -64,7 +64,7 @@ public class X509CertificateUtil {
    * @param dn the X.509 Distinguished Name, eg "CN=Test, L=London, C=GB"
    * @param pair the KeyPair
    * @param days how many days from now the Certificate is valid for
-   * @param algorithm the signing algorithm, eg "SHA1withRSA"
+   * @param algorithm the signing algorithm, eg "SHA256withRSA"
    * @return self-signed X.509 certificate
    */
   public static X509Certificate generateCertificate(String dn, KeyPair pair, int days, String algorithm) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
[KNOX-3118](https://issues.apache.org/jira/browse/KNOX-3118) : Upgrade Knox SSL Self-Signed Certificate from SHA-1 to SHA-256


## How was this patch tested?
Unit tests.
Manual tests locally.
