### PR TITLE
KNOX-3186 - Istio external authorizer support for SSOCookieProvider

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -423,7 +423,6 @@ Release build file for the Apache Knox Gateway
     <target name="start-debug-gateway" description="Start test gateway server enabling remote debugging.">
         <exec executable="java" dir="${install.dir}/${gateway-artifact}-${gateway-version}">
             <arg value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"/>
-            <arg value="--add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"/> 
             <arg value="-jar"/>
             <arg value="bin/gateway.jar"/>
         </exec>

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/JWTMessages.java
@@ -126,4 +126,16 @@ public interface JWTMessages {
 
   @Message(level = MessageLevel.ERROR, text = "Invalid URL ignored. Not a valid JWKS url {0}")
   void invalidJwksUrl(String jwksUrl);
+
+  @Message(level = MessageLevel.ERROR, text = "Original redirect URL is not in the whitelist {0}")
+  void invalidOriginalUrlDomain(String originalMainDomain);
+
+  @Message( level = MessageLevel.INFO, text = "Using original url: {0}, set by the header: {1}" )
+  void originalHeaderURLForwarding( String originalUrl, String header);
+
+  @Message( level = MessageLevel.INFO, text = "SSO is configured to use originalURL from request header: {0}" )
+  void usingOriginalUrlFromHeader( String originalUrl);
+
+  @Message(level = MessageLevel.ERROR, text = "Malformed original url passed: {0}")
+  void malformedOriginalUrlDomain(String originalMainDomain);
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds support for extracting the original URL from HTTP request headers in the SSOCookieFederationFilter, used by isto external auth configuration where the original client URL information may be lost or modified during request forwarding.

<section id="markdown-section-989dc13a-8978-4832-ad8b-5ee08d8804b0-9" class="markdown-section  " data-markdown-raw="

### New Configuration Parameters" data-section-index="9" style="scrollbar-color: var(--vscode-scrollbarSlider-background,#424242) var(--vscode-editor-background,#1e1e1e); border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgb(243, 243, 243); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(20, 20, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="scrollbar-color: var(--vscode-scrollbarSlider-background,#424242) var(--vscode-editor-background,#1e1e1e); font-weight: 600 !important; font-size: 1.15em; line-height: 1.25; margin-bottom: 8px; margin-top: 18px;"><span style="scrollbar-color: var(--vscode-scrollbarSlider-background,#424242) var(--vscode-editor-background,#1e1e1e);">New Configuration Parameters</span></h3></section>
Parameter | Default | Description
-- | -- | --
sso.use.original.url.from.header | false | Enable/disable the original URL from header feature
sso.original.url.from.header.name | X-Original-URL | Name of the header containing the original URL
sso.original.url.from.header.verify.domain | false | Enable domain validation for security
sso.original.url.from.header.domain.whitelist | N/A | Comma-separated list of allowed domains

<section id="markdown-section-989dc13a-8978-4832-ad8b-5ee08d8804b0-11" class="markdown-section  " data-markdown-raw="

| Parameter | Default | Description |
|-----------|---------|-------------|
| `sso.use.original.url.from.header` | `false` | Enable/disable the original URL from header feature |
| `sso.original.url.from.header.name` | `X-Original-URL` | Name of the header containing the original URL |
| `sso.original.url.from.header.verify.domain` | `false` | Enable domain validation for security |
| `sso.original.url.from.header.domain.whitelist` | N/A | Comma-separated list of allowed domains |

### Security Considerations
- **Domain Validation**: Optional whitelist-based validation prevents malicious redirect attacks
- **Fallback Mechanism**: Falls back to standard request URL if header is missing, empty, or invalid
- **Integration with Existing Security**: Works alongside existing `knoxsso.redirect.whitelist.regex` property
- **Input Validation**: Validates URL format and rejects malformed URLs" data-section-index="11" style="scrollbar-color: var(--vscode-scrollbarSlider-background,#424242) var(--vscode-editor-background,#1e1e1e); border-radius: 4px; line-height: 19.5px; margin: 6px 0px; position: relative; scroll-margin-bottom: 40px; scroll-margin-top: 40px; color: rgb(243, 243, 243); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(20, 20, 20); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><br class="Apple-interchange-newline">


### Configuration example

```
<provider>
         <role>federation</role>
         <name>SSOCookieProvider</name>
         <enabled>true</enabled>
         <param>
            <name>knox.token.exp.server-managed</name>
            <value>false</value>
         </param>
         
         <!-- Look for Original request url in the header, default header value is X-Original-URL-->
         <param>
            <name>sso.use.original.url.from.header</name>
            <value>true</value>
         </param>
         
         <!-- Do we need verify if the originalurl domain is in the whitelist? detault is false, we rely on knoxsso.redirect.whitelist.regex -->
         <!-- You will also have to make sure the domains are whitelisted in KNOXSSO service in SSO topology using knoxsso.redirect.whitelist.regex -->
         <param>
            <name>sso.original.url.from.header.verify.domain</name>
            <value>false</value>
         </param>
         <!-- In case you want custom header -->
         <param>
            <name>sso.original.url.from.header.name</name>
            <value>X-MyCustom-Header</value>
         </param>
      </provider>
```

## How was this patch tested?
This patch was tested locally

sso.use.original.url.from.header = false
```
curl -ik -H "X-Original-URL: https://local.com"  https://www.local.com:8443/gateway/manager/admin-ui/
HTTP/1.1 302 Found
Date: Fri, 05 Sep 2025 01:42:49 GMT
X-Frame-Options: DENY
X-XSS-Protection: 1;mode=block
Location: https://www.local.com:8443/gateway/knoxsso/api/v1/websso?originalUrl=https://www.local.com:8443/gateway/manager/admin-ui/
Content-Length: 0
```

sso.use.original.url.from.header = true
```
curl -ik -H "X-Original-URL: https://local.com"  https://www.local.com:8443/gateway/manager/admin-ui/
HTTP/1.1 302 Found
Date: Fri, 05 Sep 2025 01:44:03 GMT
X-Frame-Options: DENY
X-XSS-Protection: 1;mode=block
Location: https://www.local.com:8443/gateway/knoxsso/api/v1/websso?originalUrl=https://local.com
Content-Length: 0
```
sso.use.original.url.from.header = true and sso.original.url.from.header.name=X-MyCustom-Header
```
curl -ik -H "X-MyCustom-Header: https://example.com"  https://www.local.com:8443/gateway/manager/admin-ui/
HTTP/1.1 302 Found
Date: Fri, 05 Sep 2025 01:43:39 GMT
X-Frame-Options: DENY
X-XSS-Protection: 1;mode=block
Location: https://www.local.com:8443/gateway/knoxsso/api/v1/websso?originalUrl=https://example.com
Content-Length: 0
```

*NOTE:* There is a minor change where start-debug-gateway options are modified to make it work.
