### PR TITLE
KNOX-3303: Support configurable 'sub' claim reconciliation and client_id claim in Client Credentials flow

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -69,6 +69,7 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
 import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.knox.gateway.security.TokenIdPrincipal;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ServiceType;
@@ -405,15 +406,24 @@ public abstract class AbstractJWTFilter implements Filter {
       // token id until it is created, the username is always the same
       // in the record. Using the token id makes it a unique username for
       // audit and the like.
-      final String username = metadata.isClientId() ? tokenId : metadata.getUserName();
-
-      return createSubjectFromTokenData(username, null);
+      // However, in case of service-to-service communications, it might
+      // be useful to return the actual userName during the token exchange
+      // step in the client credentials flow (this is controlled by the thirdPartyApp)
+      // flag that was (or wasn't) submitted while the client credentials were created
+      final String userName = (metadata.isClientId() && metadata.isThirdPartyApp()) ? tokenId : metadata.getUserName();
+      final String clientId = (metadata.isClientId() && !metadata.isThirdPartyApp()) ? tokenId : null;
+      return createSubjectFromTokenData(userName, null, clientId);
     }
     return null;
   }
 
   @SuppressWarnings("rawtypes")
   protected Subject createSubjectFromTokenData(final String principal, final String expectedPrincipalClaimValue) {
+    return createSubjectFromTokenData(principal, expectedPrincipalClaimValue, null);
+  }
+
+  @SuppressWarnings("rawtypes")
+  protected Subject createSubjectFromTokenData(final String principal, final String expectedPrincipalClaimValue, final String tokenId) {
     String claimValue =
               (expectedPrincipalClaimValue != null) ? expectedPrincipalClaimValue.toLowerCase(Locale.ROOT) : null;
 
@@ -421,6 +431,9 @@ public abstract class AbstractJWTFilter implements Filter {
     Set<Principal> principals = new HashSet<>();
     Principal p = new PrimaryPrincipal(claimValue != null ? claimValue : principal);
     principals.add(p);
+    if (tokenId != null) {
+      principals.add(new TokenIdPrincipal(tokenId));
+    }
 
     // The newly constructed Sets check whether this Subject has been set read-only
     // before permitting subsequent modifications. The newly created Sets also prevent

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Date;
 import java.util.Properties;
-
+import javax.security.auth.Subject;
 import javax.servlet.FilterConfig;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -32,6 +32,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.knox.gateway.provider.federation.jwt.filter.AbstractJWTFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.JWTFederationFilter;
 import org.apache.knox.gateway.provider.federation.jwt.filter.SignatureVerificationCache;
+import org.apache.knox.gateway.security.TokenIdPrincipal;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.TokenStateService;
 import org.easymock.EasyMock;
@@ -87,6 +88,41 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
     handler.doFilter(request, response, chain);
 
     EasyMock.verify(response);
+  }
+
+  @Test
+  public void testSubjectCreationWithThirdPartyAppReconciliation() throws Exception {
+    // Scenario 1: thirdPartyApp = true (default) -> principal should be tokenId
+    testSubjectCreation(true);
+
+    // Scenario 2: thirdPartyApp = false -> principal should be userName
+    testSubjectCreation(false);
+  }
+
+  private void testSubjectCreation(boolean thirdPartyApp) throws Exception {
+    final String tokenId = "test-token-id";
+    final String userName = "test-user";
+
+    final TokenMetadata metadataTrue = EasyMock.createNiceMock(TokenMetadata.class);
+    EasyMock.expect(metadataTrue.isClientId()).andReturn(true).anyTimes();
+    EasyMock.expect(metadataTrue.isThirdPartyApp()).andReturn(thirdPartyApp).anyTimes();
+    EasyMock.expect(metadataTrue.getUserName()).andReturn(userName).anyTimes();
+
+    final TokenStateService tss = EasyMock.createNiceMock(TokenStateService.class);
+    EasyMock.expect(tss.getTokenMetadata(tokenId)).andReturn(metadataTrue).anyTimes();
+    EasyMock.replay(metadataTrue, tss);
+
+    final TestJWTFederationFilter filter = new TestJWTFederationFilter();
+    Properties props = getProperties();
+    props.put(TokenStateService.CONFIG_SERVER_MANAGED, "true");
+    filter.init(new TestFilterConfig(props, tss));
+
+    final Subject subject = filter.createSubjectFromTokenIdentifier(tokenId);
+    assertEquals(thirdPartyApp ? tokenId : userName, subject.getPrincipals().iterator().next().getName());
+    if (!thirdPartyApp) {
+      assertEquals(1, subject.getPrincipals(TokenIdPrincipal.class).size());
+      assertEquals(tokenId, subject.getPrincipals(TokenIdPrincipal.class).iterator().next().getName());
+    }
   }
 
   @Test

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
@@ -53,7 +53,7 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
     public void init() throws AliasServiceException, ServiceLifecycleException, KeyLengthException, ServletException {
         super.init();
         final String configuredThirdPartyApp = context.getInitParameter(THIRD_PARTY_APP);
-        thirdPartyApp = configuredThirdPartyApp == null || Boolean.parseBoolean(configuredThirdPartyApp);
+        thirdPartyApp = configuredThirdPartyApp == null ? true : Boolean.parseBoolean(configuredThirdPartyApp);
     }
 
     @Override

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/ClientCredentialsResource.java
@@ -17,11 +17,16 @@
  */
 package org.apache.knox.gateway.service.knoxtoken;
 
+import com.nimbusds.jose.KeyLengthException;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.AliasServiceException;
 import org.apache.knox.gateway.services.security.token.TokenMetadata;
 import org.apache.knox.gateway.services.security.token.TokenMetadataType;
 import org.apache.knox.gateway.util.JsonUtils;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
+import javax.servlet.ServletException;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -35,11 +40,21 @@ import static javax.ws.rs.core.MediaType.APPLICATION_XML;
 @Path(ClientCredentialsResource.RESOURCE_PATH)
 @Singleton
 public class ClientCredentialsResource extends PasscodeTokenResourceBase {
-    private static final String TYPE = "type";
     public static final String RESOURCE_PATH = "clientid/api/v1/oauth/credentials";
     public static final String CLIENT_ID = "client_id";
     public static final String CLIENT_SECRET = "client_secret";
     private static final String PREFIX = "clientid.";
+    private static final String THIRD_PARTY_APP = "thirdPartyApp";
+
+    private boolean thirdPartyApp;
+
+    @Override
+    @PostConstruct
+    public void init() throws AliasServiceException, ServiceLifecycleException, KeyLengthException, ServletException {
+        super.init();
+        final String configuredThirdPartyApp = context.getInitParameter(THIRD_PARTY_APP);
+        thirdPartyApp = configuredThirdPartyApp == null || Boolean.parseBoolean(configuredThirdPartyApp);
+    }
 
     @Override
     @GET
@@ -57,7 +72,8 @@ public class ClientCredentialsResource extends PasscodeTokenResourceBase {
 
     @Override
     protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {
-        tokenMetadata.add(TYPE, TokenMetadataType.CLIENT_ID.name());
+        tokenMetadata.add(TokenMetadata.TYPE, TokenMetadataType.CLIENT_ID.name());
+        tokenMetadata.add(TokenMetadata.THIRD_PARTY_APP, String.valueOf(thirdPartyApp));
         super.addArbitraryTokenMetadata(tokenMetadata);
     }
 

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -72,6 +72,7 @@ import org.apache.knox.gateway.context.ContextAttributes;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.security.GroupPrincipal;
 import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.knox.gateway.security.TokenIdPrincipal;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -1091,6 +1092,14 @@ public class TokenResource {
     }
     if (shouldIncludeGroups()) {
       jwtAttributesBuilder.setGroups(groups());
+    }
+
+    final Subject subject = SubjectUtils.getCurrentSubject();
+    if (subject != null) {
+      Set<TokenIdPrincipal> tokenIdPrincipals = subject.getPrincipals(TokenIdPrincipal.class);
+      if (!tokenIdPrincipals.isEmpty()) {
+        jwtAttributesBuilder.setClientId(tokenIdPrincipals.iterator().next().getName());
+      }
     }
 
     jwtAttributes = jwtAttributesBuilder.build();

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -1488,6 +1488,37 @@ public class TokenServiceResourceTest {
   }
 
   @Test
+  public void testClientCredentialsThirdPartyAppConfig() throws Exception {
+    tryClientCredentialsThirdPartyAppConfig(null, true);
+    tryClientCredentialsThirdPartyAppConfig("true", true);
+    tryClientCredentialsThirdPartyAppConfig("false", false);
+  }
+
+  private void tryClientCredentialsThirdPartyAppConfig(String configValue, boolean expectedValue) throws Exception {
+    try {
+      tss = new PersistentTestTokenStateService();
+      final Map<String, String> contextExpectations = new HashMap<>();
+      if (configValue != null) {
+        contextExpectations.put("clientid.thirdPartyApp", configValue);
+      }
+      configureCommonExpectations(contextExpectations, Boolean.TRUE);
+      final ClientCredentialsResource ccr = new ClientCredentialsResource();
+      ccr.request = request;
+      ccr.context = context;
+      ccr.init();
+
+      final Response response = ccr.doPost();
+      assertEquals(200, response.getStatus());
+
+      final String clientId = getTagValue(response.getEntity().toString(), ClientCredentialsResource.CLIENT_ID);
+      final TokenMetadata metadata = tss.getTokenMetadata(clientId);
+      assertEquals(expectedValue, metadata.isThirdPartyApp());
+    } finally {
+      tss = new TestTokenStateService();
+    }
+  }
+
+  @Test
   public void testClientCredentialsResponse() throws Exception {
     tryClientCredentialsResource(null);
     tryClientCredentialsResource("30000");

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/TokenIdPrincipal.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/TokenIdPrincipal.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.security;
+
+import java.security.Principal;
+
+public class TokenIdPrincipal implements Principal {
+  private final String name;
+
+  public TokenIdPrincipal(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TokenIdPrincipal that = (TokenIdPrincipal) o;
+    return name.equals(that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+}

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributes.java
@@ -39,9 +39,15 @@ public class JWTokenAttributes {
   private final Set<String> groups;
   private final String issuer;
   private String kid;
+  private final String clientId;
 
   JWTokenAttributes(String userName, List<String> audiences, String algorithm, long expires, String signingKeystoreName, String signingKeystoreAlias,
       char[] signingKeystorePassphrase, boolean managed, String jku, String type, Set<String> groups, String kid, String issuer) {
+    this(userName, audiences, algorithm, expires, signingKeystoreName, signingKeystoreAlias, signingKeystorePassphrase, managed, jku, type, groups, kid, issuer, null);
+  }
+
+  JWTokenAttributes(String userName, List<String> audiences, String algorithm, long expires, String signingKeystoreName, String signingKeystoreAlias,
+      char[] signingKeystorePassphrase, boolean managed, String jku, String type, Set<String> groups, String kid, String issuer, String clientId) {
     this.userName = userName;
     this.audiences = audiences;
     this.algorithm = algorithm;
@@ -55,6 +61,7 @@ public class JWTokenAttributes {
     this.groups = groups;
     this.kid = kid;
     this.issuer = issuer;
+    this.clientId = clientId;
   }
 
   public String getUserName() {
@@ -123,5 +130,9 @@ public class JWTokenAttributes {
 
   public String getIssuer() {
     return issuer;
+  }
+
+  public String getClientId() {
+    return clientId;
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/JWTokenAttributesBuilder.java
@@ -37,6 +37,7 @@ public class JWTokenAttributesBuilder {
   private Set<String> groups;
   private String kid;
   private String issuer = JWTokenAttributes.DEFAULT_ISSUER;
+  private String clientId;
 
   public JWTokenAttributesBuilder setUserName(String userName) {
     this.userName = userName;
@@ -107,8 +108,13 @@ public class JWTokenAttributesBuilder {
     return this;
   }
 
+  public JWTokenAttributesBuilder setClientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
   public JWTokenAttributes build() {
     return new JWTokenAttributes(userName, (audiences == null ? new ArrayList<>() : audiences), algorithm, expires, signingKeystoreName, signingKeystoreAlias,
-        signingKeystorePassphrase, managed, jku, type, groups, kid, issuer);
+        signingKeystorePassphrase, managed, jku, type, groups, kid, issuer, clientId);
   }
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/TokenMetadata.java
@@ -39,7 +39,8 @@ public class TokenMetadata {
   public static final String CREATED_BY = "createdBy";
   public static final String LAST_USED_AT = "lastUsedAt";
   public static final String TYPE = "type";
-  private static final List<String> KNOWN_MD_NAMES = Arrays.asList(USER_NAME, COMMENT, ENABLED, PASSCODE, CREATED_BY, LAST_USED_AT, TYPE);
+  public static final String THIRD_PARTY_APP = "thirdPartyApp";
+  private static final List<String> KNOWN_MD_NAMES = Arrays.asList(USER_NAME, COMMENT, ENABLED, PASSCODE, CREATED_BY, LAST_USED_AT, TYPE, THIRD_PARTY_APP);
 
   private final Map<String, String> metadataMap = new HashMap<>();
 
@@ -137,6 +138,11 @@ public class TokenMetadata {
 
   public void setType(TokenMetadataType type) {
     saveMetadata(TYPE, type.name());
+  }
+
+  public boolean isThirdPartyApp() {
+    final String thirdPartyApp = getMetadata(THIRD_PARTY_APP);
+    return thirdPartyApp == null || Boolean.parseBoolean(thirdPartyApp);
   }
 
   public void markKnoxSsoCookie() {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/services/security/token/impl/JWTToken.java
@@ -42,6 +42,7 @@ public class JWTToken implements JWT {
   public static final String KNOX_KID_CLAIM = "kid";
   public static final String KNOX_JKU_CLAIM = "jku";
   public static final String KNOX_GROUPS_CLAIM = "knox.groups";
+  public static final String CLIENT_ID_CLAIM = "client_id";
 
   SignedJWT jwt;
 
@@ -94,6 +95,9 @@ public class JWTToken implements JWT {
     }
     if (jwtAttributes.getGroups() != null) {
       builder.claim(KNOX_GROUPS_CLAIM, jwtAttributes.getGroups());
+    }
+    if (jwtAttributes.getClientId() != null) {
+      builder.claim(CLIENT_ID_CLAIM, jwtAttributes.getClientId());
     }
 
     // Add a private UUID claim for uniqueness

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/TokenMetadataTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/TokenMetadataTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.services.security.token;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TokenMetadataTest {
+
+  @Test
+  public void testIsThirdPartyAppDefault() {
+    assertTrue("Should default to true for backward compatibility", new TokenMetadata().isThirdPartyApp());
+  }
+
+  @Test
+  public void testIsThirdPartyAppExplicit() {
+    final TokenMetadata metadata = new TokenMetadata();
+    metadata.add(TokenMetadata.THIRD_PARTY_APP, "true");
+    assertTrue(metadata.isThirdPartyApp());
+    metadata.add(TokenMetadata.THIRD_PARTY_APP, "false");
+    assertFalse(metadata.isThirdPartyApp());
+  }
+
+  @Test
+  public void testIsThirdPartyAppInvalidValue() {
+    final TokenMetadata metadata = new TokenMetadata();
+    metadata.add(TokenMetadata.THIRD_PARTY_APP, "not-a-boolean");
+    assertFalse("Boolean.parseBoolean should return false for invalid strings", metadata.isThirdPartyApp());
+  }
+}

--- a/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
+++ b/gateway-spi/src/test/java/org/apache/knox/gateway/services/security/token/impl/JWTTokenTest.java
@@ -224,4 +224,16 @@ public class JWTTokenTest {
     token = new JWTToken(new JWTokenAttributesBuilder().setAlgorithm("RS256").setType(tokenType).build());
     assertEquals(token.getType(), new JOSEObjectType(tokenType));
   }
+
+  @Test
+  public void testClientIdClaim() throws Exception {
+    final String clientId = "test-client-id";
+    JWT token = new JWTToken(new JWTokenAttributesBuilder()
+            .setAlgorithm("RS256")
+            .setUserName("test-user")
+            .setClientId(clientId)
+            .build());
+
+    assertEquals(clientId, token.getClaim(JWTToken.CLIENT_ID_CLAIM));
+  }
 }


### PR DESCRIPTION
[KNOX-3303](https://issues.apache.org/jira/browse/KNOX-3303) - Support configurable 'sub' claim reconciliation in Client Credentials flow

## What changes were proposed in this pull request?
This PR enhances the OAuth2-style Client Credentials flow in Apache Knox by introducing a configurable way to reconcile the sub (subject) claim in issued access tokens.

Key features:
   1. Topology Configuration: Added a new `thirdPartyApp` parameter (defaults to `true`) to the `CLIENTID` service.
   2. Metadata Persistence: The `thirdPartyApp` flag is now stored in the Token State Service metadata when client credentials are generated.
   3. Subject Reconciliation:
       * If `thirdPartyApp=true` (default): The `sub` claim remains the technical `client_id`.
       * If `thirdPartyApp=false`: The `sub` claim is set to the `userName` of the credentials owner.
   4. Client ID Claim: When `thirdPartyApp=false`, a new claim named `client_id` is added to the JWT payload, referring to the original technical identity (the token ID). This is in line with the claims listed in [RFC 9068](https://datatracker.ietf.org/doc/html/rfc9068#section-2.2).

## How was this patch tested?

Extended the automated test suite to verify the new logic:
   1. TokenMetadataTest: Verified that `thirdPartyApp` metadata defaults to `true` and correctly parses explicit boolean values.
   2. TokenServiceResourceTest: Confirmed that `ClientCredentialsResource` correctly reads the topology configuration and persists it into the database.
   3. JWTFederationFilterTest: Validated that AbstractJWTFilter correctly reconciles the Subject principal based on the metadata flag and adds the `TokenIdPrincipal` when required.
   4. JWTTokenTest: Verified that the `client_id` claim is correctly included in the issued JWT when a technical identity (`TokenIdPrincipal`) is present.

Commands run:
```
 mvn test -Dtest=TokenMetadataTest -pl gateway-spi
 mvn test -Dtest=TokenServiceResourceTest -pl gateway-service-knoxtoken
 mvn test -Dtest=JWTFederationFilterTest -pl gateway-provider-security-jwt
 mvn test -Dtest=JWTTokenTest -pl gateway-spi
```

E2E testing.

Token exchange with client credentials without the new `thisPartyApp`:
<img width="1360" height="649" alt="image" src="https://github.com/user-attachments/assets/b3252ba3-10d1-4d6b-890f-e260c0cb82a5" />
```
postgres=# SELECT * FROM knox_token_metadata WHERE token_id = '46e4bbe8-5abf-44f0-bf7e-c910324ad679' ORDER BY token_id, md_name;               
               token_id               |    md_name    |                                     md_value                                     
--------------------------------------+---------------+----------------------------------------------------------------------------------
 46e4bbe8-5abf-44f0-bf7e-c910324ad679 | enabled       | true
 46e4bbe8-5abf-44f0-bf7e-c910324ad679 | passcode      | 77+977+9Ce+/vS5EdMuC77+9dkvfqFHvv71B77+977+9OGrvv70x77+9EO+/vTDvv73vv73Csu+/vQ==
 46e4bbe8-5abf-44f0-bf7e-c910324ad679 | thirdPartyApp | true
 46e4bbe8-5abf-44f0-bf7e-c910324ad679 | type          | CLIENT_ID
 46e4bbe8-5abf-44f0-bf7e-c910324ad679 | userName      | admin
```

Token exchange with client credentials with the new `thisPartyApp` set to `false`:
<img width="1365" height="637" alt="image" src="https://github.com/user-attachments/assets/fd26b312-ca8d-4c64-97d4-7ff5ee135382" />

```
postgres=# SELECT * FROM knox_token_metadata WHERE token_id = '46635251-a151-4935-98b9-6025957ff516' ORDER BY token_id, md_name;
               token_id               |    md_name    |                                     md_value                                     
--------------------------------------+---------------+----------------------------------------------------------------------------------
 46635251-a151-4935-98b9-6025957ff516 | enabled       | true
 46635251-a151-4935-98b9-6025957ff516 | passcode      | 77+977+977+977+9Cu+/vXHvv73NssK977+9Vu+/vQEq77+977+9dAM477+9Pu+/vXRNd++/ve+/vX0=
 46635251-a151-4935-98b9-6025957ff516 | thirdPartyApp | false
 46635251-a151-4935-98b9-6025957ff516 | type          | CLIENT_ID
 46635251-a151-4935-98b9-6025957ff516 | userName      | admin
(5 rows)
```

## Integration Tests
N/A - Sufficient unit and mock-based integration tests were added to cover the logic within the affected services and filters.

## UI changes
N/A