### PR TITLE
KNOX-3304 - Support for Openshift/SCC + Make docker entrypoint idempotent

### DIFF
--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -35,26 +35,24 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Create knox user and group
-# Using GID 8000 for the knox group to allow arbitrary UIDs with this GID
-RUN groupadd --system -g 8000 knox && useradd --system -u 8000 -g knox -d /home/knox -m knox
+RUN groupadd --system -g 8000 knox && adduser --system -u 8000 -g knox -h /home/knox knox
 
 # Dependencies
 ARG RELEASE_FILE
-ADD --chown=knox:knox ${RELEASE_FILE} /home/knox/
+# Using GID 8000 for the knox group to allow arbitrary UIDs with this GID -required for OpenShift/SCC
+ADD --chown=8000:0 ${RELEASE_FILE} /home/knox/
 
 # Extract the Knox release tar.gz
 RUN chmod 644 /home/knox/*.zip && \
     cd /home/knox && unzip /home/knox/*.zip && rm -f /home/knox/*.zip && ln -nsf /home/knox/*/ /home/knox/knox
 
-# Make sure knox owns its files and make all directories group-accessible for arbitrary UIDs
+# Prepare Knox runtime directories for arbitrary UID support (OpenShift/SCC pattern).
 RUN mkdir -p /home/knox/knox/data/security/keystores && \
-    mkdir -p /home/knox/knox/conf && \
-    chown -R knox:knox /home/knox && \
-    chmod -R g+rwX /home/knox
+    mkdir -p /home/knox/knox/conf
 
 # Add the entrypoint script
 ARG ENTRYPOINT
-COPY ${ENTRYPOINT} /home/knox/knox/entrypoint.sh
+COPY --chown=8000:0 ${ENTRYPOINT} /home/knox/knox/entrypoint.sh
 RUN chmod +x /home/knox/knox/entrypoint.sh
 
 # Add the Amazon Root CA and Let's Encrypt production certificates (best-effort)
@@ -65,7 +63,7 @@ RUN mkdir /home/knox/cacrts && \
     curl -sSLo /home/knox/cacrts/AmazonRootCA4.cer  https://www.amazontrust.com/repository/AmazonRootCA4.cer  || true && \
     curl -sSLo /home/knox/cacrts/isrgrootx1.pem     https://letsencrypt.org/certs/isrgrootx1.pem               || true && \
     curl -sSLo /home/knox/cacrts/isrg-root-x2.pem   https://letsencrypt.org/certs/isrg-root-x2.pem             || true && \
-    chown -R knox:knox /home/knox/cacrts
+    chown -R 8000:0 /home/knox/cacrts
 
 WORKDIR /home/knox/knox
 
@@ -73,6 +71,11 @@ WORKDIR /home/knox/knox
 ARG EXPOSE_PORT
 EXPOSE ${EXPOSE_PORT}
 
+# Ensure all files are owned by the knox user and the root group (for arbitrary UID support)
+RUN chown -R 8000:0 /home/knox && \
+# Recursively sets group mode = user mode, whatever permission bits apply to the owner will be copied to the group - required for OpenShift/SCC
+    chmod -R g=u /home/knox
+
 # Switch off of the root user
-USER knox
+USER 8000:0
 ENTRYPOINT ["./entrypoint.sh"]

--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update && \
        unzip \
        libnss3 \
        bash \
-       passwd && \
+       passwd \
+       curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Create knox user and group
-RUN groupadd --system -g 8000 knox && adduser --system -u 8000 -g knox -h /home/knox knox
+RUN groupadd --system -g 8000 knox && useradd --system -u 8000 -g knox -d /home/knox -m knox
 
 # Dependencies
 ARG RELEASE_FILE

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -59,7 +59,7 @@ importMultipleCerts() {
             -alias "$ALIAS" \
             -keystore "${KEYSTORE_DIR}"/truststore.jks \
             -storepass "$ALIAS_PASSPHRASE" \
-            2>/dev/null || true
+            > /dev/null 2>&1 || true
     if ! /bin/cat "$FILE" |
       /usr/bin/awk "n==$N { print }; /END CERTIFICATE/ { n++ }" |
       keytool -import \
@@ -98,7 +98,7 @@ export GATEWAY_SERVER_RUN_IN_FOREGROUND=true
 # Create Master secret
 if [[ -n ${KNOX_MASTER_SECRET} ]]
 then
-  MASTER_SECRET=$(/bin/cat "${KNOX_MASTER_SECRET}" 2>/dev/null)
+  MASTER_SECRET=$(/bin/cat "${KNOX_MASTER_SECRET}" 2> /dev/null)
 fi
 
 if [[ -n ${MASTER_SECRET} ]]
@@ -112,7 +112,7 @@ fi
 
 if [[ -n ${LDAP_PASSWORD_FILE} ]]
 then
-  LDAP_BIND_PASSWORD=$(/bin/cat "${LDAP_PASSWORD_FILE}" 2>/dev/null)
+  LDAP_BIND_PASSWORD=$(/bin/cat "${LDAP_PASSWORD_FILE}" 2> /dev/null)
 fi
 
 saveAlias ldap-bind-password "${LDAP_BIND_PASSWORD}"
@@ -140,7 +140,7 @@ fi
 if [[ -n ${KEYSTORE_PASSWORD_FILE} ]] && [[ -f ${KEYSTORE_PASSWORD_FILE} ]]
 then
   echo "Using provided keystore password file"
-  ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}" 2>/dev/null)
+  ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}" 2> /dev/null)
 else
    # If keystore password is not provided use master secret as alias passphrase
    ALIAS_PASSPHRASE="${MASTER_SECRET}"
@@ -205,7 +205,7 @@ if [[ -n $CUSTOM_CERT ]] && [[ -f ${CUSTOM_CERT} ]]
 then
   echo "Importing Custom certs."
   if ! importMultipleCerts "$CUSTOM_CERT"; then
-      echo "WARN: Unable to import custom certs from [${$CUSTOM_CERT}]. Continuing startup..."
+      echo "WARN: Unable to import custom certs from [${CUSTOM_CERT}]. Continuing startup..."
     fi
 fi
 
@@ -217,8 +217,9 @@ then
 	 amazon-ca-1:/home/knox/cacrts/AmazonRootCA1.cer
      amazon-ca-2:/home/knox/cacrts/AmazonRootCA2.cer
      amazon-ca-3:/home/knox/cacrts/AmazonRootCA3.cer
-	 amazon-ca-4:/home/knox/cacrts/AmazonRootCA4.cer
-     letsencrypt-stg-root:/home/knox/cacrts/letsencrypt-stg-root-x1.pem"
+	   amazon-ca-4:/home/knox/cacrts/AmazonRootCA4.cer
+     isrgrootx1:/home/knox/cacrts/isrgrootx1.pem
+     isrgrootx2:/home/knox/cacrts/isrg-root-x2.pem"
 fi
 
 for certinfo in ${TRUSTSTORE_IMPORTS}
@@ -233,7 +234,7 @@ do
             -keystore "${KEYSTORE_DIR}"/truststore.jks \
             -alias "${aliasId}" \
             -storepass "${ALIAS_PASSPHRASE}" \
-            2>/dev/null || true
+            > /dev/null 2>&1 || true
         keytool -importcert \
             -keystore "${KEYSTORE_DIR}"/truststore.jks \
             -alias "${aliasId}" \

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -44,6 +44,7 @@ set -o pipefail
 ## Function takes cert file as argument
 importMultipleCerts() {
   FILE=$1
+  local import_failed=0
   ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}")
   # number of certs in the PEM file
   CERTS=$(/bin/grep 'END CERTIFICATE' "$FILE"| /usr/bin/wc -l)
@@ -53,15 +54,26 @@ importMultipleCerts() {
   # step 2), increment counter when last line of cert is found
   for N in $(/usr/bin/seq 0 $((CERTS - 1))); do
     ALIAS="${FILE%.*}-$N"
-    /bin/cat "$FILE" |
+    # Make import idempotent across restarts when truststore is persisted.
+    keytool -delete \
+            -alias "$ALIAS" \
+            -keystore "${KEYSTORE_DIR}"/truststore.jks \
+            -storepass "$ALIAS_PASSPHRASE" \
+            2>/dev/null || true
+    if ! /bin/cat "$FILE" |
       /usr/bin/awk "n==$N { print }; /END CERTIFICATE/ { n++ }" |
       keytool -import \
               -trustcacerts \
               -alias "$ALIAS" \
               -keystore "${KEYSTORE_DIR}"/truststore.jks \
               -storepass "$ALIAS_PASSPHRASE" \
-              -noprompt
+              -noprompt; then
+      echo "WARN: Unable to import certificate alias [${ALIAS}] from [${FILE}]. Continuing startup..."
+      import_failed=1
+    fi
   done
+
+  return "$import_failed"
 }
 
 ## Helper function to save an alias
@@ -183,14 +195,18 @@ fi
 if [[ -n $CA_FILE ]] && [[ -f ${CA_FILE} ]]
 then
   echo "Creating truststore with provided CA certificate/s."
-  importMultipleCerts "$CA_FILE"
+  if ! importMultipleCerts "$CA_FILE"; then
+    echo "WARN: Unable to import CA certs from [${CA_FILE}]. Continuing startup..."
+  fi
 fi
 
 # Import custom certs one by one
 if [[ -n $CUSTOM_CERT ]] && [[ -f ${CUSTOM_CERT} ]]
 then
   echo "Importing Custom certs."
-  importMultipleCerts "$CUSTOM_CERT"
+  if ! importMultipleCerts "$CUSTOM_CERT"; then
+      echo "WARN: Unable to import custom certs from [${$CUSTOM_CERT}]. Continuing startup..."
+    fi
 fi
 
 # This default was set to emulate the existing behaviour
@@ -212,12 +228,18 @@ do
     if [[ -n "${aliasId}" ]] && [[ -n "${certPath}" ]] && [[ -f "${certPath}" ]]
     then
         echo "INFO: Importing certificate [${certPath}] into truststore"
+        # Replace existing alias to keep imports idempotent.
+        keytool -delete \
+            -keystore "${KEYSTORE_DIR}"/truststore.jks \
+            -alias "${aliasId}" \
+            -storepass "${ALIAS_PASSPHRASE}" \
+            2>/dev/null || true
         keytool -importcert \
             -keystore "${KEYSTORE_DIR}"/truststore.jks \
             -alias "${aliasId}" \
             -file "${certPath}" \
             -storepass "${ALIAS_PASSPHRASE}" \
-            -noprompt || true
+            -noprompt || echo "WARN: Unable to import certificate [${certPath}] with alias [${aliasId}]. Continuing startup..."
     else
         echo "ERROR: certificate [${certinfo}] not found. Not importing into truststore"
     fi

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -106,7 +106,7 @@ then
   echo "Using provided knox master secret [env:MASTER_SECRET]"
 else
   echo "Using default knox master secret"
-  MASTER_SECRET="knox"
+  MASTER_SECRET="!apacheknox!"
 fi
 /home/knox/knox/bin/knoxcli.sh create-master --master "${MASTER_SECRET}"
 


### PR DESCRIPTION
[KNOX-3304](https://issues.apache.org/jira/browse/KNOX-3304) - Support for Openshift/SCC + Make docker entrypoint idempotent

## What changes were proposed in this pull request?
The current docker image that is generated does not work with Openshift and ECS platform due to restrictions imposed by the platforms. Specifically, there are two requirements

- The helm chart that installs Knox image should use an arbitrary `runAsUse`r
- The helm chart should not have any `runAsGroup` and `fsUser` 

This PR addresses that problem by adding knox user to root group and adding knox artifacts to root user group.

## How was this patch tested?
This patch was tested locally on a docker.

## Integration Tests
N/A

## UI changes
N/A
