### PR TITLE
KNOX-3146: Failover feature for SSE HA

### DIFF
--- a/gateway-provider-ha/pom.xml
+++ b/gateway-provider-ha/pom.xml
@@ -111,6 +111,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/SSEHaCallback.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/SSEHaCallback.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.ha.dispatch;
+
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.knox.gateway.sse.SSECallback;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.apache.knox.gateway.util.HttpUtils.isConnectionError;
+
+public class SSEHaCallback extends SSECallback {
+
+    private final SSEHaDispatch dispatch;
+    private final HttpUriRequest outboundRequest;
+    private final HttpServletRequest inboundRequest;
+
+    public SSEHaCallback(HttpServletResponse outboundResponse, AsyncContext asyncContext, HttpAsyncRequestProducer producer,
+                         SSEHaDispatch dispatch, HttpUriRequest outboundRequest, HttpServletRequest inboundRequest) {
+        super(outboundResponse, asyncContext, producer);
+        this.dispatch = dispatch;
+        this.outboundRequest = outboundRequest;
+        this.inboundRequest = inboundRequest;
+    }
+
+    @Override
+    public void failed(final Exception ex) {
+        if(outboundResponse.isCommitted()) {
+            /*
+                If the response was already committed, it means the connection was closed abruptly no failover needed.
+                The endpoint shouldn't be marked as failed.
+            */
+            super.failed(ex);
+        } else {
+            if(!isConnectionError(ex.getCause() == null ? ex : ex.getCause()) && dispatch.isNonIdempotentAndNonIdempotentFailoverDisabled(outboundRequest)) {
+                dispatch.markEndpointFailed(outboundRequest, inboundRequest);
+                super.failed(ex);
+            } else {
+                releaseResources(false);
+                LOG.sseConnectionError(ex.getMessage());
+                dispatch.failoverRequest(outboundRequest, outboundResponse, inboundRequest, asyncContext);
+            }
+        }
+    }
+}

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/StickySessionCookieRemovedRequest.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/StickySessionCookieRemovedRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.ha.dispatch;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StickySessionCookieRemovedRequest extends HttpServletRequestWrapper {
+    private final Cookie[] cookies;
+
+    StickySessionCookieRemovedRequest(String cookieName, HttpServletRequest request) {
+        super(request);
+        this.cookies = filterCookies(cookieName, request.getCookies());
+    }
+
+    private Cookie[] filterCookies(String cookieName, Cookie[] cookies) {
+        if (super.getCookies() == null) {
+            return null;
+        }
+        List<Cookie> cookiesInternal = new ArrayList<>();
+        for (Cookie cookie : cookies) {
+            if (!cookieName.equals(cookie.getName())) {
+                cookiesInternal.add(cookie);
+            }
+        }
+        return cookiesInternal.toArray(new Cookie[0]);
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return cookies;
+    }
+}

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/i18n/HaDispatchMessages.java
@@ -22,6 +22,8 @@ import org.apache.knox.gateway.i18n.messages.MessageLevel;
 import org.apache.knox.gateway.i18n.messages.Messages;
 import org.apache.knox.gateway.i18n.messages.StackTrace;
 
+import java.net.URI;
+
 @Messages(logger = "org.apache.knox.gateway")
 public interface HaDispatchMessages {
   @Message(level = MessageLevel.INFO, text = "Initializing Ha Dispatch for: {0}")
@@ -56,4 +58,7 @@ public interface HaDispatchMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Request is non-idempotent {0}, failover prevented, to allow non-idempotent requests to failover set 'failoverNonIdempotentRequestEnabled=true' in HA config. Non connection related error: {1}")
   void cannotFailoverNonIdempotentRequest(String method, Throwable cause);
+
+  @Message( level = MessageLevel.DEBUG, text = "Dispatch request: {0} {1}" )
+  void dispatchRequest( String method, URI uri );
 }

--- a/gateway-spi/pom.xml
+++ b/gateway-spi/pom.xml
@@ -58,16 +58,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpasyncclient</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore-nio</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/SpiGatewayMessages.java
@@ -138,4 +138,7 @@ public interface SpiGatewayMessages {
 
   @Message( level = MessageLevel.ERROR, text = "Unable to close SSE producer" )
   void sseProducerCloseError(@StackTrace(level=MessageLevel.ERROR) Exception e);
+
+  @Message( level = MessageLevel.ERROR, text = "Failed to send error to client" )
+  void failedToSendErrorToClient(@StackTrace(level=MessageLevel.ERROR) Exception e);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/sse/SSECallback.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/sse/SSECallback.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.sse;
+
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.knox.gateway.SpiGatewayMessages;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class SSECallback implements FutureCallback<SSEResponse> {
+
+    protected static final SpiGatewayMessages LOG = MessagesFactory.get(SpiGatewayMessages.class);
+    protected final AsyncContext asyncContext;
+    private final HttpAsyncRequestProducer producer;
+    protected final HttpServletResponse outboundResponse;
+
+
+    public SSECallback(HttpServletResponse outboundResponse, AsyncContext asyncContext, HttpAsyncRequestProducer producer) {
+        this.outboundResponse = outboundResponse;
+        this.asyncContext = asyncContext;
+        this.producer = producer;
+    }
+
+    @Override
+    public void completed(final SSEResponse response) {
+        releaseResources(true);
+        LOG.sseConnectionDone();
+    }
+
+    @Override
+    public void failed(final Exception ex) {
+        try {
+            if(!outboundResponse.isCommitted()) {
+                outboundResponse.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Service connection error");
+            }
+        } catch (Exception e) {
+            LOG.failedToSendErrorToClient(e);
+        } finally {
+            releaseResources(true);
+            LOG.sseConnectionError(ex.getMessage());
+        }
+    }
+
+    @Override
+    public void cancelled() {
+        releaseResources(true);
+        LOG.sseConnectionCancelled();
+    }
+
+    protected void releaseResources(boolean releaseContext) {
+        try {
+            producer.close();
+        } catch (IOException e) {
+            LOG.sseProducerCloseError(e);
+        } finally {
+            if (releaseContext) {
+                asyncContext.complete();
+            }
+        }
+    }
+}

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/sse/SSEDispatchTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/sse/SSEDispatchTest.java
@@ -386,6 +386,8 @@ public class SSEDispatchTest {
         CountDownLatch latch = new CountDownLatch(1);
         SSEDispatch sseDispatch = this.createDispatch();
         HttpServletResponse outboundResponse = EasyMock.createNiceMock(HttpServletResponse.class);
+        outboundResponse.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Service connection error");
+        EasyMock.expectLastCall().once();
         AsyncContext asyncContext = this.getAsyncContext(latch, outboundResponse);
         HttpServletRequest inboundRequest = this.getHttpServletRequest(asyncContext);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1570,6 +1570,16 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpasyncclient</artifactId>
                 <version>${asynchttpclient.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore-nio</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR builds on [PR-947](https://github.com/apache/knox/pull/947) and [PR-1010](https://github.com/apache/knox/pull/1010). It completes the SSE feature by adding the failover capability to the HA dispatch. 

- Fixed a bug where service connection error wasn't sent to the client for non HA
- Renamed `LBHaDispatch` -> `CommonHaDispatch` since it holds failover logic as well now
- Moved failover logic from `ConfigurableHaDispatch` to `CommonHaDispatch` to avoid code duplication
- Added failover for `SSEHaDispatch`
- New tests for SSE HA to cover the new failover capability
- Moved `httpcore` dependency exclusions to the parent pom level

## How was this patch tested?

Unit tests
Manual tests

Local setup:

I had a custom SSE service running locally.

```
        <provider>
            <role>ha</role>
            <name>HaProvider</name>
            <enabled>true</enabled>
            <param>
                <name>SSERVICE</name>
                <value>
                    maxFailoverAttempts=3;failoverSleep=1000;enableStickySession=true;enabled=true;enableLoadBalancing=true;noFallback=true
                </value>
            </param>
            <param>
                <name>HUE</name>
                <value>
                    enableStickySession=true;enabled=true;enableLoadBalancing=true;maxFailoverAttempts=1;failoverSleep=1000
                </value>
            </param>
        </provider>

    <service>
        <role>HUE</role>
        <url>http://localhost3:7435</url>
        <url>http://localhost:7435</url>
        <url>http://localhost2:7435</url>
        <url>http://localhost1:7435</url>
        <url>http://localhost5:7435</url>
    </service>

    <service>
        <role>SSERVICE</role>
        <url>http://localhost3:7435</url>
        <url>http://localhost:7435</url>
        <url>http://localhost2:7435</url>
        <url>http://localhost1:7435</url>
        <url>http://localhost5:7435</url>
    </service>
```

`curl -k -i -u admin:admin-password https://localhost:8443/gateway/mytopology/hue/sse`
`curl -k -i -u admin:admin-password https://localhost:8443/gateway/mytopology/sservice/sse`