### PR TITLE
KNOX-3153: Fix Java command invocations in knoxcli.sh

### DIFF
--- a/gateway-release/home/bin/knoxcli.sh
+++ b/gateway-release/home/bin/knoxcli.sh
@@ -63,7 +63,7 @@ function buildAppJavaOpts {
     fi
 
     # Add properties to enable Knox to run on JDK 17
-    JAVA_VERSION=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+    JAVA_VERSION=$("$JAVA" -version 2>&1 | awk -F '"' '/version/ {print $2}')
     CHECK_VERSION_17="17"
     if [[ "$JAVA_VERSION" == *"$CHECK_VERSION_17"* ]]; then
         echo "Java version is $CHECK_VERSION_17. Adding properties to enable Knox to run on JDK 17"
@@ -77,7 +77,7 @@ function main {
    setVerbose "$@"
    checkJava
    buildAppJavaOpts
-   $JAVA "${APP_JAVA_OPTS[@]}" -jar "$APP_JAR" "$@" || exit 1
+   "$JAVA" "${APP_JAVA_OPTS[@]}" -jar "$APP_JAR" "$@" || exit 1
    return 0
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

knoxcli.sh should use the found java path when querying the jdk version.
Also, the launching command should also quote the JAVA variable as in knox-functions.sh appstart.

## How was this patch tested?
Tested on a dev cluster with openJDK 17.

invoke-knox-cli.sh: 
```bash
#!/bin/bash
export KNOX_GATEWAY_DATA_DIR=/var/lib/knox/gateway/data;
export KNOX_GATEWAY_CONF_DIR=/var/lib/knox/gateway/conf;

bash -x knox-bin-path/knoxcli.sh "$@"
```

Test commands:
```bash
./invoke-knox-cli.sh create-cert --hostname host-fqdn --force
./invoke-knox-cli.sh list-alias
```

The create-cert command fails as java version 17 is not detected, add-exports are not appended to the command line 
(X509CertificateUtil.java:generateCertificate(276)) - Error in generating certificate: java.lang.IllegalAccessException: class org.apache.knox.gateway.util.X509CertificateUtil cannot access class sun.security.x509.X509CertInfo (in module java.base) because module java.base does not export sun.security.x509 to unnamed module @23e028a9.
This results in a corrupted keystore as KeyStoreEngine writes a partial keystore and fails when trying to add a null certificate.
When using JAVA for the version check, add-exports are properly set and the command works as expected.

If the java executable path contains spaces, the command failed without quoting and with this change, works as expected.

Created a symlink to a folder with spaces.
```bash
mkdir /tmp/"folder with spaces"
ln -s /usr/lib/jvm/jdk1.17.0.11.0-openjdk/bin/java "/tmp/folder with spaces/java17"
```

invoke-knox-cli.sh: 
```bash
#!/bin/bash
export KNOX_GATEWAY_DATA_DIR=/var/lib/knox/gateway/data;
export KNOX_GATEWAY_CONF_DIR=/var/lib/knox/gateway/conf;
export JAVA="/tmp/folder with spaces/java17"

bash -x knox-bin-path/knoxcli.sh "$@"
```
the existing call:
```bash
$JAVA "${APP_JAVA_OPTS[@]}" -jar "$APP_JAR" "$@" || exit 1
```

```bash
./invoke-knox-cli.sh list-alias
```

```
+ /tmp/folder with spaces/java17 -Djava.library.path=... 
.../bin/knoxcli.sh: line 84: /tmp/folder: No such file or directory
+ exit 1
```

with quoting:
```bash
"$JAVA" "${APP_JAVA_OPTS[@]}" -jar "$APP_JAR" "$@" || exit 1
```

```bash
./invoke-knox-cli.sh list-alias
```

```
+ '/tmp/folder with spaces/java17' -Djava.library.path=...
Listing aliases for: __gateway
...
+ return 0
```