### PR TITLE
KNOX-3181: PasscodeTokenResourceBase should extend TokenResourceV2

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/PasscodeTokenResourceBase.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/PasscodeTokenResourceBase.java
@@ -39,7 +39,7 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.UUID;
 
-public class PasscodeTokenResourceBase extends TokenResource {
+public class PasscodeTokenResourceBase extends TokenResourceV2 {
     protected GatewayServices services;
     private static TokenServiceMessages log = MessagesFactory.get(TokenServiceMessages.class);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the base class for PasscodeTokenResourceBase from TokenResource to TokenResourceV2.

## How was this patch tested?

Full build and verify, and manually validated the HTTP methods allowed for the various token lifecycle operations using the CLIENTID service (e.g., revoke requires DELETE rather than POST).

