### PR TITLE
KNOX-3185 - Knox token limit per user is now configurable on the topology level too

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -140,6 +140,7 @@ public class TokenResource {
   private static final String TSS_MAXIMUM_LIFETIME_TEXT = "maximumLifetimeText";
   private static final String LIFESPAN_INPUT_ENABLED_PARAM = TOKEN_PARAM_PREFIX + "lifespan.input.enabled";
   private static final String LIFESPAN_INPUT_ENABLED_TEXT = "lifespanInputEnabled";
+  static final String KNOX_TOKEN_USER_LIMIT_PER_USER = TOKEN_PARAM_PREFIX + "limit.per.user";
   static final String KNOX_TOKEN_USER_LIMIT_EXCEEDED_ACTION = TOKEN_PARAM_PREFIX + "user.limit.exceeded.action";
   private static final String METADATA_QUERY_PARAM_PREFIX = "md_";
   private static final long TOKEN_TTL_DEFAULT = 30000L;
@@ -300,6 +301,16 @@ public class TokenResource {
       tokenMAC = new TokenMAC(gatewayConfig.getKnoxTokenHashAlgorithm(), aliasService.getPasswordFromAliasForGateway(TokenMAC.KNOX_TOKEN_HASH_KEY_ALIAS_NAME));
 
       tokenLimitPerUser = gatewayConfig.getMaximumNumberOfTokensPerUser();
+      final String tokenLimitPerUserParam = context.getInitParameter(KNOX_TOKEN_USER_LIMIT_PER_USER);
+      if (StringUtils.isNotBlank(tokenLimitPerUserParam)) {
+        try {
+          tokenLimitPerUser = Integer.parseInt(tokenLimitPerUserParam);
+        } catch (final NumberFormatException nfe) {
+          log.invalidConfigValue(topologyName, KNOX_TOKEN_USER_LIMIT_PER_USER, tokenLimitPerUserParam, nfe);
+          log.generalInfoMessage("Using the gateway-level token limit per user configuration.");
+        }
+      }
+
       final String userLimitExceededActionParam = context.getInitParameter(KNOX_TOKEN_USER_LIMIT_EXCEEDED_ACTION);
       if (userLimitExceededActionParam != null) {
         userLimitExceededAction = UserLimitExceededAction.valueOf(userLimitExceededActionParam);

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -21,6 +21,7 @@ import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.KNOX_TOKEN_U
 import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.KNOX_TOKEN_USER_LIMIT_DEFAULT;
 import static org.apache.knox.gateway.service.knoxtoken.TokenResource.KNOX_TOKEN_ISSUER;
 import static org.apache.knox.gateway.service.knoxtoken.TokenResource.KNOX_TOKEN_USER_LIMIT_EXCEEDED_ACTION;
+import static org.apache.knox.gateway.service.knoxtoken.TokenResource.KNOX_TOKEN_USER_LIMIT_PER_USER;
 import static org.apache.knox.gateway.service.knoxtoken.TokenResource.TOKEN_INCLUDE_GROUPS_IN_JWT_ALLOWED;
 import static org.apache.knox.gateway.services.security.token.JWTokenAttributes.DEFAULT_ISSUER;
 import static org.apache.knox.gateway.services.security.token.impl.JWTToken.KNOX_GROUPS_CLAIM;
@@ -1113,7 +1114,13 @@ public class TokenServiceResourceTest {
 
   private void testLimitingTokensPerUser(int configuredLimit, int numberOfTokens, boolean revokeOldestToken) throws Exception {
     final Map<String, String> contextExpectations = new HashMap<>();
-    contextExpectations.put(KNOX_TOKEN_USER_LIMIT, String.valueOf(configuredLimit));
+    //Setting token limit on gateway/topology level
+    if (configuredLimit > 0) {
+      contextExpectations.put(KNOX_TOKEN_USER_LIMIT_PER_USER, String.valueOf(configuredLimit));
+    } else {
+      contextExpectations.put(KNOX_TOKEN_USER_LIMIT, String.valueOf(configuredLimit));
+    }
+
     if (revokeOldestToken) {
       contextExpectations.put(KNOX_TOKEN_USER_LIMIT_EXCEEDED_ACTION, TokenResource.UserLimitExceededAction.REMOVE_OLDEST.name());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new topology-level configuration that can be added in the `KNOXTOKEN` service called `knox.token.limit.per.user`. If this is set to a valid integer number, the gateway-level config (`gateway.knox.token.limit.per.user`) is ignored and the topology-level value is used as token limit per user.
If it's absent or set to an invalid number, the `KNOXTOKEN` service falls back to the gateway-level config 
(which defaults to `10`).

## How was this patch tested?

Updated and ran unit tests (covering the configuration of both the gateway and topology level settings).

Other than this, I concluded the following manual testing after I redeployed Knox locally with my changes:
- set `gateway.knox.token.limit.per.user` to `3` in `gateway-site.xml` and confirmed I could only generate 3 tokens
- set `knox.token.limit.per.user` to `2` in the `homepage` topology (did not touch the gateway-level config I added previously) and confirmed that I could only generate 2 tokens
- set `knox.token.limit.per.user` to `invalidNumber` and confirmed that I could only generate 3 tokens (gateway-level config) and saw the relevant log message in `gateway.log`:
```
2025-09-03 17:27:52,253 e36f34f0-53d3-43ed-b821-f4521b36e49b ERROR service.knoxtoken (TokenResource.java:init(309)) - The specified value for the knox.token.limit.per.user configuration property is not valid for the "homepage" topology: invalidNumber
2025-09-03 17:27:52,253 e36f34f0-53d3-43ed-b821-f4521b36e49b INFO  service.knoxtoken (TokenResource.java:init(310)) - Using the gateway-level token limit per user configuration.
```