### PR TITLE
KNOX-3351: Resolve LDAP roles for users with no groups

### DIFF
--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
@@ -105,9 +105,9 @@ public abstract class AbstractAuthResource {
     final Set<String> matchingGroupNames = subject == null ? Collections.emptySet()
             : SubjectUtils.getGroupPrincipals(subject).stream().filter(group -> groupFilterPattern.matcher(group.getName()).matches()).map(group -> group.getName())
             .collect(Collectors.toSet());
-    if (!matchingGroupNames.isEmpty()) {
-      final Collection<String> roles = lookupRoles(primaryPrincipalName, matchingGroupNames);
-      final List<String> groupStrings = GroupUtils.getGroupStrings(roles == null ? matchingGroupNames : roles, groupHeaderLengthLimit, groupHeaderSizeLimit);
+    final Collection<String> roles = lookupRoles(primaryPrincipalName, matchingGroupNames);
+    if (!matchingGroupNames.isEmpty() || !roles.isEmpty()) {
+      final List<String> groupStrings = GroupUtils.getGroupStrings(roles.isEmpty() ? matchingGroupNames : roles, groupHeaderLengthLimit, groupHeaderSizeLimit);
       for (int i = 0; i < groupStrings.size(); i++) {
         getResponse().addHeader(String.format(Locale.ROOT, ACTOR_GROUPS_HEADER_FORMAT, authHeaderActorGroupsPrefix, i + 1), groupStrings.get(i));
       }
@@ -116,17 +116,16 @@ public abstract class AbstractAuthResource {
   }
 
   private Collection<String> lookupRoles(String userName, Collection<String> groups) {
+    Collection<String> roles = null;
       try {
         if (ldapRolesLookupService != null && ldapRolesLookupService.enabled()) {
-          return ldapRolesLookupService.lookupRoles(userName, groups);
-        } else {
-          return null;
+          roles = ldapRolesLookupService.lookupRoles(userName, groups);
         }
       } catch (Exception e) {
         // Couldn't lookup roles: log and return null so that the API will return the groups
         LOG.ldapRolesLookupFailed(userName, e);
-        return null;
       }
+      return roles == null ? Collections.emptySet() : roles;
   }
 
 }


### PR DESCRIPTION
[KNOX-3351](https://issues.apache.org/jira/browse/KNOX-3351) - Resolve LDAP roles for users with no groups

## What changes were proposed in this pull request?

Modified `AbstractAuthResource` to ensure that LDAP role lookup is performed even if the user does not belong to any groups. 

Key changes:
   - Moved the `lookupRoles` call outside of the `matchingGroupNames.isEmpty()` check to allow role resolution for users with zero groups.
   - Updated the header addition logic to trigger if either groups or roles are present
   - Refactored `lookupRoles` to consistently return an empty collection instead of `null`, simplifying the downstream logic and avoiding `NullPointerException` risks.

This ensures that users with no groups can still have their roles resolved and included in the `X-Knox-Actor-Groups` headers.

## How was this patch tested?

Verified the logic change ensures `lookupRoles` is invoked even when the initial group set is empty (by running existing unit tests).

## Integration Tests
N/A

## UI changes
N/A