### PR TITLE
KNOX-3148: Make SameSite configurable for pac4j session cookies

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -130,6 +130,9 @@ public class Pac4jDispatcherFilter implements Filter, SessionInvalidator {
   /* default value is same is KNOXSSO token ttl default */
   private static final String PAC4J_COOKIE_MAX_AGE_DEFAULT = "-1";
 
+  public static final String PAC4J_COOKIE_SAMESITE = "pac4j.cookie.samesite";
+  private static final String PAC4J_COOKIE_SAMESITE_DEFAULT = "Strict";
+
   private static final String PAC4J_CSRF_TOKEN = "pac4jCsrfToken";
   private static boolean SSL_ENABLED = true;
 
@@ -229,6 +232,8 @@ public class Pac4jDispatcherFilter implements Filter, SessionInvalidator {
       setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT);
       /* add cookie expiry */
       setSessionStoreConfig(filterConfig, PAC4J_COOKIE_MAX_AGE, PAC4J_COOKIE_MAX_AGE_DEFAULT);
+      /* add cookie samesite */
+      setSessionStoreConfig(filterConfig, PAC4J_COOKIE_SAMESITE, PAC4J_COOKIE_SAMESITE_DEFAULT);
       //decorating client configuration (if needed)
       PAC4J_CLIENT_CONFIGURATION_DECORATOR.decorateClients(clients, properties);
     }

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/MockHttpServletResponse.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/MockHttpServletResponse.java
@@ -25,15 +25,16 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class MockHttpServletResponse extends HttpServletResponseWrapper {
 
-    private List<Cookie> cookies = new ArrayList<>();
+    private final List<Cookie> cookies = new ArrayList<>();
     private int status;
-    private Map<String, String> headers = new HashMap<>();
+    private final Map<String, List<String>> headers = new HashMap<>();
 
     public MockHttpServletResponse() {
         super(setupMockResponse());
@@ -47,15 +48,17 @@ public class MockHttpServletResponse extends HttpServletResponseWrapper {
 
     @Override
     public void setHeader(String name, String value) {
-        headers.put(name, value);
+        headers.put(name, new ArrayList<>(Collections.singletonList(value)));
     }
 
     @Override
     public void addHeader(String name, String value) {
-        headers.put(name, value);
+        List<String> values = headers.getOrDefault(name, new ArrayList<>());
+        values.add(value);
+        headers.put(name, values);
     }
 
-    public Map<String, String> getHeaders() {
+    public Map<String, List<String>> getHeaders() {
         return headers;
     }
 

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilterTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilterTest.java
@@ -104,14 +104,14 @@ public class Pac4jDispatcherFilterTest {
         EasyMock.expect(mocks.context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(mocks.gatewayConfig).anyTimes();
     }
 
-    private void verifyCookiemaxAge(FilterConfig filterConfig, String expectedCookieMaxAge) throws Exception {
+    private void verifyCookieConfig(FilterConfig filterConfig, String key, String expected) throws Exception {
         Pac4jDispatcherFilter filter = new Pac4jDispatcherFilter();
         filter.init(filterConfig);
 
         java.lang.reflect.Field configField = filter.getClass().getDeclaredField("sessionStoreConfigs");
         configField.setAccessible(true);
         Map<String, String> sessionStoreConfigs = (Map<String, String>) configField.get(filter);
-        Assert.assertEquals(expectedCookieMaxAge, sessionStoreConfigs.get(Pac4jDispatcherFilter.PAC4J_COOKIE_MAX_AGE));
+        Assert.assertEquals(expected, sessionStoreConfigs.get(key));
     }
 
 
@@ -129,7 +129,7 @@ public class Pac4jDispatcherFilterTest {
 
         EasyMock.replay(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
 
-        verifyCookiemaxAge(mocks.filterConfig, expectedCookieMaxAge);
+        verifyCookieConfig(mocks.filterConfig, Pac4jDispatcherFilter.PAC4J_COOKIE_MAX_AGE,  expectedCookieMaxAge);
 
         // Verify all mock interactions
         EasyMock.verify(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
@@ -152,7 +152,44 @@ public class Pac4jDispatcherFilterTest {
 
         EasyMock.replay(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
 
-        verifyCookiemaxAge(mocks.filterConfig, expectedCookieMaxAge);
+        verifyCookieConfig(mocks.filterConfig, Pac4jDispatcherFilter.PAC4J_COOKIE_MAX_AGE,  expectedCookieMaxAge);
+
+        // Verify all mock interactions
+        EasyMock.verify(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
+    }
+
+    @Test
+    public void testDefaultCookieSameSite() throws Exception {
+        final String expectedSameSite = "Strict";
+        List<String> params = new ArrayList<>();
+        params.add(Pac4jDispatcherFilter.PAC4J_CALLBACK_URL);
+        params.add("clientName");
+        params.add(SAML_KEYSTORE_PATH);
+        params.add(SAML_IDENTITY_PROVIDER_METADATA_PATH);
+
+        TestMocks mocks = createMocks();
+        setupCommonExpectations(mocks, Collections.EMPTY_LIST);
+
+        EasyMock.replay(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
+
+        verifyCookieConfig(mocks.filterConfig, Pac4jDispatcherFilter.PAC4J_COOKIE_SAMESITE,  expectedSameSite);
+
+        // Verify all mock interactions
+        EasyMock.verify(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
+    }
+
+    @Test
+    public void testCustomCookieSameSite() throws Exception {
+        final String expectedSameSite = "None";
+        List<String> additionalParams = new ArrayList<>();
+        additionalParams.add(Pac4jDispatcherFilter.PAC4J_COOKIE_SAMESITE);
+        TestMocks mocks = createMocks();
+        setupCommonExpectations(mocks, additionalParams);
+        EasyMock.expect(mocks.filterConfig.getInitParameter(Pac4jDispatcherFilter.PAC4J_COOKIE_SAMESITE)).andReturn(expectedSameSite).anyTimes();
+
+        EasyMock.replay(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
+
+        verifyCookieConfig(mocks.filterConfig, Pac4jDispatcherFilter.PAC4J_COOKIE_SAMESITE,  expectedSameSite);
 
         // Verify all mock interactions
         EasyMock.verify(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStoreTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/session/KnoxSessionStoreTest.java
@@ -24,11 +24,12 @@ import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.saml.profile.SAML2Profile;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -68,9 +69,11 @@ public class KnoxSessionStoreTest {
     final Map<String, String> sessionStoreConfigs = new HashMap();
 
     final Capture<org.pac4j.core.context.Cookie> captureCookieValue = EasyMock.newCapture();
-    final WebContext mockContext = EasyMock.createNiceMock(WebContext.class);
+    final JEEContext mockContext = EasyMock.createNiceMock(JEEContext.class);
+    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     EasyMock.expect(mockContext.getFullRequestURL()).andReturn("https://local.com/gateway/knoxsso/").anyTimes();
     mockContext.addResponseCookie(EasyMock.capture(captureCookieValue));
+    EasyMock.expect(mockContext.getNativeResponse()).andReturn(response).anyTimes();
 
     EasyMock.replay(mockContext);
 

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -65,6 +65,7 @@ import org.apache.knox.gateway.services.security.token.impl.JWT;
 import org.apache.knox.gateway.session.control.ConcurrentSessionVerifier;
 import org.apache.knox.gateway.util.CookieUtils;
 import org.apache.knox.gateway.util.RegExUtils;
+import org.apache.knox.gateway.util.SetCookieHeader;
 import org.apache.knox.gateway.util.Tokens;
 import org.apache.knox.gateway.util.Urls;
 import org.apache.knox.gateway.util.WhitelistUtils;
@@ -409,23 +410,22 @@ public class WebSSOResource {
      * SameSite param. Change this back to Cookie impl. after
      * SameSite header is supported by javax.servlet.http.Cookie.
      */
-    final StringBuilder setCookie = new StringBuilder(50);
     try {
-      setCookie.append(cookieName).append('=').append(token.toString());
-      setCookie.append("; Path=/");
+      SetCookieHeader setCookieHeader = new SetCookieHeader(cookieName, token.toString());
+      setCookieHeader.setPath("/");
       final String domain = Urls.getDomainName(original, domainSuffix);
       if (domain != null) {
-        setCookie.append("; Domain=").append(domain);
+        setCookieHeader.setDomain(domain);
       }
-      setCookie.append("; HttpOnly");
+      setCookieHeader.setHttpOnly(true);
       if (secureOnly) {
-        setCookie.append("; Secure");
+        setCookieHeader.setSecure(true);
       }
       if (maxAge != -1) {
-        setCookie.append("; Max-Age=").append(maxAge);
+        setCookieHeader.setMaxAge(maxAge);
       }
-      setCookie.append("; SameSite=").append(this.sameSiteValue);
-      response.setHeader("Set-Cookie", setCookie.toString());
+      setCookieHeader.setSameSite(sameSiteValue);
+      response.setHeader("Set-Cookie", setCookieHeader.toString());
       LOGGER.addedJWTCookie(logSafeToken);
     } catch (Exception e) {
       LOGGER.unableAddCookieToResponse(e.getMessage(),

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/SetCookieHeader.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/SetCookieHeader.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SetCookieHeader {
+    private final String name;
+    private final String value;
+    private final Map<String, String> attributes = new HashMap<>();
+
+    private String path;
+    private String domain;
+    private int maxAge = -1;
+    private boolean httpOnly;
+    private boolean secure;
+    private String sameSite;
+
+    public SetCookieHeader(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public int getMaxAge() {
+        return maxAge;
+    }
+
+    public boolean isHttpOnly() {
+        return httpOnly;
+    }
+
+    public boolean isSecure() {
+        return secure;
+    }
+
+    public String getSameSite() {
+        return sameSite;
+    }
+
+    public String getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+    public void setMaxAge(int maxAge) {
+        this.maxAge = maxAge;
+    }
+
+    public void setHttpOnly(boolean httpOnly) {
+        this.httpOnly = httpOnly;
+    }
+
+    public void setSecure(boolean secure) {
+        this.secure = secure;
+    }
+
+    public void setSameSite(String sameSite) {
+        this.sameSite = sameSite;
+    }
+
+    public void setAttribute(String name, String value) {
+        attributes.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(name);
+        sb.append('=').append(value);
+
+        if(path != null) {
+            sb.append("; Path=").append(path);
+        }
+        if(domain != null) {
+            sb.append("; Domain=").append(domain);
+        }
+        if(maxAge != -1) {
+            sb.append("; Max-Age=").append(maxAge);
+        }
+        if(httpOnly) {
+            sb.append("; HttpOnly");
+        }
+        if(secure) {
+            sb.append("; Secure");
+        }
+        if(sameSite != null) {
+            sb.append("; SameSite=").append(sameSite);
+        }
+
+        for(Map.Entry<String, String> entry : attributes.entrySet()) {
+            sb.append("; ").append(entry.getKey()).append('=').append(entry.getValue());
+        }
+
+        return sb.toString();
+    }
+}

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/SetCookieHeaderTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/SetCookieHeaderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SetCookieHeaderTest {
+
+    @Test
+    public void testBasicSetCookie() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        assertEquals("name=value", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testEmptyValueSetCookie() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", null);
+        assertEquals("name=null", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithPath() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setPath("/");
+        assertEquals("name=value; Path=/", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithDomain() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setDomain("example.com");
+        assertEquals("name=value; Domain=example.com", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithMaxAge() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setMaxAge(231);
+        assertEquals("name=value; Max-Age=231", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithHttpOnly() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setHttpOnly(true);
+        assertEquals("name=value; HttpOnly", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithSecure() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setSecure(true);
+        assertEquals("name=value; Secure", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithSameSite() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setSameSite("Strict");
+        assertEquals("name=value; SameSite=Strict", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithAdditionalAttribute() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setAttribute("Attribute", "value");
+        assertEquals("name=value; Attribute=value", setCookieHeader.toString());
+    }
+
+    @Test
+    public void testSetCookieWithAll() {
+        SetCookieHeader setCookieHeader = new SetCookieHeader("name", "value");
+        setCookieHeader.setDomain("example.com");
+        setCookieHeader.setMaxAge(231);
+        setCookieHeader.setHttpOnly(true);
+        setCookieHeader.setSecure(true);
+        setCookieHeader.setPath("/path");
+        setCookieHeader.setSameSite("Lax");
+        setCookieHeader.setAttribute("Attribute", "attrValue");
+
+        String setCookieHeaderString = setCookieHeader.toString();
+
+        assertTrue("Name/value pair is incorrect", setCookieHeaderString.contains("name=value"));
+        assertTrue("Domain is incorrect", setCookieHeaderString.contains("; Domain=example.com"));
+        assertTrue("Max-Age is incorrect", setCookieHeaderString.contains("; Max-Age=231"));
+        assertTrue("HttpOnly is incorrect", setCookieHeaderString.contains("; HttpOnly"));
+        assertTrue("Secure is incorrect", setCookieHeaderString.contains("; Secure"));
+        assertTrue("Path is incorrect", setCookieHeaderString.contains("; Path=/path"));
+        assertTrue("SameSite is incorrect", setCookieHeaderString.contains("; SameSite=Lax"));
+        assertTrue("Additional attribute is incorrect", setCookieHeaderString.contains("; Attribute=attrValue"));
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change makes the SameSite attribute for the pac4j session cookies configurable. The default value is `Strict`.
The pac4j Cookie class doesn't support the SameSite attribute so I had to change the implementation to Set-Cookie headers.
Modified MockHttpServletResponse class to accommodate the testing of multiple Set-Cookie headers.

## How was this patch tested?

Manually tested, unit tests
![image](https://github.com/user-attachments/assets/d3dc44e2-9ab4-449e-ae3f-04ec58156754)

