### PR TITLE
KNOX-3314: Ensure secure length for encryptQueryString generated by d…

### DIFF
--- a/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/SimpleDescriptorHandlerFuncTest.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.easymock.EasyMock.anyObject;
@@ -250,8 +251,8 @@ public class SimpleDescriptorHandlerFuncTest {
       assertEquals("Unexpected cluster name for the alias (should be the topology name).",
                    testDescriptor.getName(), capturedCluster.getValue());
       assertEquals("Unexpected alias name.", "encryptQueryString", capturedAlias.getValue());
-      assertEquals("Unexpected alias value (should be master secret + topology name.",
-                   testMasterSecret + testDescriptor.getName(), capturedPwd.getValue());
+      assertEquals("Unexpected alias value.",
+                   String.format(Locale.ROOT, SimpleDescriptorHandler.ENCRYPT_QUERY_STRING_TEMPLATE, testMasterSecret, testDescriptor.getName()), capturedPwd.getValue());
 
       assertEquals(1, NoOpServiceDiscovery.discoveryCalled);
     } catch (Exception e) {

--- a/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
+++ b/gateway-topology-simple/src/main/java/org/apache/knox/gateway/topology/simple/SimpleDescriptorHandler.java
@@ -99,6 +99,8 @@ public class SimpleDescriptorHandler {
                                                                                   "CLIENTID",
                                                                                   "HEALTH").collect(Collectors.toSet()));
 
+    public static final String ENCRYPT_QUERY_STRING_TEMPLATE = "knox:query-encryption:%s:%s";
+
     public static Map<String, File> handle(GatewayConfig config, File desc, File destDirectory, Service...gatewayServices) throws IOException {
         return handle(config, SimpleDescriptorFactory.parse(desc.getAbsolutePath()), desc.getParentFile(), destDirectory, gatewayServices);
     }
@@ -312,7 +314,7 @@ public class SimpleDescriptorHandler {
                             AliasService aliasService = services.getService(ServiceType.ALIAS_SERVICE);
                             if (aliasService != null) {
                                 // Derive and set the query param encryption password
-                                String queryEncryptionPass = new String(ms.getMasterSecret()) + topologyName;
+                                String queryEncryptionPass = String.format(Locale.ROOT, ENCRYPT_QUERY_STRING_TEMPLATE, new String(ms.getMasterSecret()), topologyName);
                                 aliasService.addAliasForCluster(topologyName, "encryptQueryString", queryEncryptionPass);
                                 result = true;
                             }


### PR DESCRIPTION
…escriptors

(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

[KNOX-3314](https://issues.apache.org/jira/browse/KNOX-3314) - Ensure encryptQueryString length generated by descriptors

## What changes were proposed in this pull request?

Changed the `encryptQueryString` template generated by descriptors to ensure secure length

## How was this patch tested?
Unit tests