### PR TITLE
KNOX-3315: Adds BCFKS as an option cert export

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -809,7 +809,7 @@ public class KnoxCLI extends Configured implements Tool {
             X509CertificateUtil.writeCertificateToPkcs12(cert, new File(keyStoreDir + "gateway-client-trust.pkcs12"));
             out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-client-trust.pkcs12");
           } else if ("BCFKS".equalsIgnoreCase(type)) {
-            X509CertificateUtil.writeCertificatesToKeyStore(new Certificate[] { cert }, new File(keyStoreDir + "gateway-client-trust.bcfks"), "bcfks", null);
+            X509CertificateUtil.writeCertificateToBcfks(cert, new File(keyStoreDir + "gateway-client-trust.bcfks"));
             out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-client-trust.bcfks");
           } else {
             out.println("Invalid type for export file provided. Export has not been done. Please use: [PEM|JKS|JCEKS|PKCS12] default value is PEM.");

--- a/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/util/KnoxCLI.java
@@ -756,12 +756,12 @@ public class KnoxCLI extends Configured implements Tool {
 
   public class CertExportCommand extends Command {
 
-    public static final String USAGE = "export-cert [--type PEM|JKS|JCEKS|PKCS12]";
+    public static final String USAGE = "export-cert [--type PEM|JKS|JCEKS|PKCS12|BCFKS]";
     public static final String DESC = "The export-cert command exports the public certificate\n" +
                                       "from the a gateway.jks keystore with the alias of gateway-identity.\n" +
                                       "It will be exported to `{GATEWAY_HOME}/data/security/keystores/` with a name of `gateway-client-trust.<type>`" +
                                       "Using the --type option you can specify which keystore type you need (default: PEM)\n" +
-                                      "NOTE: The password for the JKS, JCEKS and PKCS12 types is `changeit`.\n" +
+                                      "NOTE: The password for the JKS, JCEKS, PKCS12 and BCFKS types is `changeit`.\n" +
                                       "It can be changed using: `keytool -storepasswd -storetype <type> -keystore gateway-client-trust.<type>`";
 
     private GatewayConfig getGatewayConfig() {
@@ -808,6 +808,9 @@ public class KnoxCLI extends Configured implements Tool {
           } else if ("PKCS12".equalsIgnoreCase(type)) {
             X509CertificateUtil.writeCertificateToPkcs12(cert, new File(keyStoreDir + "gateway-client-trust.pkcs12"));
             out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-client-trust.pkcs12");
+          } else if ("BCFKS".equalsIgnoreCase(type)) {
+            X509CertificateUtil.writeCertificatesToKeyStore(new Certificate[] { cert }, new File(keyStoreDir + "gateway-client-trust.bcfks"), "bcfks", null);
+            out.println("Certificate gateway-identity has been successfully exported to: " + keyStoreDir + "gateway-client-trust.bcfks");
           } else {
             out.println("Invalid type for export file provided. Export has not been done. Please use: [PEM|JKS|JCEKS|PKCS12] default value is PEM.");
           }

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -88,6 +88,7 @@ public class KnoxMetadataResource {
   private Set<String> pinnedTopologies;
   private java.nio.file.Path pemFilePath;
   private java.nio.file.Path jksFilePath;
+  private java.nio.file.Path bcfksFilePath;
 
   @Context
   private HttpServletRequest request;
@@ -147,6 +148,9 @@ public class KnoxMetadataResource {
       } else if ("jks".equals(certType)) {
         generateCertificateJks(certificateChain, config);
         return generateSuccessFileDownloadResponse(jksFilePath);
+      } else if ("bcfks".equals(certType)) {
+        generateCertificateBcfks(certificateChain, config);
+        return generateSuccessFileDownloadResponse(bcfksFilePath);
       } else {
         return generateFailureFileDownloadResponse(Status.BAD_REQUEST, "Invalid certification type provided!");
       }
@@ -205,6 +209,17 @@ public class KnoxMetadataResource {
       }
     } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
       LOG.failedToGeneratePublicCert("JKS", e.getMessage(), e);
+    }
+  }
+
+  private void generateCertificateBcfks(Certificate[] certificateChain, GatewayConfig gatewayConfig) {
+    try {
+      if (bcfksFilePath == null || !bcfksFilePath.toFile().exists()) {
+        bcfksFilePath = Paths.get(gatewayConfig.getGatewaySecurityDir(), "gateway-client-trust.bcfks");
+        X509CertificateUtil.writeCertificatesToKeyStore(certificateChain, bcfksFilePath.toFile(), "bcfks", null);
+      }
+    } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+      LOG.failedToGeneratePublicCert("BCFKS", e.getMessage(), e);
     }
   }
 

--- a/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
+++ b/gateway-service-metadata/src/main/java/org/apache/knox/gateway/service/metadata/KnoxMetadataResource.java
@@ -216,7 +216,7 @@ public class KnoxMetadataResource {
     try {
       if (bcfksFilePath == null || !bcfksFilePath.toFile().exists()) {
         bcfksFilePath = Paths.get(gatewayConfig.getGatewaySecurityDir(), "gateway-client-trust.bcfks");
-        X509CertificateUtil.writeCertificatesToKeyStore(certificateChain, bcfksFilePath.toFile(), "bcfks", null);
+        X509CertificateUtil.writeCertificatesToBcfks(certificateChain, bcfksFilePath.toFile(), null);
       }
     } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
       LOG.failedToGeneratePublicCert("BCFKS", e.getMessage(), e);

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -172,7 +172,7 @@ public class X509CertificateUtil {
   /*
    * Writes an arbitrary number of certificates into the given keystore file protected by the given password
    */
-  public static void writeCertificatesToKeyStore(Certificate[] certs, final File file, String type, String keystorePassword)
+  private static void writeCertificatesToKeyStore(Certificate[] certs, final File file, String type, String keystorePassword)
       throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
     if (certs != null) {
       KeyStore ks = KeyStore.getInstance(type);
@@ -213,6 +213,16 @@ public class X509CertificateUtil {
   public static void writeCertificateToPkcs12(Certificate cert, final File file)
       throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
     writeCertificateToKeyStore(cert, file, "pkcs12");
+  }
+
+  public static void writeCertificateToBcfks(Certificate cert, final File file)
+          throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+    writeCertificateToKeyStore(cert, file, "bcfks");
+  }
+
+  public static void writeCertificatesToBcfks(Certificate[] certs, final File file, String keystorePassword)
+          throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
+    writeCertificatesToKeyStore(certs, file, "bcfks", keystorePassword);
   }
 
   /**

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/X509CertificateUtil.java
@@ -172,7 +172,7 @@ public class X509CertificateUtil {
   /*
    * Writes an arbitrary number of certificates into the given keystore file protected by the given password
    */
-  private static void writeCertificatesToKeyStore(Certificate[] certs, final File file, String type, String keystorePassword)
+  public static void writeCertificatesToKeyStore(Certificate[] certs, final File file, String type, String keystorePassword)
       throws IOException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
     if (certs != null) {
       KeyStore ks = KeyStore.getInstance(type);

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/X509CertificateUtilTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/X509CertificateUtilTest.java
@@ -60,7 +60,7 @@ public class X509CertificateUtilTest {
 
       // 2. Write it to a BCFKS keystore
       File bcfksFile = temporaryFolder.newFile("test.bcfks");
-      X509CertificateUtil.writeCertificatesToKeyStore(new Certificate[]{cert}, bcfksFile, "BCFKS", "password");
+      X509CertificateUtil.writeCertificatesToBcfks(new Certificate[]{cert}, bcfksFile, "password");
 
       // 3. Verify the keystore
       KeyStore keyStore = KeyStore.getInstance("BCFKS");

--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/X509CertificateUtilTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/X509CertificateUtilTest.java
@@ -17,19 +17,25 @@
  */
 package org.apache.knox.gateway.util;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLServerSocketFactory;
 import javax.net.ssl.SSLSocket;
+import java.io.File;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -38,6 +44,35 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 public class X509CertificateUtilTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testWriteCertificatesToKeyStoreBCFKS() throws Exception {
+    Security.addProvider(new BouncyCastleProvider());
+    try {
+      // 1. Generate a self-signed certificate
+      KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+      keyPairGenerator.initialize(2048);
+      KeyPair keyPair = keyPairGenerator.generateKeyPair();
+      X509Certificate cert = X509CertificateUtil.generateCertificate("CN=localhost", keyPair, 30, "SHA256withRSA");
+
+      // 2. Write it to a BCFKS keystore
+      File bcfksFile = temporaryFolder.newFile("test.bcfks");
+      X509CertificateUtil.writeCertificatesToKeyStore(new Certificate[]{cert}, bcfksFile, "BCFKS", "password");
+
+      // 3. Verify the keystore
+      KeyStore keyStore = KeyStore.getInstance("BCFKS");
+      keyStore.load(java.nio.file.Files.newInputStream(bcfksFile.toPath()), "password".toCharArray());
+      Assert.assertTrue(keyStore.containsAlias("gateway-identity1"));
+      Certificate loadedCert = keyStore.getCertificate("gateway-identity1");
+      Assert.assertNotNull(loadedCert);
+      Assert.assertEquals(cert, loadedCert);
+    } finally {
+      Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+    }
+  }
 
   @Test
   public void testFetchPublicCertsFromServer() throws Exception {


### PR DESCRIPTION
[KNOX-3315](https://issues.apache.org/jira/browse/KNOX-3315) - Update publicCert endpoint to be able to generate BCFKS as well

## What changes were proposed in this pull request?

Adds the ability for the publicCert endpoint to be able to generate BCFKS as well. Added the same for the KnoxCLI export-cert command.

## How was this patch tested?

Unit tests, tested on FIPS cluster where the necessary BC FIPS provider for BCFKS is there.

`/usr/java/default/bin/keytool -list -keystore gateway-client-trust.bcfks -v -storetype BCFKS -providerclass com.safelogic.cryptocomply.jcajce.provider.CryptoComplyFipsProvider -providerpath com-safelogic-cryptocomply-fips-core.jar -storepass XXX`
