### PR TITLE
KNOX-3445: ignore GatewayServerTest.testRefreshGatewayConfig temporarily

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
@@ -21,6 +21,7 @@ import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.easymock.EasyMock;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -47,6 +48,7 @@ public class GatewayServerTest {
   }
 
   @Test
+  @Ignore
   public void testRefreshGatewayConfig() throws Exception {
     GatewayConfigImpl config = EasyMock.createNiceMock(GatewayConfigImpl.class);
 


### PR DESCRIPTION
[KNOX-3345](https://issues.apache.org/jira/browse/KNOX-3345) - Disable `org.apache.knox.gateway.GatewayServerTest#testRefreshGatewayConfig`

## What changes were proposed in this pull request?

Disabled `org.apache.knox.gateway.GatewayServerTest#testRefreshGatewayConfig`

## How was this patch tested?

N/A

## Integration Tests
N/A

## UI changes
N/A
