### PR TITLE
KNOX-3194 - CM-initiated rolling restart and waitForStalenessSuccess commands should trigger a discovery round

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -234,8 +234,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.DEBUG, text = "There is no any activation event found within the given time period")
   void noActivationEventFound();
 
-  @Message(level = MessageLevel.DEBUG, text = "Activation event relevance: {0} = {1} ({2} / {3} / {4} / {5})")
-  void activationEventRelevance(String eventId, String relevance, String command, String status, String serviceType, boolean serviceModelGeneratorExists);
+  @Message(level = MessageLevel.DEBUG, text = "Activation event relevance: {0} = {1} ({2} / {3} / {4} / {5} / {6})")
+  void activationEventRelevance(String eventId, boolean relevance, String command, String status, String serviceType, boolean serviceModelGeneratorExists,
+                                boolean rollingOrStalenessRestart);
 
   @Message(level = MessageLevel.DEBUG, text = "Scale event relevance: {0} = {1} ({2} / {3} / {4})")
   void scaleEventRelevance(String eventId, String relevance, String eventCode, String serviceType, boolean serviceModelGeneratorExists);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -512,7 +512,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
       log.noActivationEventFound();
     } else {
       for (ApiEvent event : events) {
-        if(isStartEvent(event) || isScaleEvent(event)) {
+        if (isStartEvent(event) || isScaleEvent(event)) {
           relevantEvents.add(new RelevantEvent(event));
         }
       }
@@ -527,9 +527,13 @@ public class PollingConfigurationAnalyzer implements Runnable {
     final String command = getAttribute(attributeMap, COMMAND);
     final String status = getAttribute(attributeMap, COMMAND_STATUS);
     final String serviceType = getAttribute(attributeMap, RelevantEvent.ATTR_SERVICE_TYPE);
+    final String service = getAttribute(attributeMap, RelevantEvent.ATTR_SERVICE);
     final boolean serviceModelGeneratorExists = serviceModelGeneratorsHolder.getServiceModelGenerators(serviceType) != null;
-    final boolean relevant = START_COMMANDS.contains(command) && SUCCEEDED_STATUS.equals(status) && serviceModelGeneratorExists;
-    log.activationEventRelevance(event.getId(), String.valueOf(relevant), command, status, serviceType, serviceModelGeneratorExists);
+    final boolean clusterRollingOrStalenessRestart = CM_SERVICE.equals(service) && CM_SERVICE_TYPE.equals(serviceType)
+            && (ROLLING_RESTART_COMMAND.equals(command) || RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND.equals(command));
+    final boolean relevant = (clusterRollingOrStalenessRestart && SUCCEEDED_STATUS.equals(status))
+            || (START_COMMANDS.contains(command) && SUCCEEDED_STATUS.equals(status) && serviceModelGeneratorExists);
+    log.activationEventRelevance(event.getId(), relevant, command, status, serviceType, serviceModelGeneratorExists, clusterRollingOrStalenessRestart);
     return relevant;
   }
 

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -228,11 +228,11 @@ public class PollingConfigurationAnalyzerTest {
 
     // Simulate a successful rolling cluster restart event
     ApiEvent rollingRestartEvent = createApiEvent(clusterName,
-                                                  HiveOnTezServiceModelGenerator.SERVICE_TYPE,
-                                                  HiveOnTezServiceModelGenerator.SERVICE,
-                                                  PollingConfigurationAnalyzer.ROLLING_RESTART_COMMAND,
-                                                  PollingConfigurationAnalyzer.SUCCEEDED_STATUS,
-                                                  "EV_CLUSTER_ROLLING_RESTARTED");
+            PollingConfigurationAnalyzer.CM_SERVICE_TYPE,
+            PollingConfigurationAnalyzer.CM_SERVICE,
+            PollingConfigurationAnalyzer.ROLLING_RESTART_COMMAND,
+            PollingConfigurationAnalyzer.SUCCEEDED_STATUS,
+            "EV_CLUSTER_ROLLING_RESTARTED");
 
     ChangeListener listener =
             doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
@@ -248,10 +248,10 @@ public class PollingConfigurationAnalyzerTest {
     final String clusterName = "Cluster 8";
 
     // Simulate a successful restart waiting for staleness event
-    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, HiveOnTezServiceModelGenerator.SERVICE_TYPE, HiveOnTezServiceModelGenerator.SERVICE,
+    final ApiEvent restartWaitingForStalenessSuccessEvent = createApiEvent(clusterName, PollingConfigurationAnalyzer.CM_SERVICE_TYPE, PollingConfigurationAnalyzer.CM_SERVICE,
         PollingConfigurationAnalyzer.RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS, "EV_CLUSTER_RESTARTED");
 
-    final ChangeListener listener = doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
+    final ChangeListener listener = doTestEvent(restartWaitingForStalenessSuccessEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
     assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
   }
 
@@ -261,7 +261,7 @@ public class PollingConfigurationAnalyzerTest {
     final String clusterName = "Cluster 9";
 
     // Simulate a successful restart waiting for staleness event with id = 123
-    final ApiEvent rollingRestartEvent = createApiEvent(clusterName, HiveOnTezServiceModelGenerator.SERVICE_TYPE, HiveOnTezServiceModelGenerator.SERVICE,
+    final ApiEvent restartWaitingForStalenessSuccessEvent = createApiEvent(clusterName, PollingConfigurationAnalyzer.CM_SERVICE_TYPE, PollingConfigurationAnalyzer.CM_SERVICE,
         PollingConfigurationAnalyzer.RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS, "EV_CLUSTER_RESTARTED",
         "123");
 
@@ -269,12 +269,12 @@ public class PollingConfigurationAnalyzerTest {
     final TestablePollingConfigAnalyzer pca = buildPollingConfigAnalyzer(address, clusterName, Collections.emptyMap(), listener);
 
     // this should trigger a change notification
-    doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
+    doTestEvent(restartWaitingForStalenessSuccessEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
     assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
 
     // this should NOT trigger a notification as the same event has already been processed
     listener.clearNotification();
-    doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
+    doTestEvent(restartWaitingForStalenessSuccessEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
     assertFalse("Unexpected change notification", listener.wasNotified(address, clusterName));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in KNOX-3194, the cluster-level `RollingRestart` and `RestartWaitingForStalenessSuccess` should trigger a full service discovery.

## How was this patch tested?

Updated and executed existing unit tests.

Manual testing on a real cluster with HMS (I'll add details later...)