### PR TITLE
KNOX-3299: adding inline documentation for usage of env. var: TRUSTSTORE_IMPORTS

### DIFF
--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -30,6 +30,11 @@
 # - DATABASE_CONNECTION_PASSWORD - (optional) gateway database password
 # - DATABASE_CONNECTION_TRUSTSTORE_PASSWORD - (optional) gateway database ssl truststore password
 # - CUSTOM_CERT - (optional) the location of a file containing the custom certs
+# - TRUSTSTORE_IMPORTS - (optional) - a string containing  one or more of the following: {aliasIdForImport:PEMEncodedTrustCertificateFileLocation} separated by space(s).
+#   Example:
+#   TRUSTSTORE_IMPORTS="myRootCA:/mountedpath/enterprise_root_cert.pem myBizPartnerCA:/mountedpath/mybiz_partner_cert.pem"
+#   Description:
+#   This will import the specified certificates into the truststore JKS with the provided alias name(s) during the container startup process.
 
 
 set -e


### PR DESCRIPTION
KNOX-3299: adding inline documentation for usage of env. var: TRUSTSTORE_IMPORTS

## What changes were proposed in this pull request?

added few inline documentation on how to define and use the environment variable:  TRUSTSTORE_IMPORTS

## How was this patch tested?

shellcheck was done - no issues found.

## Integration Tests

No changes to Integration Test suites

## UI changes

No UI Changes

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
