### PR TITLE
KNOX-3327: Support periodic refresh of gateway configuration

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayMessages.java
@@ -687,6 +687,12 @@ public interface GatewayMessages {
   @Message(level = MessageLevel.INFO, text = "Stopping service: {0}")
   void stoppingService(String serviceTypeName);
 
+  @Message(level = MessageLevel.INFO, text = "Refreshed gateway config")
+  void refreshedGatewayConfig();
+
+  @Message(level = MessageLevel.WARN, text = "Unable to refresh gateway config")
+  void unableToReloadGatewayConfig(@StackTrace(level = MessageLevel.DEBUG) Exception e);
+
   @Message(level = MessageLevel.INFO, text = "Redeploying topology {0} due to service definition change {1} / {2} / {3}")
   void redeployingTopologyOnServiceDefinitionChange(String topologyName, String serviceName, String role, String version);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -109,6 +109,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
@@ -126,8 +127,13 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
+
+import static org.apache.knox.gateway.config.impl.GatewayConfigImpl.RELOADABLE_CONFIG_FILENAME;
 
 public class GatewayServer {
   private static final GatewayResources res = ResourcesFactory.get(GatewayResources.class);
@@ -143,6 +149,9 @@ public class GatewayServer {
   private static GatewayServices services;
 
   private static Properties buildProperties;
+
+  private static final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
+  private static FileTime lastReloadTime;
 
   private Server jetty;
   private GatewayConfig config;
@@ -171,12 +180,13 @@ public class GatewayServer {
         if (services == null) {
           log.failedToInstantiateGatewayServices();
         }
-        final GatewayConfig config = new GatewayConfigImpl();
+        final GatewayConfigImpl config = new GatewayConfigImpl();
         validateConfigurableGatewayDirectories(config);
         if (config.isHadoopKerberosSecured()) {
           validateKerberosConfig(config);
           configureKerberosSecurity( config );
         }
+        setupGatewayConfigRefresh(config);
         Map<String,String> options = new HashMap<>();
         options.put(GatewayCommandLine.PERSIST_LONG, Boolean.toString(cmd.hasOption(GatewayCommandLine.PERSIST_LONG)));
         services.init(config, options);
@@ -227,6 +237,35 @@ public class GatewayServer {
 
   public static synchronized GatewayServices getGatewayServices() {
     return services;
+  }
+
+  private static void setupGatewayConfigRefresh(GatewayConfigImpl config) {
+    Path resourcePath = Paths.get(config.getGatewayConfDir(), RELOADABLE_CONFIG_FILENAME);
+    int refreshInterval = config.getConfigRefreshInterval();
+    if(refreshInterval > 0) {
+      exec.scheduleAtFixedRate(() -> refreshGatewayConfig(config, resourcePath),
+              0, refreshInterval, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  /**
+   * Check if the resourcePath has been modified since the last reload time
+   * If so then reload the configuration to pick up the new configs
+   * @param resourcePath resource path to check and reload
+   */
+  private static synchronized void refreshGatewayConfig(GatewayConfigImpl config, Path resourcePath) {
+    try {
+      if(Files.exists(resourcePath) && Files.isReadable(resourcePath)) {
+        FileTime lastModifiedTime = Files.getLastModifiedTime(resourcePath);
+        if (lastReloadTime == null || lastReloadTime.compareTo(lastModifiedTime) < 0) {
+          lastReloadTime = lastModifiedTime;
+          config.reloadConfiguration();
+          log.refreshedGatewayConfig();
+        }
+      }
+    } catch (IOException e) {
+      log.unableToReloadGatewayConfig(e);
+    }
   }
 
   private static void logSysProp( String name ) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -104,7 +104,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   private static final String DEFAULT_APPLICATIONS_DIR = "applications";
 
-  private static final String[] GATEWAY_CONFIG_FILENAMES = {GATEWAY_CONFIG_FILE_PREFIX + "-default.xml", GATEWAY_CONFIG_FILE_PREFIX + "-site.xml"};
+  public static final String RELOADABLE_CONFIG_FILENAME = GATEWAY_CONFIG_FILE_PREFIX + "-reloadable.xml";
+
+  private static final String[] GATEWAY_CONFIG_FILENAMES = {GATEWAY_CONFIG_FILE_PREFIX + "-default.xml", GATEWAY_CONFIG_FILE_PREFIX + "-site.xml", RELOADABLE_CONFIG_FILENAME};
 
   private static final String GATEWAY_SERVICE_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".service.";
   public static final String HTTP_HOST = GATEWAY_CONFIG_FILE_PREFIX + ".host";
@@ -276,6 +278,9 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
 
   static final String REMOTE_ALIAS_SERVICE_CONFIG_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.config.prefix";
   static final String REMOTE_ALIAS_SERVICE_CONFIG_PREFIX_DEFAULT = GATEWAY_CONFIG_FILE_PREFIX + ".remote.alias.service.config.";
+
+  static final String CONFIG_REFRESH_INTERVAL = GATEWAY_CONFIG_FILE_PREFIX + ".config.refresh.interval";
+  static final int CONFIG_REFRESH_INTERVAL_DEFAULT = 10000;
 
   private static final List<String> DEFAULT_GLOBAL_RULES_SERVICES = Arrays.asList(
       "NAMENODE", "JOBTRACKER", "WEBHDFS", "WEBHCAT",
@@ -1330,6 +1335,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
     }
 
     return set;
+  }
+
+  @Override
+  public int getConfigRefreshInterval() {
+    return getInt(CONFIG_REFRESH_INTERVAL, CONFIG_REFRESH_INTERVAL_DEFAULT);
   }
 
   @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
@@ -24,8 +24,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 
@@ -41,7 +43,7 @@ public class GatewayServerTest {
     GatewayConfigImpl config = EasyMock.createNiceMock(GatewayConfigImpl.class);
 
     File configFile = folder.newFile("gateway-reloadable.xml");
-    try (java.io.PrintWriter writer = new java.io.PrintWriter(configFile)) {
+    try (PrintWriter writer = new PrintWriter(configFile, StandardCharsets.UTF_8)) {
       writer.println("<configuration>");
       writer.println("  <property>");
       writer.println("    <name>test.prop</name>");
@@ -76,7 +78,7 @@ public class GatewayServerTest {
 
     // Update file to trigger reload
     Thread.sleep(1000); // Ensure timestamp changes
-    try (java.io.PrintWriter writer = new java.io.PrintWriter(configFile)) {
+    try (PrintWriter writer = new PrintWriter(configFile, StandardCharsets.UTF_8)) {
       writer.println("<configuration>");
       writer.println("  <property>");
       writer.println("    <name>test.prop</name>");

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway;
+
+import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
+import org.easymock.EasyMock;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+import static org.junit.Assert.assertNotNull;
+
+public class GatewayServerTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void testRefreshGatewayConfig() throws Exception {
+    GatewayConfigImpl config = EasyMock.createNiceMock(GatewayConfigImpl.class);
+
+    File configFile = folder.newFile("gateway-reloadable.xml");
+    try (java.io.PrintWriter writer = new java.io.PrintWriter(configFile)) {
+      writer.println("<configuration>");
+      writer.println("  <property>");
+      writer.println("    <name>test.prop</name>");
+      writer.println("    <value>test.val</value>");
+      writer.println("  </property>");
+      writer.println("</configuration>");
+    }
+
+    Method refreshMethod = GatewayServer.class.getDeclaredMethod("refreshGatewayConfig", GatewayConfigImpl.class, Path.class);
+    refreshMethod.setAccessible(true);
+
+    // Initial load
+    config.reloadConfiguration();
+    EasyMock.expectLastCall().once();
+    EasyMock.replay(config);
+
+    refreshMethod.invoke(null, config, configFile.toPath());
+
+    EasyMock.verify(config);
+
+    // Check lastReloadTime is set
+    Field lastReloadTimeField = GatewayServer.class.getDeclaredField("lastReloadTime");
+    lastReloadTimeField.setAccessible(true);
+    FileTime lastReloadTime = (FileTime) lastReloadTimeField.get(null);
+    assertNotNull(lastReloadTime);
+
+    // Second call without change should not trigger reload
+    EasyMock.reset(config);
+    EasyMock.replay(config);
+    refreshMethod.invoke(null, config, configFile.toPath());
+    EasyMock.verify(config);
+
+    // Update file to trigger reload
+    Thread.sleep(1000); // Ensure timestamp changes
+    try (java.io.PrintWriter writer = new java.io.PrintWriter(configFile)) {
+      writer.println("<configuration>");
+      writer.println("  <property>");
+      writer.println("    <name>test.prop</name>");
+      writer.println("    <value>test.val2</value>");
+      writer.println("  </property>");
+      writer.println("</configuration>");
+    }
+
+    EasyMock.reset(config);
+    config.reloadConfiguration();
+    EasyMock.expectLastCall().once();
+    EasyMock.replay(config);
+
+    refreshMethod.invoke(null, config, configFile.toPath());
+    EasyMock.verify(config);
+  }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.util.ArrayList;
@@ -45,9 +46,14 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.impl.ZookeeperRemoteAliasService;
 import org.apache.knox.test.TestUtils;
 import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class GatewayConfigImplTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
 
   @Test( timeout = TestUtils.SHORT_TIMEOUT )
   public void testHttpServerSettings() {
@@ -728,5 +734,36 @@ public class GatewayConfigImplTest {
   public void testCmSslCiphersWithoutDefaults() {
     final List<String> result = new GatewayConfigImpl().getClouderaManagerClientSSLCiphers();
     assertNull(result);
+  }
+
+  @Test
+  public void testGetConfigRefreshInterval() {
+    GatewayConfigImpl config = new GatewayConfigImpl();
+    assertThat(config.getConfigRefreshInterval(), is(10000));
+
+    config.setInt("gateway.config.refresh.interval", 5000);
+    assertThat(config.getConfigRefreshInterval(), is(5000));
+  }
+
+  @Test
+  public void testReloadableConfigLoading() throws Exception {
+    File dir = folder.newFolder("conf");
+    File reloadableFile = new File(dir, "gateway-reloadable.xml");
+    try (java.io.PrintWriter writer = new java.io.PrintWriter(reloadableFile)) {
+      writer.println("<configuration>");
+      writer.println("  <property>");
+      writer.println("    <name>test.reloadable.prop</name>");
+      writer.println("    <value>test.reloadable.val</value>");
+      writer.println("  </property>");
+      writer.println("</configuration>");
+    }
+
+    try {
+      System.setProperty("KNOX_GATEWAY_CONF_DIR", dir.getAbsolutePath());
+      GatewayConfigImpl config = new GatewayConfigImpl();
+      assertThat(config.get("test.reloadable.prop"), is("test.reloadable.val"));
+    } finally {
+      System.clearProperty("KNOX_GATEWAY_CONF_DIR");
+    }
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/config/impl/GatewayConfigImplTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.util.ArrayList;
@@ -749,7 +751,7 @@ public class GatewayConfigImplTest {
   public void testReloadableConfigLoading() throws Exception {
     File dir = folder.newFolder("conf");
     File reloadableFile = new File(dir, "gateway-reloadable.xml");
-    try (java.io.PrintWriter writer = new java.io.PrintWriter(reloadableFile)) {
+    try (PrintWriter writer = new PrintWriter(reloadableFile, StandardCharsets.UTF_8)) {
       writer.println("<configuration>");
       writer.println("  <property>");
       writer.println("    <name>test.reloadable.prop</name>");

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -863,6 +863,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public int getConfigRefreshInterval() {
+    return 0;
+  }
+
+  @Override
   public long getClouderaManagerDescriptorsMonitoringInterval() {
     return 0;
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -747,6 +747,12 @@ public interface GatewayConfig {
   Set<String> getServicesToIgnoreDoAs();
 
   /**
+   * @return refresh interval in ms
+   * @since 3.0.0
+   */
+  int getConfigRefreshInterval();
+
+  /**
    * @return the monitoring interval (in milliseconds) of Cloudera Manager descriptors
    */
   long getClouderaManagerDescriptorsMonitoringInterval();


### PR DESCRIPTION
[KNOX-1234](https://issues.apache.org/jira/browse/KNOX-3327) -  Support periodic refresh of gateway configuration

## What changes were proposed in this pull request?

This PR introduces the ability for the Knox Gateway to periodically refresh its configuration from a specific reloadable file (gateway-reloadable.xml). This allows administrators to modify certain gateway-level configurations at runtime
  without restarting the entire Gateway process.

  Key changes include:
   - Configuration Inclusion: Updated `GatewayConfigImpl` to include `gateway-reloadable.xml `in the prioritized list of configuration files.
   - Refresh Interval: Introduced` gateway.config.refresh.interval `(defaulting to 10,000ms) to control how often the gateway checks for updates.
   - Background Monitor: Added a scheduled executor in GatewayServer that monitors the modification timestamp of the reloadable configuration file and triggers a configuration reload if changes are detected.
   - SPI Updates: Added getConfigRefreshInterval() to the GatewayConfig interface.

## How was this patch tested?

  The patch was tested using new and updated automated unit tests:

   1. `GatewayConfigImplTest.testGetConfigRefreshInterval`: Verified that the refresh interval configuration is correctly parsed.
   2. `GatewayConfigImplTest.testReloadableConfigLoading`: Verified that properties defined in `gateway-reloadable.xml` are correctly loaded into the configuration object upon initialization.
   3. `GatewayServerTest.testRefreshGatewayConfig`: Verified the logic that monitors file timestamps. Confirmed that:
       - An initial reload is triggered on first check.
       - Subsequent checks do not trigger a reload if the file hasn't changed.
       - Updating the file modification time correctly triggers a new reload.

 Steps to run tests:
  `mvn test -Dtest=GatewayConfigImplTest,GatewayServerTest -pl gateway-server`

## Integration Tests
  Unit tests were added to gateway-server to cover the new functionality. These tests use TemporaryFolder and manual XML generation to simulate file system changes and verify the reload behavior.


## UI changes
N/A