### PR TITLE
KNOX-3171 - Remove trailing slash for yarn proxy rewrite

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/rewrite.xml
@@ -143,7 +143,7 @@
 </rule>
 
 <rule dir="OUT" name="YARNUI/yarn/outbound/proxy" pattern="*://*:*/proxy/{**}">
-    <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+    <rewrite template="{$frontend[url]}/yarn/proxy/{**}"/>
 </rule>
 <rule flow="OR" dir="OUT" name="YARNUI/yarn/outbound/headers/jobhistory/job/location">
     <match pattern="{scheme}://{host}:{port}/jobhistory/logs/{**}">
@@ -241,15 +241,15 @@
 
 <rule flow="OR" dir="OUT" name="YARNUI/yarn/outbound/apps/history">
     <match pattern="*://*:*/proxy/{**}">
-        <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+        <rewrite template="{$frontend[url]}/yarn/proxy/{**}"/>
     </match>
     <match pattern="/proxy/{**}">
-        <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+        <rewrite template="{$frontend[url]}/yarn/proxy/{**}"/>
     </match>
 </rule>
 <rule dir="OUT" name="YARNUI/yarn/outbound/apps/history1">
     <match pattern="/proxy/{**}?{**}"/>
-    <rewrite template="{$frontend[url]}/yarn/proxy/{**}/?{**}"/>
+    <rewrite template="{$frontend[url]}/yarn/proxy/{**}?{**}"/>
 </rule>
 
 <rule dir="OUT" name="YARNUI/yarn/outbound/cluster/container">
@@ -278,7 +278,7 @@ https://knox_host:knox_port/gateway/yarnui/yarn/nodemanager/node/containerlogs/c
     <rewrite template="{$frontend[url]}/yarn/nodemanager/node/containerlogs/{**}?{**}?{scheme}?{host}?{port}"/>
 </rule>
 <rule dir="OUT" name="YARNUI/yarn/outbound/proxy1" pattern="/proxy/{**}">
-    <rewrite template="{$frontend[url]}/yarn/proxy/{**}/"/>
+    <rewrite template="{$frontend[url]}/yarn/proxy/{**}"/>
 </rule>
 
 <rule dir="OUT" name="YARNUI/yarn/outbound/nodelink" pattern="{scheme}://{host}:{port}">

--- a/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnuiv2/3.0.0/rewrite.xml
@@ -247,10 +247,10 @@
 
   <rule flow="OR" dir="OUT" name="YARNUIV2/yarnuiv2/outbound/apps/history">
     <match pattern="*://*:*/proxy/{**}">
-      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}/?{**}"/>
+      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}?{**}"/>
     </match>
     <match pattern="/proxy/{**}?{**}">
-      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}/?{**}"/>
+      <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}?{**}"/>
     </match>
   </rule>
 
@@ -259,7 +259,7 @@
   </rule>
 
   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/proxy" pattern="*://*:*/proxy/{**}">
-    <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}/"/>
+    <rewrite template="{$frontend[url]}/yarnuiv2/proxy/{**}"/>
   </rule>
 
   <rule dir="OUT" name="YARNUIV2/yarnuiv2/outbound/cluster/apps" pattern="*://*:*/cluster/app/{**}">


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

## What changes were proposed in this pull request?
Remove trailing slash is YARN proxy rewrite rules which now cause issues with Spark 4.0.0 UI. I don't see any other rewrite rules for YARN including a trailing slash, so not sure why the proxy ones ever needed to.

(Please fill in changes proposed in this fix)

## How was this patch tested?

Manual tested locally.

Before:

<img width="1728" height="893" alt="Screenshot 2025-07-25 at 7 23 42 AM" src="https://github.com/user-attachments/assets/e819bf51-db3a-431c-914a-1572bf0d286a" />

After:

<img width="1728" height="897" alt="Screenshot 2025-07-25 at 7 31 27 AM" src="https://github.com/user-attachments/assets/60bad3fc-606b-477a-865c-21ddcea4b68f" />



Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
