### PR TITLE
KNOX-3151: Refactored the test websocketclient awaitClose method, fix…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/websockets/ProxyWebSocketAdapter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/websockets/ProxyWebSocketAdapter.java
@@ -206,13 +206,13 @@ public class ProxyWebSocketAdapter extends WebSocketAdapter {
 
     LOG.onError(t.toString());
     if (t.toString().contains("exceeds maximum size")) {
-      if(frontendSession != null && !frontendSession.isOpen()) {
+      if(frontendSession != null && frontendSession.isOpen()) {
         frontendSession.close(StatusCode.MESSAGE_TOO_LARGE, t.getMessage());
       }
     }
 
     else {
-      if(frontendSession != null && !frontendSession.isOpen()) {
+      if(frontendSession != null && frontendSession.isOpen()) {
         frontendSession.close(StatusCode.SERVER_ERROR, t.getMessage());
       }
       cleanup();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadBackendTest.java
@@ -21,7 +21,6 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
-import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -31,7 +30,6 @@ import org.easymock.EasyMock;
 import javax.websocket.CloseReason;
 import javax.websocket.ContainerProvider;
 import javax.websocket.WebSocketContainer;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Locale;
 import java.util.concurrent.Executors;
@@ -62,7 +60,7 @@ public class BadBackendTest {
    * Test for a message within limit.
    */
   @Test(timeout = 8000)
-  public void testBadBackEnd() throws IOException, Exception {
+  public void testBadBackEnd() throws Exception {
     final String message = "Echo";
 
     WebSocketContainer container = ContainerProvider.getWebSocketContainer();
@@ -72,10 +70,8 @@ public class BadBackendTest {
         proxyUri);
     session.getBasicRemote().sendText(message);
 
-    client.awaitClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(), 5000,
-        TimeUnit.MILLISECONDS);
-
-    Assert.assertThat(client.close.getCloseCode().getCode(), CoreMatchers.is(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode()));
+    Assert.assertTrue(client.awaitExpectedClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(), 5000L,
+            TimeUnit.MILLISECONDS));
   }
 
   private static void startProxy() throws Exception {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/BadUrlTest.java
@@ -44,7 +44,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -145,12 +144,8 @@ public class BadUrlTest {
     container.connectToServer(client,
         new URI(serverUri.toString() + "gateway/websocket/ws"));
 
-    client.awaitClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(),
-        5000, TimeUnit.MILLISECONDS);
-
-    Assert.assertThat(client.close.getCloseCode().getCode(),
-        CoreMatchers.is(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode()));
-
+    Assert.assertTrue(client.awaitExpectedClose(CloseReason.CloseCodes.UNEXPECTED_CONDITION.getCode(), 5000L,
+            TimeUnit.MILLISECONDS));
   }
 
   private static void startGatewayServer() throws Exception {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/MessageFailureTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/MessageFailureTest.java
@@ -81,10 +81,8 @@ public class MessageFailureTest {
         proxyUri);
     session.getBasicRemote().sendText(bigMessage);
 
-    client.awaitClose(CloseReason.CloseCodes.TOO_BIG.getCode(), 1000,
-        TimeUnit.MILLISECONDS);
-
-    Assert.assertThat(client.close.getCloseCode().getCode(), CoreMatchers.is(CloseReason.CloseCodes.TOO_BIG.getCode()));
+    Assert.assertTrue(client.awaitExpectedClose(CloseReason.CloseCodes.TOO_BIG.getCode(), 1000L,
+            TimeUnit.MILLISECONDS));
   }
 
   /**
@@ -102,10 +100,8 @@ public class MessageFailureTest {
             proxyUri);
     session.getBasicRemote().sendText(bigMessage);
 
-    client.awaitClose(CloseReason.CloseCodes.TOO_BIG.getCode(), 1000,
-            TimeUnit.MILLISECONDS);
-
-    Assert.assertThat(client.close.getCloseCode().getCode(), CoreMatchers.is(CloseReason.CloseCodes.TOO_BIG.getCode()));
+    Assert.assertTrue(client.awaitExpectedClose(CloseReason.CloseCodes.TOO_BIG.getCode(), 1000L,
+            TimeUnit.MILLISECONDS));
 
   }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketClient.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/websockets/WebsocketClient.java
@@ -95,27 +95,12 @@ public class WebsocketClient {
    * @param expectedCloseCode code to expect on close
    * @param timeoutDuration duration to wait
    * @param timeoutUnit duration unit
-   * @throws TimeoutException if waiting too long to close
+   * @throws InterruptedException if waiting is interrupted
    */
-  public void awaitClose(int expectedCloseCode, int timeoutDuration, TimeUnit timeoutUnit)
-      throws TimeoutException {
-
-    long msDur = TimeUnit.MILLISECONDS.convert(timeoutDuration, timeoutUnit);
-    long now = System.currentTimeMillis();
-    long expireOn = now + msDur;
-
-    while (close == null) {
-      try {
-        TimeUnit.MILLISECONDS.sleep(10);
-      } catch (InterruptedException ignore) {
-        /* ignore */
-      }
-      if ((System.currentTimeMillis() > expireOn)) {
-        throw new TimeoutException("Timed out reading message from queue");
-      }
-
-    }
-
+  public boolean awaitExpectedClose(int expectedCloseCode, long timeoutDuration, TimeUnit timeoutUnit)
+          throws InterruptedException {
+      return closeLatch.await(timeoutDuration, timeoutUnit) &&
+              (close != null && close.getCloseCode().getCode() == expectedCloseCode);
   }
 
   public class MessageQueue extends BlockingArrayQueue<String> {


### PR DESCRIPTION
…ed related tests, fixed an issue caused by a racing condition that resulted in intermittent MessageFailureTest.testMessageTooBig test failures

## What changes were proposed in this pull request?

- Refactored the test WebSocketClient awaitClose method to fail on not expected status codes and use the neglected countdown latch properly
- Fixed the tests that rely on the mentioned awaitClose method
- Fixed the intermittent `MessageFailureTest.testMessageTooBig` failures

I was able to reproduce the issue locally by copying the `AbstractWebSocketConnection` jetty class. I added a sleep to the close method between the `session.callApplicationOnClose(closeInfo);`and `close(closeInfo, new DisconnectCallback(this));` calls. Even a 1ms sleep is enough to consistently reproduce the issue. I believe the intermittent failures are due to a racing condition thats causing a failed close handshake resulting in 1006 (ABNORMALLY CLOSED) status code. In our `ProxyWebSocketAdapter` class the `onWebSocketError` method was checking for `!frontendSession.isOpen()` which should always be open at this point. By removing the `!` the issue is solved and the client properly receives a close event.

## How was this patch tested?

Unit tests
