### PR TITLE
KNOX-3356: Allow Cloudera Manager service discovery over cleartext HTTP

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -280,6 +280,9 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.ERROR, text = "Failed to configure truststore")
   void failedToConfigureTruststore();
 
+  @Message(level = MessageLevel.DEBUG, text = "Skipping SSL configuration for cleartext CM discovery address {0}")
+  void skippingSslConfigurationForCleartextAddress(String address);
+
   @Message(level = MessageLevel.DEBUG, text = "Looking up cluster services from service discovery repository...")
   void lookupClusterServicesFromRepository();
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/DiscoveryApiClient.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/DiscoveryApiClient.java
@@ -20,6 +20,7 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
@@ -155,6 +156,11 @@ public class DiscoveryApiClient extends ApiClient {
     return (address.endsWith("/") ? address + apiPath : address + "/" + apiPath);
   }
 
+  private boolean isSecure() {
+    final String basePath = getBasePath();
+    return basePath != null && basePath.toLowerCase(Locale.ROOT).startsWith("https:");
+  }
+
   private void configureInterceptors(List<Interceptor> interceptors) {
     final OkHttpClient.Builder builder = getHttpClient().newBuilder();
     interceptors.forEach(builder::addInterceptor);
@@ -172,6 +178,14 @@ public class DiscoveryApiClient extends ApiClient {
   }
 
   private void configureSsl(GatewayConfig gatewayConfig, KeyStore trustStore) {
+    // The CM discovery endpoint may be plain HTTP (e.g. CM TLS not enabled). In that case the
+    // TLS-only ConnectionSpec below would make OkHttp reject the connection with
+    // "CLEARTEXT communication not enabled for client". Only configure TLS for HTTPS addresses.
+    if (!isSecure()) {
+      log.skippingSslConfigurationForCleartextAddress(getBasePath());
+      return;
+    }
+
     final SSLContext truststoreSSLContext = TruststoreSSLContextUtils.getTruststoreSSLContext(trustStore);
     final X509TrustManager trustManager = TruststoreSSLContextUtils.getTrustManager(trustStore);
 

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -91,6 +91,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ClouderaManagerServiceDiscoveryTest {
 
   private static final String DISCOVERY_URL = "http://localhost:1234";
+  private static final String DISCOVERY_URL_TLS = "https://localhost:1234";
   private static final String DISCOVERY_USER = "discoveryUser";
   private static final String CLUSTER_NAME = "Cluster 1";
   private static final String DISCOVERY_PASSWORD_ALIAS = "discovery.alias";
@@ -164,7 +165,7 @@ public class ClouderaManagerServiceDiscoveryTest {
     EasyMock.expect(gwConf.getClouderaManagerClientSSLProtocols()).andReturn(Set.of(cmClientTlsVersion)).anyTimes();
     EasyMock.replay(gwConf);
 
-    ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(DISCOVERY_URL, DISCOVERY_USER, CLUSTER_NAME);
+    ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(DISCOVERY_URL_TLS, DISCOVERY_USER, CLUSTER_NAME);
 
     AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
     EasyMock.replay(aliasService);
@@ -193,6 +194,33 @@ public class ClouderaManagerServiceDiscoveryTest {
     assertNotNull(connectionSpecs.get(0).tlsVersions());
     assertFalse(connectionSpecs.get(0).tlsVersions().isEmpty());
     assertTrue(containsTlsVersion(connectionSpecs.get(0).tlsVersions(), cmClientTlsVersion));
+  }
+
+  /**
+   * KNOX-3353: when the CM discovery address is plain HTTP (CM TLS not enabled), the client must
+   * not be locked to a TLS-only ConnectionSpec, otherwise OkHttp rejects the request with
+   * "CLEARTEXT communication not enabled for client". The default specs (which include CLEARTEXT)
+   * should be left in place.
+   */
+  @Test
+  public void testApiClientAllowsCleartextForHttpDiscoveryAddress() {
+    GatewayConfig gwConf = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryApiVersion()).andReturn(GatewayConfig.DEFAULT_CLOUDERA_MANAGER_SERVICE_DISCOVERY_API_VERSION).anyTimes();
+    EasyMock.replay(gwConf);
+
+    ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(DISCOVERY_URL, DISCOVERY_USER, CLUSTER_NAME);
+
+    AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.replay(aliasService);
+
+    KeyStore trustStore = EasyMock.createNiceMock(KeyStore.class);
+    EasyMock.replay(trustStore);
+
+    ApiClient apiClient = new TestDiscoveryApiClient(gwConf, sdConfig, aliasService, trustStore);
+
+    final List<ConnectionSpec> connectionSpecs = apiClient.getHttpClient().connectionSpecs();
+    assertTrue("HTTP discovery address should keep a CLEARTEXT-capable connection spec.",
+        connectionSpecs.stream().anyMatch(spec -> spec.equals(ConnectionSpec.CLEARTEXT)));
   }
 
   private boolean containsCipherSuite(List<CipherSuite> cipherSuites, String cipherSuiteNameToCheck) {


### PR DESCRIPTION
[KNOX-3356](https://issues.apache.org/jira/browse/KNOX-3356) - Allow Cloudera Manager service discovery over cleartext HTTP

## What changes were proposed in this pull request?

When Knox is configured with TLS but the target Cloudera Manager server is not, CM service discovery fails with:
```
com.cloudera.api.swagger.client.ApiException: java.net.UnknownServiceException: CLEARTEXT communication not enabled for client
```

The root cause is in `DiscoveryApiClient.configureSsl()`: it unconditionally replaced the OkHttp client's `connectionSpecs` with a single TLS-only spec (`ConnectionSpec.MODERN_TLS`), regardless of the discovery address scheme. OkHttp matches the request URL's scheme against the allowed connection specs, so an `http://` discovery address with no `CLEARTEXT` spec is rejected before any request is sent.

This PR makes TLS configuration conditional on the discovery address actually being HTTPS:
  - Added an `isSecure()` helper that checks whether the configured base path starts with `https:`.
  - `configureSsl()` now returns early (with a DEBUG log) for cleartext addresses, leaving OkHttp's default connection specs,  which include `CLEARTEXT`,  in place.
  - Added the `skippingSslConfigurationForCleartextAddress` discovery message.

  Behavior for HTTPS discovery addresses is unchanged.
## How was this patch tested?
Automated unit tests in `ClouderaManagerServiceDiscoveryTest`:

  - Corrected `testApiClientInterceptorsWhenKerberosIsDisabledAndPasswordIsNotSet` to use an
    HTTPS discovery address (it previously used an HTTP address while asserting a TLS-only spec,
    i.e. it asserted the buggy behavior); it still verifies the configured cipher/protocol are
    applied on the HTTPS path.
  - Added `testApiClientAllowsCleartextForHttpDiscoveryAddress`, which uses an `http://` address
    and asserts the client retains a `CLEARTEXT`-capable connection spec.

  Both tests pass: `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`.

## Integration Tests
N/A

## UI changes
N/A
