### PR TITLE
KNOX-3331: Add Maven option to skip Angular UI modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,6 @@
         <module>gateway-service-vault</module>
         <module>gateway-service-test</module>
         <module>gateway-test-release</module>
-        <module>gateway-admin-ui</module>
         <module>gateway-applications</module>
         <module>gateway-shell-samples</module>
         <module>gateway-shell-release</module>
@@ -148,11 +147,7 @@
         <module>gateway-topology-hadoop-xml</module>
         <module>gateway-service-metadata</module>
         <module>gateway-service-session</module>
-        <module>knox-homepage-ui</module>
         <module>gateway-openapi-ui</module>
-        <module>knox-token-management-ui</module>
-        <module>knox-webshell-ui</module>
-        <module>knox-token-generation-ui</module>
     </modules>
 
     <properties>
@@ -423,6 +418,27 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>build-ui</id>
+
+            <activation>
+                <property>
+                    <name>!skipUi</name>
+                </property>
+            </activation>
+
+            <properties>
+                <failsafe.group>org.apache.knox.test.category.VerifyTest</failsafe.group>
+            </properties>
+
+            <modules>
+                <module>gateway-admin-ui</module>
+                <module>knox-homepage-ui</module>
+                <module>knox-token-management-ui</module>
+                <module>knox-webshell-ui</module>
+                <module>knox-token-generation-ui</module>
+            </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
[KNOX-3331](https://issues.apache.org/jira/browse/KNOX-3331) - Add Maven option to skip Angular UI modules

## What changes were proposed in this pull request?

This PR adds a Maven build option to skip Angular-based UI modules during the reactor build.

By default, the build behavior remains unchanged. When `-DskipUi` is specified, all Angular-based UI modules are excluded from the build reactor.

**Example:**

```
mvn clean install -DskipUi
```

**Motivation**

Several Angular UI modules contribute significantly to the overall build time even for backend-only changes.

From a recent full build:

```
gateway-admin-ui ................. ~26s
knox-homepage-ui ................. ~35s
knox-token-management-ui ......... ~34s
knox-token-generation-ui ......... ~22s
knox-webshell-ui ................. ~21s

Total build time:
~3m47s
```

## How was this patch tested?

Built the project with the new flag:
```
[INFO] Reactor Summary for gateway 3.0.0-SNAPSHOT:
[INFO] 
[INFO] build-tools ........................................ SUCCESS [  0.515 s]
[INFO] gateway ............................................ SUCCESS [  3.281 s]
[INFO] gateway-test-utils ................................. SUCCESS [  0.671 s]
...
[INFO] gateway-shell-release .............................. SUCCESS [  3.468 s]
[INFO] gateway-docker ..................................... SUCCESS [  1.114 s]
[INFO] gateway-release-common ............................. SUCCESS [  0.078 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:18 min
[INFO] Finished at: 2026-05-27T18:47:14+02:00
[INFO] ------------------------------------------------------------------------
```
We are now down to ~1:20 mins (almost 1/3 of the original build time). This is a huge improvement and will increase our efficiency when running Docker-based tests or other manual testing locally where UIs are not involved.

## Integration Tests
After I built the project I ran Docker-based integration tests:
```
tests-1  | ============================= test session starts ==============================
tests-1  | platform linux -- Python 3.9.25, pytest-8.3.4, pluggy-1.6.0
tests-1  | rootdir: /tests
tests-1  | collected 21 items
tests-1  | 
tests-1  | test_health.py .....                                                     [ 23%]
tests-1  | test_knox_auth_service_and_LDAP.py ..                                    [ 33%]
tests-1  | test_knox_configs.py .                                                   [ 38%]
tests-1  | test_knoxauth_preauth_and_paths.py ......                                [ 66%]
tests-1  | test_remote_auth.py ...                                                  [ 80%]
tests-1  | test_remoteauth_extauthz_additional_path.py ....                         [100%]
tests-1  | 
tests-1  | =============================== warnings summary ===============================
...
tests-1  | 
tests-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
tests-1  | ----------------- generated xml file: /tests/test-results.xml ------------------
tests-1  | ======================= 21 passed, 21 warnings in 0.80s ========================

```

## UI changes
N/A