### PR TITLE
KNOX-3200: Removed EOL ehcache-shiro library. Brought in the necessar…

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -201,6 +201,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
+   This product bundles various third-party components also under the
+   Apache Software License 2.0.
+
+   Ehcache-shiro (https://github.com/ehcache/ehcache-shiro)
+   ./gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheIterator.java
+   ./gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheCollectionWrapper.java
+   ./gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheSetWrapper.java
+   ./gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheShiro.java
+   ./gateway-provider-security-shiro/src/main/resources/ehcache-default-config.xml
 
 Apache Knox Subcomponents (binary distributions):
 

--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -76,10 +76,6 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.ehcache.integrations.shiro</groupId>
-            <artifactId>shiro-ehcache3</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.kohsuke</groupId>

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheCollectionWrapper.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheCollectionWrapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Terracotta, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.ehcache;
+
+import org.apache.shiro.cache.Cache;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+
+abstract class EhcacheCollectionWrapper<E> extends AbstractCollection<E> {
+
+    private final Cache shiroCache;
+
+    private final org.ehcache.Cache ehcacheCache;
+
+    EhcacheCollectionWrapper(Cache shiroCache, org.ehcache.Cache ehcacheCache) {
+        this.shiroCache = shiroCache;
+        this.ehcacheCache = ehcacheCache;
+    }
+
+    @Override
+    public int size() {
+        return shiroCache.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return !ehcacheCache.iterator().hasNext();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException("addAll");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("removeAll");
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("retainAll");
+    }
+}

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheIterator.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheIterator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Terracotta, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.ehcache;
+
+import java.util.Iterator;
+
+abstract class EhcacheIterator<K, V, T> implements Iterator<T> {
+
+    private final Iterator<org.ehcache.Cache.Entry<K, V>> cacheIterator;
+
+    EhcacheIterator(Iterator<org.ehcache.Cache.Entry<K, V>> cacheIterator) {
+        this.cacheIterator = cacheIterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return cacheIterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return getNext(cacheIterator);
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    protected abstract T getNext(Iterator<org.ehcache.Cache.Entry<K, V>> cacheIterator);
+}

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheSetWrapper.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheSetWrapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Terracotta, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.ehcache;
+
+import org.apache.shiro.cache.Cache;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+
+abstract class EhcacheSetWrapper<E> extends AbstractSet<E> {
+
+    private final Collection<E> delegate;
+
+    EhcacheSetWrapper(Cache shiroCache, org.ehcache.Cache ehcacheCache) {
+        delegate = new EhcacheCollectionWrapper<E>(shiroCache, ehcacheCache) {
+            @Override
+            public Iterator<E> iterator() {
+                throw new IllegalStateException("Should not use this iterator");
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        return delegate.addAll(c);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return delegate.remove(o);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return delegate.retainAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return delegate.retainAll(c);
+    }
+}

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheShiro.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/ehcache/EhcacheShiro.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Terracotta, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.knox.gateway.ehcache;
+
+import org.apache.shiro.cache.Cache;
+import org.apache.shiro.cache.CacheException;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+public class EhcacheShiro<K, V> implements Cache<K, V> {
+
+    private final org.ehcache.Cache<K, V> cache;
+
+    public EhcacheShiro(org.ehcache.Cache cache) {
+        if (cache == null) {
+            throw new IllegalArgumentException("Cache argument cannot be null.");
+        }
+
+        this.cache = cache;
+    }
+
+    @Override
+    public V get(K k) throws CacheException {
+        if (k == null) {
+            return null;
+        }
+
+        return cache.get(k);
+    }
+
+    @Override
+    public V put(K k, V v) throws CacheException {
+        V previousValue = null;
+
+        while (true) {
+            previousValue = cache.get(k);
+            if (previousValue == null) {
+                if (cache.putIfAbsent(k, v) == null) {
+                    break;
+                }
+            } else {
+                if (cache.replace(k, v) != null) {
+                    break;
+                }
+            }
+        }
+
+        return previousValue;
+    }
+
+    @Override
+    public V remove(K k) throws CacheException {
+        V previousValue = null;
+
+        while (true) {
+            previousValue = cache.get(k);
+            if (previousValue == null) {
+                break;
+            } else {
+                if (cache.remove(k, previousValue)) {
+                    break;
+                }
+            }
+        }
+
+        return previousValue;
+    }
+
+    @Override
+    public void clear() throws CacheException {
+        cache.clear();
+    }
+
+    @Override
+    public int size() {
+        Iterator<org.ehcache.Cache.Entry<K, V>> iterator = cache.iterator();
+        int size = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            size++;
+        }
+
+        return size;
+    }
+
+    @Override
+    public Set<K> keys() {
+        return new EhcacheSetWrapper<K>(this, cache) {
+            @Override
+            public Iterator<K> iterator() {
+                return new EhcacheIterator<K, V, K>(cache.iterator()) {
+                    @Override
+                    protected K getNext(Iterator<org.ehcache.Cache.Entry<K, V>> cacheIterator) {
+                        return cacheIterator.next().getKey();
+                    }
+                };
+            }
+        };
+    }
+
+    @Override
+    public Collection<V> values() {
+        return new EhcacheCollectionWrapper<V>(this, cache) {
+            @Override
+            public Iterator<V> iterator() {
+                return new EhcacheIterator<K, V, V>(cache.iterator()) {
+                    @Override
+                    protected V getNext(Iterator<org.ehcache.Cache.Entry<K, V>> cacheIterator) {
+                        return cacheIterator.next().getValue();
+                    }
+                };
+            }
+        };
+    }
+}

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxCacheManager.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxCacheManager.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.shirorealm;
 
 import org.apache.knox.gateway.ShiroMessages;
+import org.apache.knox.gateway.ehcache.EhcacheShiro;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.shiro.ShiroException;
 import org.apache.shiro.cache.Cache;
@@ -32,7 +33,6 @@ import org.ehcache.config.CacheConfiguration;
 import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.impl.config.persistence.CacheManagerPersistenceConfiguration;
-import org.ehcache.integrations.shiro.EhcacheShiro;
 import org.ehcache.spi.service.ServiceCreationConfiguration;
 import org.ehcache.xml.XmlConfiguration;
 
@@ -48,7 +48,7 @@ public class KnoxCacheManager implements org.apache.shiro.cache.CacheManager, In
   private static final ShiroMessages LOG = MessagesFactory.get(ShiroMessages.class);
 
   private org.ehcache.CacheManager manager;
-  private String cacheManagerConfigFile = "classpath:org/ehcache/integrations/shiro/ehcache.xml";
+  private String cacheManagerConfigFile = "classpath:ehcache-default-config.xml";
   private boolean cacheManagerImplicitlyCreated;
   private XmlConfiguration cacheConfiguration;
   private static final String DEFAULT_FOLDER_NAME = "ehcache-shiro";
@@ -178,7 +178,6 @@ public class KnoxCacheManager implements org.apache.shiro.cache.CacheManager, In
     if (loader == null) {
       loader = this.getClass().getClassLoader();
     }
-
     return loader.getResource(URL);
   }
 

--- a/gateway-provider-security-shiro/src/main/resources/ehcache-default-config.xml
+++ b/gateway-provider-security-shiro/src/main/resources/ehcache-default-config.xml
@@ -1,0 +1,56 @@
+<!--
+Copyright Terracotta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<config xmlns="http://www.ehcache.org/v3">
+
+    <persistence directory="${java.io.tmpdir}/shiro-ehcache"/>
+
+    <cache alias="shiro-activeSessionCache">
+        <key-type serializer="org.ehcache.impl.serialization.CompactJavaSerializer">
+            java.lang.Object
+        </key-type>
+        <value-type serializer="org.ehcache.impl.serialization.CompactJavaSerializer">
+            java.lang.Object
+        </value-type>
+
+        <resources>
+            <heap unit="entries">10000</heap>
+            <disk unit="GB">1</disk>
+        </resources>
+    </cache>
+
+    <cache alias="org.apache.shiro.realm.text.PropertiesRealm-0-accounts">
+        <key-type serializer="org.ehcache.impl.serialization.CompactJavaSerializer">
+            java.lang.Object
+        </key-type>
+        <value-type serializer="org.ehcache.impl.serialization.CompactJavaSerializer">
+            java.lang.Object
+        </value-type>
+
+        <resources>
+            <heap unit="entries">1000</heap>
+            <disk unit="GB">1</disk>
+        </resources>
+    </cache>
+
+    <cache-template name="defaultCacheConfiguration">
+        <expiry>
+            <tti unit="seconds">120</tti>
+        </expiry>
+        <heap unit="entries">10000</heap>
+    </cache-template>
+
+</config>

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,6 @@
         <!-- After JDK 11 we can use 0.12.4 from maven central -->
         <pty4j.version>0.11.4</pty4j.version>
         <rest-assured.version>4.3.3</rest-assured.version>
-        <shiro-ehcache3.version>1.0.0</shiro-ehcache3.version>
         <shiro.version>1.13.0</shiro.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
@@ -2154,22 +2153,6 @@
                 <groupId>org.ehcache</groupId>
                 <artifactId>ehcache</artifactId>
                 <version>${ehcache.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.ehcache.integrations.shiro</groupId>
-                <artifactId>shiro-ehcache3</artifactId>
-                <version>${shiro-ehcache3.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.ehcache</groupId>
-                        <artifactId>ehcache</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.shiro</groupId>
-                        <artifactId>shiro-core</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
…y files with the original license headers. Added ehcache-shiro to LICENSE

## What changes were proposed in this pull request?
[Ehcache-shiro](https://github.com/ehcache/ehcache-shiro) is an EOL library with its one and only release being 9 years old.
This change brings in the necessary files that ensure that Ehcache 3.x is working with Shiro. The files were slightly modified to make sure there are no PMD violations during Knox's build. The original Apache License headers are kept untouched and Knox's LICENSE is updated accordingly.

## How was this patch tested?
Unit tests, Manual tests

