### PR TITLE
KNOX-3168: Updating json-smart to 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <jna.version>5.9.0</jna.version>
         <joda-time.version>2.10.8</joda-time.version>
         <json-path.version>2.9.0</json-path.version>
-        <json-smart.version>2.4.9</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <junit.version>4.13.2</junit.version>
         <lang-tag.version>1.5</lang-tag.version>
         <libpam4j.version>1.11</libpam4j.version>


### PR DESCRIPTION
Upgrading json-smart from 2.4.9 to 2.5.2

What changes were proposed in this pull request?
This PR proposes for the latest version of the json-smart.

How was this patch tested?
Tested on local by running the build via mvn -Prelease clean install.