### PR TITLE
KNOX-3326: Add TCPS support for Oracle DB

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/database/OracleDataSourceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/database/OracleDataSourceFactory.java
@@ -51,6 +51,23 @@ public class OracleDataSourceFactory extends AbstractDataSourceFactory {
             oracleDataSource.setUser(dbUser);
             oracleDataSource.setPassword(dbPassword);
         }
+
+        configureSsl(gatewayConfig, aliasService, oracleDataSource);
+
         return oracleDataSource;
+    }
+
+    private void configureSsl(GatewayConfig gatewayConfig, AliasService aliasService, oracle.jdbc.pool.OracleDataSource oracleDataSource) throws AliasServiceException, SQLException {
+        if (gatewayConfig.isDatabaseSslEnabled()) {
+            oracleDataSource.setNetworkProtocol("tcps");
+            if (gatewayConfig.verifyDatabaseSslServerCertificate()) {
+                oracleDataSource.setConnectionProperty("javax.net.ssl.trustStore", gatewayConfig.getDatabaseSslTruststoreFileName());
+                oracleDataSource.setConnectionProperty("javax.net.ssl.trustStoreType", "JKS");
+                final String truststorePassword = getDatabaseAlias(aliasService, DATABASE_TRUSTSTORE_PASSWORD_ALIAS_NAME);
+                if (truststorePassword != null) {
+                    oracleDataSource.setConnectionProperty("javax.net.ssl.trustStorePassword", truststorePassword);
+                }
+            }
+        }
     }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/database/DataSourceProviderTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/database/DataSourceProviderTest.java
@@ -275,6 +275,22 @@ public class DataSourceProviderTest {
     EasyMock.verify(gatewayConfig);
   }
 
+  @Test
+  public void oracleDataSourceShouldHaveProperSslConnectionProperties() throws Exception {
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    final AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    setBasicOracleExpectations(gatewayConfig, aliasService);
+    EasyMock.expect(gatewayConfig.isDatabaseSslEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(gatewayConfig.verifyDatabaseSslServerCertificate()).andReturn(true).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseSslTruststoreFileName()).andReturn("/path/to/truststore").anyTimes();
+    EasyMock.replay(gatewayConfig, aliasService);
+    final OracleDataSource dataSource = (OracleDataSource) DataSourceProvider.getDataSource(gatewayConfig, aliasService);
+    assertEquals("tcps", dataSource.getNetworkProtocol());
+    assertEquals("/path/to/truststore", dataSource.getConnectionProperty("javax.net.ssl.trustStore"));
+    assertEquals("JKS", dataSource.getConnectionProperty("javax.net.ssl.trustStoreType"));
+    //Can't validate the truststore password because oracle datasource doesn't return it.
+  }
+
   private void setBasicOracleExpectations(GatewayConfig gatewayConfig, AliasService aliasService) throws AliasServiceException {
     EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(DatabaseType.ORACLE.type()).anyTimes();
     EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
@@ -282,5 +298,6 @@ public class DataSourceProviderTest {
     EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("sampleDatabase");
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(AbstractDataSourceFactory.DATABASE_USER_ALIAS_NAME)).andReturn("user".toCharArray()).anyTimes();
     EasyMock.expect(aliasService.getPasswordFromAliasForGateway(AbstractDataSourceFactory.DATABASE_PASSWORD_ALIAS_NAME)).andReturn("password".toCharArray()).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(AbstractDataSourceFactory.DATABASE_TRUSTSTORE_PASSWORD_ALIAS_NAME)).andReturn("ts_password".toCharArray()).anyTimes();
   }
 }


### PR DESCRIPTION
[KNOX-3326](https://issues.apache.org/jira/browse/KNOX-3326) - Add SSL configuration for Oracle DB support

## What changes were proposed in this pull request?

Adds SSL configuration support to Oracle DB

## How was this patch tested?

Tested with an actual Oracle DB that had TCPS setup

```
    <property>
        <name>gateway.service.tokenstate.impl</name>
        <value>org.apache.knox.gateway.services.token.impl.JDBCTokenStateService</value>
    </property>
    <property>
        <name>gateway.database.connection.url</name>
        <value>jdbc:oracle:thin:@tcps://host:2484/FREEPDB1?oracle.net.ssl_server_dn_match=false</value>
    </property>
    <property>
        <name>gateway.database.type</name>
        <value>oracle</value>
    </property>
    <property>
        <name>gateway.database.ssl.enabled</name>
        <value>true</value>
    </property>
    <property>
        <name>gateway.database.ssl.verify.server.cert</name>
        <value>true</value>
    </property>
    <property>
        <name>gateway.database.ssl.truststore.file</name>
        <value>/tmp/oracle_truststore.jks</value>
    </property>
```

`install/knox-3.0.0-SNAPSHOT/bin/knoxcli.sh generate-jwk --saveAlias knox.token.hash.key`

`install/knox-3.0.0-SNAPSHOT/bin/knoxcli.sh create-aliases --alias gateway_database_user --value knox_user --alias gateway_database_password --value mypw23 --alias gateway_database_ssl_truststore_password --value mypw22`

```
SQL> select * from KNOX_TOKENS;

TOKEN_ID
--------------------------------------------------------------------------------
ISSUE_TIME EXPIRATION MAX_LIFETIME
---------- ---------- ------------
6263c147-27cb-4ebd-970a-6c043a56e0e6
1.7793E+12 1.7793E+12	1.7799E+12

6fd0abee-5929-4c8e-946b-837651676a6f
1.7793E+12 1.7793E+12	1.7799E+12
```

<img width="1903" height="781" alt="image" src="https://github.com/user-attachments/assets/fedd8813-1e5a-4e9c-a349-3c0ea0f2e53f" />

<img width="1913" height="403" alt="image" src="https://github.com/user-attachments/assets/5ebf826d-6dc6-4e9e-81ed-bae7f42fa8ee" />

## Integration Tests
N/A

## UI changes
N/A
