### PR TITLE
KNOX-3350: Populate groups in KnoxSSO cookie when configured

### DIFF
--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
@@ -51,6 +52,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.audit.log4j.audit.Log4jAuditor;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.security.SubjectUtils;
 import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceType;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -84,6 +86,7 @@ public class WebSSOResource {
   private static final String SSO_COOKIE_TOKEN_TYPE_PARAM = "knoxsso.token.type";
   private static final String SSO_COOKIE_TOKEN_AUDIENCES_PARAM = "knoxsso.token.audiences";
   private static final String SSO_COOKIE_TOKEN_SIG_ALG = "knoxsso.token.sigalg";
+  private static final String SSO_COOKIE_INCLUDE_GROUPS_PARAM = "knoxsso.token.include.groups";
   private static final String SSO_COOKIE_TOKEN_WHITELIST_PARAM = "knoxsso.redirect.whitelist.regex";
 
   private static final String SSO_SIGNINGKEY_KEYSTORE_NAME = "knoxsso.signingkey.keystore.name";
@@ -111,6 +114,7 @@ public class WebSSOResource {
   private List<String> targetAudiences = new ArrayList<>();
   private boolean enableSession;
   private String signatureAlgorithm;
+  private boolean includeGroups;
   private List<String> ssoExpectedparams = new ArrayList<>();
   private String clusterName;
   private String tokenIssuer;
@@ -224,6 +228,8 @@ public class WebSSOResource {
     }
     final String configuredTokenType = context.getInitParameter(SSO_COOKIE_TOKEN_TYPE_PARAM);
     tokenType = StringUtils.isBlank(configuredTokenType) ? JOSEObjectType.JWT.getType() : configuredTokenType;
+
+    includeGroups = Boolean.parseBoolean(context.getInitParameter(SSO_COOKIE_INCLUDE_GROUPS_PARAM));
   }
 
   @GET
@@ -314,7 +320,9 @@ public class WebSSOResource {
               .setSigningKeystorePassphrase(signingKeystorePassphrase)
               .setManaged(tokenStateService != null)
               .setType(tokenType)
+              .setGroups(groups())
               .build();
+
       JWT token = tokenAuthority.issueToken(jwtAttributes);
 
       // Coverity CID 1327959
@@ -349,9 +357,11 @@ public class WebSSOResource {
       // todo log return error response
     }
 
-
-
     return Response.seeOther(location).entity("{ \"redirectTo\" : " + original + " }").build();
+  }
+
+  Set<String> groups() {
+    return includeGroups ? SubjectUtils.getCurrentGroupPrincipalNames() : null;
   }
 
   protected String getOriginalUrlFromQueryParams() {

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -689,6 +689,55 @@ public class WebSSOResourceTest {
   }
 
   @Test
+  public void testIncludeGroupsTrue() throws Exception {
+    testIncludeGroups(Boolean.TRUE, Collections.singleton("group1"), true);
+  }
+
+  @Test
+  public void testIncludeGroupsFalse() throws Exception {
+    testIncludeGroups(Boolean.FALSE, Collections.singleton("group1"), false);
+  }
+
+  @Test
+  public void testIncludeGroupsOmitted() throws Exception {
+    testIncludeGroups(null, Collections.singleton("group1"), false);
+  }
+
+  private void testIncludeGroups(Boolean includeGroupsParam, Set<String> groupsToReturn, boolean expectedInToken) throws Exception {
+    final boolean includeGroups = includeGroupsParam != null && includeGroupsParam;
+    configureCommonExpectations(includeGroups ? Map.of("knoxsso.token.include.groups", includeGroupsParam.toString()) : Map.of());
+
+    final TestWebSSOResource webSSOResponse = new TestWebSSOResource(includeGroups ? groupsToReturn : null);
+    webSSOResponse.request = request;
+    webSSOResponse.response = responseWrapper;
+    webSSOResponse.context = context;
+    webSSOResponse.init();
+
+    // Issue a token
+    webSSOResponse.doGet();
+
+    // Check the cookie
+    final Cookie cookie = responseWrapper.getCookie("hadoop-jwt");
+    assertNotNull(cookie);
+
+    final JWT parsedToken = new JWTToken(cookie.getValue());
+    assertEquals("alice", parsedToken.getSubject());
+    assertTrue(authority.verifyToken(parsedToken));
+
+    // Verify the groups
+    List<String> tokenGroups = (List<String>) parsedToken.getClaimAsObject(JWTToken.KNOX_GROUPS_CLAIM);
+    if (expectedInToken) {
+      assertNotNull(tokenGroups);
+      assertEquals(groupsToReturn.size(), tokenGroups.size());
+      for (String group : groupsToReturn) {
+        assertTrue(tokenGroups.contains(group));
+      }
+    } else {
+      Assert.assertNull(tokenGroups);
+    }
+  }
+
+  @Test
   public void testConcurrentSessionLimitHit() throws Exception {
     configureCommonExpectations(Collections.emptyMap(), false, false, false);
 
@@ -808,6 +857,24 @@ public class WebSSOResourceTest {
     assertEquals(ORIGINAL_URL, result);
   }
 
+
+  private static class TestWebSSOResource extends WebSSOResource {
+    private final Set<String> groups;
+
+    private TestWebSSOResource(Set<String> groups) {
+      this.groups = groups;
+    }
+
+
+    @Override
+    Set<String> groups() {
+      try {
+        return groups;
+      } catch (Exception e) {
+        return null;
+      }
+    }
+  }
 
   /**
    * A wrapper for HttpServletResponseWrapper to store the cookies

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -1149,11 +1149,7 @@ public class TokenResource {
   }
 
   protected Set<String> groups() {
-    Subject subject = SubjectUtils.getCurrentSubject();
-    Set<String> groups = subject.getPrincipals(GroupPrincipal.class).stream()
-            .map(GroupPrincipal::getName)
-            .collect(Collectors.toSet());
-    return groups;
+    return SubjectUtils.getCurrentGroupPrincipalNames();
   }
 
   protected void addArbitraryTokenMetadata(TokenMetadata tokenMetadata) {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
@@ -26,6 +26,7 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * General utility methods for interrogating the standard java Subject
@@ -92,6 +93,11 @@ public class SubjectUtils {
   public static Set<GroupPrincipal> getCurrentGroupPrincipals() {
     final Subject subject = getCurrentSubject();
     return subject == null ? Collections.emptySet() : getGroupPrincipals(subject);
+  }
+
+  public static Set<String> getCurrentGroupPrincipalNames() {
+    final Set<GroupPrincipal> groupPrincipals = getCurrentGroupPrincipals();
+    return groupPrincipals.isEmpty() ? Collections.emptySet() : groupPrincipals.stream().map(Principal::getName).collect(Collectors.toSet());
   }
 
   public static Set<GroupPrincipal> getGroupPrincipals(Subject subject) {


### PR DESCRIPTION
[KNOX-3350](https://issues.apache.org/jira/browse/KNOX-3350) - Add group information into the generated JWT in WebSSOResource

 ## What changes were proposed in this pull request?
This PR introduces the ability to include group information in the JWT tokens generated by `WebSSOResource` (KnoxSSO). 


 Key changes include:
  * Added a new configuration parameter `knoxsso.token.include.groups` to control whether group information should be included in the issued JWT.
  * Updated `getAuthenticationToken` in `WebSSOResource` to populate the `groups` claim in `JWTokenAttributes` when the feature is enabled.
  * Standardized group retrieval in `TokenResource` by utilizing `SubjectUtils.getCurrentGroupPrincipalNames()`.

## How was this patch tested?

The changes were verified by adding comprehensive unit tests in `WebSSOResourceTest`:
  * `testIncludeGroupsTrue`: Verifies that groups are correctly included in the JWT when `knoxsso.token.include.groups` is set to `true`.
  * `testIncludeGroupsFalse`: Verifies that groups are excluded when the parameter is set to `false`.
  * `testIncludeGroupsOmitted`: Verifies that the default behavior (when the parameter is missing) is to exclude groups.

## Integration Tests
I ran manual testing using my local Knox instance against the `knoxsso` topology. I logged in as `recursiveUser`, verified `hadoop-jwt` (extracted from DEV tools in Chrome) is generated, then checked its content on `jwt.io`:

1. Without `knoxsso.token.include.groups`:
<img width="1338" height="525" alt="image" src="https://github.com/user-attachments/assets/c6af3bd7-3ee3-4f20-a968-4bbc38673190" />

2. `knoxsso.token.include.groups = false`:
<img width="1332" height="520" alt="image" src="https://github.com/user-attachments/assets/bdd3ea1d-ecfb-4604-9aa5-311373b8e4c4" />

3. `knoxsso.token.include.groups = true`:
<img width="1333" height="626" alt="image" src="https://github.com/user-attachments/assets/605f9429-abcc-4db0-b6df-09dd880516b5" />


## UI changes
N/A