### PR TITLE
KNOX-3319 : Ranger REST API not fully implemented in cdp-proxy-api (Dineshkumar Yadav <dineshkumar.yadav@outlook.com>)

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/ranger/2.3.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/2.3.0/rewrite.xml
@@ -49,4 +49,24 @@
     <rule dir="IN" name="RANGER/ranger/inbound/roles/path" pattern="*://*:*/**/ranger/service/roles/{path=**}?{**}">
         <rewrite template="{$serviceUrl[RANGER]}/service/roles/{path=**}?{**}"/>
     </rule>
+
+    <!-- Ranger Admin users -->
+    <rule dir="IN" name="RANGER/ranger/inbound/users" pattern="*://*:*/**/ranger/service/users?{**}">
+            <rewrite template="{$serviceUrl[RANGER]}/service/users?{**}"/>
+    </rule>
+    <rule dir="IN" name="RANGER/ranger/inbound/users/path" pattern="*://*:*/**/ranger/service/users/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/users/{path=**}?{**}"/>
+    </rule>
+    <!-- Ranger Admin keys -->
+    <rule dir="IN" name="RANGER/ranger/inbound/keys/path" pattern="*://*:*/**/ranger/service/keys/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/keys/{path=**}?{**}"/>
+    </rule>
+    <!-- Ranger Admin audit -->
+    <rule dir="IN" name="RANGER/ranger/inbound/audit/path" pattern="*://*:*/**/ranger/service/audit/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/audit/{path=**}?{**}"/>
+    </rule>
+    <!-- Ranger Admin Security Zones -->
+    <rule dir="IN" name="RANGER/ranger/inbound/zones/path" pattern="*://*:*/**/ranger/service/zones/{path=**}?{**}">
+        <rewrite template="{$serviceUrl[RANGER]}/service/zones/{path=**}?{**}"/>
+    </rule>
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/ranger/2.3.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/ranger/2.3.0/service.xml
@@ -31,6 +31,11 @@
         <route path="/ranger/service/tags/**"/>
         <route path="/ranger/service/xaudit/**"/>
         <route path="/ranger/service/roles/**"/>
+        <route path="/ranger/service/users"/>
+        <route path="/ranger/service/users/**"/>
+        <route path="/ranger/service/keys/**"/>
+        <route path="/ranger/service/audit/**"/>
+        <route path="/ranger/service/zones/**"/>
         <route path="/ranger"/>
     </routes>
     <dispatch classname="org.apache.knox.gateway.dispatch.ConfigurableDispatch"


### PR DESCRIPTION
[KNKNOX-3319](https://issues.apache.org/jira/browse/KNOX-3319) - Ranger REST API not fully implemented in cdp-proxy-api

## What changes were proposed in this pull request?

The following Ranger API endpoints are missing from the Ranger service definitions in Knox:
 API Expected path in topology

    UserREST: /ranger/service/users/
    XKeyREST: /ranger/service/keys/
    AuditMetricsREST: /ranger/service/audit/
    SecurityZoneREST: /ranger/service/zones/

This PR adds this path.

## How was this patch tested?
