### PR TITLE
KNOX-3339: Upgrade log4j2 to 2.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <junit.version>4.13.2</junit.version>
         <kotlin-stdlib.version>1.9.10</kotlin-stdlib.version>
         <libpam4j.version>1.11</libpam4j.version>
-        <log4j2.version>2.20.0</log4j2.version>
+        <log4j2.version>2.26.0</log4j2.version>
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>


### PR DESCRIPTION
[KNOX-3339](https://issues.apache.org/jira/browse/KNOX-3339) - Upgrade log4j2 to 2.26.0

## What changes were proposed in this pull request?

Upgrades log4j2 to 2.26.0

## How was this patch tested?

Tested locally. Checked logs, changed log level, changed loggers, changed runtime log levels

## Integration Tests
N/A

## UI changes
N/A
