### PR TITLE
KNOX-3348: Upgrade BouncyCastle to 1.84

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,8 @@
         <asm.version>9.0</asm.version>
         <aspectj.version>1.9.6</aspectj.version>
         <asynchttpclient.version>4.1.5</asynchttpclient.version>
-        <bcprov-jdk18on.version>1.79</bcprov-jdk18on.version>
-        <bcpkix-jdk18on.version>1.79</bcpkix-jdk18on.version>
+        <bcprov-jdk18on.version>1.84</bcprov-jdk18on.version>
+        <bcpkix-jdk18on.version>1.84</bcpkix-jdk18on.version>
         <ben-manes.caffeine.version>2.8.8</ben-manes.caffeine.version>
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <cglib.version>3.3.0</cglib.version>
@@ -2595,10 +2595,6 @@
                     <exclusion>
                         <groupId>dom4j</groupId>
                         <artifactId>dom4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
[KNOX-3348](https://issues.apache.org/jira/browse/KNOX-3348) - Upgrade BouncyCastle to 1.84

## What changes were proposed in this pull request?

- Upgrade BouncyCastle libraries to 1.84
- Removed exclude where its no longer necessary

## How was this patch tested?
Tested classpath with:
`mvn dependency:tree  -Dincludes="org.bouncycastle:*"`

Tested pac4j flow, ran unit tests that were failing in the dependabot PR due to missing bcprov upgrade

## Integration Tests
N/A

## UI changes
N/A