### PR TITLE
KNOX-3352: Set scheme for Iceberg REST catalog based on ssl enabled c…

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGenerator.java
@@ -36,6 +36,7 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
   static final String HTTP_PORT = "hive_metastore_catalog_servlet_port";
   static final String HTTP_PATH = "hive_metastore_catalog_servlet_path";
   static final String REST_CATALOG_ENABLED = "hive_rest_catalog_enabled";
+  static final String SSL_ENABLED    = "hiveserver2_enable_ssl";
 
   static final String DEFAULT_HTTP_PATH = "icecli";
 
@@ -74,7 +75,8 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
                                       ApiRole role,
                                       ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
-    String scheme = "http";
+    boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));
+    String scheme = sslEnabled ? "https" : "http";
     String port = getHttpPort(serviceConfig);
     String httpPath = getHttpPath(serviceConfig);
 
@@ -87,6 +89,7 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
     model.addServiceProperty(HTTP_PORT, getHttpPort(serviceConfig));
     model.addServiceProperty(HTTP_PATH, getHttpPath(serviceConfig));
     model.addServiceProperty(REST_CATALOG_ENABLED, getRestCatalogEnabled(serviceConfig));
+    model.addServiceProperty(SSL_ENABLED, Boolean.toString(sslEnabled));
 
     return model;
   }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGeneratorTest.java
@@ -53,7 +53,7 @@ public class IcebergRestServiceModelGeneratorTest extends AbstractServiceModelGe
     serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PORT, "8090");
     serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PATH, "icecli");
     serviceConfig.put(IcebergRestServiceModelGenerator.REST_CATALOG_ENABLED, "true");
-    serviceConfig.put(IcebergRestServiceModelGenerator.SSL_ENABLED, "true");
+    serviceConfig.put(IcebergRestServiceModelGenerator.SSL_ENABLED, "false");
 
     final Map<String, String> roleConfig = Collections.emptyMap();
 

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGeneratorTest.java
@@ -50,9 +50,23 @@ public class IcebergRestServiceModelGeneratorTest extends AbstractServiceModelGe
   @Test
   public void testServiceModel() {
     final Map<String, String> serviceConfig = new HashMap<>();
-    serviceConfig.put("hive_metastore_catalog_servlet_port", "8090");
-    serviceConfig.put("hive_metastore_catalog_servlet_path", "icecli");
-    serviceConfig.put("hive_rest_catalog_enabled", "true");
+    serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PORT, "8090");
+    serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PATH, "icecli");
+    serviceConfig.put(IcebergRestServiceModelGenerator.REST_CATALOG_ENABLED, "true");
+    serviceConfig.put(IcebergRestServiceModelGenerator.SSL_ENABLED, "true");
+
+    final Map<String, String> roleConfig = Collections.emptyMap();
+
+    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+  }
+
+  @Test
+  public void testServiceModelSslEnabled() {
+    final Map<String, String> serviceConfig = new HashMap<>();
+    serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PORT, "8091");
+    serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PATH, "icecli2");
+    serviceConfig.put(IcebergRestServiceModelGenerator.REST_CATALOG_ENABLED, "false");
+    serviceConfig.put(IcebergRestServiceModelGenerator.SSL_ENABLED, "true");
 
     final Map<String, String> roleConfig = Collections.emptyMap();
 


### PR DESCRIPTION
…onfig

[KNOX-3352](https://issues.apache.org/jira/browse/KNOX-3352) - Iceberg REST catalog CM service discovery won't generate the correct model for secure HMS

## What changes were proposed in this pull request?

- Set scheme for Iceberg REST catalog based on ssl enabled config

## How was this patch tested?

Unit tests

## Integration Tests
N/A
## UI changes
N/A
