### PR TITLE
KNOX-3129 - Add expiry to APIKEY and CLIENTID API Responses

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
@@ -76,6 +76,7 @@ public class APIKeyResource extends PasscodeTokenResourceBase {
             final HashMap<String, Object> map = new HashMap<>();
             map.put(KEY_ID, tokenId);
             map.put(API_KEY, passcode);
+            addExpiryIfNotNever(map);
             String jsonResponse = JsonUtils.renderAsJsonString(map);
             return resp.responseBuilder.entity(jsonResponse).build();
         }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
@@ -75,6 +75,7 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
             final HashMap<String, Object> map = new HashMap<>();
             map.put(CLIENT_ID, tokenId);
             map.put(CLIENT_SECRET, passcode);
+            addExpiryIfNotNever(map);
             String jsonResponse = JsonUtils.renderAsJsonString(map);
             return resp.responseBuilder.entity(jsonResponse).build();
         }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1321,11 +1321,18 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testClientCredentialsResponse() throws Exception {
+    tryClientCredentialsResource(null);
+    tryClientCredentialsResource("30000");
+  }
+
+  public void tryClientCredentialsResource(String expiryInMs) throws Exception {
     Map<String, String> contextExpectations = new HashMap<>();
     try {
       tss = new PersistentTestTokenStateService();
+      if (expiryInMs != null) {
+        contextExpectations.put("knox.token.ttl", expiryInMs);
+      }
       configureCommonExpectations(contextExpectations, Boolean.TRUE);
-
       ClientCredentialsResource ccr = new ClientCredentialsResource();
       ccr.request = request;
       ccr.context = context;
@@ -1338,6 +1345,13 @@ public class TokenServiceResourceTest {
       assertNotNull(clientId);
       String clientSecret = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_SECRET);
       assertNotNull(clientSecret);
+      String expiresIn = getTagValue(response.getEntity().toString(), APIKeyResource.EXPIRES_IN);
+      if (expiryInMs == null) {
+        assertNull(expiresIn);
+      } else {
+        assertNotNull(expiresIn);
+        assertEquals(30, Integer.parseInt(expiresIn));
+      }
     } finally {
       tss = new TestTokenStateService();
     }
@@ -1421,9 +1435,18 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testAPIKeyResponse() throws Exception {
+    tryAPIKeyResponse(null);
+    tryAPIKeyResponse("30000");
+  }
+
+  public void tryAPIKeyResponse(String expiryInMs) throws Exception {
     Map<String, String> contextExpectations = new HashMap<>();
     try {
       tss = new PersistentTestTokenStateService();
+      // let the default built into
+      if (expiryInMs != null) {
+        contextExpectations.put("knox.token.ttl", expiryInMs);
+      }
       configureCommonExpectations(contextExpectations, Boolean.TRUE);
 
       APIKeyResource ccr = new APIKeyResource();
@@ -1438,6 +1461,13 @@ public class TokenServiceResourceTest {
       assertNotNull(keyId);
       String apikey = getTagValue(response.getEntity().toString(), APIKeyResource.API_KEY);
       assertNotNull(apikey);
+      String expiresIn = getTagValue(response.getEntity().toString(), APIKeyResource.EXPIRES_IN);
+      if (expiryInMs == null) {
+        assertNull(expiresIn);
+      } else {
+        assertNotNull(expiresIn);
+        assertEquals(30, Integer.parseInt(expiresIn));
+      }
     } finally {
       tss = new TestTokenStateService();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

While both the CLIENTID and APIKEY APIs default the knox.token.ttl to -1 to never expire, we do not prevent actual expirations. In the case that there is a configured expiration, return the expiration in the response as appropriate for the clients.

## How was this patch tested?

Added new unit tests.
Built and ran all existing and new tests.
Manually tested:

```
curl -ivku admin:admin-password -X POST "https://localhost:8443/gateway/sandbox/clientid/api/v1/oauth/credentials?comment=ljm&contact=test-contact&md_externalUserName=Larry%20McCay&md_email=email&md_companyName=companyName"
.
.
.

{"client_secret":"WTJSaU16QmpOVGt0T....oak9ETXROREkyTUdRek5HVTROVGhpOjpPVFkzTkRBNVpHUXRZekF5T0MwME1tSTNMV0l3WldRdE5qUTVabU0xTm1JM09Ea3o=","expires_in":54,"client_id":"cdb30c59-1fe5-4...d34e858b"}
```
