### PR TITLE
KNOX-3296: Expand CI integration tests: health metrics, HSTS, and KnoxLDAP auth paths

### DIFF
--- a/.github/workflows/tests/test_health.py
+++ b/.github/workflows/tests/test_health.py
@@ -23,6 +23,11 @@ from common_utils import assert_hsts_header, gateway_base_url, knox_get
 class TestKnoxHealth(unittest.TestCase):
     """Integration checks for the gateway health REST API (ping and metrics)."""
 
+    # Top-level keys expected in /metrics JSON (aligned with Java GatewayHealthFuncTest).
+    _METRICS_TOP_LEVEL_KEYS = frozenset(
+        {"timers", "histograms", "counters", "gauges", "version", "meters"}
+    )
+
     def setUp(self):
         self.base_url = gateway_base_url()
 
@@ -60,23 +65,30 @@ class TestKnoxHealth(unittest.TestCase):
         response = knox_get(url)
         self.assertEqual(response.status_code, 200)
         payload = json.loads(response.text)
-        expected = {"timers", "histograms", "counters", "gauges", "version", "meters"}
-        self.assertTrue(expected.issubset(payload.keys()), msg=f"Missing keys: {expected - set(payload.keys())}")
+        self.assertTrue(
+            self._METRICS_TOP_LEVEL_KEYS.issubset(payload.keys()),
+            msg=f"Missing keys: {self._METRICS_TOP_LEVEL_KEYS - set(payload.keys())}",
+        )
 
     def test_health_metrics_without_pretty_returns_json(self):
-        """Metrics without pretty still returns 200 and parseable JSON."""
+        """Metrics without pretty still returns 200, parseable JSON, and the same top-level keys as pretty."""
         url = self.base_url + "gateway/health/v1/metrics"
         response = knox_get(url)
         self.assertEqual(response.status_code, 200)
         self.assertIn("application/json", response.headers.get("Content-Type", ""))
         payload = json.loads(response.text)
         self.assertIsInstance(payload, dict)
+        self.assertTrue(
+            self._METRICS_TOP_LEVEL_KEYS.issubset(payload.keys()),
+            msg=f"Missing keys: {self._METRICS_TOP_LEVEL_KEYS - set(payload.keys())}",
+        )
 
     def test_health_ping_content_type_is_plain_text(self):
-        """Ping response declares text/plain Content-Type."""
+        """Ping response declares text/plain Content-Type and body OK."""
         url = self.base_url + "gateway/health/v1/ping"
         response = knox_get(url)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text.strip(), "OK")
         content_type = response.headers.get("Content-Type", "")
         self.assertIn("text/plain", content_type)
 

--- a/.github/workflows/tests/test_health.py
+++ b/.github/workflows/tests/test_health.py
@@ -21,13 +21,13 @@ from common_utils import assert_hsts_header, gateway_base_url, knox_get
 
 
 class TestKnoxHealth(unittest.TestCase):
+    """Integration checks for the gateway health REST API (ping and metrics)."""
+
     def setUp(self):
         self.base_url = gateway_base_url()
 
     def test_health_ping_ok_and_hsts(self):
-        """
-        Basic health check to ensure Knox is up and running.
-        """
+        """Ping returns 200, body OK, and the gateway sends the expected HSTS header."""
         url = self.base_url + "gateway/health/v1/ping"
         print(f"Checking connectivity to {url}...")
         try:
@@ -43,6 +43,7 @@ class TestKnoxHealth(unittest.TestCase):
             self.fail(f"Health check failed with unexpected error: {e}")
 
     def test_health_metrics_returns_json(self):
+        """Metrics with pretty=true returns 200 and a JSON object with application/json content type."""
         url = self.base_url + "gateway/health/v1/metrics?pretty=true"
         response = knox_get(url)
         self.assertEqual(response.status_code, 200)
@@ -63,6 +64,7 @@ class TestKnoxHealth(unittest.TestCase):
         self.assertTrue(expected.issubset(payload.keys()), msg=f"Missing keys: {expected - set(payload.keys())}")
 
     def test_health_metrics_without_pretty_returns_json(self):
+        """Metrics without pretty still returns 200 and parseable JSON."""
         url = self.base_url + "gateway/health/v1/metrics"
         response = knox_get(url)
         self.assertEqual(response.status_code, 200)
@@ -71,6 +73,7 @@ class TestKnoxHealth(unittest.TestCase):
         self.assertIsInstance(payload, dict)
 
     def test_health_ping_content_type_is_plain_text(self):
+        """Ping response declares text/plain Content-Type."""
         url = self.base_url + "gateway/health/v1/ping"
         response = knox_get(url)
         self.assertEqual(response.status_code, 200)

--- a/.github/workflows/tests/test_health.py
+++ b/.github/workflows/tests/test_health.py
@@ -53,6 +53,30 @@ class TestKnoxHealth(unittest.TestCase):
         payload = json.loads(response.text)
         self.assertIsInstance(payload, dict)
 
+    def test_health_metrics_contains_core_fields(self):
+        """Metrics JSON should expose the same top-level keys as the Java GatewayHealthFuncTest."""
+        url = self.base_url + "gateway/health/v1/metrics?pretty=true"
+        response = knox_get(url)
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.text)
+        expected = {"timers", "histograms", "counters", "gauges", "version", "meters"}
+        self.assertTrue(expected.issubset(payload.keys()), msg=f"Missing keys: {expected - set(payload.keys())}")
+
+    def test_health_metrics_without_pretty_returns_json(self):
+        url = self.base_url + "gateway/health/v1/metrics"
+        response = knox_get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application/json", response.headers.get("Content-Type", ""))
+        payload = json.loads(response.text)
+        self.assertIsInstance(payload, dict)
+
+    def test_health_ping_content_type_is_plain_text(self):
+        url = self.base_url + "gateway/health/v1/ping"
+        response = knox_get(url)
+        self.assertEqual(response.status_code, 200)
+        content_type = response.headers.get("Content-Type", "")
+        self.assertIn("text/plain", content_type)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/.github/workflows/tests/test_knoxauth_preauth_and_paths.py
+++ b/.github/workflows/tests/test_knoxauth_preauth_and_paths.py
@@ -16,7 +16,7 @@ import unittest
 
 from requests.auth import HTTPBasicAuth
 
-from common_utils import gateway_base_url, knox_get, knox_post
+from common_utils import collect_actor_group_values, gateway_base_url, knox_get, knox_post
 
 
 class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
@@ -46,6 +46,25 @@ class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
         actor_id_header = "x-knox-actor-username"
         self.assertIn(actor_id_header, response.headers)
         self.assertEqual(response.headers[actor_id_header], "guest")
+
+    def test_preauth_get_with_guest_credentials(self):
+        response = knox_get(
+            self.preauth_url,
+            auth=HTTPBasicAuth("guest", "guest-password"),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("x-knox-actor-username"), "guest")
+
+    def test_preauth_get_with_admin_includes_mapped_groups(self):
+        response = knox_get(
+            self.preauth_url,
+            auth=HTTPBasicAuth("admin", "admin-password"),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("x-knox-actor-username"), "admin")
+        groups = collect_actor_group_values(response, prefix="x-knox-actor-groups")
+        for name in ("longGroupName1", "longGroupName2"):
+            self.assertIn(name, groups)
 
     def test_extauthz_additional_path_not_ignored_in_knoxldap(self):
         response = knox_get(

--- a/.github/workflows/tests/test_knoxauth_preauth_and_paths.py
+++ b/.github/workflows/tests/test_knoxauth_preauth_and_paths.py
@@ -20,16 +20,20 @@ from common_utils import collect_actor_group_values, gateway_base_url, knox_get,
 
 
 class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
+    """KnoxLDAP auth service: preauth behavior and extauthz path handling."""
+
     def setUp(self):
         self.base_url = gateway_base_url()
         self.preauth_url = self.base_url + "gateway/knoxldap/auth/api/v1/pre"
         self.extauthz_url = self.base_url + "gateway/knoxldap/auth/api/v1/extauthz"
 
     def test_preauth_requires_auth(self):
+        """Preauth without credentials must return 401."""
         response = knox_get(self.preauth_url)
         self.assertEqual(response.status_code, 401)
 
     def test_preauth_bad_credentials_unauthorized(self):
+        """Invalid Basic auth must return 401."""
         response = knox_get(
             self.preauth_url,
             auth=HTTPBasicAuth("baduser", "badpass"),
@@ -37,6 +41,7 @@ class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_preauth_post_supported(self):
+        """POST preauth with guest credentials returns 200 and x-knox-actor-username."""
         response = knox_post(
             self.preauth_url,
             auth=HTTPBasicAuth("guest", "guest-password"),
@@ -48,6 +53,7 @@ class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
         self.assertEqual(response.headers[actor_id_header], "guest")
 
     def test_preauth_get_with_guest_credentials(self):
+        """GET preauth with guest returns 200 and actor username guest."""
         response = knox_get(
             self.preauth_url,
             auth=HTTPBasicAuth("guest", "guest-password"),
@@ -56,6 +62,7 @@ class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
         self.assertEqual(response.headers.get("x-knox-actor-username"), "guest")
 
     def test_preauth_get_with_admin_includes_mapped_groups(self):
+        """GET preauth with admin returns mapped LDAP groups in x-knox-actor-groups* headers."""
         response = knox_get(
             self.preauth_url,
             auth=HTTPBasicAuth("admin", "admin-password"),
@@ -67,6 +74,7 @@ class TestKnoxAuthServicePreAuthAndPaths(unittest.TestCase):
             self.assertIn(name, groups)
 
     def test_extauthz_additional_path_not_ignored_in_knoxldap(self):
+        """Unknown path under extauthz returns 404; extra segments are not ignored as success."""
         response = knox_get(
             self.extauthz_url + "/does-not-exist",
             auth=HTTPBasicAuth("guest", "guest-password"),


### PR DESCRIPTION

What changes were proposed in this pull request?
This pull request extends [.github/workflows/tests](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/.github/workflows/tests) and the Docker Compose–based CI path so Knox is exercised with additional automated integration coverage:

test_health.py: Asserts /gateway/health/v1/metrics returns JSON (with and without pretty), checks top-level metric keys align with the Java health test expectations, and verifies /gateway/health/v1/ping responds with text/plain in addition to the existing ping and HSTS checks.
test_knoxauth_preauth_and_paths.py: Covers KnoxLDAP preauth (401 without or with bad credentials; 200 for POST/GET with valid credentials; x-knox-actor-username and group headers for admin) and verifies extauthz does not swallow unknown path segments (404 for a non-existent subpath).

How was this patch tested?
Built the workflow Knox image and ran the compose stack, then executed the integration test container (same flow as .github/workflows/tests/README.md).

Command (from the repo root, paths as in the README):

docker compose -f ./.github/workflows/compose/docker-compose.yml up --build --exit-code-from tests tests

Confirmed pytest collects and passes the new cases together with existing workflow tests (health ping, LDAP auth service, configs, remote auth, etc.).

Integration Tests
Yes. New/updated tests live under .github/workflows/tests: