### PR TITLE
KNOX-3354: Remove index suffix from actor groups header for roles in AbstractAuthResource

### DIFF
--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
@@ -107,9 +107,11 @@ public abstract class AbstractAuthResource {
             .collect(Collectors.toSet());
     final Collection<String> roles = lookupRoles(primaryPrincipalName, matchingGroupNames);
     if (!matchingGroupNames.isEmpty() || !roles.isEmpty()) {
-      final List<String> groupStrings = GroupUtils.getGroupStrings(roles.isEmpty() ? matchingGroupNames : roles, groupHeaderLengthLimit, groupHeaderSizeLimit);
+      final boolean useRoles = !roles.isEmpty();
+      final List<String> groupStrings = GroupUtils.getGroupStrings(useRoles ? roles : matchingGroupNames, groupHeaderLengthLimit, groupHeaderSizeLimit);
       for (int i = 0; i < groupStrings.size(); i++) {
-        getResponse().addHeader(String.format(Locale.ROOT, ACTOR_GROUPS_HEADER_FORMAT, authHeaderActorGroupsPrefix, i + 1), groupStrings.get(i));
+        final String headerName = useRoles ? authHeaderActorGroupsPrefix : String.format(Locale.ROOT, ACTOR_GROUPS_HEADER_FORMAT, authHeaderActorGroupsPrefix, i + 1);
+        getResponse().addHeader(headerName, groupStrings.get(i));
       }
     }
     return ok().build();

--- a/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/ExtAuthzResourceTest.java
+++ b/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/ExtAuthzResourceTest.java
@@ -119,6 +119,9 @@ public class ExtAuthzResourceTest {
     response.setHeader(AbstractAuthResource.DEFAULT_AUTH_ACTOR_ID_HEADER_NAME, USER_NAME);
     EasyMock.expectLastCall();
 
+    response.addHeader(EasyMock.eq(AbstractAuthResource.DEFAULT_AUTH_ACTOR_GROUPS_HEADER_PREFIX), EasyMock.anyString());
+    EasyMock.expectLastCall().anyTimes();
+
     EasyMock.replay(context, response, mockRolesService, mockGatewayServices);
 
     groups.forEach(group -> subject.getPrincipals().add(new GroupPrincipal(group)));

--- a/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/PreAuthResourceTest.java
+++ b/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/PreAuthResourceTest.java
@@ -56,15 +56,15 @@ public class PreAuthResourceTest {
     subject.getPrincipals().add(new PrimaryPrincipal(USER_NAME));
   }
 
-  private void configureCommonExpectations(String actorIdHeaderName) {
+  private void configureCommonExpectations(String actorIdHeaderName) throws Exception {
     configureCommonExpectations(actorIdHeaderName, null, Collections.emptySet());
   }
 
-  private void configureCommonExpectations(String actorIdHeaderName, String groupsHeaderPrefix, Collection<String> groups) {
+  private void configureCommonExpectations(String actorIdHeaderName, String groupsHeaderPrefix, Collection<String> groups) throws Exception {
     configureCommonExpectations(actorIdHeaderName, groupsHeaderPrefix, groups, null);
   }
 
-  private void configureCommonExpectations(String actorIdHeaderName, String groupsHeaderPrefix, Collection<String> groups, GatewayServices gatewayServices) {
+  private void configureCommonExpectations(String actorIdHeaderName, String groupsHeaderPrefix, Collection<String> groups, GatewayServices gatewayServices) throws Exception {
     context = EasyMock.createNiceMock(ServletContext.class);
     EasyMock.expect(context.getInitParameter(PreAuthResource.AUTH_ACTOR_ID_HEADER_NAME)).andReturn(actorIdHeaderName).anyTimes();
     EasyMock.expect(context.getInitParameter(PreAuthResource.AUTH_ACTOR_GROUPS_HEADER_PREFIX)).andReturn(groupsHeaderPrefix).anyTimes();
@@ -77,7 +77,18 @@ public class PreAuthResourceTest {
       EasyMock.expectLastCall();
     }
 
-    if (!groups.isEmpty()) {
+    if (gatewayServices != null) {
+      EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(gatewayServices);
+      final LDAPRolesLookupService rolesLookupService = gatewayServices.getService(ServiceType.LDAP_ROLES_LOOKUP_SERVICE);
+      if (rolesLookupService != null && rolesLookupService.enabled()) {
+        Collection<String> roles = rolesLookupService.lookupRoles(USER_NAME, groups);
+        if (roles != null && !roles.isEmpty()) {
+          final String expectedGroupsHeaderPrefix = (groupsHeaderPrefix == null ? PreAuthResource.DEFAULT_AUTH_ACTOR_GROUPS_HEADER_PREFIX : groupsHeaderPrefix);
+          response.addHeader(EasyMock.eq(expectedGroupsHeaderPrefix), EasyMock.anyString());
+          EasyMock.expectLastCall().anyTimes();
+        }
+      }
+    } else if (!groups.isEmpty()) {
       groups.forEach(group -> subject.getPrincipals().add(new GroupPrincipal(group)));
       final int groupStringSize = calculateGroupStringSize(groups);
       final int expectedGroupHeaderCount = groupStringSize / 1000 + 1;
@@ -87,11 +98,6 @@ public class PreAuthResourceTest {
         response.addHeader(EasyMock.eq(expectedGroupsHeaderPrefix + i), EasyMock.anyString());
         EasyMock.expectLastCall();
       }
-    }
-
-    if (gatewayServices != null) {
-      EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(gatewayServices);
-
     }
 
     EasyMock.replay(context, request, response);


### PR DESCRIPTION
[KNOX-3354](https://issues.apache.org/jira/browse/KNOX-3354) - Remove index suffix from actor groups header for roles in AbstractAuthResource

## What changes were proposed in this pull request?

Modified `AbstractAuthResource` to use the raw value of `authHeaderActorGroupsPrefix` when populating headers for roles, removing the indexed format (e.g., -1). Groups continue to use the indexed format to maintain backward compatibility.

   - Updated `AbstractAuthResource.doGetImpl()` to distinguish between roles and groups for header naming.
   - Updated `PreAuthResourceTest` and `ExtAuthzResourceTest` to reflect and verify the new header behavior.

## How was this patch tested?

Ran automated unit tests in the gateway-service-auth module:
  ```mvn test -pl gateway-service-auth```

Verified that both `PreAuthResourceTest` and `ExtAuthzResourceTest` pass, specifically validating the new logic for role-based headers without suffixes and group-based headers with suffixes.

Manual testing:
I configured my `sandbox` topology with the `KNOXAUTH` service as follows:
```
     <role>KNOX-AUTH-SERVICE</role>
     <param>
       <name>preauth.auth.header.actor.id.name</name>
       <value>x-knox-username</value>
     </param>
     <param>
       <name>preauth.auth.header.actor.groups.prefix</name>
       <value>x-knox-roles</value>
     </param>
     <param>
       <name>preauth.group.filter.pattern</name>
       <value>.*</value>
     </param>
     <param>
       <name>auth.bearer.token.env</name>
       <value>BEARER_AUTH_TOKEN</value>
     </param>
    </service>
```
Made sure I've a mock roles lookup backend (using WireMock), then issued the following `curl` request:
```
$ curl -iu recursiveUser:recursiveUser-password http://localhost:8443/gateway/sandbox/auth/api/v1/pre
HTTP/1.1 200 OK
Date: Thu, 18 Jun 2026 09:12:31 GMT
Set-Cookie: KNOXSESSIONID=node0126djbk7idu4916qak4j9yhz3v0.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 17-Jun-2026 09:12:31 GMT; SameSite=lax
x-knox-username: recursiveUser
x-knox-roles: platform:awc-admin-recursiveUser,ml-workspace-abc:viewer-recursiveUser
Content-Length: 0
```

I also tested this feature without role lookup being configured (I did not change the topology, the header names suggest 'roles', but they are resolved groups):
```
$ curl -iu recursiveUser:recursiveUser-password http://localhost:8443/gateway/sandbox/auth/api/v1/pre
HTTP/1.1 200 OK
Date: Thu, 18 Jun 2026 09:21:33 GMT
Set-Cookie: KNOXSESSIONID=node0cnvt51iv71noaia4osal29jr1.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Wed, 17-Jun-2026 09:21:33 GMT; SameSite=lax
x-knox-username: recursiveUser
x-knox-roles-1: level1,level3,level2
Content-Length: 0

```

## Integration Tests
N/A

## UI changes
N/A