### PR TITLE
KNOX-3329: New database truststore type config

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -353,6 +353,7 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   private static final String GATEWAY_DATABASE_SSL_ENABLED =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.enabled";
   private static final String GATEWAY_DATABASE_VERIFY_SERVER_CERT =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.verify.server.cert";
   private static final String GATEWAY_DATABASE_TRUSTSTORE_FILE =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.truststore.file";
+  private static final String GATEWAY_DATABASE_SSL_TRUSTSTORE_TYPE =  GATEWAY_CONFIG_FILE_PREFIX + ".database.ssl.truststore.type";
 
   // Concurrent session properties
   private static final String GATEWAY_SESSION_VERIFICATION_PREFIX = GATEWAY_CONFIG_FILE_PREFIX + ".session.verification";
@@ -1539,6 +1540,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   @Override
   public String getDatabaseSslTruststoreFileName() {
     return get(GATEWAY_DATABASE_TRUSTSTORE_FILE);
+  }
+
+  @Override
+  public String getDatabaseSslTruststoreType() {
+    return get(GATEWAY_DATABASE_SSL_TRUSTSTORE_TYPE, "JKS");
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/database/MysqlDataSourceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/database/MysqlDataSourceFactory.java
@@ -49,7 +49,7 @@ public class MysqlDataSourceFactory extends AbstractDataSourceFactory {
             if (gatewayConfig.verifyDatabaseSslServerCertificate()) {
                 dataSource.setSslMode(PropertyDefinitions.SslMode.VERIFY_CA.name());
                 dataSource.setVerifyServerCertificate(true);
-                dataSource.setTrustCertificateKeyStoreType("JKS");
+                dataSource.setTrustCertificateKeyStoreType(gatewayConfig.getDatabaseSslTruststoreType());
                 dataSource.setTrustCertificateKeyStoreUrl("file:" + gatewayConfig.getDatabaseSslTruststoreFileName());
                 dataSource.setTrustCertificateKeyStorePassword(getDatabaseAlias(aliasService, DATABASE_TRUSTSTORE_PASSWORD_ALIAS_NAME));
             } else {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/database/OracleDataSourceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/database/OracleDataSourceFactory.java
@@ -62,7 +62,7 @@ public class OracleDataSourceFactory extends AbstractDataSourceFactory {
             oracleDataSource.setNetworkProtocol("tcps");
             if (gatewayConfig.verifyDatabaseSslServerCertificate()) {
                 oracleDataSource.setConnectionProperty("javax.net.ssl.trustStore", gatewayConfig.getDatabaseSslTruststoreFileName());
-                oracleDataSource.setConnectionProperty("javax.net.ssl.trustStoreType", "JKS");
+                oracleDataSource.setConnectionProperty("javax.net.ssl.trustStoreType", gatewayConfig.getDatabaseSslTruststoreType());
                 final String truststorePassword = getDatabaseAlias(aliasService, DATABASE_TRUSTSTORE_PASSWORD_ALIAS_NAME);
                 if (truststorePassword != null) {
                     oracleDataSource.setConnectionProperty("javax.net.ssl.trustStorePassword", truststorePassword);

--- a/gateway-server/src/test/java/org/apache/knox/gateway/database/DataSourceProviderTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/database/DataSourceProviderTest.java
@@ -185,6 +185,26 @@ public class DataSourceProviderTest {
   }
 
   @Test
+  public void mysqlDataSourceShouldHaveProperSslConnectionProperties() throws Exception {
+    GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(gatewayConfig.getDatabaseType()).andReturn(DatabaseType.MYSQL.type()).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseHost()).andReturn("localhost").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabasePort()).andReturn(3306).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseName()).andReturn("sampleDatabase");
+    EasyMock.expect(gatewayConfig.isDatabaseSslEnabled()).andReturn(true).anyTimes();
+    EasyMock.expect(gatewayConfig.verifyDatabaseSslServerCertificate()).andReturn(true).anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseSslTruststoreFileName()).andReturn("/path/to/truststore").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseSslTruststoreType()).andReturn("BCFKS").anyTimes();
+
+    EasyMock.replay(gatewayConfig, aliasService);
+    MysqlDataSource dataSource = (MysqlDataSource) DataSourceProvider.getDataSource(gatewayConfig, aliasService);
+    assertTrue(dataSource.getUseSSL());
+    assertEquals("BCFKS", dataSource.getTrustCertificateKeyStoreType());
+    assertEquals("file:/path/to/truststore", dataSource.getTrustCertificateKeyStoreUrl());
+  }
+
+  @Test
   public void testGetMySqlDatasourceFromJdbcConnectionUrl() throws Exception {
     String connectionUrl = "jdbc:mysql://mysql_host:1234/testDb?user=user&password=secret&ssl=true&sslmode=verify-ca&sslrootcert=/var/lib/knox/gateway/conf/postgresql/root.crt";
     GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
@@ -283,11 +303,12 @@ public class DataSourceProviderTest {
     EasyMock.expect(gatewayConfig.isDatabaseSslEnabled()).andReturn(true).anyTimes();
     EasyMock.expect(gatewayConfig.verifyDatabaseSslServerCertificate()).andReturn(true).anyTimes();
     EasyMock.expect(gatewayConfig.getDatabaseSslTruststoreFileName()).andReturn("/path/to/truststore").anyTimes();
+    EasyMock.expect(gatewayConfig.getDatabaseSslTruststoreType()).andReturn("BCFKS").anyTimes();
     EasyMock.replay(gatewayConfig, aliasService);
     final OracleDataSource dataSource = (OracleDataSource) DataSourceProvider.getDataSource(gatewayConfig, aliasService);
     assertEquals("tcps", dataSource.getNetworkProtocol());
     assertEquals("/path/to/truststore", dataSource.getConnectionProperty("javax.net.ssl.trustStore"));
-    assertEquals("JKS", dataSource.getConnectionProperty("javax.net.ssl.trustStoreType"));
+    assertEquals("BCFKS", dataSource.getConnectionProperty("javax.net.ssl.trustStoreType"));
     //Can't validate the truststore password because oracle datasource doesn't return it.
   }
 

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -76,6 +76,8 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   private boolean sslEnabled;
   private String truststoreType = "jks";
   private String keystoreType = "jks";
+  private String databaseSslTruststoreType = "JKS";
+
   private boolean isTopologyPortMappingEnabled = true;
   private ConcurrentMap<String, Integer> topologyPortMapping = new ConcurrentHashMap<>();
   private int backupVersionLimit = -1;
@@ -365,12 +367,21 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getDatabaseSslTruststoreType() {
+    return databaseSslTruststoreType;
+  }
+
+  @Override
   public String getTruststorePasswordAlias() {
     return null;
   }
 
   public void setTruststoreType( String truststoreType ) {
     this.truststoreType = truststoreType;
+  }
+
+  public void setDatabaseSslTruststoreType(String databaseSslTruststoreType) {
+    this.databaseSslTruststoreType = databaseSslTruststoreType;
   }
 
   @Override

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -233,6 +233,8 @@ public interface GatewayConfig {
 
   String getTruststoreType();
 
+  String getDatabaseSslTruststoreType();
+
   /**
    * Returns the configured value for the alias name to use when to looking up the Gateway's
    * truststore password.


### PR DESCRIPTION
[KNOX-3329](https://issues.apache.org/jira/browse/KNOX-3329) - New config for database truststore file type

## What changes were proposed in this pull request?

Adds a new config to set the database cert file. It was hardcoded to be JKS for Mysql and Oracle.

- Postgres supports only PEM
- Mysql support PEM, JKS, BCFKS ...
- Oracle supports JKS, BCFKS ... (no PEM)

## How was this patch tested?

Unit tests, manual tests

## Integration Tests
N/A

## UI changes
N/A