### PR TITLE
KNOX-3336: New LDAP Service Factory

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/DefaultGatewayServices.java
@@ -21,13 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.knox.gateway.GatewayMessages;
-import org.apache.knox.gateway.GatewayServer;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.deploy.DeploymentContext;
 import org.apache.knox.gateway.descriptor.FilterParamDescriptor;
 import org.apache.knox.gateway.descriptor.ResourceDescriptor;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.services.ldap.KnoxLDAPService;
 import org.apache.knox.gateway.services.security.KeystoreService;
 import org.apache.knox.gateway.services.security.KeystoreServiceException;
 import org.apache.knox.gateway.topology.Provider;
@@ -85,13 +83,7 @@ public class DefaultGatewayServices extends AbstractGatewayServices {
 
     addService(ServiceType.GATEWAY_STATUS_SERVICE, gatewayServiceFactory.create(this, ServiceType.GATEWAY_STATUS_SERVICE, config, options));
 
-    // LDAP Service - infrastructure service for embedded LDAP server
-    if (config.isLDAPEnabled()) {
-      KnoxLDAPService ldapService = new KnoxLDAPService();
-      ldapService.init(config, options);
-      GatewayServer.registerConfigChangeListener(ldapService);
-      addService(ServiceType.LDAP_SERVICE, ldapService);
-    }
+    addService(ServiceType.LDAP_SERVICE, gatewayServiceFactory.create(this, ServiceType.LDAP_SERVICE, config, options));
   }
 
   @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/LdapServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/LdapServiceFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.factory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.knox.gateway.GatewayServer;
+import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.Service;
+import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.ldap.KnoxLDAPService;
+
+public class LdapServiceFactory extends AbstractServiceFactory {
+
+    @Override
+    protected Service createService(GatewayServices gatewayServices, ServiceType serviceType, GatewayConfig gatewayConfig, Map<String, String> options,
+                                    String implementation) throws ServiceLifecycleException {
+        Service service = null;
+        if (shouldCreateService(implementation)) {
+            service = new KnoxLDAPService();
+            GatewayServer.registerConfigChangeListener((KnoxLDAPService) service);
+        }
+        return service;
+    }
+
+    @Override
+    protected ServiceType getServiceType() {
+        return ServiceType.LDAP_SERVICE;
+    }
+
+    @Override
+    protected Collection<String> getKnownImplementations() {
+        return Collections.singleton(KnoxLDAPService.class.getName());
+    }
+}

--- a/gateway-server/src/main/resources/META-INF/services/org.apache.knox.gateway.services.ServiceFactory
+++ b/gateway-server/src/main/resources/META-INF/services/org.apache.knox.gateway.services.ServiceFactory
@@ -33,3 +33,4 @@ org.apache.knox.gateway.services.factory.TokenStateServiceFactory
 org.apache.knox.gateway.services.factory.TopologyServiceFactory
 org.apache.knox.gateway.services.factory.ConcurrentSessionVerifierFactory
 org.apache.knox.gateway.services.factory.GatewayStatusServiceFactory
+org.apache.knox.gateway.services.factory.LdapServiceFactory


### PR DESCRIPTION
[KNOX-3336](https://issues.apache.org/jira/browse/KNOX-3336) - New LDAP Service Factory

## What changes were proposed in this pull request?

- Moved the LDAP Service creation into its own factory class to follow the existing pattern
- Bugfix: If `ldap.enabled` was set to `false` initially reloadable configs wouldn't mater because the LDAP service was unable to start. The isLDAPEnabled guard is no longer needed in DefaultGatewayServices because KnoxLDAPService.init() already handles it — when disabled, it simply sets enabled = false and returns, making start()/stop() no-ops. The service object is lightweight when inert, and keeping it alive lets onGatewayConfigChanged() dynamically enable LDAP without a gateway restart.

## How was this patch tested?

Unit tests, local test with reloadable.

Manual test:
Started a local Knox and LDAP instance. Changed the knoxsso ldap port to 3890 and tried to login into the homepage which failed. Updated the gateway-reloadable.xml with the below ldap configs and I was able to log into the homepage.


```
2026-06-08 18:00:34,783  INFO  knox.gateway (GatewayServer.java:refreshGatewayConfig(275)) - Refreshed gateway config
2026-06-08 18:00:34,786  INFO  services.ldap (KnoxLDAPService.java:onGatewayConfigChanged(87)) - Reloading LDAP configuration
2026-06-08 18:00:34,798  INFO  services.ldap (KnoxLDAPServerManager.java:stop(240)) - Stopping LDAP service on port 0
2026-06-08 18:00:34,798  INFO  services.ldap (KnoxLDAPServerManager.java:stop(260)) - LDAP service stopped successfully
2026-06-08 18:00:34,800  INFO  services.ldap (InterceptorFactory.java:createInterceptor(49)) - Creating interceptor: backend (via ServiceLoader)
2026-06-08 18:00:34,801  INFO  services.ldap (BackendFactory.java:createBackend(46)) - Loading backend: ldap (via ServiceLoader)
2026-06-08 18:00:34,804  INFO  services.ldap (LdapProxyBackend.java:<init>(146)) - Loading backend: localldap (via Proxying dc=proxy,dc=com to ldap://localhost:33389 (dc=hadoop,dc=apache,dc=org) with uid attribute using group searches)
2026-06-08 18:00:34,819  INFO  services.ldap (LdapProxyBackend.java:initializeConnectionPool(201)) - Loading backend: ldap (via Initialized connection pool with maxActive=8)
2026-06-08 18:00:34,819  INFO  services.ldap (KnoxLDAPServerManager.java:start(133)) - Starting LDAP service on port 3,890 with base DN: dc=proxy,dc=com
2026-06-08 18:00:35,110  INFO  services.ldap (KnoxLDAPServerManager.java:start(186)) - LDAP service started successfully on port 3,890
```

knoxsso.xml:

```
<param>
    <name>main.ldapRealm.contextFactory.url</name>
    <value>ldap://localhost:3890</value>
</param> 
```

gateway-reloadable.xml

```
    <!-- LDAP Proxy Service Configuration -->
    <property>
        <name>gateway.ldap.enabled</name>
        <value>true</value>
        <description>Enable the embedded LDAP service for user and group lookups. Set to true to enable.</description>
    </property>
    <property>
        <name>gateway.ldap.port</name>
        <value>3890</value>
        <description>Port for the LDAP service to listen on. Default is 3890.</description>
    </property>
    <property>
        <name>gateway.ldap.base.dn</name>
        <value>dc=proxy,dc=com</value>
        <description>Base DN for LDAP entries in the proxy server. Default is dc=proxy,dc=com.</description>
    </property>
    <property>
        <name>gateway.ldap.interceptor.names</name>
        <value>localldap</value>
        <description>Interceptor names for LDAP service.</description>
    </property>

    <!-- Local LDAP Server -->
    <property>
        <name>gateway.ldap.interceptor.localldap.interceptorType</name>
        <value>backend</value>
        <description>Type of interceptor. Currently supported: backend, duplicateuserfilter</description>
    </property>
    <property>
        <name>gateway.ldap.interceptor.localldap.backendType</name>
        <value>ldap</value>
        <description>Type of backend. Currently supported: file, ldap. Future: jdbc, knox.</description>
    </property>
    <property>
        <name>gateway.ldap.interceptor.localldap.url</name>
        <value>ldap://localhost:33389</value>
        <description>LDAP server URL for proxy backend</description>
    </property>
    <property>
        <name>gateway.ldap.interceptor.localldap.remoteBaseDn</name>
        <value>dc=hadoop,dc=apache,dc=org</value>
        <description>Base DN of the remote LDAP server</description>
    </property>
    <property>
        <name>gateway.ldap.interceptor.localldap.systemUsername</name>
        <value>uid=guest,ou=people,dc=hadoop,dc=apache,dc=org</value>
        <description>LDAP bind DN for proxy backend authentication</description>
    </property>
    <property>
        <name>gateway.ldap.interceptor.localldap.systemPassword</name>
        <value>guest-password</value>
        <description>LDAP bind password for proxy backend authentication</description>
    </property>

```
## Integration Tests
N/A

## UI changes
N/A
