### PR TITLE
KNOX-3184: Upgrade commons-logging to 1.3.5. Remove exclude from hado…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <commons-io.version>2.17.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
-        <commons-logging.version>1.2</commons-logging.version>
+        <commons-logging.version>1.3.5</commons-logging.version>
         <commons-math3.version>3.6.1</commons-math3.version>
         <commons-net.version>3.9.0</commons-net.version>
         <commons-text.version>1.10.0</commons-text.version>
@@ -1801,10 +1801,6 @@
                     <exclusion>
                         <groupId>commons-httpclient</groupId>
                         <artifactId>commons-httpclient</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
                     </exclusion>
 
                     <exclusion>


### PR DESCRIPTION
…op-common since it doesn't pull in commons-logging anymore

## What changes were proposed in this pull request?

- Upgraded `commons-logging` to 1.3.5
- Removed `commons-logging` exclude from `hadoop-common` since it doesn't pull it in anymore

## How was this patch tested?

Build, unit tests, basic functionality (homepage, knoxsso)
`mvn dependency:tree -Dincludes=commons-logging:commons-logging`
