### PR TITLE
KNOX-3332: Add listeners on gateway config changes

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -28,6 +28,7 @@ import org.apache.knox.gateway.audit.api.Auditor;
 import org.apache.knox.gateway.audit.api.ResourceType;
 import org.apache.knox.gateway.audit.log4j.audit.AuditConstants;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.config.GatewayConfigurationException;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.deploy.DeploymentException;
@@ -127,6 +128,7 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -147,6 +149,8 @@ public class GatewayServer {
 
   private static GatewayServer server;
   private static GatewayServices services;
+
+  private static final List<GatewayConfigChangeListener> configChangeListeners = new CopyOnWriteArrayList<>();
 
   private static Properties buildProperties;
 
@@ -239,6 +243,14 @@ public class GatewayServer {
     return services;
   }
 
+  public static void registerConfigChangeListener(GatewayConfigChangeListener listener) {
+    configChangeListeners.add(listener);
+  }
+
+  public static void unregisterConfigChangeListener(GatewayConfigChangeListener listener) {
+    configChangeListeners.remove(listener);
+  }
+
   private static void setupGatewayConfigRefresh(GatewayConfigImpl config) {
     Path resourcePath = Paths.get(config.getGatewayConfDir(), RELOADABLE_CONFIG_FILENAME);
     int refreshInterval = config.getConfigRefreshInterval();
@@ -261,6 +273,9 @@ public class GatewayServer {
           lastReloadTime = lastModifiedTime;
           config.reloadConfiguration();
           log.refreshedGatewayConfig();
+          for (GatewayConfigChangeListener listener : configChangeListeners) {
+            listener.onGatewayConfigChanged();
+          }
         }
       }
     } catch (IOException e) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/GatewayServer.java
@@ -274,7 +274,7 @@ public class GatewayServer {
           config.reloadConfiguration();
           log.refreshedGatewayConfig();
           for (GatewayConfigChangeListener listener : configChangeListeners) {
-            listener.onGatewayConfigChanged();
+            listener.onGatewayConfigChanged(config);
           }
         }
       }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.knox.gateway.GatewayMessages;
+import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
@@ -88,6 +89,7 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
     if (config.isLDAPEnabled()) {
       KnoxLDAPService ldapService = new KnoxLDAPService();
       ldapService.init(config, options);
+      GatewayServer.registerConfigChangeListener(ldapService);
       addService(ServiceType.LDAP_SERVICE, ldapService);
     }
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -30,6 +30,9 @@ import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition;
 import org.apache.directory.server.core.partition.ldif.LdifPartition;
 import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.knox.gateway.GatewayServer;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ldap.backend.BackendFactory;
 import org.apache.knox.gateway.services.ldap.backend.LdapBackend;
@@ -42,9 +45,10 @@ import java.util.Map;
 /**
  * Manages the ApacheDS LDAP server instance with pluggable backends
  */
-public class KnoxLDAPServerManager {
+public class KnoxLDAPServerManager implements GatewayConfigChangeListener {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
 
+    private GatewayConfig config;
     private DirectoryService directoryService;
     private LdapServer ldapServer;
     private LdapBackend backend;
@@ -56,21 +60,38 @@ public class KnoxLDAPServerManager {
     /**
      * Initialize the LDAP server with the given configuration
      *
-     * @param workDir Directory for LDAP data storage
-     * @param port Port for LDAP server to listen on
-     * @param baseDn Base DN for LDAP entries in the proxy server
-     * @param backendType Type of backend to use
-     * @param backendConfig Backend-specific configuration
-     * @param remoteBaseDn Base DN of the remote LDAP server (for proxy backends)
+     * @param config Gateway configuration
      */
-    public void initialize(File workDir, int port, String baseDn, String backendType, Map<String, String> backendConfig, String remoteBaseDn) throws Exception {
-        this.workDir = workDir;
-        this.port = port;
-        this.baseDn = baseDn;
-        this.remoteBaseDn = remoteBaseDn;
+    public void initialize(GatewayConfig config) throws Exception {
+        if (this.config == null) {
+            GatewayServer.registerConfigChangeListener(this);
+        }
+        this.config = config;
+
+        // Prepare work directory for LDAP data
+        File gatewayDataDir = new File(config.getGatewayDataDir());
+        this.workDir = new File(gatewayDataDir, "ldap-server");
+
+        // Get configuration
+        this.port = config.getLDAPPort();
+        this.baseDn = config.getLDAPBaseDN();
+        String backendType = config.getLDAPBackendType();
+
+        // Get backend-specific configuration using prefixed properties
+        Map<String, String> backendConfig = config.getLDAPBackendConfig(backendType);
+
+        // Add common configuration
+        backendConfig.put("baseDn", baseDn);
+
+        // Add legacy dataFile property for backwards compatibility with file backend
+        if ("file".equalsIgnoreCase(backendType) && !backendConfig.containsKey("dataFile")) {
+            backendConfig.put("dataFile", config.getLDAPBackendDataFile());
+        }
+
+        // For proxy backends, extract remoteBaseDn if present
+        this.remoteBaseDn = backendConfig.get("remoteBaseDn");
 
         // Initialize backend
-        backendConfig.put("baseDn", baseDn);
         backend = BackendFactory.createBackend(backendType, backendConfig);
 
         // Clean up previous run if it didn't shut down cleanly
@@ -81,6 +102,26 @@ public class KnoxLDAPServerManager {
         }
 
         workDir.mkdirs();
+    }
+
+    @Override
+    public void onGatewayConfigChanged() {
+        LOG.ldapReloadingConfig();
+        try {
+            boolean wasRunning = isRunning();
+            if (wasRunning) {
+                stop();
+            }
+            // Re-initialize and start if it was running or if it's now enabled
+            if (config.isLDAPEnabled()) {
+                initialize(config);
+                if (wasRunning) {
+                    start();
+                }
+            }
+        } catch (Exception e) {
+            LOG.ldapServiceReloadFailed(e);
+        }
     }
 
     /**

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -30,9 +30,7 @@ import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition;
 import org.apache.directory.server.core.partition.ldif.LdifPartition;
 import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
-import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
-import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ldap.backend.BackendFactory;
 import org.apache.knox.gateway.services.ldap.backend.LdapBackend;
@@ -45,10 +43,9 @@ import java.util.Map;
 /**
  * Manages the ApacheDS LDAP server instance with pluggable backends
  */
-public class KnoxLDAPServerManager implements GatewayConfigChangeListener {
+public class KnoxLDAPServerManager {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
 
-    private GatewayConfig config;
     private DirectoryService directoryService;
     private LdapServer ldapServer;
     private LdapBackend backend;
@@ -63,11 +60,6 @@ public class KnoxLDAPServerManager implements GatewayConfigChangeListener {
      * @param config Gateway configuration
      */
     public void initialize(GatewayConfig config) throws Exception {
-        if (this.config == null) {
-            GatewayServer.registerConfigChangeListener(this);
-        }
-        this.config = config;
-
         // Prepare work directory for LDAP data
         File gatewayDataDir = new File(config.getGatewayDataDir());
         this.workDir = new File(gatewayDataDir, "ldap-server");
@@ -102,26 +94,6 @@ public class KnoxLDAPServerManager implements GatewayConfigChangeListener {
         }
 
         workDir.mkdirs();
-    }
-
-    @Override
-    public void onGatewayConfigChanged() {
-        LOG.ldapReloadingConfig();
-        try {
-            boolean wasRunning = isRunning();
-            if (wasRunning) {
-                stop();
-            }
-            // Re-initialize and start if it was running or if it's now enabled
-            if (config.isLDAPEnabled()) {
-                initialize(config);
-                if (wasRunning) {
-                    start();
-                }
-            }
-        } catch (Exception e) {
-            LOG.ldapServiceReloadFailed(e);
-        }
     }
 
     /**

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
@@ -22,7 +22,6 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 
-import java.io.File;
 import java.util.Map;
 
 /**
@@ -46,32 +45,7 @@ public class KnoxLDAPService implements Service {
         try {
             // Initialize the LDAP server manager with configuration
             ldapServerManager = new KnoxLDAPServerManager();
-
-            // Prepare work directory for LDAP data
-            File gatewayDataDir = new File(config.getGatewayDataDir());
-            File ldapWorkDir = new File(gatewayDataDir, "ldap-server");
-
-            // Get configuration
-            int port = config.getLDAPPort();
-            String baseDn = config.getLDAPBaseDN();
-            String backendType = config.getLDAPBackendType();
-
-            // Get backend-specific configuration using prefixed properties
-            Map<String, String> backendConfig = config.getLDAPBackendConfig(backendType);
-
-            // Add common configuration
-            backendConfig.put("baseDn", baseDn);
-
-            // Add legacy dataFile property for backwards compatibility with file backend
-            if ("file".equalsIgnoreCase(backendType) && !backendConfig.containsKey("dataFile")) {
-                backendConfig.put("dataFile", config.getLDAPBackendDataFile());
-            }
-
-            // For proxy backends, extract remoteBaseDn if present
-            String remoteBaseDn = backendConfig.get("remoteBaseDn");
-
-            // Initialize but don't start yet
-            ldapServerManager.initialize(ldapWorkDir, port, baseDn, backendType, backendConfig, remoteBaseDn);
+            ldapServerManager.initialize(config);
 
         } catch (Exception e) {
             throw new ServiceLifecycleException("Failed to initialize LDAP service", e);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.services.ldap;
 
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
@@ -28,7 +29,7 @@ import java.util.Map;
  * Knox LDAP Service - provides an embedded LDAP server with pluggable backends
  * for user and group lookups.
  */
-public class KnoxLDAPService implements Service {
+public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
 
     private KnoxLDAPServerManager ldapServerManager;
@@ -81,6 +82,34 @@ public class KnoxLDAPService implements Service {
         }
     }
 
+    @Override
+    public void onGatewayConfigChanged(GatewayConfig config) {
+        LOG.ldapReloadingConfig();
+        try {
+            this.enabled = config.isLDAPEnabled();
+
+            if (ldapServerManager != null) {
+                boolean wasRunning = ldapServerManager.isRunning();
+                if (wasRunning) {
+                    ldapServerManager.stop();
+                }
+                // Re-initialize and start if it's now enabled
+                if (this.enabled) {
+                    ldapServerManager.initialize(config);
+                    if (wasRunning) {
+                        ldapServerManager.start();
+                    }
+                }
+            } else if (this.enabled) {
+                // If it wasn't there, but now it's enabled, we need to create and initialize it.
+                ldapServerManager = new KnoxLDAPServerManager();
+                ldapServerManager.initialize(config);
+                ldapServerManager.start();
+            }
+        } catch (Exception e) {
+            LOG.ldapServiceReloadFailed(e);
+        }
+    }
     /**
      * Get the port the LDAP server is listening on
      */

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
@@ -88,28 +88,20 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
         try {
             this.enabled = config.isLDAPEnabled();
 
-            if (ldapServerManager != null) {
-                boolean wasRunning = ldapServerManager.isRunning();
-                if (wasRunning) {
-                    ldapServerManager.stop();
-                }
-                // Re-initialize and start if it's now enabled
-                if (this.enabled) {
-                    ldapServerManager.initialize(config);
-                    if (wasRunning) {
-                        ldapServerManager.start();
-                    }
-                }
-            } else if (this.enabled) {
-                // If it wasn't there, but now it's enabled, we need to create and initialize it.
-                ldapServerManager = new KnoxLDAPServerManager();
+            if (this.enabled) {
+                this.ldapServerManager = this.ldapServerManager == null ? new KnoxLDAPServerManager() : this.ldapServerManager;
+                ldapServerManager.stop();
                 ldapServerManager.initialize(config);
                 ldapServerManager.start();
+            } else if (ldapServerManager != null) {
+                ldapServerManager.stop();
+                ldapServerManager = null;
             }
         } catch (Exception e) {
             LOG.ldapServiceReloadFailed(e);
         }
     }
+
     /**
      * Get the port the LDAP server is listening on
      */

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
@@ -102,4 +102,12 @@ public interface LdapMessages {
 
     @Message(level = MessageLevel.WARN, text = "LDAP authentication failed for user: {0}")
     void ldapAuthFailed(String user, @StackTrace(level = MessageLevel.INFO) Throwable cause);
+
+    @Message(level = MessageLevel.INFO,
+            text = "Reloading LDAP configuration")
+    void ldapReloadingConfig();
+
+    @Message(level = MessageLevel.ERROR,
+            text = "Failed to reload LDAP service: {0}")
+    void ldapServiceReloadFailed(@StackTrace(level = MessageLevel.DEBUG) Exception e);
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
@@ -107,7 +107,7 @@ public class GatewayServerTest {
     }
 
     final boolean[] notified = {false};
-    GatewayConfigChangeListener listener = () -> notified[0] = true;
+    GatewayConfigChangeListener listener = (c) -> notified[0] = true;
 
     GatewayServer.registerConfigChangeListener(listener);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway;
 
+import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.easymock.EasyMock;
 import org.junit.Rule;
@@ -32,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class GatewayServerTest {
 
@@ -94,5 +96,35 @@ public class GatewayServerTest {
 
     refreshMethod.invoke(null, config, configFile.toPath());
     EasyMock.verify(config);
+  }
+
+  @Test
+  public void testGatewayConfigChangeListener() throws Exception {
+    GatewayConfigImpl config = EasyMock.createNiceMock(GatewayConfigImpl.class);
+    File configFile = folder.newFile("gateway-reloadable-listener.xml");
+    try (PrintWriter writer = new PrintWriter(configFile, StandardCharsets.UTF_8)) {
+      writer.println("<configuration></configuration>");
+    }
+
+    final boolean[] notified = {false};
+    GatewayConfigChangeListener listener = () -> notified[0] = true;
+
+    GatewayServer.registerConfigChangeListener(listener);
+
+    try {
+      Method refreshMethod = GatewayServer.class.getDeclaredMethod("refreshGatewayConfig", GatewayConfigImpl.class, Path.class);
+      refreshMethod.setAccessible(true);
+
+      // Reset lastReloadTime to ensure refresh happens
+      Field lastReloadTimeField = GatewayServer.class.getDeclaredField("lastReloadTime");
+      lastReloadTimeField.setAccessible(true);
+      lastReloadTimeField.set(null, null);
+
+      refreshMethod.invoke(null, config, configFile.toPath());
+
+      assertTrue("Listener should have been notified", notified[0]);
+    } finally {
+      GatewayServer.unregisterConfigChangeListener(listener);
+    }
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -200,7 +200,7 @@ public class KnoxLDAPServerManagerTest {
     public void testOnGatewayConfigChanged() throws Exception {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
-        expect(mockConfig.getLDAPPort()).andReturn(3890).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(3890).times(1).andReturn(3891).anyTimes();
         expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
         expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
@@ -209,11 +209,12 @@ public class KnoxLDAPServerManagerTest {
         replay(mockConfig);
 
         serverManager.initialize(mockConfig);
+        assertEquals("Initial port should be 3890", 3890, serverManager.getPort());
 
-        // Test reload
+        // Test reload with new port
         serverManager.onGatewayConfigChanged();
 
-        assertEquals("Port should be maintained after reload", 3890, serverManager.getPort());
+        assertEquals("Port should be updated to 3891 after reload", 3891, serverManager.getPort());
     }
 
     private void cleanupTempFiles() {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.ldap;
 
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.easymock.EasyMock;
 import org.junit.Test;
 import org.junit.Before;
 import org.junit.After;
@@ -25,6 +27,8 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -71,9 +75,16 @@ public class KnoxLDAPServerManagerTest {
 
     @Test
     public void testInitializeWithFileBackend() throws Exception {
-        Map<String, String> backendConfig = createFileBackendConfig();
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(3890).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(new HashMap<>()).anyTimes();
+        replay(mockConfig);
 
-        serverManager.initialize(tempWorkDir, 3890, "dc=test,dc=com", "file", backendConfig, null);
+        serverManager.initialize(mockConfig);
 
         assertEquals("Port should be set correctly", 3890, serverManager.getPort());
         assertEquals("Base DN should be set correctly", "dc=test,dc=com", serverManager.getBaseDn());
@@ -82,9 +93,22 @@ public class KnoxLDAPServerManagerTest {
 
     @Test
     public void testInitializeWithLdapBackend() throws Exception {
-        Map<String, String> backendConfig = createLdapBackendConfig();
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(3891).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=proxy,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("ldap").anyTimes();
 
-        serverManager.initialize(tempWorkDir, 3891, "dc=proxy,dc=com", "ldap", backendConfig, "dc=hadoop,dc=apache,dc=org");
+        Map<String, String> backendConfig = new HashMap<>();
+        backendConfig.put("url", "ldap://localhost:33389");
+        backendConfig.put("remoteBaseDn", "dc=hadoop,dc=apache,dc=org");
+        backendConfig.put("systemUsername", "cn=admin,dc=hadoop,dc=apache,dc=org");
+        backendConfig.put("systemPassword", "admin-password");
+
+        expect(mockConfig.getLDAPBackendConfig("ldap")).andReturn(backendConfig).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
 
         assertEquals("Port should be set correctly", 3891, serverManager.getPort());
         assertEquals("Base DN should be set correctly", "dc=proxy,dc=com", serverManager.getBaseDn());
@@ -93,23 +117,36 @@ public class KnoxLDAPServerManagerTest {
 
     @Test(expected = Exception.class)
     public void testInitializeWithInvalidBackendType() throws Exception {
-        Map<String, String> backendConfig = new HashMap<>();
-        backendConfig.put("baseDn", "dc=test,dc=com");
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("invalid").anyTimes();
+        expect(mockConfig.getLDAPBackendConfig("invalid")).andReturn(new HashMap<>()).anyTimes();
+        replay(mockConfig);
 
-        serverManager.initialize(tempWorkDir, 3890, "dc=test,dc=com", "invalid", backendConfig, null);
+        serverManager.initialize(mockConfig);
     }
 
     @Test
     public void testLockFileCleanup() throws Exception {
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(new HashMap<>()).anyTimes();
+        replay(mockConfig);
+
+        // The manager will use tempWorkDir.getParent()/ldap-server as workDir
+        File actualWorkDir = new File(tempWorkDir.getParent(), "ldap-server");
+        actualWorkDir.mkdirs();
+
         // Create a lock file to simulate previous unclean shutdown
-        File runDir = new File(tempWorkDir, "run");
+        File runDir = new File(actualWorkDir, "run");
         runDir.mkdirs();
         File lockFile = new File(runDir, "instance.lock");
         lockFile.createNewFile();
         assertTrue("Lock file should exist before initialization", lockFile.exists());
 
-        Map<String, String> backendConfig = createFileBackendConfig();
-        serverManager.initialize(tempWorkDir, 3890, "dc=test,dc=com", "file", backendConfig, null);
+        serverManager.initialize(mockConfig);
 
         assertFalse("Lock file should be cleaned up during initialization", lockFile.exists());
     }
@@ -123,8 +160,14 @@ public class KnoxLDAPServerManagerTest {
 
     @Test
     public void testStopBeforeStart() throws Exception {
-        Map<String, String> backendConfig = createFileBackendConfig();
-        serverManager.initialize(tempWorkDir, 3890, "dc=test,dc=com", "file", backendConfig, null);
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(new HashMap<>()).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
 
         // Should not throw exception when stopping before starting
         serverManager.stop();
@@ -132,8 +175,14 @@ public class KnoxLDAPServerManagerTest {
 
     @Test
     public void testMultipleStopCalls() throws Exception {
-        Map<String, String> backendConfig = createFileBackendConfig();
-        serverManager.initialize(tempWorkDir, 3890, "dc=test,dc=com", "file", backendConfig, null);
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(new HashMap<>()).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
 
         // Multiple stop calls should not throw exceptions
         serverManager.stop();
@@ -147,21 +196,24 @@ public class KnoxLDAPServerManagerTest {
         serverManager.start();
     }
 
-    private Map<String, String> createFileBackendConfig() {
-        Map<String, String> config = new HashMap<>();
-        config.put("baseDn", "dc=test,dc=com");
-        config.put("dataFile", tempLdapFile.getAbsolutePath());
-        return config;
-    }
+    @Test
+    public void testOnGatewayConfigChanged() throws Exception {
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(3890).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(new HashMap<>()).anyTimes();
+        expect(mockConfig.isLDAPEnabled()).andReturn(true).anyTimes();
+        replay(mockConfig);
 
-    private Map<String, String> createLdapBackendConfig() {
-        Map<String, String> config = new HashMap<>();
-        config.put("baseDn", "dc=proxy,dc=com");
-        config.put("url", "ldap://localhost:33389");
-        config.put("remoteBaseDn", "dc=hadoop,dc=apache,dc=org");
-        config.put("systemUsername", "cn=admin,dc=hadoop,dc=apache,dc=org");
-        config.put("systemPassword", "admin-password");
-        return config;
+        serverManager.initialize(mockConfig);
+
+        // Test reload
+        serverManager.onGatewayConfigChanged();
+
+        assertEquals("Port should be maintained after reload", 3890, serverManager.getPort());
     }
 
     private void cleanupTempFiles() {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -196,27 +196,6 @@ public class KnoxLDAPServerManagerTest {
         serverManager.start();
     }
 
-    @Test
-    public void testOnGatewayConfigChanged() throws Exception {
-        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
-        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
-        expect(mockConfig.getLDAPPort()).andReturn(3890).times(1).andReturn(3891).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
-        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
-        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
-        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(new HashMap<>()).anyTimes();
-        expect(mockConfig.isLDAPEnabled()).andReturn(true).anyTimes();
-        replay(mockConfig);
-
-        serverManager.initialize(mockConfig);
-        assertEquals("Initial port should be 3890", 3890, serverManager.getPort());
-
-        // Test reload with new port
-        serverManager.onGatewayConfigChanged();
-
-        assertEquals("Port should be updated to 3891 after reload", 3891, serverManager.getPort());
-    }
-
     private void cleanupTempFiles() {
         if (tempLdapFile != null && tempLdapFile.exists()) {
             tempLdapFile.delete();

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServiceTest.java
@@ -165,6 +165,31 @@ public class KnoxLDAPServiceTest {
         assertFalse("Should not be enabled when not initialized", ldapService.isEnabled());
     }
 
+    @Test
+    public void testOnGatewayConfigChanged() throws Exception {
+        expect(mockConfig.isLDAPEnabled()).andReturn(true).anyTimes();
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempDataDir.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(3890).times(1).andReturn(3891).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBackendType()).andReturn("file").anyTimes();
+
+        Map<String, String> fileBackendConfig = new HashMap<>();
+        fileBackendConfig.put("dataFile", tempLdapFile.getAbsolutePath());
+        expect(mockConfig.getLDAPBackendConfig("file")).andReturn(fileBackendConfig).anyTimes();
+
+        replay(mockConfig);
+
+        ldapService.init(mockConfig, new HashMap<>());
+        assertEquals("Initial port should be 3890", 3890, ldapService.getLdapPort());
+
+        // Test reload with new port
+        ldapService.onGatewayConfigChanged(mockConfig);
+
+        assertEquals("Port should be updated to 3891 after reload", 3891, ldapService.getLdapPort());
+
+        verify(mockConfig);
+    }
+
     private void setupMockConfigForFileBackend() {
         expect(mockConfig.isLDAPEnabled()).andReturn(true);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempDataDir.getAbsolutePath());

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfigChangeListener.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfigChangeListener.java
@@ -18,5 +18,5 @@
 package org.apache.knox.gateway.config;
 
 public interface GatewayConfigChangeListener {
-  void onGatewayConfigChanged();
+  void onGatewayConfigChanged(GatewayConfig config);
 }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfigChangeListener.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfigChangeListener.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.config;
+
+public interface GatewayConfigChangeListener {
+  void onGatewayConfigChanged();
+}


### PR DESCRIPTION
[KNOX-3332](https://issues.apache.org/jira/browse/KNOX-3332) - Add listeners on gateway config changes for observers

## What changes were proposed in this pull request?

- Adds an observer pattern so clients are notified if gateway config changes.
- Knox LDAP Server Manager reloads the LDAP configs if there are changes and restart the LDAP service.

## How was this patch tested?

Unit tests

Manual test:
Started a local Knox and LDAP instance. Changed the knoxsso ldap port to 33390 and tried to login into the homepage which failed. Updated the gateway-reloadable.xml with the new port 33395 and I was able to log into the homepage.

```
2026-05-29 11:26:10,426  INFO  knox.gateway (GatewayServer.java:refreshGatewayConfig(275)) - Refreshed gateway config
2026-05-29 11:26:10,426  INFO  services.ldap (KnoxLDAPServerManager.java:onGatewayConfigChanged(109)) - Reloading LDAP configuration
2026-05-29 11:26:10,427  INFO  services.ldap (KnoxLDAPServerManager.java:stop(218)) - Stopping LDAP service on port 33,390
2026-05-29 11:26:10,445  INFO  services.ldap (KnoxLDAPServerManager.java:stop(236)) - LDAP service stopped successfully
2026-05-29 11:26:10,448  INFO  services.ldap (BackendFactory.java:createBackend(39)) - Loading backend: ldap (via ServiceLoader)
2026-05-29 11:26:10,448  INFO  services.ldap (LdapProxyBackend.java:initialize(140)) - Loading backend: ldap (via Proxying dc=hadoop,dc=apache,dc=org to ldap://localhost:33389 (dc=hadoop,dc=apache,dc=org) with uid attribute using group searches)
2026-05-29 11:26:10,449  INFO  services.ldap (LdapProxyBackend.java:initializeConnectionPool(180)) - Loading backend: ldap (via Initialized connection pool with maxActive=8)
2026-05-29 11:26:10,449  INFO  services.ldap (KnoxLDAPServerManager.java:start(131)) - Starting LDAP service on port 33,395 with base DN: dc=hadoop,dc=apache,dc=org
2026-05-29 11:26:10,540  INFO  services.ldap (KnoxLDAPServerManager.java:start(190)) - LDAP service started successfully on port 33,395
```

gateway-site.xml
```
    <!-- KnoxLDAP Service Configuration -->
    <property>
        <name>gateway.ldap.enabled</name>
        <value>true</value>
    </property>
    <property>
        <name>gateway.ldap.port</name>
        <value>33390</value>
    </property>
    <property>
        <name>gateway.ldap.base.dn</name>
        <value>dc=hadoop,dc=apache,dc=org</value>
    </property>
    <property>
        <name>gateway.ldap.backend.type</name>
        <value>ldap</value>
    </property>

    <!-- LDAP Backend specific configuration (proxying to demo ldap) -->
    <property>
        <name>gateway.ldap.backend.ldap.url</name>
        <value>ldap://localhost:33389</value>
    </property>
    <property>
        <name>gateway.ldap.backend.ldap.remoteBaseDn</name>
        <value>dc=hadoop,dc=apache,dc=org</value>
    </property>
    <property>
        <name>gateway.ldap.backend.ldap.systemUsername</name>
        <value>uid=guest,ou=people,dc=hadoop,dc=apache,dc=org</value>
    </property>
    <property>
        <name>gateway.ldap.backend.ldap.systemPassword</name>
        <value>guest-password</value>
    </property>
    <property>
        <name>gateway.ldap.backend.ldap.userSearchBase</name>
        <value>ou=people,dc=hadoop,dc=apache,dc=org</value>
    </property>
    <property>
        <name>gateway.ldap.backend.ldap.groupSearchBase</name>
        <value>ou=groups,dc=hadoop,dc=apache,dc=org</value>
    </property>
    <property>
        <name>gateway.ldap.backend.ldap.groupMemberAttribute</name>
        <value>member</value>
    </property>
```

knoxsso.xml:
```
<param>
  <name>main.ldapRealm.contextFactory.url</name>
  <value>ldap://localhost:33395</value>
</param>  
```

gateway-reloadable.xml
```
<configuration>
    <property>
        <name>gateway.ldap.port</name>
        <value>33395</value>
    </property>
</configuration>
```


## Integration Tests
N/A

## UI changes
N/A
