### PR TITLE
KNOX-3310: Fix redundant ALIAS_PASSPHRASE assignment and improve logging

### DIFF
--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -42,10 +42,10 @@ set -o pipefail
 
 ## Helper function used to import certs into truststore
 ## Function takes cert file as argument
+## At this time ALIAS_PASSPHRASE is already initialized
 importMultipleCerts() {
   FILE=$1
   local import_failed=0
-  ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}")
   # number of certs in the PEM file
   CERTS=$(/bin/grep 'END CERTIFICATE' "$FILE"| /usr/bin/wc -l)
   # For every cert in the PEM file, extract it and import into the JKS keystore
@@ -139,10 +139,11 @@ fi
 
 if [[ -n ${KEYSTORE_PASSWORD_FILE} ]] && [[ -f ${KEYSTORE_PASSWORD_FILE} ]]
 then
-  echo "Using provided keystore password file"
+  echo "Setting ALIAS_PASSPHRASE from provided keystore password file: ${KEYSTORE_PASSWORD_FILE}"
   ALIAS_PASSPHRASE=$(/bin/cat "${KEYSTORE_PASSWORD_FILE}" 2> /dev/null)
 else
    # If keystore password is not provided use master secret as alias passphrase
+   echo "Setting ALIAS_PASSPHRASE to MASTER_SECRET"
    ALIAS_PASSPHRASE="${MASTER_SECRET}"
 fi
 


### PR DESCRIPTION
[KNOX-3310](https://issues.apache.org/jira/browse/KNOX-3310) - Fixing ALIAS_PASSPHRASE issues while importing custom certs.

## What changes were proposed in this pull request?

This PR fixes a bug in the Docker entrypoint script and improves logging during the security initialization phase.

Changes
   - Bug Fix: Removed the redundant `ALIAS_PASSPHRASE` assignment within `importMultipleCerts`. This prevents the script from exiting prematurely (due to set -e) when a keystore password file is not provided.
   - Logging Improvements: 
       - Added explicit logging to show which file is being used to set the `ALIAS_PASSPHRASE`.
       - Added logging to indicate when the script falls back to using the `MASTER_SECRET`.
   - Documentation: Added a comment to the `importMultipleCerts` function to clarify its dependency on the pre-initialized `ALIAS_PASSPHRASE` variable.

  Impact
   - Stability: Prevents startup failures in default configurations where `KEYSTORE_PASSWORD_FILE` is not used.
   - Observability: Makes it much easier to debug keystore/truststore password issues by looking at the container logs.

## How was this patch tested?

Still needed to be tested in k8s clusters.

## Integration Tests
N/A

## UI changes
N/A