### PR TITLE
KNOX-3048 - Add support for group-based impersonation

### DIFF
--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilter.java
@@ -17,33 +17,6 @@
  */
 package org.apache.knox.gateway.identityasserter.common.filter;
 
-import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
-import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.ROLE;
-import static org.apache.knox.gateway.identityasserter.common.filter.VirtualGroupMapper.addRequestFunctions;
-
-import java.io.IOException;
-import java.security.AccessController;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
-import java.util.stream.Collectors;
-import javax.security.auth.Subject;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.IdentityAsserterMessages;
@@ -62,286 +35,333 @@ import org.apache.knox.gateway.util.AuthFilterUtils;
 import org.apache.knox.gateway.util.AuthorizationException;
 import org.apache.knox.gateway.util.HttpExceptionUtils;
 
+import javax.security.auth.Subject;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.AccessController;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.ROLE;
+import static org.apache.knox.gateway.identityasserter.common.filter.VirtualGroupMapper.addRequestFunctions;
+import static org.apache.knox.gateway.util.AuthFilterUtils.GROUP_IMPERSONATION_ENABLED_PARAM;
+import static org.apache.knox.gateway.util.AuthFilterUtils.IMPERSONATION_ENABLED_PARAM;
+
 public class CommonIdentityAssertionFilter extends AbstractIdentityAssertionFilter {
-  private static final IdentityAsserterMessages LOG = MessagesFactory.get(IdentityAsserterMessages.class);
+    public static final String VIRTUAL_GROUP_MAPPING_PREFIX = "group.mapping.";
+    public static final String GROUP_PRINCIPAL_MAPPING = "group.principal.mapping";
+    public static final String PRINCIPAL_MAPPING = "principal.mapping";
+    public static final String ADVANCED_PRINCIPAL_MAPPING = "expression.principal.mapping";
+    private static final IdentityAsserterMessages LOG = MessagesFactory.get(IdentityAsserterMessages.class);
+    private static final String PRINCIPAL_PARAM = "user.name";
+    private static final String DOAS_PRINCIPAL_PARAM = "doAs";
+    /* List of all default and configured impersonation params */
+    protected final List<String> impersonationParamsList = new ArrayList<>();
+    private final Parser parser = new Parser();
+    protected boolean impersonationEnabled;
+    private SimplePrincipalMapper mapper = new SimplePrincipalMapper();
+    private VirtualGroupMapper virtualGroupMapper;
+    private AbstractSyntaxTree expressionPrincipalMapping;
+    private String topologyName;
 
-  public static final String VIRTUAL_GROUP_MAPPING_PREFIX = "group.mapping.";
-  public static final String GROUP_PRINCIPAL_MAPPING = "group.principal.mapping";
-  public static final String PRINCIPAL_MAPPING = "principal.mapping";
-  public static final String ADVANCED_PRINCIPAL_MAPPING = "expression.principal.mapping";
-  private static final String PRINCIPAL_PARAM = "user.name";
-  private static final String DOAS_PRINCIPAL_PARAM = "doAs";
-  static final String IMPERSONATION_ENABLED_PARAM = AuthFilterUtils.PROXYUSER_PREFIX + ".impersonation.enabled";
-
-  private SimplePrincipalMapper mapper = new SimplePrincipalMapper();
-  private final Parser parser = new Parser();
-  private VirtualGroupMapper virtualGroupMapper;
-  /* List of all default and configured impersonation params */
-  protected final List<String> impersonationParamsList = new ArrayList<>();
-  protected boolean impersonationEnabled;
-  private AbstractSyntaxTree expressionPrincipalMapping;
-  private String topologyName;
-
-  @Override
-  public void init(FilterConfig filterConfig) throws ServletException {
-    topologyName = (String) filterConfig.getServletContext().getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE);
-    String principalMapping = filterConfig.getInitParameter(PRINCIPAL_MAPPING);
-    if (principalMapping == null || principalMapping.isEmpty()) {
-      principalMapping = filterConfig.getServletContext().getInitParameter(PRINCIPAL_MAPPING);
-    }
-    String groupPrincipalMapping = filterConfig.getInitParameter(GROUP_PRINCIPAL_MAPPING);
-    if (groupPrincipalMapping == null || groupPrincipalMapping.isEmpty()) {
-      groupPrincipalMapping = filterConfig.getServletContext().getInitParameter(GROUP_PRINCIPAL_MAPPING);
-    }
-    if (principalMapping != null && !principalMapping.isEmpty() || groupPrincipalMapping != null && !groupPrincipalMapping.isEmpty()) {
-      try {
-        mapper.loadMappingTable(principalMapping, groupPrincipalMapping);
-      } catch (PrincipalMappingException e) {
-        throw new ServletException("Unable to load principal mapping table.", e);
-      }
-    }
-    expressionPrincipalMapping = parseAdvancedPrincipalMapping(filterConfig);
-
-    final List<String> initParameterNames = AuthFilterUtils.getInitParameterNamesAsList(filterConfig);
-
-    virtualGroupMapper = new VirtualGroupMapper(loadVirtualGroups(filterConfig, initParameterNames));
-
-    initImpersonationParamsList(filterConfig);
-    initProxyUserConfiguration(filterConfig, initParameterNames);
-  }
-
-  private AbstractSyntaxTree parseAdvancedPrincipalMapping(FilterConfig filterConfig) {
-    String expression = filterConfig.getInitParameter(ADVANCED_PRINCIPAL_MAPPING);
-    if (StringUtils.isBlank(expression)) {
-      expression = filterConfig.getServletContext().getInitParameter(ADVANCED_PRINCIPAL_MAPPING);
-    }
-    return StringUtils.isBlank(expression) ? null : parser.parse(expression);
-  }
-
-  /*
-   * Initialize the impersonation params list.
-   * This list contains query params that needs to be scrubbed
-   * from the outgoing request.
-   */
-  private void initImpersonationParamsList(FilterConfig filterConfig) {
-    String impersonationListFromConfig = filterConfig.getInitParameter(IMPERSONATION_PARAMS);
-    if (impersonationListFromConfig == null || impersonationListFromConfig.isEmpty()) {
-      impersonationListFromConfig = filterConfig.getServletContext().getInitParameter(IMPERSONATION_PARAMS);
+    private static List<String> virtualGroupParameterNames(List<String> initParameterNames) {
+        return initParameterNames == null ? new ArrayList<>()
+                : initParameterNames.stream().filter(name -> name.startsWith(VIRTUAL_GROUP_MAPPING_PREFIX)).collect(Collectors.toList());
     }
 
-    /* Add default impersonation params */
-    impersonationParamsList.add(DOAS_PRINCIPAL_PARAM);
-    impersonationParamsList.add(PRINCIPAL_PARAM);
+    private static String[] unique(String[] groups) {
+        return new HashSet<>(Arrays.asList(groups)).toArray(new String[0]);
+    }
 
-    if (impersonationListFromConfig != null && !impersonationListFromConfig.isEmpty()) {
-      /* Add configured impersonation params */
-      LOG.impersonationConfig(impersonationListFromConfig);
-      final StringTokenizer t = new StringTokenizer(impersonationListFromConfig, ",");
-      while (t.hasMoreElements()) {
-        final String token = t.nextToken().trim();
-        if (!impersonationParamsList.contains(token)) {
-          impersonationParamsList.add(token);
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        topologyName = (String) filterConfig.getServletContext().getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE);
+        String principalMapping = filterConfig.getInitParameter(PRINCIPAL_MAPPING);
+        if (principalMapping == null || principalMapping.isEmpty()) {
+            principalMapping = filterConfig.getServletContext().getInitParameter(PRINCIPAL_MAPPING);
         }
-      }
-    }
-  }
-
-  private void initProxyUserConfiguration(FilterConfig filterConfig, List<String> initParameterNames) {
-    final String impersonationEnabledValue = filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM);
-    impersonationEnabled = impersonationEnabledValue == null ? Boolean.FALSE : Boolean.parseBoolean(impersonationEnabledValue);
-
-    if (impersonationEnabled) {
-      if (AuthFilterUtils.hasProxyConfig(topologyName, "HadoopAuth")) {
-        LOG.ignoreProxyuserConfig();
-        impersonationEnabled = false; //explicitly set to false to avoid redundant authorization attempts at request processing time
-      } else {
-        AuthFilterUtils.refreshSuperUserGroupsConfiguration(filterConfig, initParameterNames, topologyName, ROLE);
-        filterConfig.getServletContext().setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.TRUE);
-      }
-    } else {
-      filterConfig.getServletContext().setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.FALSE);
-    }
-  }
-
-  boolean isImpersonationEnabled() {
-    return impersonationEnabled;
-  }
-
-  private Map<String, AbstractSyntaxTree> loadVirtualGroups(FilterConfig filterConfig, List<String> initParameterNames) {
-    Map<String, AbstractSyntaxTree> predicateToGroupMapping = new HashMap<>();
-    loadVirtualGroupConfig(filterConfig, initParameterNames, predicateToGroupMapping);
-    if (predicateToGroupMapping.isEmpty() && filterConfig.getServletContext() != null) {
-      loadVirtualGroupConfig(filterConfig.getServletContext(), predicateToGroupMapping);
-    }
-    return predicateToGroupMapping;
-  }
-
-  private void loadVirtualGroupConfig(FilterConfig config, List<String> initParameterNames, Map<String, AbstractSyntaxTree> result) {
-    for (String paramName : virtualGroupParameterNames(initParameterNames)) {
-      addGroup(result, paramName, config.getInitParameter(paramName));
-    }
-  }
-
-  private void loadVirtualGroupConfig(ServletContext context, Map<String, AbstractSyntaxTree> result) {
-    final List<String> contextInitParams = context.getInitParameterNames() == null ? Collections.emptyList()
-        : Collections.list(context.getInitParameterNames());
-    for (String paramName : virtualGroupParameterNames(contextInitParams)) {
-      addGroup(result, paramName, context.getInitParameter(paramName));
-    }
-  }
-
-  private void addGroup(Map<String, AbstractSyntaxTree> result, String paramName, String predicate) {
-    try {
-      AbstractSyntaxTree ast = parser.parse(predicate);
-      String groupName = paramName.substring(VIRTUAL_GROUP_MAPPING_PREFIX.length()).trim();
-      if (StringUtils.isBlank(groupName)) {
-        LOG.missingVirtualGroupName();
-      } else {
-        result.put(groupName, ast);
-      }
-    } catch (SyntaxException e) {
-      LOG.parseError(paramName, predicate, e);
-    }
-  }
-
-  private static List<String> virtualGroupParameterNames(List<String> initParameterNames) {
-    return initParameterNames == null ? new ArrayList<>()
-        : initParameterNames.stream().filter(name -> name.startsWith(VIRTUAL_GROUP_MAPPING_PREFIX)).collect(Collectors.toList());
-  }
-
-  @Override
-  public void destroy() {
-  }
-
-  /**
-   * Obtain the standard javax.security.auth.Subject, retrieve the caller principal, map
-   * to the identity to be asserted as appropriate and create the provider specific
-   * assertion token. Add the assertion token to the request.
-   */
-  @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-      throws IOException, ServletException {
-    Subject subject = Subject.getSubject(AccessController.getContext());
-
-    if (subject == null) {
-      LOG.subjectNotAvailable();
-      throw new IllegalStateException("Required Subject Missing");
-    }
-
-    String mappedPrincipalName = null;
-    try {
-      mappedPrincipalName = handleProxyUserImpersonation(request, subject);
-    } catch(AuthorizationException e) {
-      LOG.hadoopAuthProxyUserFailed(e);
-      HttpExceptionUtils.createServletExceptionResponse((HttpServletResponse) response, HttpServletResponse.SC_FORBIDDEN, e);
-      return;
-    }
-
-    // mapping principal name using user principal mapping (if configured)
-    mappedPrincipalName = mapUserPrincipalBase(mappedPrincipalName);
-    mappedPrincipalName = mapUserPrincipal(mappedPrincipalName);
-    if (expressionPrincipalMapping != null) {
-      String result = evalAdvancedPrincipalMapping(request, subject, mappedPrincipalName);
-      if (result != null) {
-        mappedPrincipalName = result;
-      }
-    }
-    String[] mappedGroups = mapGroupPrincipalsBase(mappedPrincipalName, subject);
-    String[] groups = mapGroupPrincipals(mappedPrincipalName, subject);
-    String[] virtualGroups = virtualGroupMapper.mapGroups(mappedPrincipalName, combine(subject, groups), request).toArray(new String[0]);
-    groups = combineGroupMappings(mappedGroups, groups);
-    groups = combineGroupMappings(virtualGroups, groups);
-
-    HttpServletRequestWrapper wrapper = wrapHttpServletRequest(request, mappedPrincipalName);
-
-
-    continueChainAsPrincipal(wrapper, response, chain, mappedPrincipalName, unique(groups));
-  }
-
-  private String evalAdvancedPrincipalMapping(ServletRequest request, Subject subject, String originalPrincipal) {
-    Interpreter interpreter = new Interpreter();
-    interpreter.addConstant("username", originalPrincipal);
-    interpreter.addConstant("groups", groups(subject));
-    addRequestFunctions(request, interpreter);
-    Object mappedPrincipal = interpreter.eval(expressionPrincipalMapping);
-    if (mappedPrincipal instanceof String) {
-      return (String)mappedPrincipal;
-    } else {
-      LOG.invalidAdvancedPrincipalMappingResult(originalPrincipal, expressionPrincipalMapping, mappedPrincipal);
-      return null;
-    }
-  }
-
-  private String handleProxyUserImpersonation(ServletRequest request, Subject subject) throws AuthorizationException {
-    String principalName = SubjectUtils.getEffectivePrincipalName(subject);
-    if (impersonationEnabled) {
-      final String doAsUser = request.getParameter(AuthFilterUtils.QUERY_PARAMETER_DOAS);
-      if (doAsUser != null && !doAsUser.equals(principalName)) {
-        LOG.hadoopAuthDoAsUser(doAsUser, principalName, request.getRemoteAddr());
-        if (principalName != null) {
-          AuthFilterUtils.authorizeImpersonationRequest((HttpServletRequest) request, principalName, doAsUser, topologyName, ROLE);
-          LOG.hadoopAuthProxyUserSuccess();
-          principalName = doAsUser;
+        String groupPrincipalMapping = filterConfig.getInitParameter(GROUP_PRINCIPAL_MAPPING);
+        if (groupPrincipalMapping == null || groupPrincipalMapping.isEmpty()) {
+            groupPrincipalMapping = filterConfig.getServletContext().getInitParameter(GROUP_PRINCIPAL_MAPPING);
         }
-      }
+        if (principalMapping != null && !principalMapping.isEmpty() || groupPrincipalMapping != null && !groupPrincipalMapping.isEmpty()) {
+            try {
+                mapper.loadMappingTable(principalMapping, groupPrincipalMapping);
+            } catch (PrincipalMappingException e) {
+                throw new ServletException("Unable to load principal mapping table.", e);
+            }
+        }
+        expressionPrincipalMapping = parseAdvancedPrincipalMapping(filterConfig);
+
+        final List<String> initParameterNames = AuthFilterUtils.getInitParameterNamesAsList(filterConfig);
+
+        virtualGroupMapper = new VirtualGroupMapper(loadVirtualGroups(filterConfig, initParameterNames));
+
+        initImpersonationParamsList(filterConfig);
+        initProxyUserConfiguration(filterConfig, initParameterNames);
     }
-    return principalName;
-  }
 
-  private Set<String> combine(Subject subject, String[] groups) {
-    Set<String> result = groups(subject);
-    if (groups != null) {
-      result.addAll(Arrays.asList(groups));
+    private AbstractSyntaxTree parseAdvancedPrincipalMapping(FilterConfig filterConfig) {
+        String expression = filterConfig.getInitParameter(ADVANCED_PRINCIPAL_MAPPING);
+        if (StringUtils.isBlank(expression)) {
+            expression = filterConfig.getServletContext().getInitParameter(ADVANCED_PRINCIPAL_MAPPING);
+        }
+        return StringUtils.isBlank(expression) ? null : parser.parse(expression);
     }
-    return result;
-  }
 
-  private static String[] unique(String[] groups) {
-    return new HashSet<>(Arrays.asList(groups)).toArray(new String[0]);
-  }
+    /*
+     * Initialize the impersonation params list.
+     * This list contains query params that needs to be scrubbed
+     * from the outgoing request.
+     */
+    private void initImpersonationParamsList(FilterConfig filterConfig) {
+        String impersonationListFromConfig = filterConfig.getInitParameter(IMPERSONATION_PARAMS);
+        if (impersonationListFromConfig == null || impersonationListFromConfig.isEmpty()) {
+            impersonationListFromConfig = filterConfig.getServletContext().getInitParameter(IMPERSONATION_PARAMS);
+        }
 
-  protected String[] combineGroupMappings(String[] mappedGroups, String[] groups) {
-    if (mappedGroups != null && groups != null) {
-      return ArrayUtils.addAll(mappedGroups, groups);
+        /* Add default impersonation params */
+        impersonationParamsList.add(DOAS_PRINCIPAL_PARAM);
+        impersonationParamsList.add(PRINCIPAL_PARAM);
+
+        if (impersonationListFromConfig != null && !impersonationListFromConfig.isEmpty()) {
+            /* Add configured impersonation params */
+            LOG.impersonationConfig(impersonationListFromConfig);
+            final StringTokenizer t = new StringTokenizer(impersonationListFromConfig, ",");
+            while (t.hasMoreElements()) {
+                final String token = t.nextToken().trim();
+                if (!impersonationParamsList.contains(token)) {
+                    impersonationParamsList.add(token);
+                }
+            }
+        }
     }
-    else {
-      return groups != null ? groups : mappedGroups;
+
+    private void initProxyUserConfiguration(FilterConfig filterConfig, List<String> initParameterNames) {
+        impersonationEnabled = shouldAddImpersonationProvider(filterConfig);
+        if (impersonationEnabled) {
+            if (AuthFilterUtils.hasProxyConfig(topologyName, "HadoopAuth")) {
+                LOG.ignoreProxyuserConfig();
+                impersonationEnabled = false; //explicitly set to false to avoid redundant authorization attempts at request processing time
+            } else {
+                AuthFilterUtils.refreshSuperUserGroupsConfiguration(filterConfig, initParameterNames, topologyName, ROLE);
+                filterConfig.getServletContext().setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.TRUE);
+            }
+        } else {
+            filterConfig.getServletContext().setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.FALSE);
+        }
     }
-  }
 
-  public HttpServletRequestWrapper wrapHttpServletRequest(
-      ServletRequest request, String mappedPrincipalName) {
-    // wrap the request so that the proper principal is returned
-    // from request methods
-    return new IdentityAsserterHttpServletRequestWrapper(
-        (HttpServletRequest) request,
-        mappedPrincipalName,
-        impersonationParamsList);
-  }
+    /**
+     * Check if the impersonation provider should be added to the filter chain based on
+     * user and group impersonation settings.
+     *
+     * @param filterConfig
+     * @return
+     */
+    boolean shouldAddImpersonationProvider(final FilterConfig filterConfig) {
+        boolean userImpersonationEnabledValue = false;
+        boolean groupImpersonationEnabledValue = false;
+        /* Check if user or group impersonation is enabled */
+        if (filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM) != null) {
+            String userImpersonationEnabledString = filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM);
+            userImpersonationEnabledValue = userImpersonationEnabledString == null ? Boolean.FALSE : Boolean.parseBoolean(userImpersonationEnabledString);
+        }
 
-  protected String[] mapGroupPrincipalsBase(String mappedPrincipalName, Subject subject) {
-    return mapper.mapGroupPrincipal(mappedPrincipalName);
-  }
+        if (filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM) != null) {
+            String groupImpersonationEnabledString = filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM);
+            groupImpersonationEnabledValue = groupImpersonationEnabledString == null ? Boolean.FALSE : Boolean.parseBoolean(groupImpersonationEnabledString);
 
-  protected String mapUserPrincipalBase(String principalName) {
-    return mapper.mapUserPrincipal(principalName);
-  }
+        }
+        return (userImpersonationEnabledValue || groupImpersonationEnabledValue);
+    }
 
-  private Set<String> groups(Subject subject) {
-    return subject.getPrincipals(GroupPrincipal.class).stream()
-            .map(GroupPrincipal::getName)
-            .collect(Collectors.toSet());
-  }
+    boolean isImpersonationEnabled() {
+        return impersonationEnabled;
+    }
 
-  @Override
-  public String[] mapGroupPrincipals(String mappedPrincipalName, Subject subject) {
-    // NOP
-    return null;
-  }
+    private Map<String, AbstractSyntaxTree> loadVirtualGroups(FilterConfig filterConfig, List<String> initParameterNames) {
+        Map<String, AbstractSyntaxTree> predicateToGroupMapping = new HashMap<>();
+        loadVirtualGroupConfig(filterConfig, initParameterNames, predicateToGroupMapping);
+        if (predicateToGroupMapping.isEmpty() && filterConfig.getServletContext() != null) {
+            loadVirtualGroupConfig(filterConfig.getServletContext(), predicateToGroupMapping);
+        }
+        return predicateToGroupMapping;
+    }
 
-  @Override
-  public String mapUserPrincipal(String principalName) {
-    // NOP
-    return principalName;
-  }
+    private void loadVirtualGroupConfig(FilterConfig config, List<String> initParameterNames, Map<String, AbstractSyntaxTree> result) {
+        for (String paramName : virtualGroupParameterNames(initParameterNames)) {
+            addGroup(result, paramName, config.getInitParameter(paramName));
+        }
+    }
+
+    private void loadVirtualGroupConfig(ServletContext context, Map<String, AbstractSyntaxTree> result) {
+        final List<String> contextInitParams = context.getInitParameterNames() == null ? Collections.emptyList()
+                : Collections.list(context.getInitParameterNames());
+        for (String paramName : virtualGroupParameterNames(contextInitParams)) {
+            addGroup(result, paramName, context.getInitParameter(paramName));
+        }
+    }
+
+    private void addGroup(Map<String, AbstractSyntaxTree> result, String paramName, String predicate) {
+        try {
+            AbstractSyntaxTree ast = parser.parse(predicate);
+            String groupName = paramName.substring(VIRTUAL_GROUP_MAPPING_PREFIX.length()).trim();
+            if (StringUtils.isBlank(groupName)) {
+                LOG.missingVirtualGroupName();
+            } else {
+                result.put(groupName, ast);
+            }
+        } catch (SyntaxException e) {
+            LOG.parseError(paramName, predicate, e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    /**
+     * Obtain the standard javax.security.auth.Subject, retrieve the caller principal, map
+     * to the identity to be asserted as appropriate and create the provider specific
+     * assertion token. Add the assertion token to the request.
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+
+        if (subject == null) {
+            LOG.subjectNotAvailable();
+            throw new IllegalStateException("Required Subject Missing");
+        }
+
+        String mappedPrincipalName = null;
+        try {
+            mappedPrincipalName = handleProxyUserImpersonation(request, subject);
+        } catch (AuthorizationException e) {
+            LOG.hadoopAuthProxyUserFailed(e);
+            HttpExceptionUtils.createServletExceptionResponse((HttpServletResponse) response, HttpServletResponse.SC_FORBIDDEN, e);
+            return;
+        }
+
+        // mapping principal name using user principal mapping (if configured)
+        mappedPrincipalName = mapUserPrincipalBase(mappedPrincipalName);
+        mappedPrincipalName = mapUserPrincipal(mappedPrincipalName);
+        if (expressionPrincipalMapping != null) {
+            String result = evalAdvancedPrincipalMapping(request, subject, mappedPrincipalName);
+            if (result != null) {
+                mappedPrincipalName = result;
+            }
+        }
+        String[] mappedGroups = mapGroupPrincipalsBase(mappedPrincipalName, subject);
+        String[] groups = mapGroupPrincipals(mappedPrincipalName, subject);
+        String[] virtualGroups = virtualGroupMapper.mapGroups(mappedPrincipalName, combine(subject, groups), request).toArray(new String[0]);
+        groups = combineGroupMappings(mappedGroups, groups);
+        groups = combineGroupMappings(virtualGroups, groups);
+
+        HttpServletRequestWrapper wrapper = wrapHttpServletRequest(request, mappedPrincipalName);
+
+
+        continueChainAsPrincipal(wrapper, response, chain, mappedPrincipalName, unique(groups));
+    }
+
+    private String evalAdvancedPrincipalMapping(ServletRequest request, Subject subject, String originalPrincipal) {
+        Interpreter interpreter = new Interpreter();
+        interpreter.addConstant("username", originalPrincipal);
+        interpreter.addConstant("groups", groups(subject));
+        addRequestFunctions(request, interpreter);
+        Object mappedPrincipal = interpreter.eval(expressionPrincipalMapping);
+        if (mappedPrincipal instanceof String) {
+            return (String) mappedPrincipal;
+        } else {
+            LOG.invalidAdvancedPrincipalMappingResult(originalPrincipal, expressionPrincipalMapping, mappedPrincipal);
+            return null;
+        }
+    }
+
+    private String handleProxyUserImpersonation(ServletRequest request, Subject subject) throws AuthorizationException {
+        String principalName = SubjectUtils.getEffectivePrincipalName(subject);
+        if (impersonationEnabled) {
+            final String doAsUser = request.getParameter(AuthFilterUtils.QUERY_PARAMETER_DOAS);
+            if (doAsUser != null && !doAsUser.equals(principalName)) {
+                LOG.hadoopAuthDoAsUser(doAsUser, principalName, request.getRemoteAddr());
+                if (principalName != null) {
+                    AuthFilterUtils.authorizeImpersonationRequest((HttpServletRequest) request, principalName, doAsUser, topologyName, ROLE);
+                    LOG.hadoopAuthProxyUserSuccess();
+                    principalName = doAsUser;
+                }
+            }
+        }
+        return principalName;
+    }
+
+    private Set<String> combine(Subject subject, String[] groups) {
+        Set<String> result = groups(subject);
+        if (groups != null) {
+            result.addAll(Arrays.asList(groups));
+        }
+        return result;
+    }
+
+    protected String[] combineGroupMappings(String[] mappedGroups, String[] groups) {
+        if (mappedGroups != null && groups != null) {
+            return ArrayUtils.addAll(mappedGroups, groups);
+        } else {
+            return groups != null ? groups : mappedGroups;
+        }
+    }
+
+    public HttpServletRequestWrapper wrapHttpServletRequest(
+            ServletRequest request, String mappedPrincipalName) {
+        // wrap the request so that the proper principal is returned
+        // from request methods
+        return new IdentityAsserterHttpServletRequestWrapper(
+                (HttpServletRequest) request,
+                mappedPrincipalName,
+                impersonationParamsList);
+    }
+
+    protected String[] mapGroupPrincipalsBase(String mappedPrincipalName, Subject subject) {
+        return mapper.mapGroupPrincipal(mappedPrincipalName);
+    }
+
+    protected String mapUserPrincipalBase(String principalName) {
+        return mapper.mapUserPrincipal(principalName);
+    }
+
+    private Set<String> groups(Subject subject) {
+        return subject.getPrincipals(GroupPrincipal.class).stream()
+                .map(GroupPrincipal::getName)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String[] mapGroupPrincipals(String mappedPrincipalName, Subject subject) {
+        // NOP
+        return null;
+    }
+
+    @Override
+    public String mapUserPrincipal(String principalName) {
+        // NOP
+        return principalName;
+    }
 }

--- a/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilterTest.java
+++ b/gateway-provider-identity-assertion-common/src/test/java/org/apache/knox/gateway/identityasserter/common/filter/CommonIdentityAssertionFilterTest.java
@@ -17,13 +17,27 @@
  */
 package org.apache.knox.gateway.identityasserter.common.filter;
 
-import static org.apache.knox.gateway.audit.log4j.audit.Log4jAuditService.MDC_AUDIT_CONTEXT_KEY;
-import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
-import static org.easymock.EasyMock.createMock;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.apache.knox.gateway.context.ContextAttributes;
+import org.apache.knox.gateway.security.GroupPrincipal;
+import org.apache.knox.gateway.security.PrimaryPrincipal;
+import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.util.AuthFilterUtils;
+import org.apache.logging.log4j.ThreadContext;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 
+import javax.security.auth.Subject;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -38,270 +52,253 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import javax.security.auth.Subject;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.knox.gateway.context.ContextAttributes;
-import org.apache.knox.gateway.security.GroupPrincipal;
-import org.apache.knox.gateway.security.PrimaryPrincipal;
-import org.apache.knox.gateway.security.SubjectUtils;
-import org.apache.knox.gateway.services.GatewayServices;
-import org.apache.knox.gateway.util.AuthFilterUtils;
-import org.apache.logging.log4j.ThreadContext;
-import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
+import static org.apache.knox.gateway.audit.log4j.audit.Log4jAuditService.MDC_AUDIT_CONTEXT_KEY;
+import static org.apache.knox.gateway.identityasserter.common.filter.AbstractIdentityAsserterDeploymentContributor.IMPERSONATION_PARAMS;
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class CommonIdentityAssertionFilterTest {
-  private String username;
-  private CommonIdentityAssertionFilter filter;
-  private Set<String> calculatedGroups = new HashSet<>();
+    private String username;
+    private CommonIdentityAssertionFilter filter;
+    private Set<String> calculatedGroups = new HashSet<>();
 
-  @Before
-  public void setUp() {
-    filter = new CommonIdentityAssertionFilter() {
-      @Override
-      public String mapUserPrincipal(String principalName) {
-        username = principalName.toUpperCase(Locale.ROOT);
-        return principalName;
-      }
+    @Before
+    public void setUp() {
+        filter = new CommonIdentityAssertionFilter() {
+            @Override
+            public String mapUserPrincipal(String principalName) {
+                username = principalName.toUpperCase(Locale.ROOT);
+                return principalName;
+            }
 
-      @Override
-      public String[] mapGroupPrincipals(String principalName, Subject subject) {
-        String[] groups = new String[4];
-        int i = 0;
-        for(GroupPrincipal p : subject.getPrincipals(GroupPrincipal.class)) {
-          groups[i] = p.getName().toUpperCase(Locale.ROOT);
-          i++;
+            @Override
+            public String[] mapGroupPrincipals(String principalName, Subject subject) {
+                String[] groups = new String[4];
+                int i = 0;
+                for (GroupPrincipal p : subject.getPrincipals(GroupPrincipal.class)) {
+                    groups[i] = p.getName().toUpperCase(Locale.ROOT);
+                    i++;
+                }
+                return groups;
+            }
+
+            @Override
+            protected String[] combineGroupMappings(String[] mappedGroups, String[] groups) {
+                calculatedGroups.addAll(Arrays.asList(super.combineGroupMappings(mappedGroups, groups)));
+                return super.combineGroupMappings(mappedGroups, groups);
+            }
+
+            @Override
+            protected void continueChainAsPrincipal(HttpServletRequestWrapper request, ServletResponse response, FilterChain chain, String mappedPrincipalName, String[] groups) throws IOException, ServletException {
+                assertEquals("Groups should not have duplicates: " + Arrays.toString(groups),
+                        new HashSet<>(Arrays.asList(groups)).size(),
+                        groups.length);
+                super.continueChainAsPrincipal(request, response, chain, mappedPrincipalName, groups);
+            }
+        };
+        ThreadContext.put(MDC_AUDIT_CONTEXT_KEY, "dummy");
+    }
+
+    @Test
+    public void testSimpleFilter() throws ServletException, IOException {
+        ServletContext servletContext = createMock(ServletContext.class);
+        EasyMock.expect(servletContext.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn("topology1").anyTimes();
+        servletContext.setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.FALSE);
+        EasyMock.expectLastCall();
+        EasyMock.replay(servletContext);
+        FilterConfig config = EasyMock.createNiceMock(FilterConfig.class);
+        EasyMock.expect(config.getServletContext()).andReturn(servletContext).anyTimes();
+        EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.ADVANCED_PRINCIPAL_MAPPING)).
+                andReturn("username").anyTimes();
+        EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING)).
+                andReturn("*=everyone;lmccay=test-virtual-group").once();
+        EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).
+                andReturn("ljm=lmccay;").once();
+        EasyMock.expect(config.getInitParameterNames()).
+                andReturn(Collections.enumeration(Arrays.asList(
+                        CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING,
+                        CommonIdentityAssertionFilter.PRINCIPAL_MAPPING,
+                        CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group",
+                        CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX))) // invalid group with no name
+                .anyTimes();
+        EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS)).
+                andReturn("doAs").anyTimes();
+        EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")).
+                andReturn("(and (username 'lmccay') (and (member 'users') (member 'admin')))").anyTimes();
+        EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX)).
+                andReturn("true").anyTimes();
+        EasyMock.replay(config);
+
+        final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+        EasyMock.replay(request);
+
+        final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+        EasyMock.replay(response);
+
+        final FilterChain chain = (req, resp) -> {
+        };
+
+        Subject subject = new Subject();
+        subject.getPrincipals().add(new PrimaryPrincipal("ljm"));
+        subject.getPrincipals().add(new GroupPrincipal("users"));
+        subject.getPrincipals().add(new GroupPrincipal("admin"));
+        try {
+            Subject.doAs(
+                    subject,
+                    (PrivilegedExceptionAction<Object>) () -> {
+                        filter.init(config);
+                        filter.doFilter(request, response, chain);
+                        return null;
+                    });
+        } catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            if (t instanceof IOException) {
+                throw (IOException) t;
+            } else if (t instanceof ServletException) {
+                throw (ServletException) t;
+            } else {
+                throw new ServletException(t);
+            }
         }
-        return groups;
-      }
 
-      @Override
-      protected String[] combineGroupMappings(String[] mappedGroups, String[] groups) {
-        calculatedGroups.addAll(Arrays.asList(super.combineGroupMappings(mappedGroups, groups)));
-        return super.combineGroupMappings(mappedGroups, groups);
-      }
-
-      @Override
-      protected void continueChainAsPrincipal(HttpServletRequestWrapper request, ServletResponse response, FilterChain chain, String mappedPrincipalName, String[] groups) throws IOException, ServletException {
-        assertEquals("Groups should not have duplicates: " + Arrays.toString(groups),
-                new HashSet<>(Arrays.asList(groups)).size(),
-                groups.length);
-        super.continueChainAsPrincipal(request, response, chain, mappedPrincipalName, groups);
-      }
-    };
-    ThreadContext.put(MDC_AUDIT_CONTEXT_KEY, "dummy");
-  }
-
-  @Test
-  public void testSimpleFilter() throws ServletException, IOException {
-    ServletContext servletContext = createMock(ServletContext.class);
-    EasyMock.expect(servletContext.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn("topology1").anyTimes();
-    servletContext.setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.FALSE);
-    EasyMock.expectLastCall();
-    EasyMock.replay(servletContext);
-    FilterConfig config = EasyMock.createNiceMock( FilterConfig.class );
-    EasyMock.expect(config.getServletContext()).andReturn(servletContext).anyTimes();
-    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.ADVANCED_PRINCIPAL_MAPPING)).
-            andReturn("username").anyTimes();
-    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING)).
-        andReturn("*=everyone;lmccay=test-virtual-group").once();
-    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).
-        andReturn("ljm=lmccay;").once();
-    EasyMock.expect(config.getInitParameterNames()).
-            andReturn(Collections.enumeration(Arrays.asList(
-                    CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING,
-                    CommonIdentityAssertionFilter.PRINCIPAL_MAPPING,
-                    CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group",
-                    CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX))) // invalid group with no name
-            .anyTimes();
-    EasyMock.expect(config.getInitParameter(IMPERSONATION_PARAMS)).
-        andReturn("doAs").anyTimes();
-    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX + "test-virtual-group")).
-            andReturn("(and (username 'lmccay') (and (member 'users') (member 'admin')))").anyTimes();
-    EasyMock.expect(config.getInitParameter(CommonIdentityAssertionFilter.VIRTUAL_GROUP_MAPPING_PREFIX)).
-            andReturn("true").anyTimes();
-    EasyMock.replay( config );
-
-    final HttpServletRequest request = EasyMock.createNiceMock( HttpServletRequest.class );
-    EasyMock.replay( request );
-
-    final HttpServletResponse response = EasyMock.createNiceMock( HttpServletResponse.class );
-    EasyMock.replay( response );
-
-    final FilterChain chain = (req, resp) -> {};
-
-    Subject subject = new Subject();
-    subject.getPrincipals().add(new PrimaryPrincipal("ljm"));
-    subject.getPrincipals().add(new GroupPrincipal("users"));
-    subject.getPrincipals().add(new GroupPrincipal("admin"));
-    try {
-      Subject.doAs(
-        subject,
-              (PrivilegedExceptionAction<Object>) () -> {
-                filter.init(config);
-                filter.doFilter(request, response, chain);
-                return null;
-              });
-    }
-    catch (PrivilegedActionException e) {
-      Throwable t = e.getCause();
-      if (t instanceof IOException) {
-        throw (IOException) t;
-      }
-      else if (t instanceof ServletException) {
-        throw (ServletException) t;
-      }
-      else {
-        throw new ServletException(t);
-      }
+        assertEquals("LMCCAY", username);
+        assertTrue("Should be greater than 2", calculatedGroups.size() > 2);
+        assertTrue(calculatedGroups.containsAll(Arrays.asList("everyone", "USERS", "ADMIN", "test-virtual-group")));
+        assertFalse(calculatedGroups.contains(""));
     }
 
-    assertEquals("LMCCAY", username);
-    assertTrue("Should be greater than 2", calculatedGroups.size() > 2);
-    assertTrue(calculatedGroups.containsAll(Arrays.asList("everyone", "USERS", "ADMIN", "test-virtual-group")));
-    assertFalse(calculatedGroups.contains(""));
-  }
+    @Test
+    public void testProxyUserImpersonationDisabled() throws Exception {
+        testProxyUserImpersonationEnabled(false);
 
-  @Test
-  public void testProxyUserImpersonationDisabled() throws Exception {
-    testProxyUserImpersonationEnabled(false);
-
-  }
-
-  @Test
-  public void testProxyUserImpersonationEnabled() throws Exception {
-    testProxyUserImpersonationEnabled(true);
-  }
-
-  @Test
-  public void testProxyUserImpersonationEnabledAndConfiguredInHadoopAuth() throws Exception {
-    testProxyUserImpersonationEnabled(true, true, Arrays.asList());
-  }
-
-  @Test
-  public void testProxyUserImpersonationFailWithoutProxyUserConfig() throws Exception {
-    final String impersonatedUser = "bob";
-
-    // enable impersonation without configuring context/filter expectations
-    testProxyUserImpersonationEnabled(true);
-
-    final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
-    EasyMock.expect(request.getParameter(AuthFilterUtils.QUERY_PARAMETER_DOAS)).andReturn(impersonatedUser).once();
-
-    final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    final PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    EasyMock.expect(response.getWriter()).andReturn(writer).anyTimes();
-    EasyMock.replay(request, response);
-
-    final FilterChainWrapper chain = new FilterChainWrapper((req, resp) -> {
-    });
-
-    final Subject subject = new Subject();
-    subject.getPrincipals().add(new PrimaryPrincipal("admin"));
-    Subject.doAs(subject, (PrivilegedExceptionAction<Object>) () -> {
-      filter.doFilter(request, response, chain);
-      return null;
-    });
-    assertTrue(new String(out.toByteArray(), StandardCharsets.UTF_8).contains("User: admin is not allowed to impersonate bob"));
-  }
-
-  @Test
-  public void testProxyUserImpersonationApplied() throws Exception {
-    final String impersonatedUser = "bob";
-
-    // enable impersonation and configure context/filter expectations
-    final List<String> proxyUserConfig = Arrays.asList(AuthFilterUtils.PROXYUSER_PREFIX + ".admin.users", AuthFilterUtils.PROXYUSER_PREFIX + ".admin.hosts");
-    testProxyUserImpersonationEnabled(true, false, proxyUserConfig);
-
-    final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
-    EasyMock.expect(request.getParameter(AuthFilterUtils.QUERY_PARAMETER_DOAS)).andReturn(impersonatedUser).once();
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    EasyMock.replay(request, response);
-
-    final FilterChainWrapper chain = new FilterChainWrapper((req, resp) -> {
-    });
-
-    final Subject subject = new Subject();
-    subject.getPrincipals().add(new PrimaryPrincipal("admin"));
-    Subject.doAs(subject, (PrivilegedExceptionAction<Object>) () -> {
-      filter.doFilter(request, response, chain);
-      return null;
-    });
-    assertTrue(filter.isImpersonationEnabled());
-    final Subject impersonatedSubject = chain.getSubject();
-    assertTrue(SubjectUtils.isImpersonating(impersonatedSubject));
-    assertEquals("admin", SubjectUtils.getPrimaryPrincipalName(impersonatedSubject));
-    assertEquals("bob", SubjectUtils.getEffectivePrincipalName(impersonatedSubject));
-  }
-
-  private static final class FilterChainWrapper implements FilterChain {
-    private final FilterChain wrappedFilterChain;
-    private Subject subject;
-
-    FilterChainWrapper(FilterChain wrappedFilterChain) {
-      this.wrappedFilterChain = wrappedFilterChain;
     }
 
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
-      this.subject = SubjectUtils.getCurrentSubject();
-      wrappedFilterChain.doFilter(request, response);
+    @Test
+    public void testProxyUserImpersonationEnabled() throws Exception {
+        testProxyUserImpersonationEnabled(true);
     }
 
-    Subject getSubject() {
-      return subject;
-    }
-  }
-
-  private void testProxyUserImpersonationEnabled(boolean impersonationEnabled) throws Exception {
-    testProxyUserImpersonationEnabled(impersonationEnabled, false, Arrays.asList());
-  }
-
-  private void testProxyUserImpersonationEnabled(boolean impersonationEnabled, boolean configuredInHadoopAuth, List<String> filterConfigParameterNames)
-      throws Exception {
-    ServletContext servletContext = createMock(ServletContext.class);
-    EasyMock.expect(servletContext.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn("topology1").anyTimes();
-    EasyMock.expect(servletContext.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
-    EasyMock.expect(servletContext.getInitParameter(CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
-    EasyMock.expect(servletContext.getInitParameter(CommonIdentityAssertionFilter.ADVANCED_PRINCIPAL_MAPPING)).andReturn("username").anyTimes();
-    EasyMock.expect(servletContext.getInitParameterNames()).andReturn(Collections.enumeration(filterConfigParameterNames)).anyTimes();
-    EasyMock.expect(servletContext.getInitParameter(IMPERSONATION_PARAMS)).andReturn("doAs").anyTimes();
-    if (!configuredInHadoopAuth) {
-      servletContext.setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.valueOf(impersonationEnabled));
-      EasyMock.expectLastCall();
-    }
-    final FilterConfig filterConfig = EasyMock.createNiceMock(FilterConfig.class);
-    final String impersonatedEnabledParam = impersonationEnabled ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
-    EasyMock.expect(filterConfig.getInitParameter(CommonIdentityAssertionFilter.IMPERSONATION_ENABLED_PARAM)).andReturn(impersonatedEnabledParam);
-    EasyMock.expect(filterConfig.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
-    EasyMock.expect(filterConfig.getInitParameter(CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
-    EasyMock.expect(filterConfig.getInitParameterNames()).andReturn(Collections.enumeration(filterConfigParameterNames)).atLeastOnce();
-    filterConfigParameterNames.forEach(filterConfigParameterName -> {
-      EasyMock.expect(filterConfig.getInitParameter(filterConfigParameterName)).andReturn("*").anyTimes();
-    });
-    EasyMock.expect(filterConfig.getServletContext()).andReturn(servletContext).anyTimes();
-    EasyMock.replay(servletContext, filterConfig);
-
-    if (configuredInHadoopAuth) {
-      AuthFilterUtils.refreshSuperUserGroupsConfiguration(filterConfig, Arrays.asList(), "topology1", "HadoopAuth");
-    } else {
-      AuthFilterUtils.removeProxyUserConfig("topology1", "HadoopAuth");
+    @Test
+    public void testProxyUserImpersonationEnabledAndConfiguredInHadoopAuth() throws Exception {
+        testProxyUserImpersonationEnabled(true, true, Arrays.asList());
     }
 
-    filter.init(filterConfig);
-    assertEquals(impersonationEnabled && !configuredInHadoopAuth, filter.isImpersonationEnabled());
-    EasyMock.verify(servletContext, filterConfig);
-  }
+    @Test
+    public void testProxyUserImpersonationFailWithoutProxyUserConfig() throws Exception {
+        final String impersonatedUser = "bob";
+
+        // enable impersonation without configuring context/filter expectations
+        testProxyUserImpersonationEnabled(true);
+
+        final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+        EasyMock.expect(request.getParameter(AuthFilterUtils.QUERY_PARAMETER_DOAS)).andReturn(impersonatedUser).once();
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
+        final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+        EasyMock.expect(response.getWriter()).andReturn(writer).anyTimes();
+        EasyMock.replay(request, response);
+
+        final FilterChainWrapper chain = new FilterChainWrapper((req, resp) -> {
+        });
+
+        final Subject subject = new Subject();
+        subject.getPrincipals().add(new PrimaryPrincipal("admin"));
+        Subject.doAs(subject, (PrivilegedExceptionAction<Object>) () -> {
+            filter.doFilter(request, response, chain);
+            return null;
+        });
+        assertTrue(new String(out.toByteArray(), StandardCharsets.UTF_8).contains("User: admin is not allowed to impersonate bob"));
+    }
+
+    @Test
+    public void testProxyUserImpersonationApplied() throws Exception {
+        final String impersonatedUser = "bob";
+
+        // enable impersonation and configure context/filter expectations
+        final List<String> proxyUserConfig = Arrays.asList(AuthFilterUtils.PROXYUSER_PREFIX + ".admin.users", AuthFilterUtils.PROXYUSER_PREFIX + ".admin.hosts");
+        testProxyUserImpersonationEnabled(true, false, proxyUserConfig);
+
+        final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+        EasyMock.expect(request.getParameter(AuthFilterUtils.QUERY_PARAMETER_DOAS)).andReturn(impersonatedUser).once();
+        final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+        EasyMock.replay(request, response);
+
+        final FilterChainWrapper chain = new FilterChainWrapper((req, resp) -> {
+        });
+
+        final Subject subject = new Subject();
+        subject.getPrincipals().add(new PrimaryPrincipal("admin"));
+        Subject.doAs(subject, (PrivilegedExceptionAction<Object>) () -> {
+            filter.doFilter(request, response, chain);
+            return null;
+        });
+        assertTrue(filter.isImpersonationEnabled());
+        final Subject impersonatedSubject = chain.getSubject();
+        assertTrue(SubjectUtils.isImpersonating(impersonatedSubject));
+        assertEquals("admin", SubjectUtils.getPrimaryPrincipalName(impersonatedSubject));
+        assertEquals("bob", SubjectUtils.getEffectivePrincipalName(impersonatedSubject));
+    }
+
+    private void testProxyUserImpersonationEnabled(boolean impersonationEnabled) throws Exception {
+        testProxyUserImpersonationEnabled(impersonationEnabled, false, Arrays.asList());
+    }
+
+    private void testProxyUserImpersonationEnabled(boolean impersonationEnabled, boolean configuredInHadoopAuth, List<String> filterConfigParameterNames)
+            throws Exception {
+        ServletContext servletContext = createMock(ServletContext.class);
+        EasyMock.expect(servletContext.getAttribute(GatewayServices.GATEWAY_CLUSTER_ATTRIBUTE)).andReturn("topology1").anyTimes();
+        EasyMock.expect(servletContext.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
+        EasyMock.expect(servletContext.getInitParameter(CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
+        EasyMock.expect(servletContext.getInitParameter(CommonIdentityAssertionFilter.ADVANCED_PRINCIPAL_MAPPING)).andReturn("username").anyTimes();
+        EasyMock.expect(servletContext.getInitParameterNames()).andReturn(Collections.enumeration(filterConfigParameterNames)).anyTimes();
+        EasyMock.expect(servletContext.getInitParameter(IMPERSONATION_PARAMS)).andReturn("doAs").anyTimes();
+        if (!configuredInHadoopAuth) {
+            servletContext.setAttribute(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.valueOf(impersonationEnabled));
+            EasyMock.expectLastCall();
+        }
+        final FilterConfig filterConfig = EasyMock.createNiceMock(FilterConfig.class);
+        final String impersonatedEnabledParam = impersonationEnabled ? Boolean.TRUE.toString() : Boolean.FALSE.toString();
+        EasyMock.expect(filterConfig.getInitParameter(AuthFilterUtils.IMPERSONATION_ENABLED_PARAM)).andReturn(impersonatedEnabledParam).anyTimes();
+        EasyMock.expect(filterConfig.getInitParameter(CommonIdentityAssertionFilter.PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
+        EasyMock.expect(filterConfig.getInitParameter(CommonIdentityAssertionFilter.GROUP_PRINCIPAL_MAPPING)).andReturn(null).anyTimes();
+        EasyMock.expect(filterConfig.getInitParameterNames()).andReturn(Collections.enumeration(filterConfigParameterNames)).atLeastOnce();
+        filterConfigParameterNames.forEach(filterConfigParameterName -> {
+            EasyMock.expect(filterConfig.getInitParameter(filterConfigParameterName)).andReturn("*").anyTimes();
+        });
+        EasyMock.expect(filterConfig.getServletContext()).andReturn(servletContext).anyTimes();
+        EasyMock.replay(servletContext, filterConfig);
+
+        if (configuredInHadoopAuth) {
+            AuthFilterUtils.refreshSuperUserGroupsConfiguration(filterConfig, Arrays.asList(), "topology1", "HadoopAuth");
+        } else {
+            AuthFilterUtils.removeProxyUserConfig("topology1", "HadoopAuth");
+        }
+
+        filter.init(filterConfig);
+        assertEquals(impersonationEnabled && !configuredInHadoopAuth, filter.isImpersonationEnabled());
+        EasyMock.verify(servletContext, filterConfig);
+    }
+
+    private static final class FilterChainWrapper implements FilterChain {
+        private final FilterChain wrappedFilterChain;
+        private Subject subject;
+
+        FilterChainWrapper(FilterChain wrappedFilterChain) {
+            this.wrappedFilterChain = wrappedFilterChain;
+        }
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+            this.subject = SubjectUtils.getCurrentSubject();
+            wrappedFilterChain.doFilter(request, response);
+        }
+
+        Subject getSubject() {
+            return subject;
+        }
+    }
 
 }

--- a/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
+++ b/gateway-provider-security-hadoopauth/src/test/java/org/apache/knox/gateway/hadoopauth/filter/HadoopAuthFilterTest.java
@@ -18,6 +18,8 @@
 package org.apache.knox.gateway.hadoopauth.filter;
 
 import static org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter.JWT_INSTANCE_KEY_FALLBACK;
+import static org.apache.knox.gateway.util.AuthFilterUtils.GROUP_IMPERSONATION_ENABLED_PARAM;
+import static org.apache.knox.gateway.util.AuthFilterUtils.IMPERSONATION_ENABLED_PARAM;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.captureInt;
@@ -143,6 +145,8 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getServletContext()).andReturn(servletContext).atLeastOnce();
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
     Properties configProperties = createMock(Properties.class);
     expect(configProperties.getProperty("signature.secret.file")).andReturn("signature.secret.file").atLeastOnce();
@@ -207,6 +211,8 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("support.jwt")).andReturn("false").anyTimes();
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
 
     EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL);
@@ -257,6 +263,8 @@ public class HadoopAuthFilterTest {
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -318,6 +326,8 @@ public class HadoopAuthFilterTest {
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -379,6 +389,8 @@ public class HadoopAuthFilterTest {
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -440,6 +452,8 @@ public class HadoopAuthFilterTest {
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -502,6 +516,8 @@ public class HadoopAuthFilterTest {
     /* update the default list to use favicon.ico */
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(request_semicolon_path).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
 
     HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
     /* capture errors */
@@ -579,6 +595,8 @@ public class HadoopAuthFilterTest {
     expect(filterConfig.getInitParameter("hadoop.auth.unauthenticated.path.list")).andReturn(null).anyTimes();
     expect(filterConfig.getInitParameter("clusterName")).andReturn("topology1").anyTimes();
     expect(filterConfig.getInitParameter(JWT_INSTANCE_KEY_FALLBACK)).andReturn("false").anyTimes();
+    expect(filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
+    expect(filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM)).andReturn(null).anyTimes();
     final boolean isJwtSupported = Boolean.parseBoolean(supportJwt);
     if (isJwtSupported) {
       expect(filterConfig.getInitParameter(JWTFederationFilter.KNOX_TOKEN_AUDIENCES)).andReturn(null).anyTimes();

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -216,5 +216,42 @@
             <artifactId>velocity-engine-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-auth</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>dnsjava</groupId>
+                    <artifactId>dnsjava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-annotations</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>dnsjava</groupId>
+                    <artifactId>dnsjava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -85,6 +85,9 @@ public interface GatewaySpiMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to load truststore due to {0}")
   void failedToLoadTruststore(String message, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
+  @Message(level = MessageLevel.ERROR, text = "Impersonation failed, user {0} does not belong to configured proxy group")
+  void failedToImpersonateViaGroups(String user);
+
   @Message(level = MessageLevel.WARN, text = "Duplicated filter param key: {0}")
   void duplicatedFilterParamKey(String name);
 
@@ -93,4 +96,7 @@ public interface GatewaySpiMessages {
 
   @Message(level=MessageLevel.DEBUG, text="Ignoring cookie path scope filter for default topology")
   void ignoringCookiePathScopeForDefaultTopology();
+
+  @Message(level=MessageLevel.DEBUG, text="Loaded proxy groups ACLs: {0}")
+  void loadedProxyGroupsAcls(String acls);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/AuthFilterUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/AuthFilterUtils.java
@@ -17,6 +17,18 @@
  */
 package org.apache.knox.gateway.util;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authorize.ImpersonationProvider;
+import org.apache.knox.gateway.i18n.GatewaySpiMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
@@ -27,227 +39,236 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletRequest;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authorize.DefaultImpersonationProvider;
-import org.apache.hadoop.security.authorize.ImpersonationProvider;
-import org.apache.knox.gateway.i18n.GatewaySpiMessages;
-import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-
 public class AuthFilterUtils {
-  public static final String DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM = "/knoxtoken/api/v1/jwks.json";
-  public static final String PROXYUSER_PREFIX = "hadoop.proxyuser";
-  public static final String QUERY_PARAMETER_DOAS = "doAs";
-  public static final String REAL_USER_NAME_ATTRIBUTE = "real.user.name";
-  public static final String DO_GLOBAL_LOGOUT_ATTRIBUTE = "do.global.logout";
+    public static final String DEFAULT_AUTH_UNAUTHENTICATED_PATHS_PARAM = "/knoxtoken/api/v1/jwks.json";
+    public static final String PROXYUSER_PREFIX = "hadoop.proxyuser";
+    public static final String PROXYGROUP_PREFIX = "hadoop.proxygroup";
+    public static final String QUERY_PARAMETER_DOAS = "doAs";
+    public static final String REAL_USER_NAME_ATTRIBUTE = "real.user.name";
+    public static final String DO_GLOBAL_LOGOUT_ATTRIBUTE = "do.global.logout";
+    public static final String IMPERSONATION_ENABLED_PARAM = AuthFilterUtils.PROXYUSER_PREFIX + ".impersonation.enabled";
+    public static final String GROUP_IMPERSONATION_ENABLED_PARAM = AuthFilterUtils.PROXYGROUP_PREFIX + ".impersonation.enabled";
 
-  private static final GatewaySpiMessages LOG = MessagesFactory.get(GatewaySpiMessages.class);
-  private static final Map<String, Map<String, ImpersonationProvider>> TOPOLOGY_IMPERSONATION_PROVIDERS = new ConcurrentHashMap<>();
-  private static final Lock refreshSuperUserGroupsLock = new ReentrantLock();
+    private static final GatewaySpiMessages LOG = MessagesFactory.get(GatewaySpiMessages.class);
+    private static final Map<String, Map<String, ImpersonationProvider>> TOPOLOGY_IMPERSONATION_PROVIDERS = new ConcurrentHashMap<>();
+    private static final Lock refreshSuperUserGroupsLock = new ReentrantLock();
 
-  /**
-   * A helper method that checks whether request contains
-   * unauthenticated path
-   * @param request
-   * @return
-   */
-  public static boolean doesRequestContainUnauthPath(
-      final Set<String> unAuthenticatedPaths, final ServletRequest request) {
-    /* make sure the path matches EXACTLY to prevent auth bypass */
-    return unAuthenticatedPaths.contains(((HttpServletRequest) request).getPathInfo());
-  }
-
-  /**
-   * A helper method that parses a string and adds to the
-   * provided unauthenticated set.
-   * @param unAuthenticatedPaths
-   * @param list
-   */
-  public static void parseStringThenAdd(final Set<String> unAuthenticatedPaths, final String list) {
-    final StringTokenizer tokenizer = new StringTokenizer(list, ";,");
-    while (tokenizer.hasMoreTokens()) {
-      unAuthenticatedPaths.add(tokenizer.nextToken());
-    }
-  }
-
-  /**
-   * A method that parses a string (delimiters = ;,) and adds them to the
-   * provided un-authenticated path set.
-   * @param unAuthenticatedPaths
-   * @param list
-   * @param defaultList
-   */
-  public static void addUnauthPaths(final Set<String> unAuthenticatedPaths, final String list, final String defaultList) {
-    /* add default unauthenticated paths list */
-    parseStringThenAdd(unAuthenticatedPaths, defaultList);
-    /* add provided unauthenticated paths list if specified */
-    if (!StringUtils.isBlank(list)) {
-      AuthFilterUtils.parseStringThenAdd(unAuthenticatedPaths, list);
-    }
-  }
-
-  public static void refreshSuperUserGroupsConfiguration(ServletContext context, List<String> initParameterNames, String topologyName, String role) {
-    if (context == null) {
-      throw new IllegalArgumentException("Cannot get proxyuser configuration from NULL context");
-    }
-    refreshSuperUserGroupsConfiguration(context, null, initParameterNames, topologyName, role);
-  }
-
-  public static void refreshSuperUserGroupsConfiguration(FilterConfig filterConfig, List<String> initParameterNames, String topologyName, String role) {
-    if (filterConfig == null) {
-      throw new IllegalArgumentException("Cannot get proxyuser configuration from NULL filter config");
-    }
-    refreshSuperUserGroupsConfiguration(null, filterConfig, initParameterNames, topologyName, role);
-  }
-
-  private static void refreshSuperUserGroupsConfiguration(ServletContext context, FilterConfig filterConfig, List<String> initParameterNames, String topologyName, String role) {
-    final Configuration conf = new Configuration(false);
-    if (initParameterNames != null) {
-      initParameterNames.stream().filter(name -> name.startsWith(PROXYUSER_PREFIX + ".")).forEach(name -> {
-        String value = context == null ? filterConfig.getInitParameter(name) : context.getInitParameter(name);
-        conf.set(name, value);
-      });
+    /**
+     * A helper method that checks whether request contains
+     * unauthenticated path
+     *
+     * @param request
+     * @return
+     */
+    public static boolean doesRequestContainUnauthPath(
+            final Set<String> unAuthenticatedPaths, final ServletRequest request) {
+        /* make sure the path matches EXACTLY to prevent auth bypass */
+        return unAuthenticatedPaths.contains(((HttpServletRequest) request).getPathInfo());
     }
 
-    saveImpersonationProvider(topologyName, role, conf);
-  }
-
-  private static void saveImpersonationProvider(String topologyName, String role, final Configuration conf) {
-    refreshSuperUserGroupsLock.lock();
-    try {
-      final ImpersonationProvider impersonationProvider = new DefaultImpersonationProvider();
-      impersonationProvider.setConf(conf);
-      impersonationProvider.init(PROXYUSER_PREFIX);
-      LOG.createImpersonationProvider(topologyName, role, PROXYUSER_PREFIX, conf.getPropsWithPrefix(PROXYUSER_PREFIX + ".").toString());
-      TOPOLOGY_IMPERSONATION_PROVIDERS.putIfAbsent(topologyName, new ConcurrentHashMap<String, ImpersonationProvider>());
-      TOPOLOGY_IMPERSONATION_PROVIDERS.get(topologyName).put(role, impersonationProvider);
-    } finally {
-      refreshSuperUserGroupsLock.unlock();
+    /**
+     * A helper method that parses a string and adds to the
+     * provided unauthenticated set.
+     *
+     * @param unAuthenticatedPaths
+     * @param list
+     */
+    public static void parseStringThenAdd(final Set<String> unAuthenticatedPaths, final String list) {
+        final StringTokenizer tokenizer = new StringTokenizer(list, ";,");
+        while (tokenizer.hasMoreTokens()) {
+            unAuthenticatedPaths.add(tokenizer.nextToken());
+        }
     }
-  }
 
-  public static HttpServletRequest getProxyRequest(HttpServletRequest request, String doAsUser, String topologyName, String role) throws AuthorizationException {
-    return getProxyRequest(request, request.getUserPrincipal().getName(), doAsUser, topologyName, role);
-  }
+    /**
+     * A method that parses a string (delimiters = ;,) and adds them to the
+     * provided un-authenticated path set.
+     *
+     * @param unAuthenticatedPaths
+     * @param list
+     * @param defaultList
+     */
+    public static void addUnauthPaths(final Set<String> unAuthenticatedPaths, final String list, final String defaultList) {
+        /* add default unauthenticated paths list */
+        parseStringThenAdd(unAuthenticatedPaths, defaultList);
+        /* add provided unauthenticated paths list if specified */
+        if (!StringUtils.isBlank(list)) {
+            AuthFilterUtils.parseStringThenAdd(unAuthenticatedPaths, list);
+        }
+    }
+    public static void refreshSuperUserGroupsConfiguration(FilterConfig filterConfig, List<String> initParameterNames, String topologyName, String role) {
+        if (filterConfig == null) {
+            throw new IllegalArgumentException("Cannot get proxyuser configuration from NULL filter config");
+        }
+        refreshSuperUserGroupsConfiguration(null, filterConfig, initParameterNames, topologyName, role);
+    }
 
-  public static HttpServletRequest getProxyRequest(HttpServletRequest request, String remoteUser, String doAsUser, String topologyName, String role) throws AuthorizationException {
-    final UserGroupInformation remoteRequestUgi = getRemoteRequestUgi(remoteUser, doAsUser);
-    if (remoteRequestUgi != null) {
-      authorizeImpersonationRequest(request, remoteRequestUgi, topologyName, role);
-
-      return new HttpServletRequestWrapper(request) {
-        @Override
-        public String getRemoteUser() {
-          return remoteRequestUgi.getShortUserName();
+    private static void refreshSuperUserGroupsConfiguration(ServletContext context, FilterConfig filterConfig, List<String> initParameterNames, String topologyName, String role) {
+        if (filterConfig == null) {
+            throw new IllegalArgumentException("Cannot get proxyuser configuration from NULL filter config");
         }
 
-        @Override
-        public Principal getUserPrincipal() {
-          return remoteRequestUgi::getUserName;
+        final Configuration conf = new Configuration(false);
+        if (initParameterNames != null) {
+            initParameterNames.stream().filter(name -> name.startsWith(PROXYUSER_PREFIX + ".")).forEach(name -> {
+                String value = context == null ? filterConfig.getInitParameter(name) : context.getInitParameter(name);
+                conf.set(name, value);
+            });
+
+            initParameterNames.stream().filter(name -> name.startsWith(PROXYGROUP_PREFIX + ".")).forEach(name -> {
+                String value = context == null ? filterConfig.getInitParameter(name) : context.getInitParameter(name);
+                conf.set(name, value);
+            });
         }
 
-        @Override
-        public Object getAttribute(String name) {
-          if (name != null && name.equals(REAL_USER_NAME_ATTRIBUTE)) {
-            return remoteRequestUgi.getRealUser().getShortUserName();
-          } else {
-            return super.getAttribute(name);
-          }
+        saveImpersonationProvider(filterConfig, topologyName, role, conf);
+    }
+
+    private static void saveImpersonationProvider(FilterConfig filterConfig, String topologyName, String role, final Configuration conf) {
+        refreshSuperUserGroupsLock.lock();
+        try {
+            boolean isProxyUserEnabled = false;
+            boolean isProxyGroupEnabled = false;
+            /* Check if user or group impersonation is enabled */
+            if (filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM) != null) {
+                String userImpersonationEnabledString = filterConfig.getInitParameter(IMPERSONATION_ENABLED_PARAM);
+                isProxyUserEnabled = userImpersonationEnabledString == null ? Boolean.FALSE : Boolean.parseBoolean(userImpersonationEnabledString);
+            }
+
+            if (filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM) != null) {
+                String groupImpersonationEnabledString = filterConfig.getInitParameter(GROUP_IMPERSONATION_ENABLED_PARAM);
+                isProxyGroupEnabled = groupImpersonationEnabledString == null ? Boolean.FALSE : Boolean.parseBoolean(groupImpersonationEnabledString);
+
+            }
+
+            final GroupBasedImpersonationProvider groupBasedImpersonationProvider = new GroupBasedImpersonationProvider(isProxyUserEnabled, isProxyGroupEnabled);
+            groupBasedImpersonationProvider.setConf(conf);
+            groupBasedImpersonationProvider.init(PROXYUSER_PREFIX, PROXYGROUP_PREFIX);
+            LOG.createImpersonationProvider(topologyName, role, PROXYUSER_PREFIX, conf.getPropsWithPrefix(PROXYUSER_PREFIX + ".").toString());
+            LOG.createImpersonationProvider(topologyName, role, PROXYGROUP_PREFIX, conf.getPropsWithPrefix(PROXYGROUP_PREFIX + ".").toString());
+
+            TOPOLOGY_IMPERSONATION_PROVIDERS.putIfAbsent(topologyName, new ConcurrentHashMap<String, ImpersonationProvider>());
+            TOPOLOGY_IMPERSONATION_PROVIDERS.get(topologyName).put(role, groupBasedImpersonationProvider);
+        } finally {
+            refreshSuperUserGroupsLock.unlock();
         }
-      };
-
     }
-    return null;
-  }
 
-  public static void authorizeImpersonationRequest(HttpServletRequest request, String remoteUser, String doAsUser, String topologyName, String role) throws AuthorizationException {
-    final UserGroupInformation remoteRequestUgi = getRemoteRequestUgi(remoteUser, doAsUser);
-    if (remoteRequestUgi != null) {
-      authorizeImpersonationRequest(request, remoteRequestUgi, topologyName, role);
+    public static HttpServletRequest getProxyRequest(HttpServletRequest request, String doAsUser, String topologyName, String role) throws AuthorizationException {
+        return getProxyRequest(request, request.getUserPrincipal().getName(), doAsUser, topologyName, role);
     }
-  }
 
-  private static void authorizeImpersonationRequest(HttpServletRequest request, UserGroupInformation remoteRequestUgi, String topologyName, String role)
-      throws AuthorizationException {
+    public static HttpServletRequest getProxyRequest(HttpServletRequest request, String remoteUser, String doAsUser, String topologyName, String role) throws AuthorizationException {
+        final UserGroupInformation remoteRequestUgi = getRemoteRequestUgi(remoteUser, doAsUser);
+        if (remoteRequestUgi != null) {
+            authorizeImpersonationRequest(request, remoteRequestUgi, topologyName, role);
 
-    final ImpersonationProvider impersonationProvider = getImpersonationProvider(topologyName, role);
+            return new HttpServletRequestWrapper(request) {
+                @Override
+                public String getRemoteUser() {
+                    return remoteRequestUgi.getShortUserName();
+                }
 
-    if (impersonationProvider != null) {
-      try {
-        impersonationProvider.authorize(remoteRequestUgi, request.getRemoteAddr());
-      } catch (org.apache.hadoop.security.authorize.AuthorizationException e) {
-        throw new AuthorizationException(e);
-      }
-    } else {
-      throw new AuthorizationException("ImpersonationProvider for " + topologyName + " / " + role + " not found!");
+                @Override
+                public Principal getUserPrincipal() {
+                    return remoteRequestUgi::getUserName;
+                }
+
+                @Override
+                public Object getAttribute(String name) {
+                    if (name != null && name.equals(REAL_USER_NAME_ATTRIBUTE)) {
+                        return remoteRequestUgi.getRealUser().getShortUserName();
+                    } else {
+                        return super.getAttribute(name);
+                    }
+                }
+            };
+
+        }
+        return null;
     }
-  }
 
-  private static ImpersonationProvider getImpersonationProvider(String topologyName, String role) {
-    refreshSuperUserGroupsLock.lock();
-    final ImpersonationProvider impersonationProvider;
-    try {
-      impersonationProvider = (TOPOLOGY_IMPERSONATION_PROVIDERS.getOrDefault(topologyName, Collections.emptyMap())).get(role);
-    } finally {
-      refreshSuperUserGroupsLock.unlock();
+    public static void authorizeImpersonationRequest(HttpServletRequest request, String remoteUser, String doAsUser, String topologyName, String role) throws AuthorizationException {
+        final UserGroupInformation remoteRequestUgi = getRemoteRequestUgi(remoteUser, doAsUser);
+        if (remoteRequestUgi != null) {
+            authorizeImpersonationRequest(request, remoteRequestUgi, topologyName, role);
+        }
     }
-    return impersonationProvider;
-  }
 
-  private static UserGroupInformation getRemoteRequestUgi(String remoteUser, String doAsUser) {
-    if (remoteUser != null) {
-      final UserGroupInformation remoteUserUgi = UserGroupInformation.createRemoteUser(remoteUser);
-      return UserGroupInformation.createProxyUser(doAsUser, remoteUserUgi);
+    private static void authorizeImpersonationRequest(HttpServletRequest request, UserGroupInformation remoteRequestUgi, String topologyName, String role)
+            throws AuthorizationException {
+
+        final ImpersonationProvider impersonationProvider = getImpersonationProvider(topologyName, role);
+
+        if (impersonationProvider != null) {
+            try {
+                impersonationProvider.authorize(remoteRequestUgi, request.getRemoteAddr());
+            } catch (org.apache.hadoop.security.authorize.AuthorizationException e) {
+                throw new AuthorizationException(e);
+            }
+        } else {
+            throw new AuthorizationException("ImpersonationProvider for " + topologyName + " / " + role + " not found!");
+        }
     }
-    return null;
-  }
 
-  public static boolean hasProxyConfig(String topologyName, String role) {
-    return getImpersonationProvider(topologyName, role) != null;
-  }
-
-  public static void removeProxyUserConfig(String topologyName, String role) {
-    if (hasProxyConfig(topologyName, role)) {
-      refreshSuperUserGroupsLock.lock();
-      try {
-        TOPOLOGY_IMPERSONATION_PROVIDERS.get(topologyName).remove(role);
-      } finally {
-        refreshSuperUserGroupsLock.unlock();
-      }
+    private static ImpersonationProvider getImpersonationProvider(String topologyName, String role) {
+        refreshSuperUserGroupsLock.lock();
+        final ImpersonationProvider impersonationProvider;
+        try {
+            impersonationProvider = (TOPOLOGY_IMPERSONATION_PROVIDERS.getOrDefault(topologyName, Collections.emptyMap())).get(role);
+        } finally {
+            refreshSuperUserGroupsLock.unlock();
+        }
+        return impersonationProvider;
     }
-  }
 
-  /**
-   * FilterConfig.getInitParameters() returns an enumeration and the first time we
-   * iterate thru on its elements we can process the parameter names as desired
-   * (because hasMoreElements returns true). The subsequent calls, however, will not
-   * succeed because getInitParameters() returns the same object where the
-   * hasMoreElements returns false.
-   * <p>
-   * In classes where there are multiple iterations should be conducted, a
-   * collection should be used instead.
-   *
-   * @return the names of the filter's initialization parameters as a List of
-   *         String objects, or an empty List if the filter has no initialization
-   *         parameters.
-   */
-  public static List<String> getInitParameterNamesAsList(FilterConfig filterConfig) {
-    return filterConfig.getInitParameterNames() == null ? Collections.emptyList() : Collections.list(filterConfig.getInitParameterNames());
-  }
+    private static UserGroupInformation getRemoteRequestUgi(String remoteUser, String doAsUser) {
+        if (remoteUser != null) {
+            final UserGroupInformation remoteUserUgi = UserGroupInformation.createRemoteUser(remoteUser);
+            return UserGroupInformation.createProxyUser(doAsUser, remoteUserUgi);
+        }
+        return null;
+    }
 
-  public static void markDoGlobalLogoutInRequest(HttpServletRequest request) {
-    request.setAttribute(DO_GLOBAL_LOGOUT_ATTRIBUTE, "true");
-  }
+    public static boolean hasProxyConfig(String topologyName, String role) {
+        return getImpersonationProvider(topologyName, role) != null;
+    }
 
-  public static boolean shouldDoGlobalLogout(HttpServletRequest request) {
-    return request.getAttribute(DO_GLOBAL_LOGOUT_ATTRIBUTE) == null ? false : Boolean.parseBoolean((String) request.getAttribute(DO_GLOBAL_LOGOUT_ATTRIBUTE));
-  }
+    public static void removeProxyUserConfig(String topologyName, String role) {
+        if (hasProxyConfig(topologyName, role)) {
+            refreshSuperUserGroupsLock.lock();
+            try {
+                TOPOLOGY_IMPERSONATION_PROVIDERS.get(topologyName).remove(role);
+            } finally {
+                refreshSuperUserGroupsLock.unlock();
+            }
+        }
+    }
+
+    /**
+     * FilterConfig.getInitParameters() returns an enumeration and the first time we
+     * iterate thru on its elements we can process the parameter names as desired
+     * (because hasMoreElements returns true). The subsequent calls, however, will not
+     * succeed because getInitParameters() returns the same object where the
+     * hasMoreElements returns false.
+     * <p>
+     * In classes where there are multiple iterations should be conducted, a
+     * collection should be used instead.
+     *
+     * @return the names of the filter's initialization parameters as a List of
+     * String objects, or an empty List if the filter has no initialization
+     * parameters.
+     */
+    public static List<String> getInitParameterNamesAsList(FilterConfig filterConfig) {
+        return filterConfig.getInitParameterNames() == null ? Collections.emptyList() : Collections.list(filterConfig.getInitParameterNames());
+    }
+
+    public static void markDoGlobalLogoutInRequest(HttpServletRequest request) {
+        request.setAttribute(DO_GLOBAL_LOGOUT_ATTRIBUTE, "true");
+    }
+
+    public static boolean shouldDoGlobalLogout(HttpServletRequest request) {
+        return request.getAttribute(DO_GLOBAL_LOGOUT_ATTRIBUTE) == null ? false : Boolean.parseBoolean((String) request.getAttribute(DO_GLOBAL_LOGOUT_ATTRIBUTE));
+    }
 
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/GroupBasedImpersonationProvider.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/GroupBasedImpersonationProvider.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authorize.AccessControlList;
+import org.apache.hadoop.security.authorize.AuthorizationException;
+import org.apache.hadoop.security.authorize.DefaultImpersonationProvider;
+import org.apache.hadoop.util.MachineList;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * An extension of Hadoop's DefaultImpersonationProvider that adds support for group-based impersonation.
+ * This provider allows users who belong to specific groups to impersonate other users.
+ */
+public class GroupBasedImpersonationProvider extends DefaultImpersonationProvider {
+    private static final String CONF_HOSTS = ".hosts";
+    private static final String CONF_USERS = ".users";
+    private static final String CONF_GROUPS = ".groups";
+    private final Map<String, AccessControlList> proxyGroupsAcls = new HashMap<>();
+    /* is the proxy user configuration enabled  */
+    boolean isProxyUserEnabled = true;
+    /* is the proxy group configuration enabled, defaulting it to false for backwards compatibility  */
+    boolean isProxyGroupEnabled;
+    private Map<String, MachineList> groupProxyHosts = new HashMap<>();
+    private String groupConfigPrefix;
+
+    public GroupBasedImpersonationProvider() {
+        super();
+    }
+
+    public GroupBasedImpersonationProvider(boolean isProxyUserEnabled, boolean isProxyGroupEnabled) {
+        super();
+        this.isProxyUserEnabled = isProxyUserEnabled;
+        this.isProxyGroupEnabled = isProxyGroupEnabled;
+    }
+
+    @Override
+    public Configuration getConf() {
+        return super.getConf();
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+        super.setConf(conf);
+    }
+
+    public void init(String configurationPrefix, String proxyGroupPrefix) {
+        super.init(configurationPrefix);
+        initGroupBasedProvider(proxyGroupPrefix);
+    }
+
+    private void initGroupBasedProvider(String proxyGroupPrefix) {
+        groupConfigPrefix = proxyGroupPrefix +
+                (proxyGroupPrefix.endsWith(".") ? "" : ".");
+
+        // constructing regex to match the following patterns:
+        //   $configPrefix.[ANY].users
+        //   $configPrefix.[ANY].groups
+        //   $configPrefix.[ANY].hosts
+        //
+        String prefixRegEx = groupConfigPrefix.replace(".", "\\.");
+        String usersGroupsRegEx = prefixRegEx + "[\\S]*(" +
+                Pattern.quote(CONF_USERS) + "|" + Pattern.quote(CONF_GROUPS) + ")";
+        String hostsRegEx = prefixRegEx + "[\\S]*" + Pattern.quote(CONF_HOSTS);
+
+        // get list of users and groups per proxygroup
+        // Map of <hadoop.proxygroup.[VIRTUAL_GROUP].users|groups, group1,group2>
+        Map<String, String> allMatchKeys =
+                getConf().getValByRegex(usersGroupsRegEx);
+
+        for (Map.Entry<String, String> entry : allMatchKeys.entrySet()) {
+            //aclKey = hadoop.proxygroup.[VIRTUAL_GROUP]
+            String aclKey = getAclKey(entry.getKey());
+
+            if (!proxyGroupsAcls.containsKey(aclKey)) {
+                proxyGroupsAcls.put(aclKey, new AccessControlList(
+                        allMatchKeys.get(aclKey + CONF_USERS),
+                        allMatchKeys.get(aclKey + CONF_GROUPS)));
+            }
+        }
+
+        // get hosts per proxygroup
+        allMatchKeys = getConf().getValByRegex(hostsRegEx);
+        for (Map.Entry<String, String> entry : allMatchKeys.entrySet()) {
+            groupProxyHosts.put(entry.getKey(),
+                    new MachineList(entry.getValue()));
+        }
+    }
+
+    private String getAclKey(String key) {
+        int endIndex = key.lastIndexOf('.');
+        if (endIndex != -1) {
+            return key.substring(0, endIndex);
+        }
+        return key;
+    }
+
+    @Override
+    public void authorize(UserGroupInformation user, InetAddress remoteAddress) throws AuthorizationException {
+
+        if (isProxyUserEnabled) {
+            /* authorize proxy user */
+            super.authorize(user, remoteAddress);
+        }
+
+        if (isProxyGroupEnabled) {
+            if (user == null) {
+                throw new IllegalArgumentException("user is null.");
+            }
+
+            final UserGroupInformation realUser = user.getRealUser();
+            if (realUser == null) {
+                return;
+            }
+
+            // Get the real user's groups (both real and virtual)
+            Set<String> realUserGroups = new HashSet<>();
+            if (user.getRealUser().getGroupNames() != null) {
+                Collections.addAll(realUserGroups, user.getRealUser().getGroupNames());
+            }
+
+            boolean proxyGroupFound = false;
+            // Check if any of the real user's groups have permission to impersonate the proxy user
+            for (String group : realUserGroups) {
+                final AccessControlList acl = proxyGroupsAcls.get(groupConfigPrefix +
+                        group);
+
+                if (acl == null || !acl.isUserAllowed(user)) {
+                    continue;
+                } else {
+                    proxyGroupFound = true;
+                    break;
+                }
+            }
+
+            if (!proxyGroupFound) {
+                throw new AuthorizationException("User: " + realUser.getUserName() + " with groups " + realUserGroups
+                        + " is not allowed to impersonate " + user.getUserName());
+            }
+
+            boolean proxyGroupHostFound = false;
+            for (final String group : realUserGroups) {
+                final MachineList machineList = groupProxyHosts.get(groupConfigPrefix + group + CONF_HOSTS);
+
+                if (machineList == null || !machineList.includes(remoteAddress)) {
+                    continue;
+                } else {
+                    proxyGroupHostFound = true;
+                    break;
+                }
+            }
+
+            if (!proxyGroupHostFound) {
+                throw new AuthorizationException("Unauthorized connection for super-user: "
+                        + realUser.getUserName() + " with groups " + realUserGroups + " from IP " + remoteAddress);
+            }
+        }
+    }
+}

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/util/GroupBasedImpersonationProviderTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/util/GroupBasedImpersonationProviderTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.util;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.knox.gateway.util.AuthFilterUtils.PROXYGROUP_PREFIX;
+import static org.apache.knox.gateway.util.AuthFilterUtils.PROXYUSER_PREFIX;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class GroupBasedImpersonationProviderTest {
+
+    @Rule
+    public Timeout globalTimeout = new Timeout(10000, TimeUnit.MILLISECONDS);
+    private GroupBasedImpersonationProvider provider;
+    private Configuration config;
+
+    @Before
+    public void setUp() {
+        provider = new GroupBasedImpersonationProvider(true, true);
+        config = new Configuration();
+
+        config.set("hadoop.proxyuser.testuser.groups", "*");
+        config.set("hadoop.proxyuser.testuser.hosts", "*");
+
+        // Setup 3 proxy users
+        config.set("hadoop.proxygroup.virtual_group_1.groups", "*");
+        config.set("hadoop.proxygroup.virtual_group_1.hosts", "*");
+        config.set("hadoop.proxygroup.virtual.group_2.groups", "*");
+        config.set("hadoop.proxygroup.virtual.group_2.hosts", "*");
+        config.set("hadoop.proxygroup.virtual group_3.groups", "*");
+        config.set("hadoop.proxygroup.virtual group_3.hosts", "*");
+        provider.setConf(config);
+        provider.init(PROXYUSER_PREFIX, PROXYGROUP_PREFIX);
+    }
+
+    @Test
+    public void testGetConf() {
+        assertEquals(config, provider.getConf());
+    }
+
+    @Test
+    public void testSetConf() {
+        Configuration newConfig = new Configuration(false);
+        provider.setConf(newConfig);
+        assertEquals(newConfig, provider.getConf());
+    }
+
+    @Test
+    public void testInitWithEmptyConfig() {
+        provider.init("hadoop.proxygroup");
+        // No exception should be thrown
+    }
+
+    @Test
+    public void testInitWithValidConfig() {
+        // Set up configuration with valid proxy groups
+        config.set("hadoop.proxygroup.admin.users", "user1,user2");
+        config.set("hadoop.proxygroup.admin.groups", "group1,group2");
+        config.set("hadoop.proxygroup.admin.hosts", "host1,host2");
+
+        provider.init("hadoop.proxygroup");
+        // No exception should be thrown
+    }
+
+    @Test
+    public void testGetAclKey() throws Exception {
+        // Test the private getAclKey method using reflection
+        java.lang.reflect.Method method = GroupBasedImpersonationProvider.class.getDeclaredMethod("getAclKey", String.class);
+        method.setAccessible(true);
+
+        assertEquals("hadoop.proxygroup.admin", method.invoke(provider, "hadoop.proxygroup.admin.users"));
+        assertEquals("hadoop.proxygroup.admin", method.invoke(provider, "hadoop.proxygroup.admin.groups"));
+        assertEquals("key", method.invoke(provider, "key"));
+    }
+
+    @Test
+    public void testAuthorizationSuccess() throws AuthorizationException, org.apache.hadoop.security.authorize.AuthorizationException {
+        String proxyUser = "testuser";
+        String[] proxyGroups = {"virtual_group_1"};
+
+        UserGroupInformation realUserUGI = Mockito.mock(UserGroupInformation.class);
+        UserGroupInformation userGroupInformation = Mockito.mock(UserGroupInformation.class);
+
+        when(realUserUGI.getShortUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getGroupNames()).thenReturn(proxyGroups);
+
+        when(userGroupInformation.getRealUser()).thenReturn(realUserUGI);
+        provider.authorize(userGroupInformation, "2.2.2.2");
+
+        String[] proxyGroups2 = {"virtual.group_2"};
+        when(realUserUGI.getShortUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getGroupNames()).thenReturn(proxyGroups2);
+        when(userGroupInformation.getRealUser()).thenReturn(realUserUGI);
+        provider.authorize(userGroupInformation, "2.2.2.2");
+    }
+
+    /**
+     * Test the case where proxy user is disabled and only proxy groups is enabled.
+     * i.e.
+     * hadoop.proxyuser.impersonation.enabled = false
+     * hadoop.proxygroup.impersonation.enabled = true
+     *
+     * @throws AuthorizationException
+     * @throws org.apache.hadoop.security.authorize.AuthorizationException
+     */
+    @Test
+    public void testAuthorizationSuccessWithOnlyProxyGroupsConfigured() throws AuthorizationException, org.apache.hadoop.security.authorize.AuthorizationException {
+
+        GroupBasedImpersonationProvider gProvider = new GroupBasedImpersonationProvider(false, true);
+        Configuration gConfig = new Configuration();
+        // Setup 3 proxy users
+        gConfig.set("hadoop.proxygroup.virtual_group_1.groups", "*");
+        gConfig.set("hadoop.proxygroup.virtual_group_1.hosts", "*");
+        gConfig.set("hadoop.proxygroup.virtual.group_2.groups", "*");
+        gConfig.set("hadoop.proxygroup.virtual.group_2.hosts", "*");
+        gConfig.set("hadoop.proxygroup.virtual group_3.groups", "*");
+        gConfig.set("hadoop.proxygroup.virtual group_3.hosts", "*");
+        gProvider.setConf(gConfig);
+        gProvider.init(PROXYUSER_PREFIX, PROXYGROUP_PREFIX);
+
+        String proxyUser = "testuser";
+        String[] proxyGroups = {"virtual_group_1"};
+
+        UserGroupInformation realUserUGI = Mockito.mock(UserGroupInformation.class);
+        UserGroupInformation userGroupInformation = Mockito.mock(UserGroupInformation.class);
+
+        when(realUserUGI.getShortUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getGroupNames()).thenReturn(proxyGroups);
+
+        when(userGroupInformation.getRealUser()).thenReturn(realUserUGI);
+        gProvider.authorize(userGroupInformation, "2.2.2.2");
+
+        String[] proxyGroups2 = {"virtual.group_2"};
+        when(realUserUGI.getShortUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getGroupNames()).thenReturn(proxyGroups2);
+        when(userGroupInformation.getRealUser()).thenReturn(realUserUGI);
+        gProvider.authorize(userGroupInformation, "2.2.2.2");
+    }
+
+    @Test(expected = org.apache.hadoop.security.authorize.AuthorizationException.class)
+    public void testAuthorizationFailure() throws Exception {
+        String proxyUser = "dummyUser";
+        String[] proxyGroups = {"virtual group_3"};
+
+        UserGroupInformation realUserUGI = Mockito.mock(UserGroupInformation.class);
+        UserGroupInformation userGroupInformation = Mockito.mock(UserGroupInformation.class);
+
+        when(realUserUGI.getUserName()).thenReturn(proxyUser);
+        when(realUserUGI.getGroupNames()).thenReturn(proxyGroups);
+
+        when(userGroupInformation.getRealUser()).thenReturn(realUserUGI);
+        provider.authorize(userGroupInformation, "2.2.2.2");
+    }
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added support for Group Based impersonation provider. 

```
<!-- turn the feature on -->
<param>
     <name>hadoop.proxygroup.impersonation.enabled</name>
     <value>true</value>
</param>

<!-- proxy group configs -->
<param>
     <name>hadoop.proxygroup.KNOX_ADMIN.groups</name>
     <value>*</value>
</param>

<param>
     <name>hadoop.proxygroup.VIRTUAL_GROUP.groups</name>
     <value>*</value>
</param>

<param>
     <name>hadoop.proxygroup.VIRTUAL_GROUP.hosts</name>
     <value>*</value>
</param>

``` 


## How was this patch tested?
Unit tests and local testing
