### PR TITLE
KNOX-3325 - Bump maven enforcer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -629,11 +629,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <!--
-                                    Maven 3.6.2 has issues
-                                    https://issues.apache.org/jira/browse/KNOX-2305
-                                    -->
-                                    <version>[3.1.0,3.6.2),(3.6.2,)</version>
+                                    <version>[3.8.1,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>[17,18)</version>


### PR DESCRIPTION
[KNOX-3325](https://issues.apache.org/jira/browse/KNOX-3325) - Bump maven enforcer version

## What changes were proposed in this pull request?

Enforce minimum maven version for knox is 3.8.1

