### PR TITLE
KNOX-3302: Falling back to gateway-level credential store while looking up LDAP system password

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapContextFactory.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapContextFactory.java
@@ -24,6 +24,7 @@ import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.ldap.LdapContext;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.GatewayMessages;
 import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
@@ -43,26 +44,25 @@ import org.apache.shiro.realm.ldap.JndiLdapContextFactory;
  */
 public class KnoxLdapContextFactory extends JndiLdapContextFactory {
 
-    private static GatewayMessages LOG = MessagesFactory.get( GatewayMessages.class );
-
+    private static GatewayMessages LOG = MessagesFactory.get(GatewayMessages.class);
     private String systemAuthenticationMechanism = "simple";
     private String clusterName = "";
 
     public KnoxLdapContextFactory() {
-      setAuthenticationMechanism("simple");
+        setAuthenticationMechanism("simple");
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     protected LdapContext createLdapContext(Hashtable env) throws NamingException {
-        if(getSystemUsername() != null && getSystemUsername().equals(env.get(Context.SECURITY_PRINCIPAL))) {
+        if (getSystemUsername() != null && getSystemUsername().equals(env.get(Context.SECURITY_PRINCIPAL))) {
             env.put(Context.SECURITY_AUTHENTICATION, getSystemAuthenticationMechanism());
         }
         return super.createLdapContext(env);
     }
 
     public String getSystemAuthenticationMechanism() {
-        return systemAuthenticationMechanism != null? systemAuthenticationMechanism: getAuthenticationMechanism();
+        return systemAuthenticationMechanism != null ? systemAuthenticationMechanism : getAuthenticationMechanism();
     }
 
     public void setSystemAuthenticationMechanism(String systemAuthenticationMechanism) {
@@ -70,55 +70,49 @@ public class KnoxLdapContextFactory extends JndiLdapContextFactory {
     }
 
     @Override
-    public void setSystemPassword(String systemPass) {
-      if ( systemPass == null ) {
-        return;
-      }
+    public void setSystemPassword(final String systemPass) {
+        if (StringUtils.isBlank(systemPass)) {
+            return;
+        }
 
-      systemPass = systemPass.trim();
-      if (systemPass.isEmpty()) {
-        return;
-      }
+        final AliasService aliasService = getAliasService();
 
-      if (!systemPass.startsWith("S{ALIAS=")) {
-        super.setSystemPassword( systemPass );
-        return;
-      }
-
-      systemPass= systemPass.substring( "S{ALIAS=".length(), systemPass.length() - 1 );
-      String aliasName = systemPass;
-
-      GatewayServices services = GatewayServer.getGatewayServices();
-      AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
-
-      String clusterName = getClusterName();
-      //System.err.println("FACTORY systempass 30: " + systemPass);
-      //System.err.println("FACTORY clustername 40: " + clusterName);
-      //System.err.println("FACTORY SystemProperty GatewayHome 50: " + System.getProperty(GatewayConfig.GATEWAY_HOME_VAR));
-      char[] password = null;
-      try {
-        password = aliasService.getPasswordFromAliasForCluster(clusterName, systemPass);
-      } catch (AliasServiceException e) {
-        LOG.unableToGetPassword(e);
-      }
-      //System.err.println("FACTORY password: " + ((password == null) ? "NULL" : new String(password)));
-      if ( password != null ) {
-        //System.err.println("FACTORY SUCCESS 20 system password :" + new String(password));
-        super.setSystemPassword( new String(password) );
-      } else {
-        //System.err.println("FACTORY FORCING system password to blank");
-        super.setSystemPassword("" );
-        LOG.aliasValueNotFound(clusterName, aliasName);
-      }
+        if (!aliasService.isAlias(systemPass)) {
+            super.setSystemPassword(systemPass);
+        } else {
+            final String systemPasswordAlias = aliasService.extractAlias(systemPass);
+            char[] systemPassword = null;
+            try {
+                // try to locate system password in the topology-level credential store first
+                systemPassword = aliasService.getPasswordFromAliasForCluster(clusterName, systemPasswordAlias);
+                if (systemPassword == null) {
+                    // fall back to gateway-level credential store
+                    systemPassword = aliasService.getPasswordFromAliasForGateway(systemPasswordAlias);
+                }
+            } catch (AliasServiceException e) {
+                LOG.unableToGetPassword(e);
+            }
+            if (systemPassword != null) {
+                super.setSystemPassword(new String(systemPassword));
+            } else {
+                super.setSystemPassword(""); //needs to be set to blank
+                LOG.aliasValueNotFound(clusterName, systemPasswordAlias);
+            }
+        }
     }
 
     public String getClusterName() {
-      return clusterName;
+        return clusterName;
     }
 
     public void setClusterName(String clusterName) {
-      if (clusterName != null) {
-        this.clusterName = clusterName.trim();
-      }
+        if (clusterName != null) {
+            this.clusterName = clusterName.trim();
+        }
+    }
+
+    protected AliasService getAliasService() {
+        final GatewayServices services = GatewayServer.getGatewayServices();
+        return services.getService(ServiceType.ALIAS_SERVICE);
     }
 }

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapContextFactoryTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapContextFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.shirorealm;
+
+import org.apache.knox.gateway.services.security.AliasService;
+import org.apache.knox.gateway.services.security.AliasServiceException;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KnoxLdapContextFactoryTest {
+
+    private AliasService aliasService;
+
+    @Before
+    public void setup() {
+        aliasService = EasyMock.createNiceMock(AliasService.class);
+    }
+
+    /**
+     * Test-specific subclass to avoid using GatewayServer static method
+     */
+    private class TestKnoxLdapContextFactory extends KnoxLdapContextFactory {
+        @Override
+        protected AliasService getAliasService() {
+            return aliasService;
+        }
+    }
+
+    @Test
+    public void testSetSystemPasswordBlank() {
+        final KnoxLdapContextFactory factory = new TestKnoxLdapContextFactory();
+        factory.setSystemPassword("");
+        assertNull(factory.getSystemPassword());
+
+        factory.setSystemPassword(null);
+        assertNull(factory.getSystemPassword());
+    }
+
+    @Test
+    public void testSetSystemPasswordIsNotAlias() {
+        final KnoxLdapContextFactory factory = new TestKnoxLdapContextFactory();
+        final String password = "password";
+        factory.setSystemPassword(password);
+        assertEquals(password, factory.getSystemPassword());
+    }
+
+    @Test
+    public void testSetSystemPasswordIsAliasFoundInClusterCredentialStore() throws Exception {
+        testAliasFoundInCredentialStore(PasswordLocation.CLUSTER);
+    }
+
+    @Test
+    public void testSetSystemPasswordIsAliasFoundInGatewayCredentialStore() throws Exception {
+        testAliasFoundInCredentialStore(PasswordLocation.GATEWAY);
+    }
+
+    @Test
+    public void testSetSystemPasswordNotFound() throws Exception {
+        testAliasFoundInCredentialStore(PasswordLocation.NOWHERE);
+    }
+
+    private enum PasswordLocation {
+        CLUSTER, GATEWAY, NOWHERE;
+    }
+
+    private void testAliasFoundInCredentialStore(final PasswordLocation location) throws AliasServiceException {
+        final String clusterName = "test-cluster";
+        final KnoxLdapContextFactory factory = new TestKnoxLdapContextFactory();
+        factory.setClusterName(clusterName);
+        final String systemPasswordAlias = "systemPasswordAlias";
+        final String systemPassword = AliasService.ALIAS_PREFIX + systemPasswordAlias + "}";
+        final char[] resolvedPassword = "resolved-password".toCharArray();
+
+        EasyMock.expect(aliasService.isAlias(systemPassword)).andReturn(true).anyTimes();
+        EasyMock.expect(aliasService.extractAlias(systemPassword)).andReturn(systemPasswordAlias).anyTimes();
+        EasyMock.expect(aliasService.getPasswordFromAliasForCluster(clusterName, systemPasswordAlias)).andReturn(location == PasswordLocation.CLUSTER ? resolvedPassword : null);
+        if (location != PasswordLocation.CLUSTER) {
+            EasyMock.expect(aliasService.getPasswordFromAliasForGateway(systemPasswordAlias)).andReturn(location == PasswordLocation.GATEWAY ? resolvedPassword : null);
+        }
+        EasyMock.replay(aliasService);
+
+        factory.setSystemPassword(systemPassword);
+        if (location == PasswordLocation.NOWHERE) {
+            assertEquals("", factory.getSystemPassword());
+        } else {
+            assertEquals(new String(resolvedPassword), factory.getSystemPassword());
+        }
+
+        EasyMock.verify(aliasService);
+    }
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/AliasService.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/AliasService.java
@@ -26,6 +26,15 @@ import org.apache.knox.gateway.services.Service;
 
 public interface AliasService extends Service {
   String NO_CLUSTER_NAME = "__gateway";
+  String ALIAS_PREFIX = "S{ALIAS=";
+
+  default boolean isAlias(final String aliasToCheck) {
+    return aliasToCheck.startsWith(ALIAS_PREFIX);
+  }
+
+  default String extractAlias(final String aliasToCheck) {
+    return aliasToCheck.substring(ALIAS_PREFIX.length(), aliasToCheck.length() - 1);
+  }
 
   List<String> getAliasesForCluster(String clusterName)
       throws AliasServiceException;


### PR DESCRIPTION
[KNOX-3302](https://issues.apache.org/jira/browse/KNOX-3302) - Falling back to gateway-level credential store while looking up LDAP system password

## What changes were proposed in this pull request?

  This pull request improves the LDAP system password alias resolution in the Shiro realm (KnoxLdapContextFactory). Key changes include:
   * Fallback Alias Resolution: Updated `KnoxLdapContextFactory` to check the gateway-level credential store if a system password alias is not found in the cluster-level (topology) credential store.
   * Centralized Alias Logic: Added isAlias and extractAlias default methods to the `AliasService` interface to standardize how alias strings (e.g., `S{ALIAS=...`}) are identified and processed across the codebase.
   * Improved Testability: Refactored KnoxLdapContextFactory to allow for better unit testing by extracting the AliasService lookup into a protected method.
   * Code Cleanup: Replaced manual string parsing with the new AliasService methods and added validation for blank passwords using StringUtils.

 ## How was this patch tested?
The changes were verified by adding a new unit test class: `org.apache.knox.gateway.shirorealm.KnoxLdapContextFactoryTest`.

  The following scenarios were tested:
   1. Blank Password: Verified that null or empty strings do not trigger alias resolution.
   2. Literal Password: Verified that passwords not matching the alias pattern are used as-is.
   3. Cluster-level Alias: Verified successful resolution when the alias exists in the cluster-specific credential store.
   4. Gateway-level Fallback: Verified that the factory correctly falls back to the gateway credential store when the alias is missing from the cluster store.
   5. Missing Alias: Verified that the system password is set to an empty string and a warning is logged when an alias cannot be resolved in either store.

 ## Integration Tests
  No new integration tests were added as the logic was fully covered by the new unit tests in KnoxLdapContextFactoryTest. Existing Shiro-related integration tests should be monitored for regressions.

##  UI changes
  N/A

