### PR TITLE
KNOX-3298: Change ApiClientFactory password check to isNotBlank

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ApiClientFactory.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ApiClientFactory.java
@@ -34,7 +34,7 @@ public class ApiClientFactory {
                                                   final AliasService aliasService, final KeyStore truststore) {
         try {
             final char[] trustStorePassword = aliasService.getPasswordFromAliasForGateway(TRUSTSTORE_PASSWORD_ALIAS);
-            if (trustStorePassword != null) {
+            if (trustStorePassword != null && trustStorePassword.length > 0) {
                 System.setProperty(TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY, new String(trustStorePassword));
             }
             return new DiscoveryApiClient(gatewayConfig, discoveryConfig, aliasService, truststore);

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ApiClientFactoryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ApiClientFactoryTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.security.AliasServiceException;
@@ -46,16 +47,20 @@ public class ApiClientFactoryTest {
 
     @Test
     public void testSystemPropertySetWhenAliasExists() throws AliasServiceException {
-        testGetApiClient(true);
+        testGetApiClient(true, "changeit");
     }
 
     @Test
     public void testSystemPropertyNotSetWhenAliasNotExists() throws AliasServiceException {
-        testGetApiClient(false);
+        testGetApiClient(false, null);
     }
 
-    private void testGetApiClient(final boolean shouldSetSystemProperty) throws AliasServiceException {
-        final String trustStorePassword = "changeit";
+    @Test
+    public void testSystemPropertySetWhenAliasEmpty() throws AliasServiceException {
+        testGetApiClient(true, "");
+    }
+
+    private void testGetApiClient(final boolean shouldSetSystemProperty, String trustStorePassword) throws AliasServiceException {
         final RecordingProperties testProps = new RecordingProperties(originalProps);
         System.setProperties(testProps);
 
@@ -82,7 +87,7 @@ public class ApiClientFactoryTest {
         EasyMock.replay(aliasService, gatewayConfig, serviceDiscoveryConfig, trustStore);
         ApiClientFactory.getApiClient(gatewayConfig, serviceDiscoveryConfig, aliasService, trustStore);
 
-        if (shouldSetSystemProperty) {
+        if (shouldSetSystemProperty && StringUtils.isNotBlank(trustStorePassword)) {
             Assert.assertEquals(ApiClientFactory.TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY, testProps.lastSetKey);
             Assert.assertEquals(trustStorePassword, testProps.lastSetValue);
             Assert.assertEquals(ApiClientFactory.TRUSTSTORE_PASSWORD_SYSTEM_PROPERTY, testProps.lastRemovedKey);


### PR DESCRIPTION
[KNOX-3298](https://issues.apache.org/jira/browse/KNOX-3298) - Change ApiClientFactory password check to isNotBlank

## What changes were proposed in this pull request?

- Change ApiClientFactory isNotNull password check to isNotBlank check

## How was this patch tested?

Unit tests

## Integration Tests
N/A

## UI changes
N/A