### PR TITLE
KNOX-3187 - Show pop-up window on Token Management/Generation pages when Knox token hash key is missing

### DIFF
--- a/knox-token-generation-ui/token-generation/app/token-generation.component.ts
+++ b/knox-token-generation-ui/token-generation/app/token-generation.component.ts
@@ -68,6 +68,7 @@ export class TokenGenerationComponent implements OnInit {
   // Data coming from TokenStateService status request
   tssStatus: TssStatusData;
 
+
   constructor(private http: HttpClient, private tokenGenService: TokenGenService) {
     this.tssStatusMessageLevel = 'info';
     this.tssStatusMessage = '';
@@ -79,7 +80,14 @@ export class TokenGenerationComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.setTokenStateServiceStatus();
+    this.tokenGenService.isTokenHashKeyPresent().then(
+        tokenHashKeyPresent => {
+          if (tokenHashKeyPresent) {
+            this.setTokenStateServiceStatus();
+          } else {
+            this.showMissingKnoxTokenHashKeyPopup();
+          }
+        });
   }
 
   generateToken() {
@@ -110,13 +118,13 @@ export class TokenGenerationComponent implements OnInit {
 
   setTokenStateServiceStatus() {
     this.tokenGenService.getTokenStateServiceStatus()
-    .then(tssStatus => {
-      this.tssStatus = tssStatus;
-      this.decideTssMessage();
-    })
-    .catch((errorMessage) => {
-      this.requestErrorMessage = errorMessage;
-    });
+        .then(tssStatus => {
+          this.tssStatus = tssStatus;
+          this.decideTssMessage();
+        })
+        .catch((errorMessage) => {
+          this.requestErrorMessage = errorMessage;
+        });
   }
 
   copyTextToClipboard(elementId) {
@@ -205,5 +213,15 @@ export class TokenGenerationComponent implements OnInit {
   private setTssMessage(level: 'info' | 'warning' | 'error', message: string) {
     this.tssStatusMessageLevel = level;
     this.tssStatusMessage = message;
+  }
+
+  private showMissingKnoxTokenHashKeyPopup(): void {
+    const message = 'The required gateway-level alias, knox.token.hash.key, is missing.';
+    Swal.fire({
+      icon: 'warning',
+      title: 'Token Generation Disabled!',
+      text: message,
+      confirmButtonColor: '#7cd1f9'
+    });
   }
 }

--- a/knox-token-management-ui/token-management/app/token.management.component.html
+++ b/knox-token-management-ui/token-management/app/token.management.component.html
@@ -15,12 +15,12 @@
 <div>
 
     <div>
-        <button (click)="gotoTokenGenerationPage();">Generate New Token</button>
-        <button type="button" title="Refresh Knox Tokens" (click)="fetchKnoxTokens();">
+        <button (click)="gotoTokenGenerationPage();" [disabled]="!isTokenHashKeyPresent()">Generate New Token</button>
+        <button type="button" title="Refresh Knox Tokens" (click)="fetchKnoxTokens();" [disabled]="!isTokenHashKeyPresent()">
             <span class="glyphicon glyphicon-refresh"></span>
         </button>
         <span style="float: right;">
-            <mat-slide-toggle (change)="onChangeShowDisabledCookies($event)" [(ngModel)]="showDisabledKnoxSsoCookies">
+            <mat-slide-toggle (change)="onChangeShowDisabledCookies($event)" [(ngModel)]="showDisabledKnoxSsoCookies" [disabled]="!isTokenHashKeyPresent()">
               Show Disabled KnoxSSO Cookies
             </mat-slide-toggle>
         </span>
@@ -28,7 +28,7 @@
 
     <div *ngIf="userCanSeeAllTokens()">
         <span style="float: right;">
-            <mat-slide-toggle (change)="onChangeShowMyTokensOnly($event)" [(ngModel)]="showMyTokensOnly">
+            <mat-slide-toggle (change)="onChangeShowMyTokensOnly($event)" [(ngModel)]="showMyTokensOnly" [disabled]="!isTokenHashKeyPresent()">
               Show My Tokens Only
             </mat-slide-toggle>
         </span>

--- a/knox-token-management-ui/token-management/app/token.management.service.ts
+++ b/knox-token-management-ui/token-management/app/token.management.service.ts
@@ -38,6 +38,7 @@ export class TokenManagementService {
     revokeKnoxTokenUrl = this.apiUrl + 'revoke';
     revokeKnoxTokensBatchUrl = this.apiUrl + 'revokeTokens';
     getTssStatusUrl = this.apiUrl + 'getTssStatus';
+    metadataInfoUrl = this.topologyContext + 'api/v1/metadata/info';
 
     constructor(private http: HttpClient) {}
 
@@ -121,6 +122,25 @@ export class TokenManagementService {
             .catch((err: HttpErrorResponse) => {
                 console.debug('TokenManagementService --> revokeTokensInBatch() --> ' + this.revokeKnoxTokensBatchUrl
                               + '\n  error: ' + err.status + ' ' + err.message);
+                if (err.status === 401) {
+                    window.location.assign(document.location.pathname);
+                } else {
+                    return this.handleError(err);
+                }
+            });
+    }
+
+    isTokenHashKeyPresent(): Promise<boolean> {
+        let headers = new HttpHeaders();
+        headers = this.addJsonHeaders(headers);
+        return this.http.get(this.metadataInfoUrl, { headers: headers})
+            .toPromise()
+            .then(response => {
+                return response['generalProxyInfo']?.['enableTokenManagement'] === 'true';
+            })
+            .catch((err: HttpErrorResponse) => {
+                console.debug('TokenManagementService --> isTokenHashKeyPresent() --> '
+                    + this.metadataInfoUrl + '\n  error: ' + err.message);
                 if (err.status === 401) {
                     window.location.assign(document.location.pathname);
                 } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

From now on, when users want to see Token Management or Token Generation pages without a pre-configured `knox.token.hash.key` gateway-level alias, they are shown with the following pop-up windows:
<img width="1721" height="595" alt="image" src="https://github.com/user-attachments/assets/d2ca2c47-fdb8-485d-b811-7f98bac336e7" />
<img width="1699" height="652" alt="image" src="https://github.com/user-attachments/assets/62fbf831-52e8-46b2-a660-585a6559b4a8" />

I also disabled the control-buttons on the Token Management page in that case, because it makes no sense to navigate to the Token Generation page or fetch tokens.

This wasn't necessary on the Token Generation page, because the `Generate Token` button is already disabled when this happens.

## How was this patch tested?

Manually tested with and without the `knox.token.hash.key` alias in the `__gateway` credential store. All worked as expected:
- without it, the above pop-up windows were displayed
- with proper configuration I could generate.manage tokens
