### PR TITLE
KNOX-3182: Exclude netty from hadoop-common and zookeeper Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1902,6 +1902,11 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-reload4j</artifactId>
                     </exclusion>
+
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -2217,6 +2222,10 @@
                     <exclusion>
                         <groupId>ch.qos.logback</groupId>
                         <artifactId>logback-classic</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Excluded the transient netty dependency versions pulled in via hadoop-common and zookeeper.

## How was this patch tested?

Full build and unit tests were executed and passed.

