### PR TITLE
KNOX-3358: Support configurable bind credentials for the embedded Knox LDAP service

### DIFF
--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -110,15 +110,15 @@ else
 fi
 /home/knox/knox/bin/knoxcli.sh create-master --master "${MASTER_SECRET}"
 
-if [[ -n ${LDAP_PASSWORD_FILE} ]]
-then
-  LDAP_BIND_PASSWORD=$(/bin/cat "${LDAP_PASSWORD_FILE}" 2> /dev/null)
+# Check LDAP_BIND_PASSWORD first, and only fall back to the file if it’s unset or empty.
+if [[ -z ${LDAP_BIND_PASSWORD} && -n ${LDAP_PASSWORD_FILE} ]]; then
+  LDAP_BIND_PASSWORD=$(/bin/cat "${LDAP_PASSWORD_FILE}" 2>/dev/null)
 fi
 
-saveAlias ldap-bind-password "${LDAP_BIND_PASSWORD}"
 saveAlias gateway_database_user "${DATABASE_CONNECTION_USER}"
 saveAlias gateway_database_password "${DATABASE_CONNECTION_PASSWORD}"
 saveAlias gateway_database_ssl_truststore_password "${DATABASE_CONNECTION_TRUSTSTORE_PASSWORD}"
+saveAlias gateway_ldap_bind_password "${LDAP_BIND_PASSWORD}"
 
 # RemoteAuthProvider truststore password
 saveAlias rap_truststore_password "${RAP_TRUSTSTORE_PASSWORD}"

--- a/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/config/impl/GatewayConfigImpl.java
@@ -1754,6 +1754,11 @@ public class GatewayConfigImpl extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getLDAPBindUser() {
+    return get(LDAP_BIND_USER, null);
+  }
+
+  @Override
   public List<String> getLDAPInterceptorNames() {
     return splitConfigValueToList(LDAP_INTERCEPTOR_NAMES);
   }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/LdapServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/LdapServiceFactory.java
@@ -37,6 +37,7 @@ public class LdapServiceFactory extends AbstractServiceFactory {
         KnoxLDAPService service = null;
         if (shouldCreateService(implementation)) {
             service = new KnoxLDAPService();
+            service.setAliasService(getAliasService(gatewayServices));
             GatewayServer.registerConfigChangeListener(service);
             logServiceUsage(service.getClass().getName(), serviceType);
         }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -64,7 +64,7 @@ import java.util.stream.IntStream;
  */
 public class KnoxLDAPServerManager {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
-    private static final String LDAP_BIND_PASSWORD_ALIAS = "gateway.ldap.bind.password";
+    private static final String LDAP_BIND_PASSWORD_ALIAS = "gateway_ldap_bind_password";
     private final AliasService aliasService;
 
     @VisibleForTesting

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -46,6 +46,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
 import org.apache.knox.gateway.services.ldap.interceptor.InterceptorFactory;
+import org.apache.knox.gateway.services.security.AliasService;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -63,6 +64,8 @@ import java.util.stream.IntStream;
  */
 public class KnoxLDAPServerManager {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
+    private static final String LDAP_BIND_PASSWORD_ALIAS = "gateway.ldap.bind.password";
+    private final AliasService aliasService;
 
     @VisibleForTesting
     DirectoryService directoryService;
@@ -72,8 +75,13 @@ public class KnoxLDAPServerManager {
     private File workDir;
     private int port;
     private String baseDn;
+    private String bindUser;
     // Collection of DNs for the proxied backend LDAP servers
     private Set<String> baseDns;
+
+    KnoxLDAPServerManager(AliasService aliasService) {
+        this.aliasService = aliasService;
+    }
 
     /**
      * Initialize the LDAP server with the given configuration
@@ -90,6 +98,7 @@ public class KnoxLDAPServerManager {
         // Get configuration
         this.port = config.getLDAPPort();
         this.baseDn = config.getLDAPBaseDN();
+        this.bindUser = config.getLDAPBindUser();
 
         createInterceptors(config);
 
@@ -177,14 +186,24 @@ public class KnoxLDAPServerManager {
 
         addInterceptors();
 
-        // Allow anonymous access
-        directoryService.setAllowAnonymousAccess(true);
+        // Require clients to bind with the configured credentials when both a bind user and
+        // a bind password (resolved from the gateway credential store) are set; otherwise
+        // keep the historical behavior of allowing anonymous access.
+        final char[] bindPasswordChars = aliasService.getPasswordFromAliasForGateway(LDAP_BIND_PASSWORD_ALIAS);
+        final String bindPassword = bindPasswordChars == null ? null : new String(bindPasswordChars);
+        final boolean requireBind = StringUtils.isNotBlank(bindUser) && StringUtils.isNotBlank(bindPassword);
+        directoryService.setAllowAnonymousAccess(!requireBind);
 
         // Start the service
         directoryService.startup();
 
         // Add base entries to the partitions
         createBaseEntries(baseDns, schemaManager);
+
+        if (requireBind) {
+            createBindUser(schemaManager, bindPassword);
+            LOG.ldapBindUserConfigured(bindUser);
+        }
 
         // Create LDAP server on configured port
         ldapServer = new LdapServer();
@@ -315,6 +334,26 @@ public class KnoxLDAPServerManager {
             groupsOu.add("objectClass", "top", "organizationalUnit");
             groupsOu.add("ou", "groups");
             directoryService.getAdminSession().add(groupsOu);
+        }
+    }
+
+    /**
+     * Create the entry used by external clients to bind against the embedded LDAP server.
+     * The bind DN's parent container (e.g. {@code ou=system} or {@code ou=people,<baseDn>})
+     * must already exist. The entry is added using the privileged admin session, which is
+     * unaffected by the anonymous-access setting.
+     */
+    private void createBindUser(SchemaManager schemaManager, String bindPassword) throws Exception {
+        Dn bindDn = new Dn(schemaManager, bindUser);
+        if (!directoryService.getAdminSession().exists(bindDn)) {
+            String rdnValue = bindDn.getRdn().getValue();
+            Entry bindEntry = new DefaultEntry(schemaManager);
+            bindEntry.setDn(bindDn);
+            bindEntry.add("objectClass", "top", "person", "organizationalPerson", "inetOrgPerson");
+            bindEntry.add("cn", rdnValue);
+            bindEntry.add("sn", rdnValue);
+            bindEntry.add("userPassword", bindPassword);
+            directoryService.getAdminSession().add(bindEntry);
         }
     }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.AliasService;
 
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,7 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
 
     KnoxLDAPServerManager ldapServerManager;
+    AliasService aliasService;
     private boolean enabled;
 
     @Override
@@ -46,11 +48,15 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
 
         try {
             // Initialize the LDAP server manager with configuration
-            ldapServerManager = new KnoxLDAPServerManager();
+            ldapServerManager = new KnoxLDAPServerManager(aliasService);
             ldapServerManager.initialize(config);
         } catch (Exception e) {
             throw new ServiceLifecycleException("Failed to initialize LDAP service", e);
         }
+    }
+
+    public void setAliasService(AliasService aliasService) {
+        this.aliasService = aliasService;
     }
 
     @Override
@@ -89,7 +95,7 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
             this.enabled = config.isLDAPEnabled();
 
             if (this.enabled) {
-                this.ldapServerManager = this.ldapServerManager == null ? new KnoxLDAPServerManager() : this.ldapServerManager;
+                this.ldapServerManager = this.ldapServerManager == null ? new KnoxLDAPServerManager(aliasService) : this.ldapServerManager;
                 ldapServerManager.stop();
                 ldapServerManager.initialize(config);
                 ldapServerManager.start();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
@@ -34,6 +34,10 @@ public interface LdapMessages {
     void ldapServiceStarted(int port);
 
     @Message(level = MessageLevel.INFO,
+            text = "Anonymous access disabled; clients must bind as: {0}")
+    void ldapBindUserConfigured(String bindDn);
+
+    @Message(level = MessageLevel.INFO,
             text = "Stopping LDAP service on port {0}")
     void ldapServiceStopping(int port);
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -18,9 +18,16 @@
 package org.apache.knox.gateway.services.ldap;
 
 import org.apache.directory.api.ldap.codec.api.ControlFactory;
+import org.apache.directory.api.ldap.model.cursor.EntryCursor;
+import org.apache.directory.api.ldap.model.exception.LdapAuthenticationException;
+import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.message.Control;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.ldap.client.api.LdapConnection;
+import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
 import org.apache.knox.gateway.services.ldap.model.constants.SchemaConstants;
 import org.easymock.EasyMock;
@@ -51,6 +58,9 @@ import static org.junit.Assert.assertFalse;
  */
 public class KnoxLDAPServerManagerTest {
 
+    private static final String BIND_DN = "uid=knox,ou=system";
+    private static final String BIND_PASSWORD = "knox-password";
+
     private KnoxLDAPServerManager serverManager;
     private File tempWorkDir;
     private File tempLdapFile;
@@ -58,7 +68,10 @@ public class KnoxLDAPServerManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        serverManager = new KnoxLDAPServerManager();
+        // By default no bind password is stored in the credential store, so the server
+        // runs with anonymous access (the historical behavior). Bind-enforcing tests
+        // rebuild the manager via useBindPassword(...).
+        serverManager = new KnoxLDAPServerManager(aliasServiceReturning(null));
 
         // Create temporary work directory
         tempWorkDir = File.createTempFile("knox-ldap-work", "");
@@ -393,6 +406,95 @@ public class KnoxLDAPServerManagerTest {
         Map<String, ControlFactory<? extends Control>> controlFactoryMap = serverManager.directoryService.getLdapCodecService().getRequestControlFactories();
         assertTrue(controlFactoryMap.containsKey(SchemaConstants.ROLES_LOOKUP_BYPASS_CONTROL_OID));
         assertTrue(controlFactoryMap.get(SchemaConstants.ROLES_LOOKUP_BYPASS_CONTROL_OID) instanceof RolesLookupBypassControlFactory);
+    }
+
+    @Test(expected = LdapException.class)
+    public void testBindRequiredRejectsAnonymous() throws Exception {
+        useBindPassword(BIND_PASSWORD);
+        serverManager.initialize(createBindEnabledConfig());
+        serverManager.start();
+
+        // Anonymous access is disabled, so an anonymous bind must be rejected.
+        try (LdapConnection connection = new LdapNetworkConnection("localhost", port)) {
+            connection.bind();
+        }
+    }
+
+    @Test
+    public void testBindWithConfiguredCredentialsSucceeds() throws Exception {
+        useBindPassword(BIND_PASSWORD);
+        serverManager.initialize(createBindEnabledConfig());
+        serverManager.start();
+
+        try (LdapConnection connection = new LdapNetworkConnection("localhost", port)) {
+            connection.bind(BIND_DN, BIND_PASSWORD);
+            assertTrue("Connection should be authenticated", connection.isAuthenticated());
+            // An authenticated client should be able to search.
+            try (EntryCursor cursor = connection.search("dc=test,dc=com", "(objectClass=*)", SearchScope.SUBTREE)) {
+                assertTrue("Authenticated search should return at least one entry", cursor.next());
+            }
+        }
+    }
+
+    @Test(expected = LdapAuthenticationException.class)
+    public void testWrongBindPasswordRejected() throws Exception {
+        useBindPassword(BIND_PASSWORD);
+        serverManager.initialize(createBindEnabledConfig());
+        serverManager.start();
+
+        try (LdapConnection connection = new LdapNetworkConnection("localhost", port)) {
+            connection.bind(BIND_DN, "wrong-password");
+        }
+    }
+
+    @Test
+    public void testAnonymousStillAllowedWhenUnconfigured() throws Exception {
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPInterceptorConfig("filebackend")).andReturn(createFileBackendInterceptorConfig()).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
+        serverManager.start();
+
+        // No bind credentials configured -> anonymous access remains allowed (backward compatible).
+        try (LdapConnection connection = new LdapNetworkConnection("localhost", port)) {
+            connection.bind();
+            try (EntryCursor cursor = connection.search("dc=test,dc=com", "(objectClass=*)", SearchScope.SUBTREE)) {
+                assertTrue("Anonymous search should return at least one entry", cursor.next());
+            }
+        }
+    }
+
+    private GatewayConfig createBindEnabledConfig() {
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBindUser()).andReturn(BIND_DN).anyTimes();
+        expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPInterceptorConfig("filebackend")).andReturn(createFileBackendInterceptorConfig()).anyTimes();
+        replay(mockConfig);
+        return mockConfig;
+    }
+
+    /** Rebuild the server manager so its credential store resolves the bind password to the given value. */
+    private void useBindPassword(String password) throws Exception {
+        serverManager = new KnoxLDAPServerManager(aliasServiceReturning(password));
+    }
+
+    /** Create an AliasService whose gateway password lookups return the given value (null => alias not set). */
+    private AliasService aliasServiceReturning(String password) throws Exception {
+        AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+        expect(aliasService.getPasswordFromAliasForGateway(EasyMock.anyString()))
+                .andReturn(password == null ? null : password.toCharArray()).anyTimes();
+        replay(aliasService);
+        return aliasService;
     }
 
     private Map<String, String> createFileBackendInterceptorConfig() {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.ldap;
 
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
+import org.apache.knox.gateway.services.security.AliasService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
@@ -49,6 +51,10 @@ public class KnoxLDAPServiceTest {
     @Before
     public void setUp() throws Exception {
         ldapService = new KnoxLDAPService();
+        // No bind password stored in the credential store -> anonymous access (default behavior).
+        final AliasService aliasService = createNiceMock(AliasService.class);
+        replay(aliasService);
+        ldapService.setAliasService(aliasService);
         mockConfig = createMock(GatewayConfig.class);
 
         // Create temporary directories and files
@@ -170,6 +176,7 @@ public class KnoxLDAPServiceTest {
         expect(mockConfig.getGatewayDataDir()).andReturn(tempDataDir.getAbsolutePath()).atLeastOnce();
         expect(mockConfig.getLDAPPort()).andReturn(3890).times(1).andReturn(3891).anyTimes();
         expect(mockConfig.getLDAPBaseDN()).andReturn("file".equals(backendType) ? "dc=test,dc=com" : "dc=proxy,dc=com").atLeastOnce();
+        expect(mockConfig.getLDAPBindUser()).andReturn(null).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("testbackend")).atLeastOnce();
         expect(mockConfig.getLDAPInterceptorConfig("testbackend")).andReturn(buildBackendConfig(backendType)).atLeastOnce();
         replay(mockConfig);

--- a/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
+++ b/gateway-spi-common/src/main/java/org/apache/knox/gateway/GatewayTestConfig.java
@@ -1246,6 +1246,11 @@ public class GatewayTestConfig extends Configuration implements GatewayConfig {
   }
 
   @Override
+  public String getLDAPBindUser() {
+    return null;
+  }
+
+  @Override
   public List<String> getLDAPInterceptorNames() {
     return List.of("testinterceptor");
   }

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/config/GatewayConfig.java
@@ -128,6 +128,7 @@ public interface GatewayConfig {
   String LDAP_ENABLED = "gateway.ldap.enabled";
   String LDAP_PORT = "gateway.ldap.port";
   String LDAP_BASE_DN = "gateway.ldap.base.dn";
+  String LDAP_BIND_USER = "gateway.ldap.bind.user";
   String LDAP_INTERCEPTOR_NAMES = "gateway.ldap.interceptor.names";
   String LDAP_BACKEND_DATA_FILE = "gateway.ldap.backend.data.file";
   String LDAP_RECURSIVE_GROUP_RESOLUTION = "gateway.ldap.recursive.group.resolution";
@@ -1071,6 +1072,12 @@ public interface GatewayConfig {
    * @return the base DN for LDAP entries
    */
   String getLDAPBaseDN();
+
+  /**
+   * @return the bind DN required to query the embedded LDAP service, or null/blank if
+   * anonymous access should be allowed
+   */
+  String getLDAPBindUser();
 
     /**
      * @return the list of interceptor names for LDAP server

--- a/knox-site/docs/service_ldap_server.md
+++ b/knox-site/docs/service_ldap_server.md
@@ -39,10 +39,68 @@ The service is configured in `gateway-site.xml`.
 | `gateway.ldap.enabled` | `false` | Enables or disables the embedded LDAP service. |
 | `gateway.ldap.port` | `3890` | The port on which the LDAP server listens. |
 | `gateway.ldap.base.dn` | `dc=proxy,dc=com` | The base DN for the LDAP server. |
+| `gateway.ldap.bind.user` | N/A | Full bind DN (e.g. `uid=knox,ou=system`) that clients must authenticate as. When set together with the `gateway.ldap.bind.password` credential store alias, anonymous access is disabled. The bind DN's parent container must already exist (`ou=system` always exists; `ou=people,{base.dn}` and `ou=groups,{base.dn}` are created automatically). |
 | `gateway.ldap.interceptor.names` | N/A | A comma separated list of interceptors to use. A separate interceptor configuration block will be used for each name. |
 | `gateway.ldap.roles.lookup.strategy` | N/A | The LDAP roles lookup strategy (`file` or `rest`). |
 | `gateway.ldap.roles.lookup.rest.api.endpoint` | N/A | The LDAP roles lookup REST API endpoint. |
 | `gateway.ldap.roles.lookup.file.path` | N/A | The LDAP roles lookup file path. |
+
+### Bind Credentials
+
+By default the embedded LDAP server permits anonymous access. To require clients to
+authenticate, set `gateway.ldap.bind.user` and store the matching password in the gateway
+credential store under the `gateway.ldap.bind.password` alias. When both are present,
+anonymous access is disabled and clients must bind with these credentials.
+
+#### Relationship between the base DN and the bind user
+
+`gateway.ldap.bind.user` is a **full DN**, not a bare username — `admin` on its own is not
+valid. The bind entry is created inside the embedded directory at start-up, so its parent
+container must already exist. The server creates the following containers under the
+configured `gateway.ldap.base.dn`:
+
+- `ou=people,{gateway.ldap.base.dn}`
+- `ou=groups,{gateway.ldap.base.dn}`
+
+(`ou=system` also always exists, independently of the base DN.) The bind DN must therefore
+be placed under one of these containers; a DN under a container that is not created (e.g.
+`ou=admins`) will fail.
+
+For example, with:
+
+```xml
+<property>
+    <name>gateway.ldap.base.dn</name>
+    <value>dc=hadoop,dc=apache,dc=org</value>
+</property>
+```
+
+a good bind user is a dedicated service identity under the auto-created `ou=people`
+container — note how the base DN is the suffix of the bind DN:
+
+```xml
+<property>
+    <name>gateway.ldap.bind.user</name>
+    <value>uid=knox,ou=people,dc=hadoop,dc=apache,dc=org</value>
+</property>
+```
+
+and the password is stored as:
+
+```shell script
+knoxcli.sh create-alias gateway.ldap.bind.password --value <password>
+```
+
+Clients then bind with the full DN, e.g.:
+
+```shell script
+ldapsearch -x -H ldap://localhost:3890 -D "uid=knox,ou=people,dc=hadoop,dc=apache,dc=org" -w <password> -b "" "(uid=admin)"
+```
+
+The bind entry is created as an `inetOrgPerson`, so either a `uid`-based RDN
+(`uid=knox,...`) or a `cn`-based RDN (`cn=bind,...`) is valid. Use a dedicated identity
+(e.g. `uid=knox`) rather than the built-in ApacheDS admin `uid=admin,ou=system`, which
+remains available with its default credentials.
 
 ### Interceptor Types
 
@@ -296,4 +354,4 @@ Alternative: Use host and port instead of URL
 
 - **Logs**: LDAP service logs can be found in `gateway.log`. Look for messages from `org.apache.knox.gateway.services.ldap`.
 - **Lock Files**: If Knox crashes, an `instance.lock` file might remain in `${GATEWAY_DATA_HOME}/ldap-server/run/`. The service attempts to clean this up on startup.
-- **Anonymous Access**: The embedded LDAP server allows anonymous access by default to facilitate discovery and simple binds, but backend lookups are performed using the configured `systemUsername`.
+- **Anonymous Access**: The embedded LDAP server allows anonymous access by default to facilitate discovery and simple binds, but backend lookups are performed using the configured `systemUsername`. To require authentication, set `gateway.ldap.bind.user` and store the corresponding password in the gateway credential store under the `gateway.ldap.bind.password` alias (e.g. `knoxcli.sh create-alias gateway.ldap.bind.password --value <password>`). Clients must then bind with those credentials (e.g. `ldapsearch -D "uid=knox,ou=system" -w <password> ...`) and anonymous queries are rejected. Note that the built-in ApacheDS admin (`uid=admin,ou=system`) remains available with its default credentials.

--- a/knox-site/docs/service_ldap_server.md
+++ b/knox-site/docs/service_ldap_server.md
@@ -39,7 +39,7 @@ The service is configured in `gateway-site.xml`.
 | `gateway.ldap.enabled` | `false` | Enables or disables the embedded LDAP service. |
 | `gateway.ldap.port` | `3890` | The port on which the LDAP server listens. |
 | `gateway.ldap.base.dn` | `dc=proxy,dc=com` | The base DN for the LDAP server. |
-| `gateway.ldap.bind.user` | N/A | Full bind DN (e.g. `uid=knox,ou=system`) that clients must authenticate as. When set together with the `gateway.ldap.bind.password` credential store alias, anonymous access is disabled. The bind DN's parent container must already exist (`ou=system` always exists; `ou=people,{base.dn}` and `ou=groups,{base.dn}` are created automatically). |
+| `gateway.ldap.bind.user` | N/A | Full bind DN (e.g. `uid=knox,ou=system`) that clients must authenticate as. When set together with the `gateway_ldap_bind_password` credential store alias, anonymous access is disabled. The bind DN's parent container must already exist (`ou=system` always exists; `ou=people,{base.dn}` and `ou=groups,{base.dn}` are created automatically). |
 | `gateway.ldap.interceptor.names` | N/A | A comma separated list of interceptors to use. A separate interceptor configuration block will be used for each name. |
 | `gateway.ldap.roles.lookup.strategy` | N/A | The LDAP roles lookup strategy (`file` or `rest`). |
 | `gateway.ldap.roles.lookup.rest.api.endpoint` | N/A | The LDAP roles lookup REST API endpoint. |
@@ -49,7 +49,7 @@ The service is configured in `gateway-site.xml`.
 
 By default the embedded LDAP server permits anonymous access. To require clients to
 authenticate, set `gateway.ldap.bind.user` and store the matching password in the gateway
-credential store under the `gateway.ldap.bind.password` alias. When both are present,
+credential store under the `gateway_ldap_bind_password` alias. When both are present,
 anonymous access is disabled and clients must bind with these credentials.
 
 #### Relationship between the base DN and the bind user
@@ -88,13 +88,13 @@ container — note how the base DN is the suffix of the bind DN:
 and the password is stored as:
 
 ```shell script
-knoxcli.sh create-alias gateway.ldap.bind.password --value <password>
+knoxcli.sh create-alias gateway_ldap_bind_password --value knoxsecret
 ```
 
 Clients then bind with the full DN, e.g.:
 
 ```shell script
-ldapsearch -x -H ldap://localhost:3890 -D "uid=knox,ou=people,dc=hadoop,dc=apache,dc=org" -w <password> -b "" "(uid=admin)"
+ldapsearch -x -H ldap://localhost:3890 -D "uid=knox,ou=people,dc=hadoop,dc=apache,dc=org" -w knoxsecret -b "" "(uid=admin)"
 ```
 
 The bind entry is created as an `inetOrgPerson`, so either a `uid`-based RDN
@@ -354,4 +354,4 @@ Alternative: Use host and port instead of URL
 
 - **Logs**: LDAP service logs can be found in `gateway.log`. Look for messages from `org.apache.knox.gateway.services.ldap`.
 - **Lock Files**: If Knox crashes, an `instance.lock` file might remain in `${GATEWAY_DATA_HOME}/ldap-server/run/`. The service attempts to clean this up on startup.
-- **Anonymous Access**: The embedded LDAP server allows anonymous access by default to facilitate discovery and simple binds, but backend lookups are performed using the configured `systemUsername`. To require authentication, set `gateway.ldap.bind.user` and store the corresponding password in the gateway credential store under the `gateway.ldap.bind.password` alias (e.g. `knoxcli.sh create-alias gateway.ldap.bind.password --value <password>`). Clients must then bind with those credentials (e.g. `ldapsearch -D "uid=knox,ou=system" -w <password> ...`) and anonymous queries are rejected. Note that the built-in ApacheDS admin (`uid=admin,ou=system`) remains available with its default credentials.
+- **Anonymous Access**: The embedded LDAP server allows anonymous access by default to facilitate discovery and simple binds, but backend lookups are performed using the configured `systemUsername`. To require authentication, set `gateway.ldap.bind.user` and store the corresponding password in the gateway credential store under the `gateway_ldap_bind_password` alias (e.g. `knoxcli.sh create-alias gateway_ldap_bind_password --value <password>`). Clients must then bind with those credentials (e.g. `ldapsearch -D "uid=knox,ou=system" -w <password> ...`) and anonymous queries are rejected. Note that the built-in ApacheDS admin (`uid=admin,ou=system`) remains available with its default credentials.


### PR DESCRIPTION
  [KNOX-3358](https://issues.apache.org/jira/browse/KNOX-3358) - Support configurable bind credentials for the embedded Knox LDAP service

  ## What changes were proposed in this pull request?

  The embedded Knox LDAP service (`KnoxLDAPService` / `KnoxLDAPServerManager`) called `directoryService.setAllowAnonymousAccess(true)` unconditionally, so any client could query the server with no credentials:
```
  $ ldapsearch -x -H ldap://localhost:33390 -b "" "(uid=admin)" cn mail memberOf
```
succeeds with no `-D` / `-W`.

This PR lets operators put the embedded server behind a bind user:
  - **`gateway.ldap.bind.user`** (new `gateway-site.xml` property) — the full bind DN clients must authenticate as (e.g. `uid=knox,ou=people,dc=hadoop,dc=apache,dc=org`).
  - **`gateway_ldap_bind_password`** (credential store alias) — the bind password, resolved from the gateway credential store via `AliasService` rather than stored in plaintext.
  
Behavior:
  - When a bind user is configured **and** the `gateway_ldap_bind_password` alias resolves to a non-blank value, anonymous access is disabled and a bind entry (`inetOrgPerson`) is created for the configured DN via the privileged admin session. Clients **must** then bind with those credentials.
  - Otherwise (the default), anonymous access remains enabled exactly as before — fully backward compatible.
  
The bind DN's parent container must already exist: the server auto-creates `ou=people,{base.dn}` and `ou=groups,{base.dn}` (and `ou=system` always exists), so the bind DN must sit under one of those.
  
  Changes:
  - `GatewayConfig` / `GatewayConfigImpl` / `GatewayTestConfig`: new `gateway.ldap.bind.user` property and `getLDAPBindUser()` getter.
  - `KnoxLDAPService`: gains an `AliasService` dependency (`setAliasService(...)`), injected by `LdapServiceFactory`, and passes it to the server manager.
  - `KnoxLDAPServerManager`: reads the bind user from config and the bind password from the `gateway_ldap_bind_password` gateway alias; conditionally disables anonymous access; new `createBindUser(...)` adds the bind entry.
  - `LdapMessages`: new INFO log emitted when bind enforcement is enabled. 
  - Docs: `knox-site/docs/service_ldap_server.md` — new "Bind Credentials" section (including the base DN ↔ bind DN relationship and a worked example) plus an updated _Anonymous Access_ note.
 
## How was this patch tested?
  
  - Added unit tests in `KnoxLDAPServerManagerTest` that start a real embedded server and use `LdapNetworkConnection` (with a mocked `AliasService` resolving the bind password) to verify:
    - anonymous bind is rejected when bind credentials are configured;
    - binding with the configured DN/password succeeds and can search;
    - binding with a wrong password is rejected (`LdapAuthenticationException`);
    - anonymous access still works when no bind credentials are configured (backward compat).
  - Updated `KnoxLDAPServiceTest` for the new `AliasService` dependency and the `getLDAPBindUser()` lookup.
  - `mvn -pl gateway-server test -Dtest=KnoxLDAPServerManagerTest,KnoxLDAPServiceTest` → BUILD SUCCESS, 25 tests pass; Checkstyle and PMD clean.
  - Manual end-to-end with `gateway.ldap.enabled=true`, `gateway.ldap.port=33390`,
    `gateway.ldap.base.dn=dc=hadoop,dc=apache,dc=org`,
    `gateway.ldap.bind.user=uid=knox,ou=people,dc=hadoop,dc=apache,dc=org`, and the
    `gateway_ldap_bind_password` alias created via
    `knoxcli.sh create-alias gateway_ldap_bind_password --value <password>`:
    - `ldapsearch -x -H ldap://localhost:33390 -b "" "(uid=admin)" cn` → fails (anonymous denied) 
    - `ldapsearch -x -H ldap://localhost:33390 -D "uid=knox,ou=people,dc=hadoop,dc=apache,dc=org" -w <password> -b "" "(uid=admin)" cn mail memberOf` → succeeds
  
## Integration Tests

No new workflow integration tests were added; the feature is covered by the unit tests above, which exercise a real embedded LDAP server over a live socket (bind + search).
  
## UI changes                                                                                                                                                                                                                   

N/A