### PR TITLE
KNOX-3183: Remove unused commons-lang 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,6 @@
         <commons-configuration2.version>2.10.1</commons-configuration2.version>
         <commons-digester3.version>3.2</commons-digester3.version>
         <commons-io.version>2.17.0</commons-io.version>
-        <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-math3.version>3.6.1</commons-math3.version>
@@ -1978,11 +1977,6 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>${commons-lang.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

commons-lang 2.6 is referenced in the parent pom however it is not used. The commons-lang library is not present in the `/dep` folder either after installing. This change removes commons-lang 2.6 from the pom.xml.

## How was this patch tested?

Build, unit tests, checked basic functionality (homepage, knoxsso)
