### PR TITLE
KNOX-3303: Subject created during identity assertion should include TokenIdPrincipal, if any

### DIFF
--- a/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAssertionFilter.java
+++ b/gateway-provider-identity-assertion-common/src/main/java/org/apache/knox/gateway/identityasserter/common/filter/AbstractIdentityAssertionFilter.java
@@ -50,6 +50,7 @@ import org.apache.knox.gateway.security.GroupPrincipal;
 import org.apache.knox.gateway.security.ImpersonatedPrincipal;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
 import org.apache.knox.gateway.security.SubjectUtils;
+import org.apache.knox.gateway.security.TokenIdPrincipal;
 
 public abstract class AbstractIdentityAssertionFilter extends
   AbstractIdentityAssertionBase implements Filter {
@@ -142,6 +143,10 @@ public abstract class AbstractIdentityAssertionFilter extends
           if (groupsMapped) {
             addMappedGroupsToSubject(mappedPrincipalName, groups, subject);
           }
+
+          final Set<TokenIdPrincipal> tokenIdPrincipals = SubjectUtils.getTokenIdPrincipals(currentSubject);
+          subject.getPrincipals().addAll(tokenIdPrincipals);
+
           doAs(request, response, chain, subject);
         }
         else {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
@@ -98,4 +98,7 @@ public class SubjectUtils {
     return subject.getPrincipals(GroupPrincipal.class);
   }
 
+  public static Set<TokenIdPrincipal> getTokenIdPrincipals(Subject subject) {
+    return subject.getPrincipals(TokenIdPrincipal.class);
+  }
 }


### PR DESCRIPTION
This is a follow-up PR for #1208 , where we introduced the new `TokenIdProncipal`, but failed to add them in the new `subject` created during identity assertion.