### PR TITLE
KNOX-3342: Fixed NPE in HadoopGroupFilter when hadoopGroups instance wasn't set

### DIFF
--- a/gateway-provider-identity-assertion-hadoop-groups/src/main/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilter.java
+++ b/gateway-provider-identity-assertion-hadoop-groups/src/main/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilter.java
@@ -130,7 +130,7 @@ public class HadoopGroupProviderFilter extends CommonIdentityAssertionFilter {
 
   protected List<String> hadoopGroups(String mappedPrincipalName) throws Exception {
     if (ldapService == null) {
-      return hadoopGroups.getGroups(mappedPrincipalName);
+      return hadoopGroups == null ? List.of() : hadoopGroups.getGroups(mappedPrincipalName);
     } else {
       LOG.useKnoxLDAPService();
       return ldapService.getUserGroups(mappedPrincipalName);

--- a/gateway-provider-identity-assertion-hadoop-groups/src/test/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilterTest.java
+++ b/gateway-provider-identity-assertion-hadoop-groups/src/test/java/org/apache/knox/gateway/identityasserter/hadoop/groups/filter/HadoopGroupProviderFilterTest.java
@@ -273,6 +273,19 @@ public class HadoopGroupProviderFilterTest {
   }
 
   @Test
+  public void testHadoopGroupsIsNull() throws Exception {
+    final HadoopGroupProviderFilter filter = new HadoopGroupProviderFilter();
+
+    final Subject subject = new Subject();
+    subject.getPrincipals().add(new PrimaryPrincipal(username));
+
+    // no init() method called -> hadoopGroups is null
+    final String[] groups = filter.mapGroupPrincipals(username, subject);
+
+    assertThat(groups.length, is(0));
+  }
+
+  @Test
   public void testLdapServiceIntegration() throws Exception {
     KnoxLDAPService ldapService = EasyMock.createNiceMock(KnoxLDAPService.class);
     doTestLdapServiceIntegration(true, Arrays.asList("group1", "group2"), ldapService);


### PR DESCRIPTION
[KNOX-3342](https://issues.apache.org/jira/browse/KNOX-3342) - NPE in HadoopGroupsFilter

## What changes were proposed in this pull request?

This is a simple change that fixes a possible NPE when `org.apache.knox.gateway.identityasserter.hadoop.groups.filter.HadoopGroupProviderFilter#hadoopGroups` is `null`.

## How was this patch tested?

Added a new unit test case to cover this issue.

## Integration Tests
N/A

## UI changes.
N/A
