### PR TITLE
KNOX-3120 - Add a specialized use API for API KEY based on KNOXTOKEN API

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
@@ -32,13 +32,13 @@ import java.util.HashMap;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 
-@Path(ClientCredentialsResource.RESOURCE_PATH)
+@Path(APIKeyResource.RESOURCE_PATH)
 @Singleton
-public class ClientCredentialsResource extends PasscodeTokenResourceBase {
+public class APIKeyResource extends PasscodeTokenResourceBase {
     private static final String TYPE = "type";
-    public static final String RESOURCE_PATH = "clientid/api/v1/oauth/credentials";
-    public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
+    public static final String RESOURCE_PATH = "apikey/api/v1/auth/key";
+    public static final String API_KEY = "api_key";
+    public static final String KEY_ID = "key_id";
 
     @Override
     @GET
@@ -56,7 +56,7 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
 
     @Override
     protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
-        tokenMetadata.add(TYPE, TokenMetadataType.CLIENT_ID.name());
+        tokenMetadata.add(TYPE, TokenMetadataType.API_KEY.name());
         super.addArbitraryTokenMetadata(tokenMetadata);
     }
 
@@ -67,14 +67,15 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
         if (response != null) {
             return response;
         }
-        TokenResponseContext resp = getTokenResponse(context);
+
+        TokenResponseContext resp = getTokenResponse (context);
         if (resp.responseMap != null) {
             String passcode = (String) resp.responseMap.map.get(PASSCODE);
             String tokenId = resp.responseMap.tokenId;
 
             final HashMap<String, Object> map = new HashMap<>();
-            map.put(CLIENT_ID, tokenId);
-            map.put(CLIENT_SECRET, passcode);
+            map.put(KEY_ID, tokenId);
+            map.put(API_KEY, passcode);
             String jsonResponse = JsonUtils.renderAsJsonString(map);
             return resp.responseBuilder.entity(jsonResponse).build();
         }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/PasscodeTokenResourceBase.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/PasscodeTokenResourceBase.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file to
+ * you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.apache.knox.gateway.services.security.token.TokenStateService;
+import org.apache.knox.gateway.services.security.token.impl.TokenMAC;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+public class PasscodeTokenResourceBase extends TokenResource {
+    protected GatewayServices services;
+    @Override
+    protected ServletContext wrapContextForDefaultParams(ServletContext context) throws ServletException {
+        ServletContext wrapperContext = new ServletContextWrapper(context);
+        wrapperContext.setInitParameter(TokenStateService.CONFIG_SERVER_MANAGED, "true");
+        wrapperContext.setInitParameter(TokenResource.TOKEN_TTL_PARAM, "-1");
+        services = (GatewayServices) wrapperContext.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
+        tokenStateService = services.getService(ServiceType.TOKEN_STATE_SERVICE);
+        final GatewayConfig gatewayConfig = (GatewayConfig) wrapperContext.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+        gatewayConfig.getKnoxTokenHashAlgorithm();
+        final AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
+        char[] hashkey;
+        try {
+            hashkey = aliasService.getPasswordFromAliasForGateway(TokenMAC.KNOX_TOKEN_HASH_KEY_ALIAS_NAME);
+        } catch (AliasServiceException e) {
+            throw new ServletException(e);
+        }
+        if (hashkey == null) {
+            generateAndStoreHMACKeyAlias();
+        }
+        return wrapperContext;
+    }
+
+    private void generateAndStoreHMACKeyAlias() {
+        final int keyLength = Integer.parseInt(JWSAlgorithm.HS256.getName().substring(2));
+        String jwkAsText = null;
+        try {
+            final OctetSequenceKey jwk = new OctetSequenceKeyGenerator(keyLength).keyID(UUID.randomUUID().toString())
+                    .algorithm(JWSAlgorithm.HS256).generate();
+            jwkAsText = jwk.getKeyValue().toJSONString().replace("\"", "");
+            getAliasService().addAliasForCluster("__gateway", TokenMAC.KNOX_TOKEN_HASH_KEY_ALIAS_NAME, jwkAsText);
+        } catch (JOSEException | AliasServiceException e) {
+            throw new RuntimeException("Error while generating " + keyLength + " bits JWK secret", e);
+        }
+    }
+
+    protected AliasService getAliasService() {
+        return services.getService(ServiceType.ALIAS_SERVICE);
+    }
+
+    protected Response checkForInvalidRequestResponse(UserContext context) {
+        Response response = enforceClientCertIfRequired();
+        if (response != null) { return response; }
+
+        response = onlyAllowGroupsToBeAddedWhenEnabled();
+        if (response != null) { return response; }
+
+        response = enforceTokenLimitsAsRequired(context.userName);
+        if (response != null) { return response; }
+
+        return response;
+    }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/deploy/APIKeyServiceDeploymentContributor.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/deploy/APIKeyServiceDeploymentContributor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken.deploy;
+
+import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
+
+public class APIKeyServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
+
+    public static final String ROLE = "APIKEY";
+
+    @Override
+    public String getRole() {
+        return ROLE;
+    }
+
+    @Override
+    public String getName() {
+        return "APIKeyService";
+    }
+
+    @Override
+    protected String[] getPackages() {
+      return new String[]{ "org.apache.knox.gateway.service.knoxtoken" };
+    }
+
+    @Override
+    protected String[] getPatterns() {
+       return new String[]{ "apikey/api/**?**" };
+    }
+}

--- a/gateway-service-knoxtoken/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ServiceDeploymentContributor
+++ b/gateway-service-knoxtoken/src/main/resources/META-INF/services/org.apache.knox.gateway.deploy.ServiceDeploymentContributor
@@ -18,3 +18,4 @@
 
 org.apache.knox.gateway.service.knoxtoken.deploy.TokenServiceDeploymentContributor
 org.apache.knox.gateway.service.knoxtoken.deploy.ClientCredentialsServiceDeploymentContributor
+org.apache.knox.gateway.service.knoxtoken.deploy.APIKeyServiceDeploymentContributor

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1320,6 +1320,30 @@ public class TokenServiceResourceTest {
   }
 
   @Test
+  public void testClientCredentialsResponse() throws Exception {
+    Map<String, String> contextExpectations = new HashMap<>();
+    try {
+      tss = new PersistentTestTokenStateService();
+      configureCommonExpectations(contextExpectations, Boolean.TRUE);
+
+      ClientCredentialsResource ccr = new ClientCredentialsResource();
+      ccr.request = request;
+      ccr.context = context;
+      ccr.init();
+
+      Response response = ccr.doPost();
+      assertEquals(200, response.getStatus());
+
+      String clientId = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_ID);
+      assertNotNull(clientId);
+      String clientSecret = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_SECRET);
+      assertNotNull(clientSecret);
+    } finally {
+      tss = new TestTokenStateService();
+    }
+  }
+
+  @Test
   public void passcodeShouldNotBeInResponseIfTokenStateServiceIsNotPersistent() throws Exception {
     testPasscodeToken(true, false, false);
   }
@@ -1396,13 +1420,13 @@ public class TokenServiceResourceTest {
   }
 
   @Test
-  public void testClientCredentialsResponse() throws Exception {
+  public void testAPIKeyResponse() throws Exception {
     Map<String, String> contextExpectations = new HashMap<>();
     try {
       tss = new PersistentTestTokenStateService();
       configureCommonExpectations(contextExpectations, Boolean.TRUE);
 
-      ClientCredentialsResource ccr = new ClientCredentialsResource();
+      APIKeyResource ccr = new APIKeyResource();
       ccr.request = request;
       ccr.context = context;
       ccr.init();
@@ -1410,10 +1434,10 @@ public class TokenServiceResourceTest {
       Response response = ccr.doPost();
       assertEquals(200, response.getStatus());
 
-      String clientId = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_ID);
-      assertNotNull(clientId);
-      String clientSecret = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_SECRET);
-      assertNotNull(clientSecret);
+      String keyId = getTagValue(response.getEntity().toString(), APIKeyResource.KEY_ID);
+      assertNotNull(keyId);
+      String apikey = getTagValue(response.getEntity().toString(), APIKeyResource.API_KEY);
+      assertNotNull(apikey);
     } finally {
       tss = new TestTokenStateService();
     }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadataType.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadataType.java
@@ -18,6 +18,6 @@ package org.apache.knox.gateway.services.security.token;
 
 public enum TokenMetadataType {
 
-  JWT, KNOXSSO_COOKIE, CLIENT_ID;
+  JWT, KNOXSSO_COOKIE, CLIENT_ID, API_KEY;
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to [KNOX-3112](https://issues.apache.org/jira/browse/KNOX-3112) which added an API for CLIENTID for acquiring client credentials flow CLIENT_ID and CLIENT_SECRET we should add a specialized extension of KNOXTOKEN for an APIKEY API.
The intent here is to add an API that both frees up KNOXTOKEN to be deployed within the same topology for known token exchange patterns as well as to codify the conventions that are being used by some that are using the passcode token as an API Key.

We will make appropriate configuration and metadata defaults within the API implementation to reduce operations and config requirements and to return a translated response with the passcode as an

{api_key: xxxx}
or some similar response that meets standard or defacto standard expectations.

## How was this patch tested?
Added new unit tests and ran all existing and new tests.
Tested manually:

```
curl -ivku admin:admin-password -X POST "https://localhost:8443/gateway/sandbox/apikey/api/v1/auth/key"

* Connection #0 to host localhost left intact
{"key_id":"d859cf22-007c-40d6-832c-8ddf068f3606","api_key":"WkRnMU9XTm1Nakl0T....1tTXRPR1JrWmpBMk9HWXpOakEyOjpPV1l6WVRFM05tRXRORFpqWVMwME5HUmtMV0pr....Nek15T0dWa1pHUm0="}

```

