### PR TITLE
KNOX-3150 - Fix a bug where jwks keys might not be cached properly

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/token/impl/DefaultTokenAuthorityService.java
@@ -236,18 +236,19 @@ public class DefaultTokenAuthorityService implements JWTokenAuthority, Service {
         long cacheTTL = config.getJwksCacheTimeToLive();
         long cacheTimeOut = config.getJwksCacheRefreshTimeout();
 
-        if(cachedJwkSources.get(jwksurl) == null) {
-          final JWKSource<SecurityContext> keySource = JWKSourceBuilder.create(new URL(jwksurl))
+        JWKSource<SecurityContext> jwksSource = cachedJwkSources.get(jwksurl);
+
+        if(jwksSource == null) {
+          jwksSource = JWKSourceBuilder.create(new URL(jwksurl))
                   .cache(cacheTTL, cacheTimeOut)
                   .refreshAheadCache(true)
                   .retrying(true)
                   .outageTolerant(outageTTL)
                   .build();
-            cachedJwkSources.put(jwksurl, keySource);
+            cachedJwkSources.put(jwksurl, jwksSource);
         }
 
-
-        JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, cachedJwkSources.get(jwksurl));
+        JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(expectedJWSAlg, jwksSource);
 
         // Create a JWT processor for the access tokens
         ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Previous fix for KNOX-3150 might not have addresses the caching issue completely. This is a followup fix to that. 

To recap, https://github.com/apache/knox/pull/1044 added support for caching JWKS keys. Following configurable options were added for caching jwks keys
These parameters can be configured in `gateway-site.xml` (in line with other parameters around JWKS configuration e.g. `gateway.token.issuers.ignore.type.validation`)

1. `gateway.jwks.cache.ttl` (default value 20 mins)
2. `gateway.jwks.cache.refresh.interval` (default value 20 mins)

## How was this patch tested?
This patch was tested locally: 
1. Created a topology with a JWKS endpoint
2. ensured that the jwks endpoint was reachable
3. Verified that the token was validated
4. Made the jwks endpoint unreachable 
5. created a new token (we cache the authentication result for older tokens so had to be a new token)
6. verified that new token was validated even when JWKS endpoint was unreachable.
7. attached debugger to gateway.
8. Followed steps 4-6 and ensured that cache was hit.
