### PR TITLE
KNOX-3246 - Make Java discovery deterministic and support JDK 11/17

### DIFF
--- a/gateway-release-common/home/bin/knox-functions.sh
+++ b/gateway-release-common/home/bin/knox-functions.sh
@@ -61,7 +61,18 @@ function setVerbose() {
   done
 }
 
-JAVA_VERSION_PATTERNS=( "1.6.0_31/bin/java$" "1.6.0_.*/bin/java$" "1.6.0.*/bin/java$" "1.6\..*/bin/java$" "/bin/java$" )
+JAVA_VERSION_PATTERNS=(
+  "/default/bin/java$"
+  "1.6.0_31/bin/java$"
+  "1.6.0_.*/bin/java$"
+  "1.6.0.*/bin/java$"
+  "1.6\..*/bin/java$"
+  "jdk1\.11.*?/bin/java$"
+  "jdk-11.*?/bin/java$"
+  "jdk1\.17.*?/bin/java$"
+  "jdk-17.*?/bin/java$"
+  "/bin/java$"
+)
 
 function findJava() {
   # Check to make sure any existing JAVA var is valid.
@@ -92,8 +103,7 @@ function findJava() {
   # Use the search patterns to find java.
   if [ "$JAVA" == "" ]; then
     for pattern in "${JAVA_VERSION_PATTERNS[@]}"; do
-      # shellcheck disable=SC2207
-      JAVA=$(find /usr -executable -name java -print 2> /dev/null | grep "$pattern" | head -n 1 )
+      JAVA=$(find -L /usr -executable -name java -print 2> /dev/null | grep "$pattern" | sort | head -n 1 )
       if [ -x "$JAVA" ]; then
         break
       else


### PR DESCRIPTION
[KNOX-3246](https://issues.apache.org/jira/browse/KNOX-3246) - Make Java discovery deterministic on hosts with multiple JDKs

## What changes were proposed in this pull request?

Extend JAVA_VERSION_PATTERNS to include modern JDK layouts and /usr/java/default. Follow symlinks during discovery and sort candidates to ensure deterministic Java selection on hosts with multiple JDKs installed.

## How was this patch tested?

Tested on my cluster with mixed JDK versions.

```
$ cat smolnar_test.sh 

#!/usr/bin/env bash

. /$KNOX_HOME/bin/knox-functions.sh

setVerbose "$@"
checkJava
```

Prior to my changes:
```
$ ./smolnar_test.sh --verbose
Found Java at /usr/java/jdk1.11.70.15-z.0_lu/bin/java
```

My changes included:
```
$ ./smolnar_test.sh --verbose
Found Java at /usr/java/default/bin/java

$ /usr/java/default/bin/java -version
openjdk version "17.0.11" 2024-04-16
OpenJDK Runtime Environment OpenLogic-OpenJDK (build 17.0.11+9-adhoc.root.jdk17u)
OpenJDK 64-Bit Server VM OpenLogic-OpenJDK (build 17.0.11+9-adhoc.root.jdk17u, mixed mode, sharing)
```

## Integration Tests
This issue is hard to reproduce in the existing docker-based framework. It requires a multi JDK setup which usually happens at cluster upgrade time.

## UI changes
None
