### PR TITLE
KNOX-3145 - Ensure Client Credentials flow client_secret belongs to t…

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -70,6 +70,8 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   public static final String GRANT_TYPE = "grant_type";
   public static final String CLIENT_CREDENTIALS = "client_credentials";
   public static final String CLIENT_SECRET = "client_secret";
+  public static final String CLIENT_ID = "client_id";
+  public static final String MISMATCHING_CLIENT_ID_AND_CLIENT_SECRET = "Client credentials flow with mismatching client_id and client_secret";
 
   public enum TokenType {
     JWT, Passcode;
@@ -240,17 +242,34 @@ public class JWTFederationFilter extends AbstractJWTFilter {
         // The received token value must be a Base64 encoded value of Base64(tokenId)::Base64(rawPasscode)
         String tokenId = null;
         String passcode = null;
+        boolean prechecks = true;
         try {
           final String[] base64DecodedTokenIdAndPasscode = decodeBase64(tokenValue).split("::");
           tokenId = decodeBase64(base64DecodedTokenIdAndPasscode[0]);
           passcode = decodeBase64(base64DecodedTokenIdAndPasscode[1]);
+          // if this is a client credentials flow request then ensure the presented clientId is
+          // the actual owner of the client_secret
+          final String requestBodyString = getRequestBodyString(request);
+          if (requestBodyString != null && !requestBodyString.isEmpty()) {
+            final String grantType = RequestBodyUtils.getRequestBodyParameter(requestBodyString, GRANT_TYPE);
+            if (grantType != null && !grantType.isEmpty()) {
+              final String clientID = RequestBodyUtils.getRequestBodyParameter(requestBodyString, CLIENT_ID);
+              // if there is no client_id then this is not a client credentials flow
+              if (clientID != null && !tokenId.equals(clientID)) {
+                prechecks = false;
+                log.wrongPasscodeToken(tokenId);
+                handleValidationError((HttpServletRequest) request, (HttpServletResponse) response,
+                        HttpServletResponse.SC_UNAUTHORIZED,
+                        MISMATCHING_CLIENT_ID_AND_CLIENT_SECRET);
+              }
+            }
+          }
         } catch (Exception e) {
           log.failedToParsePasscodeToken(e);
           handleValidationError((HttpServletRequest) request, (HttpServletResponse) response, HttpServletResponse.SC_UNAUTHORIZED,
               "Error while parsing the received passcode token");
         }
-
-        if (validateToken((HttpServletRequest) request, (HttpServletResponse) response, chain, tokenId, passcode)) {
+        if (prechecks && validateToken((HttpServletRequest) request, (HttpServletResponse) response, chain, tokenId, passcode)) {
           try {
             Subject subject = createSubjectFromTokenIdentifier(tokenId);
             continueWithEstablishedSecurityContext(subject, (HttpServletRequest) request, (HttpServletResponse) response, chain);


### PR DESCRIPTION
…he presented client_id

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?

Currently, the support for client_id and client_secret treats the inclusion of the CLIENT_ID as a formality of the client credentials flow and since the actual client_id is resolvable from the client_secret, it is ignored.

While there it may be arguable whether we need to enforce this, it seems a reasonable expectation that they should match. Let's close that gap.

## How was this patch tested?

New unit tests added and all existing and new tests run.
Manually tested.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
