### PR TITLE
KNOX-3345: Fix intermittent testRefreshGatewayConfig test issue

### DIFF
--- a/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/GatewayServerTest.java
@@ -21,7 +21,6 @@ import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.easymock.EasyMock;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -48,7 +47,6 @@ public class GatewayServerTest {
   }
 
   @Test
-  @Ignore
   public void testRefreshGatewayConfig() throws Exception {
     GatewayConfigImpl config = EasyMock.createNiceMock(GatewayConfigImpl.class);
 
@@ -65,6 +63,11 @@ public class GatewayServerTest {
     Method refreshMethod = GatewayServer.class.getDeclaredMethod("refreshGatewayConfig", GatewayConfigImpl.class, Path.class);
     refreshMethod.setAccessible(true);
 
+    // Reset static lastReloadTime to ensure test isolation
+    Field lastReloadTimeField = GatewayServer.class.getDeclaredField("lastReloadTime");
+    lastReloadTimeField.setAccessible(true);
+    lastReloadTimeField.set(null, null);
+
     // Initial load
     config.reloadConfiguration();
     EasyMock.expectLastCall().once();
@@ -75,8 +78,6 @@ public class GatewayServerTest {
     EasyMock.verify(config);
 
     // Check lastReloadTime is set
-    Field lastReloadTimeField = GatewayServer.class.getDeclaredField("lastReloadTime");
-    lastReloadTimeField.setAccessible(true);
     FileTime lastReloadTime = (FileTime) lastReloadTimeField.get(null);
     assertNotNull(lastReloadTime);
 


### PR DESCRIPTION
[KNOX-3345](https://issues.apache.org/jira/browse/KNOX-3345) - GatewayServerTest.testRefreshGatewayConfig fails intermittently

## What changes were proposed in this pull request?

- The static field GatewayServer.lastReloadTime leaks state between tests. When testGatewayConfigChangeListener runs first, resets lastReloadTime to null for itself but leaves it set after completion.

## How was this patch tested?

Ran unit tests locally

## Integration Tests
N/A

## UI changes
N/A
