### PR TITLE
KNOX-3177: gateway-service-definitions build time XML validation

### DIFF
--- a/gateway-service-definitions/pom.xml
+++ b/gateway-service-definitions/pom.xml
@@ -69,4 +69,12 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,7 @@
         <docker-maven-plugin.version>0.45.0</docker-maven-plugin.version>
         <docker.platforms>linux/amd64,linux/arm64</docker.platforms>
         <snakeyaml.version>2.4</snakeyaml.version>
+        <xml-maven-plugin.version>1.1.0</xml-maven-plugin.version>
     </properties>
     <repositories>
         <repository>
@@ -439,6 +440,29 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>xml-maven-plugin</artifactId>
+                    <version>${xml-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>validate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <validationSets>
+                            <validationSet>
+                                <dir>src/main/resources/services</dir>
+                                <includes>
+                                    <include>**/*.xml</include>
+                                </includes>
+                            </validationSet>
+                        </validationSets>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This XML validation is aiming to avoid cases like https://github.com/apache/knox/pull/1034 where a service definition were merged with an incorrect XML format. The build should fail in these cases.

## How was this patch tested?

Ran mvn verify on correct and incorrect XMLs

```
[ERROR] Failed to execute goal org.codehaus.mojo:xml-maven-plugin:1.1.0:validate (default) on project gateway-service-definitions: While parsing /Users/thanicz/dev/public/knox/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml, at file:/Users/thanicz/dev/public/knox/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml, line 23,  column 7: fatal error: The element type "rewrite" must be terminated by the matching end-tag "</rewrite>".
[ERROR] While parsing /Users/thanicz/dev/public/knox/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml, at file:/Users/thanicz/dev/public/knox/gateway-service-definitions/src/main/resources/services/pinot/1.3.0/rewrite.xml, line 23,  column 7: fatal error: The element type "rewrite" must be terminated by the matching end-tag "</rewrite>". 
```