### PR TITLE
KNOX-3308 - Token Exchange Flow using wrong param name

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -28,6 +28,7 @@ import org.apache.knox.gateway.services.security.token.impl.JWTToken;
 import org.apache.knox.gateway.util.AuthFilterUtils;
 import org.apache.knox.gateway.util.CertificateUtils;
 import org.apache.knox.gateway.util.CookieUtils;
+import org.apache.knox.gateway.util.ServletRequestUtils;
 
 import javax.security.auth.Subject;
 import javax.servlet.FilterChain;
@@ -62,7 +63,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   public static final String MISMATCHING_CLIENT_ID_AND_CLIENT_SECRET = "Client credentials flow with mismatching client_id and client_secret";
   public static final String REFRESH_TOKEN = "refresh_token";
   public static final String REFRESH_TOKEN_PARAM = "refresh_token";
-  public static final String TOKEN_EXCHANGE = "token_exchange";
+  public static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
   public static final String SUBJECT_TOKEN = "subject_token";
   public static final String CLIENT_ASSERTION_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
   public static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
@@ -315,35 +316,40 @@ public class JWTFederationFilter extends AbstractJWTFilter {
     }
 
     private Pair<TokenType, String> getTokenFromRequestBody(ServletRequest request) {
-        final String grantType = request.getParameter(GRANT_TYPE);
-        final String clientAssertionType = request.getParameter(CLIENT_ASSERTION_TYPE);
+        // unwrap the servlet request so that we can get to the request body params since we are not passing this request
+        // on to other services to handle like we do when proxying. The request wrapper is protecting the body from being
+        // consumed before it gets to the proxied service that should handle it. We don't need that protection here.
+        HttpServletRequest unwrappedRequest = ServletRequestUtils.unwrapHttpServletRequest(request);
+        final String grantType = unwrappedRequest.getParameter(GRANT_TYPE);
+        final String clientAssertionType = unwrappedRequest.getParameter(CLIENT_ASSERTION_TYPE);
         if (CLIENT_CREDENTIALS.equals(grantType)) {
           if (clientAssertionType != null && CLIENT_ASSERTION_JWT_BEARER.equals(clientAssertionType)) {
             // short lived client assertion token expected
-            return getClientTokenFromParams(request, CLIENT_ASSERTION);
+            return getClientTokenFromParams(unwrappedRequest, CLIENT_ASSERTION);
           }
           // client credentials flow: client_id and client_secret are expected
           // the client_id will be in the token as the token_id
-          final String clientSecret = request.getParameter(CLIENT_SECRET);
-          validateClientID((HttpServletRequest) request, clientSecret);
+          final String clientSecret = unwrappedRequest.getParameter(CLIENT_SECRET);
+          validateClientID((HttpServletRequest) unwrappedRequest, clientSecret);
           return Pair.of(TokenType.Passcode, clientSecret);
         } else if (REFRESH_TOKEN.equals(grantType)) {
           // refresh_token flow: the refresh_token parameter contains the actual token
-          return getClientTokenFromParams(request, REFRESH_TOKEN_PARAM);
+          return getClientTokenFromParams(unwrappedRequest, REFRESH_TOKEN_PARAM);
         } else if (TOKEN_EXCHANGE.equals(grantType)) {
           // token_exchange flow: the subject_token parameter contains the token to be exchanged
-          return getClientTokenFromParams(request, SUBJECT_TOKEN);
+          return getClientTokenFromParams(unwrappedRequest, SUBJECT_TOKEN);
         }
       return null;
     }
 
-  private Pair<TokenType, String> getClientTokenFromParams(final ServletRequest request, final String requestParamName) {
-    final String refreshOrSubjectToken = request.getParameter(requestParamName);
-    if (refreshOrSubjectToken != null) {
-      return isJWT(refreshOrSubjectToken) ? Pair.of(TokenType.JWT, refreshOrSubjectToken) : Pair.of(TokenType.Passcode, refreshOrSubjectToken);
+    private Pair<TokenType, String> getClientTokenFromParams(final ServletRequest request, final String requestParamName) {
+      final String refreshOrSubjectToken = request.getParameter(requestParamName);
+      if (refreshOrSubjectToken != null) {
+        return isJWT(refreshOrSubjectToken) ? Pair.of(TokenType.JWT, refreshOrSubjectToken) : Pair.of(TokenType.Passcode,
+                refreshOrSubjectToken);
+      }
+      return null;
     }
-    return null;
-  }
 
     private Pair<TokenType, String> parseFromHTTPBasicCredentials(final String header, final ServletRequest request) {
       Pair<TokenType, String> parsed = null;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/UrlEncodedFormRequest.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/UrlEncodedFormRequest.java
@@ -81,9 +81,6 @@ public class UrlEncodedFormRequest extends HttpServletRequestWrapper {
 
   @Override
   public String getParameter(String name) {
-    if(GRANT_TYPE.equals(name) || CLIENT_ID.equals(name) || CLIENT_SECRET.equals(name)) {
-      return super.getParameter(name);
-    }
     return queryParams.getValue(name, 0);
   }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/UrlEncodedFormRequest.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/UrlEncodedFormRequest.java
@@ -29,10 +29,6 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.UrlEncoded;
 
-import static org.apache.knox.gateway.security.CommonTokenConstants.GRANT_TYPE;
-import static org.apache.knox.gateway.security.CommonTokenConstants.CLIENT_ID;
-import static org.apache.knox.gateway.security.CommonTokenConstants.CLIENT_SECRET;
-
 /**
  * HttpServletRequest
  *

--- a/gateway-server/src/test/java/org/apache/knox/gateway/UrlEncodedFormRequestTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/UrlEncodedFormRequestTest.java
@@ -46,7 +46,7 @@ public class UrlEncodedFormRequestTest {
     UrlEncodedFormRequest wrappedRequest = new UrlEncodedFormRequest(originalRequest);
     assertEquals("x", wrappedRequest.getParameter("query1"));
     assertEquals("y", wrappedRequest.getParameter("query2"));
-    assertEquals("payload_client_id", wrappedRequest.getParameter("client_id"));
+    assertEquals("query_client_id", wrappedRequest.getParameter("client_id"));
     assertNull(wrappedRequest.getParameter("a"));
     assertNull(wrappedRequest.getParameter("b"));
     assertArrayEquals(new String[]{"x"}, wrappedRequest.getParameterValues("query1"));

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/util/ServletRequestUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/util/ServletRequestUtils.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.util;
 
 import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -61,4 +62,14 @@ public class ServletRequestUtils {
     }
   }
 
+  /**
+   * Unwrap ServletRequest through wrapper chain to get underlying HttpServletRequest
+   */
+  public static HttpServletRequest unwrapHttpServletRequest(ServletRequest request) {
+    ServletRequest current = request;
+    while (current instanceof ServletRequestWrapper) {
+      current = ((ServletRequestWrapper) current).getRequest();
+    }
+    return (HttpServletRequest) current;
+  }
 }


### PR DESCRIPTION
[KNOX-1234](https://issues.apache.org/jira/browse/KNOX-3308) - Token Exchange Flow using wrong param name

## What changes were proposed in this pull request?

The Token Exchange flow param name is inconsistent with the core OAuth specification and requires both a full urn as the name and a hyphen rather than an underscrore: urn:ietf:params:oauth:grant-type:token-exchange

JWTFederationFilter is currently coded to expect a shortname with underscore 'token_exchange'.

In addition, UrlEncodedFormRequest wrapper has a brittle getParameter implementation that hard codes the names of params that we know indicate that the processing of the request body will be handled by us and there is not danger in consuming the response out from under another handler.

Since this is in a generic path, I want to move the knowledge of that out to the code that is handling the request processing rather than trying to keep this list in sync with the consuming code. I'll add a ServletRequestUtils to unwrap the servlet request so that we can get to the params ourselves within those specific code blocks and otherwise the wrapper will no longer treat any param names specially. This will also require the move of ServletRequestUtils to the gateway-spi module.

## How was this patch tested?

Existing unit tests were corrected through the changes in the existing constants.
All unit tests were run and passed.

## Integration Tests
none
