### PR TITLE
KNOX-3297: Docker entrypoint script has issues that prevents this image being run as docker container and as a pod in k8s

### DIFF
--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:17-jdk AS build
+FROM dhi.io/eclipse-temurin:17-jdk-debian13-dev AS build
 LABEL maintainer="Apache Knox <dev@knox.apache.org>"
 
 ARG TARGETARCH
@@ -75,5 +75,4 @@ EXPOSE ${EXPOSE_PORT}
 
 # Switch off of the root user
 USER knox
-WORKDIR /home/knox/knox
 ENTRYPOINT ["./entrypoint.sh"]

--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM dhi.io/eclipse-temurin:17-jdk-debian13-dev AS build
+FROM eclipse-temurin:17-jdk AS build
 LABEL maintainer="Apache Knox <dev@knox.apache.org>"
 
 ARG TARGETARCH
@@ -75,4 +75,5 @@ EXPOSE ${EXPOSE_PORT}
 
 # Switch off of the root user
 USER knox
+WORKDIR /home/knox/knox
 ENTRYPOINT ["./entrypoint.sh"]

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -187,45 +187,40 @@ then
   importMultipleCerts "$CUSTOM_CERT"
 fi
 
-# Add Amazon Root CA 1
-keytool -importcert \
-  -keystore "${KEYSTORE_DIR}"/truststore.jks \
-  -alias amazon-ca-1 \
-  -file /home/knox/cacrts/AmazonRootCA1.cer \
-  -storepass "${ALIAS_PASSPHRASE}" \
-  -noprompt || true
+# This default was set to emulate the existing behaviour
+# Customer should be able to override this by specifying this via Docker environment settings
+if [[ ! -n ${TRUSTSTORE_IMPORTS} ]]
+then
+	TRUSTSTORE_IMPORTS="
+	 amazon-ca-1:/home/knox/cacrts/AmazonRootCA1.cer
+     amazon-ca-2:/home/knox/cacrts/AmazonRootCA2.cer
+     amazon-ca-3:/home/knox/cacrts/AmazonRootCA3.cer
+	 amazon-ca-4:/home/knox/cacrts/AmazonRootCA4.cer
+     letsencrypt-stg-root:/home/knox/cacrts/letsencrypt-stg-root-x1.pem"
+fi
 
-# Add Amazon Root CA 2
-keytool -importcert \
-  -keystore "${KEYSTORE_DIR}"/truststore.jks \
-  -alias amazon-ca-2 \
-  -file /home/knox/cacrts/AmazonRootCA2.cer \
-  -storepass "${ALIAS_PASSPHRASE}" \
-  -noprompt || true
-
-# Add Amazon Root CA 3
-keytool -importcert \
-  -keystore "${KEYSTORE_DIR}"/truststore.jks \
-  -alias amazon-ca-3 \
-  -file /home/knox/cacrts/AmazonRootCA3.cer \
-  -storepass "${ALIAS_PASSPHRASE}" \
-  -noprompt || true
-
-# Add Amazon Root CA 4
-keytool -importcert \
-  -keystore "${KEYSTORE_DIR}"/truststore.jks \
-  -alias amazon-ca-4 \
-  -file /home/knox/cacrts/AmazonRootCA4.cer \
-  -storepass "${ALIAS_PASSPHRASE}" \
-  -noprompt || true
-
-# Add letsencrypt staging root CA
-keytool -importcert \
-  -keystore "${KEYSTORE_DIR}"/truststore.jks \
-  -alias letsencrypt-stg-root \
-  -file /home/knox/cacrts/letsencrypt-stg-root-x1.pem \
-  -storepass "${ALIAS_PASSPHRASE}" \
-  -noprompt || true
+if [[ -n ${TRUSTSTORE_IMPORTS} ]]
+then
+    for certinfo in ${TRUSTSTORE_IMPORTS}
+    do
+        aliasId="`echo ${certinfo} | awk -F: '{ print $1 }'`"
+        certPath="`echo ${certinfo} | awk -F: '{ print $2 }'`"
+        if [[ -n "${aliasId}" ]] && [[ -n "${certPath}" ]] && [[ -f "${certPath}" ]]
+        then
+            echo "INFO: Importing certificate [${certPath}] into truststore"
+            keytool -importcert \
+                -keystore "${KEYSTORE_DIR}"/truststore.jks \
+                -alias "${aliasId}" \
+                -file "${certPath}" \
+                -storepass "${ALIAS_PASSPHRASE}" \
+                -noprompt || true
+        else
+            echo "ERROR: certificate [${certinfo}] not found. Not importing into truststore"
+        fi
+    done
+else
+    echo "INFO: NO truststore imports specified in [env:TRUSTSTORE_IMPORTS]. Using cacerts as it is!"
+fi
 
 export KNOX_GATEWAY_DBG_OPTS="${KNOX_GATEWAY_DBG_OPTS} -Djavax.net.ssl.trustStore=${KEYSTORE_DIR}/truststore.jks -Djavax.net.ssl.trustStorePassword=${ALIAS_PASSPHRASE}"
 

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -86,7 +86,7 @@ fi
 
 if [[ -n ${MASTER_SECRET} ]]
 then
-  echo "Using provided knox master secret [env:MASTER_SECRET}]"
+  echo "Using provided knox master secret [env:MASTER_SECRET]"
 else
   echo "Using default knox master secret"
   MASTER_SECRET="knox"
@@ -190,7 +190,7 @@ fi
 
 # This default was set to emulate the existing behaviour
 # Customer should be able to override this by specifying this via Docker environment settings
-if [[ ! -n ${TRUSTSTORE_IMPORTS} ]]
+if [[ -z ${TRUSTSTORE_IMPORTS} ]]
 then
 	TRUSTSTORE_IMPORTS="
 	 amazon-ca-1:/home/knox/cacrts/AmazonRootCA1.cer
@@ -200,28 +200,23 @@ then
      letsencrypt-stg-root:/home/knox/cacrts/letsencrypt-stg-root-x1.pem"
 fi
 
-if [[ -n ${TRUSTSTORE_IMPORTS} ]]
-then
-    for certinfo in ${TRUSTSTORE_IMPORTS}
-    do
-        aliasId="`echo ${certinfo} | awk -F: '{ print $1 }'`"
-        certPath="`echo ${certinfo} | awk -F: '{ print $2 }'`"
-        if [[ -n "${aliasId}" ]] && [[ -n "${certPath}" ]] && [[ -f "${certPath}" ]]
-        then
-            echo "INFO: Importing certificate [${certPath}] into truststore"
-            keytool -importcert \
-                -keystore "${KEYSTORE_DIR}"/truststore.jks \
-                -alias "${aliasId}" \
-                -file "${certPath}" \
-                -storepass "${ALIAS_PASSPHRASE}" \
-                -noprompt || true
-        else
-            echo "ERROR: certificate [${certinfo}] not found. Not importing into truststore"
-        fi
-    done
-else
-    echo "INFO: NO truststore imports specified in [env:TRUSTSTORE_IMPORTS]. Using cacerts as it is!"
-fi
+for certinfo in ${TRUSTSTORE_IMPORTS}
+do
+    aliasId=$(echo "${certinfo}" | awk -F: '{ print $1 }')
+    certPath=$(echo "${certinfo}" | awk -F: '{ print $2 }')
+    if [[ -n "${aliasId}" ]] && [[ -n "${certPath}" ]] && [[ -f "${certPath}" ]]
+    then
+        echo "INFO: Importing certificate [${certPath}] into truststore"
+        keytool -importcert \
+            -keystore "${KEYSTORE_DIR}"/truststore.jks \
+            -alias "${aliasId}" \
+            -file "${certPath}" \
+            -storepass "${ALIAS_PASSPHRASE}" \
+            -noprompt || true
+    else
+        echo "ERROR: certificate [${certinfo}] not found. Not importing into truststore"
+    fi
+done
 
 export KNOX_GATEWAY_DBG_OPTS="${KNOX_GATEWAY_DBG_OPTS} -Djavax.net.ssl.trustStore=${KEYSTORE_DIR}/truststore.jks -Djavax.net.ssl.trustStorePassword=${ALIAS_PASSPHRASE}"
 

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -86,11 +86,12 @@ fi
 
 if [[ -n ${MASTER_SECRET} ]]
 then
-  echo "Using provided knox master secret"
-  /home/knox/knox/bin/knoxcli.sh create-master --master "${MASTER_SECRET}"
+  echo "Using provided knox master secret [env:MASTER_SECRET}]"
 else
-  /home/knox/knox/bin/knoxcli.sh create-master --master knox
+  echo "Using default knox master secret"
+  MASTER_SECRET="knox"
 fi
+/home/knox/knox/bin/knoxcli.sh create-master --master "${MASTER_SECRET}"
 
 if [[ -n ${LDAP_PASSWORD_FILE} ]]
 then
@@ -125,7 +126,7 @@ then
   ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}" 2>/dev/null)
 else
    # If keystore password is not provided use master secret as alias passphrase
-   ALIAS_PASSPHRASE="${MASTER_SECRET}1234!"
+   ALIAS_PASSPHRASE="${MASTER_SECRET}"
 fi
 
 if [[ -n ${KNOX_CERT} ]] && [[ -f ${KNOX_CERT} ]]

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -50,7 +50,7 @@ importMultipleCerts() {
     ALIAS="${FILE%.*}-$N"
     /bin/cat "$FILE" |
       /usr/bin/awk "n==$N { print }; /END CERTIFICATE/ { n++ }" |
-      /usr/bin/keytool -import \
+      keytool -import \
               -trustcacerts \
               -alias "$ALIAS" \
               -keystore "${KEYSTORE_DIR}"/truststore.jks \
@@ -125,7 +125,7 @@ then
   ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}" 2>/dev/null)
 else
    # If keystore password is not provided use master secret as alias passphrase
-   ALIAS_PASSPHRASE=${MASTER_SECRET}
+   ALIAS_PASSPHRASE="${MASTER_SECRET}1234!"
 fi
 
 if [[ -n ${KNOX_CERT} ]] && [[ -f ${KNOX_CERT} ]]
@@ -161,7 +161,7 @@ then
     -name keystore
 
   # Create signing JKS
-  /usr/bin/keytool -importkeystore \
+  keytool -importkeystore \
     -destkeystore "${KEYSTORE_DIR}"/keystore.jks \
     -deststorepass "${ALIAS_PASSPHRASE}" \
     -srckeystore /tmp/keystore.p12 \
@@ -188,7 +188,7 @@ then
 fi
 
 # Add Amazon Root CA 1
-/usr/bin/keytool -importcert \
+keytool -importcert \
   -keystore "${KEYSTORE_DIR}"/truststore.jks \
   -alias amazon-ca-1 \
   -file /home/knox/cacrts/AmazonRootCA1.cer \
@@ -196,7 +196,7 @@ fi
   -noprompt || true
 
 # Add Amazon Root CA 2
-/usr/bin/keytool -importcert \
+keytool -importcert \
   -keystore "${KEYSTORE_DIR}"/truststore.jks \
   -alias amazon-ca-2 \
   -file /home/knox/cacrts/AmazonRootCA2.cer \
@@ -204,7 +204,7 @@ fi
   -noprompt || true
 
 # Add Amazon Root CA 3
-/usr/bin/keytool -importcert \
+keytool -importcert \
   -keystore "${KEYSTORE_DIR}"/truststore.jks \
   -alias amazon-ca-3 \
   -file /home/knox/cacrts/AmazonRootCA3.cer \
@@ -212,7 +212,7 @@ fi
   -noprompt || true
 
 # Add Amazon Root CA 4
-/usr/bin/keytool -importcert \
+keytool -importcert \
   -keystore "${KEYSTORE_DIR}"/truststore.jks \
   -alias amazon-ca-4 \
   -file /home/knox/cacrts/AmazonRootCA4.cer \
@@ -220,7 +220,7 @@ fi
   -noprompt || true
 
 # Add letsencrypt staging root CA
-/usr/bin/keytool -importcert \
+keytool -importcert \
   -keystore "${KEYSTORE_DIR}"/truststore.jks \
   -alias letsencrypt-stg-root \
   -file /home/knox/cacrts/letsencrypt-stg-root-x1.pem \


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

KNOX-3297: Docker entrypoint script has issues that prevents this image being run as docker container and as a pod in k8s

## What changes were proposed in this pull request?

1. Modified to use keytool from the PATH instead of hardcoding it.
2. Fixed a scripting error related to default init of MASTER_S... environment variable.
3. Added additional validation for file existance before additing it to truststore. Also, introduced a custom env variable TRUSTSTORE_IMPORTS to allow customers to add more number of certificates into truststore.

## How was this patch tested?

1. Validated the changes as standalone docker [run]
2. Validated by running the docker image as k8s pod

(Please explain how this patch was tested. For instance: running automated unit/integration tests, manual tests. Please write down your test steps as detailed as possible)

## Integration Tests
no new integration tests.

## UI changes
None.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
