### PR TITLE
KNOX-3124 - Add Security Header filter to WebAppSec Provider

### DIFF
--- a/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/deploy/WebAppSecContributor.java
+++ b/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/deploy/WebAppSecContributor.java
@@ -55,6 +55,10 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
   private static final String RATE_LIMITING_PREFIX = "rate.limiting";
   private static final String RATE_LIMITING_SUFFIX = "_RATE.LIMITING";
   private static final String RATE_LIMITING_ENABLED = RATE_LIMITING_PREFIX + ".enabled";
+  private static final String SECURITY_HEADER_PREFIX = "security.header";
+  private static final String SECURITY_HEADER_ENABLED = SECURITY_HEADER_PREFIX + ".enabled";
+  private static final String SECURITY_HEADER_SUFFIX = "_SECURITY.HEADER";
+  private static final String SECURITY_HEADER_FILTER_CLASSNAME = "org.apache.knox.gateway.webappsec.filter.SecurityHeaderFilter";
 
   @Override
   public String getRole() {
@@ -80,7 +84,7 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
 
     Provider webappsec = context.getTopology().getProvider(ROLE, NAME);
     if (webappsec != null && webappsec.isEnabled()) {
-      Map<String,String> map = provider.getParams();
+      Map<String, String> map = provider.getParams();
       if (params == null) {
         params = new ArrayList<>();
       }
@@ -103,9 +107,9 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       if (Boolean.parseBoolean(corsEnabled)) {
         provisionConfig(resource, providerParams, params, "cors.");
         resource.addFilter().name(getName() + CORS_SUFFIX)
-                            .role(getRole())
-                            .impl(CORS_FILTER_CLASSNAME)
-                            .params(params);
+                .role(getRole())
+                .impl(CORS_FILTER_CLASSNAME)
+                .params(params);
       }
 
       // CRSF
@@ -114,9 +118,9 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       if (Boolean.parseBoolean(csrfEnabled)) {
         provisionConfig(resource, providerParams, params, "csrf.");
         resource.addFilter().name(getName() + CSRF_SUFFIX)
-                            .role(getRole())
-                            .impl(CSRF_FILTER_CLASSNAME)
-                            .params(params);
+                .role(getRole())
+                .impl(CSRF_FILTER_CLASSNAME)
+                .params(params);
       }
 
       // X-Frame-Options - clickjacking protection
@@ -125,9 +129,9 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       if (Boolean.parseBoolean(xframeOptionsEnabled)) {
         provisionConfig(resource, providerParams, params, "xframe.");
         resource.addFilter().name(getName() + XFRAME_OPTIONS_SUFFIX)
-                            .role(getRole())
-                            .impl(XFRAME_OPTIONS_FILTER_CLASSNAME)
-                            .params(params);
+                .role(getRole())
+                .impl(XFRAME_OPTIONS_FILTER_CLASSNAME)
+                .params(params);
       }
 
       // X-Content-Type-Options - MIME type sniffing protection
@@ -136,9 +140,9 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       if (Boolean.parseBoolean(xContentTypeOptionsEnabled)) {
         provisionConfig(resource, providerParams, params, "xcontent-type.");
         resource.addFilter().name(getName() + XCONTENT_TYPE_OPTIONS_SUFFIX)
-                            .role(getRole())
-                            .impl(XCONTENT_TYPE_OPTIONS_FILTER_CLASSNAME)
-                            .params(params);
+                .role(getRole())
+                .impl(XCONTENT_TYPE_OPTIONS_FILTER_CLASSNAME)
+                .params(params);
       }
 
       // X-XSS-Protection - browser xss protection
@@ -147,9 +151,9 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       if (Boolean.parseBoolean(xssProtectionEnabled)) {
         provisionConfig(resource, providerParams, params, "xss.");
         resource.addFilter().name(getName() + XSS_PROTECTION_SUFFIX)
-                            .role(getRole())
-                            .impl(XSS_PROTECTION_FILTER_CLASSNAME)
-                            .params(params);
+                .role(getRole())
+                .impl(XSS_PROTECTION_FILTER_CLASSNAME)
+                .params(params);
       }
 
       // HTTP Strict-Transport-Security
@@ -158,9 +162,20 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       if (Boolean.parseBoolean(strictTranportEnabled)) {
         provisionConfig(resource, providerParams, params, "strict.");
         resource.addFilter().name(getName() + STRICT_TRANSPORT_SUFFIX)
-                            .role(getRole())
-                            .impl(STRICT_TRANSPORT_FILTER_CLASSNAME)
-                            .params(params);
+                .role(getRole())
+                .impl(STRICT_TRANSPORT_FILTER_CLASSNAME)
+                .params(params);
+      }
+
+      // HTTP Security Headers
+      params = new ArrayList<>();
+      String securityHeaderEnabled = map.get(SECURITY_HEADER_ENABLED);
+      if (Boolean.parseBoolean(securityHeaderEnabled)) {
+        provisionConfig(resource, providerParams, params, SECURITY_HEADER_PREFIX + ".", true, false);
+        resource.addFilter().name(getName() + SECURITY_HEADER_SUFFIX)
+                .role(getRole())
+                .impl(SECURITY_HEADER_FILTER_CLASSNAME)
+                .params(params);
       }
     }
   }

--- a/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/deploy/WebAppSecContributor.java
+++ b/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/deploy/WebAppSecContributor.java
@@ -55,10 +55,11 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
   private static final String RATE_LIMITING_PREFIX = "rate.limiting";
   private static final String RATE_LIMITING_SUFFIX = "_RATE.LIMITING";
   private static final String RATE_LIMITING_ENABLED = RATE_LIMITING_PREFIX + ".enabled";
-  private static final String SECURITY_HEADER_PREFIX = "security.header";
+  private static final String SECURITY_HEADER_PREFIX = "security.header.";
   private static final String SECURITY_HEADER_ENABLED = SECURITY_HEADER_PREFIX + ".enabled";
   private static final String SECURITY_HEADER_SUFFIX = "_SECURITY.HEADER";
   private static final String SECURITY_HEADER_FILTER_CLASSNAME = "org.apache.knox.gateway.webappsec.filter.SecurityHeaderFilter";
+  public static final String ENABLED = "enabled";
 
   @Override
   public String getRole() {
@@ -171,7 +172,7 @@ public class WebAppSecContributor extends ProviderDeploymentContributorBase {
       params = new ArrayList<>();
       String securityHeaderEnabled = map.get(SECURITY_HEADER_ENABLED);
       if (Boolean.parseBoolean(securityHeaderEnabled)) {
-        provisionConfig(resource, providerParams, params, SECURITY_HEADER_PREFIX + ".", true, false);
+        provisionConfig(resource, providerParams, params, SECURITY_HEADER_PREFIX, true, false);
         resource.addFilter().name(getName() + SECURITY_HEADER_SUFFIX)
                 .role(getRole())
                 .impl(SECURITY_HEADER_FILTER_CLASSNAME)

--- a/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/filter/SecurityHeaderFilter.java
+++ b/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/filter/SecurityHeaderFilter.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.webappsec.filter;
 
+import org.apache.knox.gateway.webappsec.deploy.WebAppSecContributor;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -35,7 +37,7 @@ import java.util.Set;
 
 public class SecurityHeaderFilter implements Filter {
 
-  private Map<String, String> map = new HashMap<>();
+  private Map<String, String> securityHeaders = new HashMap<>();
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {
@@ -43,9 +45,9 @@ public class SecurityHeaderFilter implements Filter {
     Enumeration<String> initParamNames = filterConfig.getInitParameterNames();
     while (initParamNames.hasMoreElements()) {
       String headerName = initParamNames.nextElement();
-      if (!"enabled".equals(headerName)) {
+      if (!WebAppSecContributor.ENABLED.equals(headerName)) {
         String headerValue = filterConfig.getInitParameter(headerName);
-        map.put(headerName, headerValue);
+        securityHeaders.put(headerName, headerValue);
       }
     }
   }
@@ -57,7 +59,7 @@ public class SecurityHeaderFilter implements Filter {
     HttpServletResponse httpResponse = new SecurityHeaderResponseWrapper((HttpServletResponse) response);
 
     // Dynamically add headers based on init parameters
-    for (Map.Entry<String, String> entry : map.entrySet()) {
+    for (Map.Entry<String, String> entry : securityHeaders.entrySet()) {
       String headerName = entry.getKey();
       String headerValue = entry.getValue();
       httpResponse.setHeader(headerName, headerValue);
@@ -80,14 +82,14 @@ public class SecurityHeaderFilter implements Filter {
 
     @Override
     public void addHeader(String name, String value) {
-      if (!"enabled".equals(name)) {
+      if (!WebAppSecContributor.ENABLED.equals(name)) {
         super.addHeader(name, value);
       }
     }
 
     @Override
     public void setHeader(String name, String value) {
-      if (!"enabled".equals(name)) {
+      if (!WebAppSecContributor.ENABLED.equals(name)) {
         super.setHeader(name, value);
       }
     }
@@ -95,7 +97,7 @@ public class SecurityHeaderFilter implements Filter {
     @Override
     public String getHeader(String name) {
       String value;
-      value = map.get(name);
+      value = securityHeaders.get(name);
       if (value == null) {
         value = super.getHeader(name);
       }
@@ -104,7 +106,7 @@ public class SecurityHeaderFilter implements Filter {
 
     @Override
     public Collection<String> getHeaderNames() {
-      Set<String> names = new HashSet<>(map.keySet());
+      Set<String> names = new HashSet<>(securityHeaders.keySet());
       if (super.getHeaderNames() != null) {
         names.addAll(super.getHeaderNames());
       }
@@ -113,7 +115,7 @@ public class SecurityHeaderFilter implements Filter {
 
     @Override
     public Collection<String> getHeaders(String name) {
-      Set<String> values = new HashSet<>(map.values());
+      Set<String> values = new HashSet<>(securityHeaders.values());
       if (super.getHeaders(name) != null) {
         values.addAll(super.getHeaders(name));
       }

--- a/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/filter/SecurityHeaderFilter.java
+++ b/gateway-provider-security-webappsec/src/main/java/org/apache/knox/gateway/webappsec/filter/SecurityHeaderFilter.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.webappsec.filter;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class SecurityHeaderFilter implements Filter {
+
+  private Map<String, String> map = new HashMap<>();
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    // Dynamically add headers based on init parameters
+    Enumeration<String> initParamNames = filterConfig.getInitParameterNames();
+    while (initParamNames.hasMoreElements()) {
+      String headerName = initParamNames.nextElement();
+      if (!"enabled".equals(headerName)) {
+        String headerValue = filterConfig.getInitParameter(headerName);
+        map.put(headerName, headerValue);
+      }
+    }
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+          throws IOException, ServletException {
+
+    HttpServletResponse httpResponse = new SecurityHeaderResponseWrapper((HttpServletResponse) response);
+
+    // Dynamically add headers based on init parameters
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      String headerName = entry.getKey();
+      String headerValue = entry.getValue();
+      httpResponse.setHeader(headerName, headerValue);
+    }
+
+    // Continue the filter chain
+    chain.doFilter(request, httpResponse);
+  }
+
+  @Override
+  public void destroy() {
+    // Cleanup logic if needed
+  }
+
+  class SecurityHeaderResponseWrapper extends HttpServletResponseWrapper {
+
+    SecurityHeaderResponseWrapper(HttpServletResponse res) {
+      super(res);
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+      if (!"enabled".equals(name)) {
+        super.addHeader(name, value);
+      }
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+      if (!"enabled".equals(name)) {
+        super.setHeader(name, value);
+      }
+    }
+
+    @Override
+    public String getHeader(String name) {
+      String value;
+      value = map.get(name);
+      if (value == null) {
+        value = super.getHeader(name);
+      }
+      return value;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+      Set<String> names = new HashSet<>(map.keySet());
+      if (super.getHeaderNames() != null) {
+        names.addAll(super.getHeaderNames());
+      }
+      return names;
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+      Set<String> values = new HashSet<>(map.values());
+      if (super.getHeaders(name) != null) {
+        values.addAll(super.getHeaders(name));
+      }
+      return values;
+    }
+  }
+}

--- a/gateway-provider-security-webappsec/src/test/java/org/apache/knox/gateway/webappsec/SecurityHeaderFilterTest.java
+++ b/gateway-provider-security-webappsec/src/test/java/org/apache/knox/gateway/webappsec/SecurityHeaderFilterTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.webappsec;
+
+import org.apache.knox.gateway.webappsec.filter.SecurityHeaderFilter;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import static org.junit.Assert.fail;
+
+public class SecurityHeaderFilterTest {
+
+  private static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+  private String options;
+  private Collection<String> headers;
+  private Collection<String> headerNames;
+
+  @Test
+  public void testConfiguredSecurityHeaderOptionsValue() throws Exception {
+    try {
+      final String customOption = "default-src 'self'";
+
+      SecurityHeaderFilter filter = new SecurityHeaderFilter();
+      Properties props = new Properties();
+      props.put("enabled", "true");
+      props.put(CONTENT_SECURITY_POLICY, customOption);
+      filter.init(new TestFilterConfig(props));
+
+      HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+      HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+      EasyMock.replay(request);
+      EasyMock.replay(response);
+
+      TestFilterChain chain = new TestFilterChain();
+      filter.doFilter(request, response, chain);
+      Assert.assertTrue("doFilterCalled should not be false.", chain.doFilterCalled );
+      Assert.assertEquals("SecurityHeaderFilter value incorrect", customOption, options);
+      Assert.assertEquals("SecurityHeaderFilter header count incorrect.", 1, headers.size());
+      Assert.assertEquals("SecurityHeaderFilter header value incorrect.", customOption, headers.toArray()[0]);
+      Assert.assertEquals("SecurityHeaderFilter header name count incorrect.", 1, headerNames.size());
+      Assert.assertEquals("SecurityHeaderFilter header value count incorrect.", CONTENT_SECURITY_POLICY,
+              headerNames.toArray()[0]);
+    } catch (ServletException se) {
+      fail("Should NOT have thrown a ServletException.");
+    }
+  }
+
+  private class TestFilterConfig implements FilterConfig {
+    Properties props;
+
+    TestFilterConfig(Properties props) {
+      this.props = props;
+    }
+
+    @Override
+    public String getFilterName() {
+      return null;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+      return null;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+      return props.getProperty(name, null);
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+      return (Enumeration<String>) props.propertyNames();
+    }
+
+  }
+
+  class TestFilterChain implements FilterChain {
+    boolean doFilterCalled;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+      doFilterCalled = true;
+      options = ((HttpServletResponse)response).getHeader(CONTENT_SECURITY_POLICY);
+      headers = ((HttpServletResponse)response).getHeaders(CONTENT_SECURITY_POLICY);
+      headerNames = ((HttpServletResponse)response).getHeaderNames();
+    }
+
+  }
+
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to add various security headers to a response, we can add a generic filter for which init params with the param name and value indicating the header name and string representing the directives for the header respectively.

This will allow admins to configure things like Content-Security-Policy, Cache-Control, etc. without the need to add separate filters for each one.

## How was this patch tested?

New unit tests were added.
All new and existing tests were run.
Manual testing was done with the following web app sec provider config and curl command:

```
      <provider>
         <role>webappsec</role>
         <name>WebAppSec</name>
         <enabled>true</enabled>
         <param>
            <name>csrf.customHeader</name>
            <value>X-XSRF-Header</value>
         </param>
         <param>
            <name>csrf.methodsToIgnore</name>
            <value>GET,OPTIONS,HEAD</value>
         </param>
         <param>
            <name>xframe.options.enabled</name>
            <value>true</value>
         </param>
         <param>
            <name>xss.protection.enabled</name>
            <value>true</value>
         </param>
         <param>
            <name>strict.transport.enabled</name>
            <value>true</value>
         </param>
         <param>
            <name>xframe.options</name>
            <value>SAMEORIGIN</value>
         </param>
         <param>
            <name>security.header.enabled</name>
            <value>true</value>
         </param>
         <param>
            <name>security.header.Content-Security-Policy</name>
            <value>default-src 'self'</value>
         </param>
         <param>
            <name>security.header.Cache-Control</name>
            <value>max-age=604800</value>
         </param>
      </provider>
```

Note the params with the "security.header." prefix and the headers added to the resulting output from the curl command below:

```
curl -ivku admin:admin-password -X POST "https://localhost:8443/gateway/sandbox/clientid/api/v1/oauth/credentials"

< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Thu, 10 Apr 2025 12:03:04 GMT
Date: Thu, 10 Apr 2025 12:03:04 GMT
< X-Frame-Options: SAMEORIGIN
X-Frame-Options: SAMEORIGIN
< X-XSS-Protection: 1;mode=block
X-XSS-Protection: 1;mode=block
< Strict-Transport-Security: max-age=31536000
Strict-Transport-Security: max-age=31536000
**< Cache-Control: max-age=604800
Cache-Control: max-age=604800
< Content-Security-Policy: default-src 'self'
Content-Security-Policy: default-src 'self'**
< pattern: clientid/api/**?**
pattern: clientid/api/**?**
< Set-Cookie: KNOXSESSIONID=node0oggzblclwhrm1u6i6xsx4xn33.node0; Path=/gateway/sandbox; Secure; HttpOnly
Set-Cookie: KNOXSESSIONID=node0oggzblclwhrm1u6i6xsx4xn33.node0; Path=/gateway/sandbox; Secure; HttpOnly
< Expires: Thu, 01 Jan 1970 00:00:00 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
< Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 09-Apr-2025 12:03:04 GMT; SameSite=lax
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 09-Apr-2025 12:03:04 GMT; SameSite=lax
< Content-Type: application/json
Content-Type: application/json
< Content-Length: 203
Content-Length: 203
< 
```