### PR TITLE
KNOX-3060 - Fix an issue with JsonUtilsTest.testRenderAsJsonStringWithDateFormat which can fail due to clock skew

### DIFF
--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/JsonUtilsTest.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 
@@ -133,7 +134,7 @@ public class JsonUtilsTest {
     @Test
     public void testRenderAsJsonStringWithDateFormat() {
         // Create a test object with a date
-        Date testDate = new Date(1609459200000L); // 2021-01-01 00:00:00 UTC
+        Date testDate = new Date(TimeUnit.SECONDS.toMillis(1746108169L)); // Thu, 01 May 2025 14:02:49 GMT
         TestObjectWithDate testObject = new TestObjectWithDate("test-value", testDate);
 
         // Create a custom date format
@@ -145,7 +146,7 @@ public class JsonUtilsTest {
         // Verify the JSON contains the expected values
         assertNotNull(json);
         assertThat(json, containsString("\"stringProperty\" : \"test-value\""));
-        assertThat(json, containsString("\"dateProperty\" : \"2021-01-01\""));
+        assertThat(json, containsString("\"dateProperty\" : \"2025-05-01\""));
     }
 
     // Simple test class for JSON serialization


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR addresses an issue where JsonUtilsTest.testRenderAsJsonStringWithDateFormat would fail on some machines and not other. The problem is the epoch chosen before `1609459200000L` was on a boundary or day, date and month (2020-12-31-2021-01-01), a bit of a clock skew with millisecond precision might throw the tests off. 

This PR uses the epoch `1746108169L` (in millisec) which hopefully tolerates few millisec swings as it is in the middle of the day. (Thu, 01 May 2025 14:02:49 GMT)

## How was this patch tested?
This patch was tested locally.