### PR TITLE
KNOX-3174: Upgrade commons-io to 2.17, forbidden-apis to 3.8

### DIFF
--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
@@ -835,7 +835,7 @@ public class DefaultHaDispatchTest {
           public void write( int b ) throws IOException {
             throw new IOException( "unreachable-host" ); // Fail-over condition
           }
-        }).once();
+        }).atLeastOnce();
 
     CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
     EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).anyTimes();
@@ -965,7 +965,7 @@ public class DefaultHaDispatchTest {
           public void write( int b ) throws IOException {
             throw new IOException( "unreachable-host" ); // Fail-over condition
           }
-        }).once();
+        }).atLeastOnce();
 
     CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
     EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).anyTimes();
@@ -1105,7 +1105,7 @@ public class DefaultHaDispatchTest {
               public void write( int b ) throws IOException {
                 throw new IOException( "unreachable-host" ); // Fail-over condition
               }
-            }).once();
+            }).atLeastOnce();
 
     CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
     EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).anyTimes();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -190,7 +190,7 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
 
         //save the updated content in the file
         FileUtils.write(topologyFile, updated, StandardCharsets.UTF_8);
-      } catch (IOException e) {
+      } catch (Exception e) {
         auditor.audit(Action.REDEPLOY, topology.getName(), ResourceType.TOPOLOGY, ActionOutcome.FAILURE);
         log.failedToRedeployTopology(topology.getName(), e);
       }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/LocalDirectory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/db/LocalDirectory.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,7 +62,7 @@ public class LocalDirectory {
   public String fileContent(String name) throws IOException {
     try {
       return FileUtils.readFileToString(file(name), CHARSET);
-    } catch (FileNotFoundException e) {
+    } catch (NoSuchFileException | FileNotFoundException e) {
       return null;
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <commons-compress.version>1.26.0</commons-compress.version>
         <commons-configuration2.version>2.10.1</commons-configuration2.version>
         <commons-digester3.version>3.2</commons-digester3.version>
-        <commons-io.version>2.8.0</commons-io.version>
+        <commons-io.version>2.17.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
@@ -205,7 +205,7 @@
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <fastinfoset.version>1.2.18</fastinfoset.version>
         <findsecbugs-plugin.version>1.11.0</findsecbugs-plugin.version>
-        <forbiddenapis.version>3.1</forbiddenapis.version>
+        <forbiddenapis.version>3.8</forbiddenapis.version>
         <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
         <gethostname4j.version>1.0.0</gethostname4j.version>  <!-- See here: https://github.com/mattsheppard/gethostname4j -->
         <glassfish-jaxb.version>2.3.3</glassfish-jaxb.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Upgraded commons-io to 2.17
- Upgraded forbiddenapis to 3.8
commons-io 2.17 is available in [fobidden-apis 3.8](https://github.com/policeman-tools/forbidden-apis/tree/branch_3.8/src/main/resources/de/thetaphi/forbiddenapis/signatures)

## How was this patch tested?

Unit tests
