### PR TITLE
KNOX-3079: Bump jackson to 2.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.14</httpcore.version>
-        <jackson.version>2.14.3</jackson.version>
+        <jackson.version>2.18.2</jackson.version>
         <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
         <jansi.version>1.18</jansi.version>
         <javax.activation.version>1.2.0</javax.activation.version>


### PR DESCRIPTION
Upgraded jackson from 2.14.3 to 2.18.2

What changes were proposed in this pull request?
This PR proposes for the latest version of the jackson.

How was this patch tested?
Tested on local, seems works fine with this latest version.