### PR TITLE
KNOX-3155 - Isolate the CLIENTID and APIKEY param names from KNOXTOKEN

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.services.security.token.TokenMetadataType;
 import org.apache.knox.gateway.util.JsonUtils;
 
 import javax.inject.Singleton;
+import javax.servlet.FilterConfig;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -39,6 +40,8 @@ public class APIKeyResource extends PasscodeTokenResourceBase {
     public static final String RESOURCE_PATH = "apikey/api/v1/auth/key";
     public static final String API_KEY = "api_key";
     public static final String KEY_ID = "key_id";
+
+    public static final String PREFIX = "apikey.";
 
     @Override
     @GET
@@ -58,6 +61,11 @@ public class APIKeyResource extends PasscodeTokenResourceBase {
     protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
         tokenMetadata.add(TYPE, TokenMetadataType.API_KEY.name());
         super.addArbitraryTokenMetadata(tokenMetadata);
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
     }
 
     @Override

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/APIKeyResource.java
@@ -22,7 +22,6 @@ import org.apache.knox.gateway.services.security.token.TokenMetadataType;
 import org.apache.knox.gateway.util.JsonUtils;
 
 import javax.inject.Singleton;
-import javax.servlet.FilterConfig;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
@@ -39,6 +39,7 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
     public static final String RESOURCE_PATH = "clientid/api/v1/oauth/credentials";
     public static final String CLIENT_ID = "client_id";
     public static final String CLIENT_SECRET = "client_secret";
+    private static final String PREFIX = "clientid.";
 
     @Override
     @GET
@@ -58,6 +59,11 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
     protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
         tokenMetadata.add(TYPE, TokenMetadataType.CLIENT_ID.name());
         super.addArbitraryTokenMetadata(tokenMetadata);
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
     }
 
     @Override

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ServletContextWrapper.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ServletContextWrapper.java
@@ -41,10 +41,12 @@ import java.util.Set;
 class ServletContextWrapper implements ServletContext {
     private ServletContext delegate;
     private Map<String, String> defaultParams;
+    private Map<String, String> extensionParams;
 
     ServletContextWrapper(ServletContext delegate) {
         this.delegate = delegate;
         defaultParams = new HashMap<>();
+        extensionParams = new HashMap<>();
     }
 
     @Override
@@ -149,9 +151,12 @@ class ServletContextWrapper implements ServletContext {
 
     @Override
     public String getInitParameter(String name) {
-        String value = delegate.getInitParameter(name);
+        String value = extensionParams.get(name);
         if (value == null) {
-            value =  defaultParams.get(name);
+            value =  delegate.getInitParameter(name);
+        }
+        if (value == null) {
+            value = defaultParams.get(name);
         }
         return value;
     }
@@ -167,6 +172,10 @@ class ServletContextWrapper implements ServletContext {
             combinedNames.add(delegateNames.nextElement());
         }
 
+        // Add all parameter names from the extension context
+        Set<String> extensionNames = extensionParams.keySet();
+        combinedNames.addAll(extensionNames);
+
         // Return an Enumeration of the combined set
         return Collections.enumeration(combinedNames);
     }
@@ -175,6 +184,11 @@ class ServletContextWrapper implements ServletContext {
     public boolean setInitParameter(String name, String value) {
         defaultParams.put(name, value);
         return defaultParams.get(name).equals(value);
+    }
+
+    public boolean setExtensionParameter(String name, String value) {
+        extensionParams.put(name, value);
+        return extensionParams.get(name).equals(value);
     }
 
     @Override

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1330,7 +1330,7 @@ public class TokenServiceResourceTest {
     try {
       tss = new PersistentTestTokenStateService();
       if (expiryInMs != null) {
-        contextExpectations.put("knox.token.ttl", expiryInMs);
+        contextExpectations.put("clientid.knox.token.ttl", expiryInMs);
       }
       configureCommonExpectations(contextExpectations, Boolean.TRUE);
       ClientCredentialsResource ccr = new ClientCredentialsResource();
@@ -1445,7 +1445,7 @@ public class TokenServiceResourceTest {
       tss = new PersistentTestTokenStateService();
       // let the default built into
       if (expiryInMs != null) {
-        contextExpectations.put("knox.token.ttl", expiryInMs);
+        contextExpectations.put("apikey.knox.token.ttl", expiryInMs);
       }
       configureCommonExpectations(contextExpectations, Boolean.TRUE);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Issue: The extension APIs of KNOXTOKEN: APIKEY and CLIENTID APIs are unable to be colocated with the KNOXTOKEN API in the same topology due to param name conflicts. This results in unexpected results when the TTL or other params are set in one or more of the APIs.

Solution: I provided prefixes for all extension APIs that extend the PasscodeTokenResourceBase class via a getPrefix() method on each implementation. Those prefixes are used to disambiguate the params at initialization time and then are stripped from the params and reset to the expected names in KNOXTOKEN implementation.

This insures that the params do not collide and that the implementation has the expected values at runtime.

Note: there may be a more fundamental issue that has required this change that has been lurking for quite some time. The setting of all the params from the JAXRS APIs as init params within web.xml in a flat space for the GatewayServlet seems problematic. This will require additional investigation. In the meantime, this will work for our needs and will still be safe when we address that problem.

## How was this patch tested?

Existing unit tests were run and adjusted to accommodate the new names with the prefixes.
All other unit tests were also run.

Manually tested with APIKEY and CLIENTID colocated with KNOXTOKEN and tested API specific configs and defaults to insure they work properly together.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
