### PR TITLE
KNOX-3152: Fixed pinot service xml format issue

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-Licensed to the Apache Software Foundation (ASF) under one or more
+   Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
@@ -14,9 +15,6 @@ Licensed to the Apache Software Foundation (ASF) under one or more
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
-
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <rules>
 
     <!-- Root -->

--- a/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/service.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-Licensed to the Apache Software Foundation (ASF) under one or more
+   Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
@@ -14,10 +15,6 @@ Licensed to the Apache Software Foundation (ASF) under one or more
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
-
-
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <service name="pinot" role="PINOT" version="1.3.0">
     <metadata>
         <context>/pinot/</context>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Gateway log were filled with the below error during startup due to the pinot service xmls added in [KNOX-3139](https://github.com/apache/knox/pull/1034) I fixed the service and rewrite xmls and the errors are gone.

```
ERROR knox.gateway (ServiceDefinitionsLoader.java:lambda$loadServiceDefinitions$1(92)) - Failed to unmarshall service definition file /Users/thanicz/dev/public/knox/install/knox-2.1.0-SNAPSHOT/data/services/pinot/1.3.0/service.xml file : javax.x
ml.bind.UnmarshalException
 - with linked exception:
[org.xml.sax.SAXParseException; lineNumber: 20; columnNumber: 6; The processing instruction target matching "[xX][mM][lL]" is not allowed.]
javax.xml.bind.UnmarshalException: null 
```

## How was this patch tested?

Unit tests, checked the gateway.log during startup
