### PR TITLE
KNOX-3150 - Add support for caching JWKS keys

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -357,6 +357,15 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String JWKS_OUTAGE_CACHE_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".jwks.outage.cache.ttl";
   private static final long JWKS_OUTAGE_CACHE_TTL_DEFAULT = TimeUnit.HOURS.toMillis(2);
+
+  private static final String JWKS_CACHE_TTL = GATEWAY_CONFIG_FILE_PREFIX + ".jwks.cache.ttl";
+  private static final String JWKS_CACHE_REFRESH_TIMEOUT = GATEWAY_CONFIG_FILE_PREFIX + ".jwks.cache.refresh.interval";
+  /* The default time to live of cached JWK sets, in milliseconds. Set to 20 minutes. */
+  private static final long JWKS_CACHE_TTL_DEFAULT = 20 * 60 * 1000;
+  /* The default refresh timeout of cached JWK sets, in milliseconds. Set to 15 seconds. */
+  private static final long JWKS_CACHE_REFRESH_TIMEOUT_DEFAULT = 15 * 1000;
+
+
   private static final String ISSUER_IGNORE_TYPE_VALIDATION = GATEWAY_CONFIG_FILE_PREFIX + ".token.issuers.ignore.type.validation";
 
   //Strict-Transport Option
@@ -1625,6 +1634,16 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public long getJwksOutageCacheTTL() {
     return getLong(JWKS_OUTAGE_CACHE_TTL, JWKS_OUTAGE_CACHE_TTL_DEFAULT);
+  }
+
+  @Override
+  public long getJwksCacheTimeToLive(){
+    return getLong(JWKS_CACHE_TTL, JWKS_CACHE_TTL_DEFAULT);
+  }
+
+  @Override
+  public long getJwksCacheRefreshTimeout(){
+    return getLong(JWKS_CACHE_REFRESH_TIMEOUT, JWKS_CACHE_REFRESH_TIMEOUT_DEFAULT);
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -229,7 +229,12 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
         JWSAlgorithm expectedJWSAlg = JWSAlgorithm.parse(algorithm);
         /* Retry one time in case of failure and cache JWKS in case there is outage, TTL is OUTAGE_TTL */
         long outageTTL = config.getJwksOutageCacheTTL();
+        long cacheTTL = config.getJwksCacheTimeToLive();
+        long cacheTimeOut = config.getJwksCacheRefreshTimeout();
+
         JWKSource<SecurityContext> keySource = JWKSourceBuilder.create(new URL(jwksurl))
+                .cache(cacheTTL, cacheTimeOut)
+                .refreshAheadCache(true)
                 .retrying(true)
                 .outageTolerant(outageTTL)
                 .build();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JWKSourceBuilderTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JWKSourceBuilderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.token.impl;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.KeystoreService;
+import org.apache.knox.gateway.services.security.token.TokenServiceException;
+import org.apache.knox.gateway.services.security.token.impl.JWT;
+import org.apache.knox.gateway.services.security.token.impl.JWTToken;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test class for verifying the JWKSourceBuilder parameters in DefaultTokenAuthorityService.
+ */
+public class JWKSourceBuilderTest {
+
+    /**
+     * Test that the cacheTTL and cacheTimeOut parameters are correctly passed to JWKSourceBuilder.
+     * 
+     * This test verifies that the DefaultTokenAuthorityService correctly uses the values from
+     * GatewayConfig when building the JWKSource.
+     */
+    @Test
+    public void testJWKSourceBuilderParameters() throws Exception {
+        // Define custom cache TTL and timeout values
+        final long customCacheTTL = 60000; // 1 minute
+        final long customCacheTimeout = 5000; // 5 seconds
+        final long customOutageTTL = 7200000; // 2 hours
+        
+        // Create a mock GatewayConfig that returns our custom values
+        GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+        EasyMock.expect(config.getJwksCacheTimeToLive()).andReturn(customCacheTTL).anyTimes();
+        EasyMock.expect(config.getJwksCacheRefreshTimeout()).andReturn(customCacheTimeout).anyTimes();
+        EasyMock.expect(config.getJwksOutageCacheTTL()).andReturn(customOutageTTL).anyTimes();
+        EasyMock.expect(config.getIssuersWithIgnoredTypeHeader()).andReturn(Collections.emptySet()).anyTimes();
+        
+        // Mock the necessary services
+        AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+        KeystoreService keystoreService = EasyMock.createNiceMock(KeystoreService.class);
+        
+        // Replay all mocks
+        EasyMock.replay(config, aliasService, keystoreService);
+        
+        // Create the DefaultTokenAuthorityService
+        DefaultTokenAuthorityService service = new DefaultTokenAuthorityService();
+        service.setAliasService(aliasService);
+        service.setKeystoreService(keystoreService);
+        service.init(config, new HashMap<>());
+        
+        // Create a test JWT token
+        JWT token = EasyMock.createNiceMock(JWT.class);
+        EasyMock.expect(token.getIssuer()).andReturn("test-issuer").anyTimes();
+        EasyMock.replay(token);
+        
+        // Define the JWK URL and algorithm
+        String jwksUrl = "https://example.com/.well-known/jwks.json";
+        String algorithm = "RS256";
+        Set<JOSEObjectType> allowedJwsTypes = new HashSet<>();
+        allowedJwsTypes.add(JOSEObjectType.JWT);
+        
+        try {
+            // This will throw an exception because the URL doesn't exist, but we're only
+            // interested in verifying that the correct parameters are passed to JWKSourceBuilder
+            service.verifyToken(token, jwksUrl, algorithm, allowedJwsTypes);
+            fail("Expected TokenServiceException");
+        } catch (TokenServiceException e) {
+            // Expected exception because the URL doesn't exist
+            // Verify that the exception message indicates an attempt to connect to the URL
+            assertTrue(e.getMessage().contains("Cannot verify token"));
+        }
+        
+        // Verify all mocks
+        EasyMock.verify(config, aliasService, keystoreService, token);
+    }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JWKSourceBuilderTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/token/impl/JWKSourceBuilderTest.java
@@ -18,25 +18,19 @@
 package org.apache.knox.gateway.services.token.impl;
 
 import com.nimbusds.jose.JOSEObjectType;
-import com.nimbusds.jose.jwk.source.JWKSource;
-import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
-import com.nimbusds.jose.proc.SecurityContext;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.token.TokenServiceException;
 import org.apache.knox.gateway.services.security.token.impl.JWT;
-import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -47,7 +41,7 @@ public class JWKSourceBuilderTest {
 
     /**
      * Test that the cacheTTL and cacheTimeOut parameters are correctly passed to JWKSourceBuilder.
-     * 
+     * <p>
      * This test verifies that the DefaultTokenAuthorityService correctly uses the values from
      * GatewayConfig when building the JWKSource.
      */
@@ -57,38 +51,31 @@ public class JWKSourceBuilderTest {
         final long customCacheTTL = 60000; // 1 minute
         final long customCacheTimeout = 5000; // 5 seconds
         final long customOutageTTL = 7200000; // 2 hours
-        
         // Create a mock GatewayConfig that returns our custom values
         GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
         EasyMock.expect(config.getJwksCacheTimeToLive()).andReturn(customCacheTTL).anyTimes();
         EasyMock.expect(config.getJwksCacheRefreshTimeout()).andReturn(customCacheTimeout).anyTimes();
         EasyMock.expect(config.getJwksOutageCacheTTL()).andReturn(customOutageTTL).anyTimes();
         EasyMock.expect(config.getIssuersWithIgnoredTypeHeader()).andReturn(Collections.emptySet()).anyTimes();
-        
         // Mock the necessary services
         AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
         KeystoreService keystoreService = EasyMock.createNiceMock(KeystoreService.class);
-        
         // Replay all mocks
         EasyMock.replay(config, aliasService, keystoreService);
-        
         // Create the DefaultTokenAuthorityService
         DefaultTokenAuthorityService service = new DefaultTokenAuthorityService();
         service.setAliasService(aliasService);
         service.setKeystoreService(keystoreService);
         service.init(config, new HashMap<>());
-        
         // Create a test JWT token
         JWT token = EasyMock.createNiceMock(JWT.class);
         EasyMock.expect(token.getIssuer()).andReturn("test-issuer").anyTimes();
         EasyMock.replay(token);
-        
         // Define the JWK URL and algorithm
         String jwksUrl = "https://example.com/.well-known/jwks.json";
         String algorithm = "RS256";
         Set<JOSEObjectType> allowedJwsTypes = new HashSet<>();
         allowedJwsTypes.add(JOSEObjectType.JWT);
-        
         try {
             // This will throw an exception because the URL doesn't exist, but we're only
             // interested in verifying that the correct parameters are passed to JWKSourceBuilder
@@ -99,7 +86,6 @@ public class JWKSourceBuilderTest {
             // Verify that the exception message indicates an attempt to connect to the URL
             assertTrue(e.getMessage().contains("Cannot verify token"));
         }
-        
         // Verify all mocks
         EasyMock.verify(config, aliasService, keystoreService, token);
     }

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1142,6 +1142,16 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
     return TimeUnit.HOURS.toMillis(2);
   }
 
+  @Override
+  public long getJwksCacheTimeToLive() {
+    return 0;
+  }
+
+  @Override
+  public long getJwksCacheRefreshTimeout() {
+    return 0;
+  }
+
 
   @Override
   public Set<String> getIssuersWithIgnoredTypeHeader() {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -972,6 +972,18 @@ public interface GatewayConfig {
   long getJwksOutageCacheTTL();
 
   /**
+   * The time to live of the cached JWK set, in milliseconds.
+   * @return jwks cache TTL
+   */
+  long getJwksCacheTimeToLive();
+
+  /**
+   * The cache refresh timeout, in milliseconds.
+   * @return
+   */
+  long getJwksCacheRefreshTimeout();
+
+  /**
    * Some JWT tokens could be missing typ header.
    * This config skips typ validation for tokens issued by
    * configured Issuers.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added support for caching JWKS keys. Added following configurable options to cache jwks keys 
These parameters can be configured in gateway-site.xml

1. `gateway.jwks.cache.ttl` (default value 20 mins)
2. `gateway.jwks.cache.refresh.interval` (default value 20 mins)

## How was this patch tested?
Locally, added a unit test