### PR TITLE
KNOX-3173: Removed default samesite value for pac4j session cookies

### DIFF
--- a/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
+++ b/gateway-provider-security-pac4j/src/main/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilter.java
@@ -131,7 +131,6 @@ public class Pac4jDispatcherFilter implements Filter, SessionInvalidator {
   private static final String PAC4J_COOKIE_MAX_AGE_DEFAULT = "-1";
 
   public static final String PAC4J_COOKIE_SAMESITE = "pac4j.cookie.samesite";
-  private static final String PAC4J_COOKIE_SAMESITE_DEFAULT = "Strict";
 
   private static final String PAC4J_CSRF_TOKEN = "pac4jCsrfToken";
   private static boolean SSL_ENABLED = true;
@@ -232,8 +231,10 @@ public class Pac4jDispatcherFilter implements Filter, SessionInvalidator {
       setSessionStoreConfig(filterConfig, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES, PAC4J_SESSION_STORE_EXCLUDE_CUSTOM_ATTRIBUTES_DEFAULT);
       /* add cookie expiry */
       setSessionStoreConfig(filterConfig, PAC4J_COOKIE_MAX_AGE, PAC4J_COOKIE_MAX_AGE_DEFAULT);
-      /* add cookie samesite */
-      setSessionStoreConfig(filterConfig, PAC4J_COOKIE_SAMESITE, PAC4J_COOKIE_SAMESITE_DEFAULT);
+      /* add cookie samesite IF pac4j.cookie.samesite is provided */
+      if(StringUtils.isNotBlank(filterConfig.getInitParameter(PAC4J_COOKIE_SAMESITE))) {
+        setSessionStoreConfig(filterConfig, PAC4J_COOKIE_SAMESITE, null);
+      }
       //decorating client configuration (if needed)
       PAC4J_CLIENT_CONFIGURATION_DECORATOR.decorateClients(clients, properties);
     }

--- a/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilterTest.java
+++ b/gateway-provider-security-pac4j/src/test/java/org/apache/knox/gateway/pac4j/filter/Pac4jDispatcherFilterTest.java
@@ -160,7 +160,6 @@ public class Pac4jDispatcherFilterTest {
 
     @Test
     public void testDefaultCookieSameSite() throws Exception {
-        final String expectedSameSite = "Strict";
         List<String> params = new ArrayList<>();
         params.add(Pac4jDispatcherFilter.PAC4J_CALLBACK_URL);
         params.add("clientName");
@@ -172,7 +171,7 @@ public class Pac4jDispatcherFilterTest {
 
         EasyMock.replay(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);
 
-        verifyCookieConfig(mocks.filterConfig, Pac4jDispatcherFilter.PAC4J_COOKIE_SAMESITE,  expectedSameSite);
+        verifyCookieConfig(mocks.filterConfig, Pac4jDispatcherFilter.PAC4J_COOKIE_SAMESITE,  null);
 
         // Verify all mock interactions
         EasyMock.verify(mocks.context, mocks.services, mocks.cryptoService, mocks.aliasService, mocks.keystoreService, mocks.masterService, mocks.filterConfig, mocks.gatewayConfig);


### PR DESCRIPTION
## What changes were proposed in this pull request?

[KNOX-3148](https://github.com/apache/knox/pull/1042) made the SameSite attribute configurable for the pac4j session cookies and introduced `Strict` as default value. However in same cases this might break the pac4j workflow. This change removes the default `Strict` value however it is still configurable if the user wants that. 

## How was this patch tested?

Unit tests.
Tested on a live cluster where the workflow was broken before.
