### PR TITLE
KNOX-3338: Fix UnsupportedOperationException on JDK 23+ via reflective Subject lookups

### DIFF
--- a/gateway-provider-security-shiro/pom.xml
+++ b/gateway-provider-security-shiro/pom.xml
@@ -126,5 +126,10 @@
             <artifactId>gateway-test-utils</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>de.thetaphi</groupId>
+            <artifactId>forbiddenapis</artifactId>
+        </dependency>   
     </dependencies>
 </project>

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/filter/ShiroSubjectIdentityAdapter.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/filter/ShiroSubjectIdentityAdapter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.filter;
 
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.ShiroMessages;
 import org.apache.knox.gateway.audit.api.Action;
@@ -44,6 +45,8 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.security.Principal;
 import java.security.PrivilegedExceptionAction;
@@ -70,6 +73,49 @@ public class ShiroSubjectIdentityAdapter implements Filter {
 
   /* List of URLs with anon authentication */
   private static List<Matcher> anonUrls = new ArrayList<>();
+
+  /*
+   * Subject.callAs(Subject, Callable) was introduced in JDK 18 (JEP 411).
+   * Resolved once at class-load time to avoid per-request reflection overhead.
+   * On JDK 17, SUBJECT_CALL_AS will be null and doSubjectAction() falls back
+   * to Subject.doAs() which still works on JDK 17.
+   * On JDK 23+, Subject.doAs() throws UnsupportedOperationException (KNOX-3338).
+   */
+  private static final Method SUBJECT_CALL_AS;
+
+  static {
+    Method m = null;
+    try {
+      m = javax.security.auth.Subject.class.getMethod(
+          "callAs", javax.security.auth.Subject.class, Callable.class);
+    } catch (NoSuchMethodException | SecurityException e) {
+      // JDK 17 — will fall back to Subject.doAs() in doSubjectAction()
+    }
+    SUBJECT_CALL_AS = m;
+  }
+
+  /**
+   * Executes action under the given subject's identity.
+   * Uses Subject.callAs() on JDK 18+, falls back to Subject.doAs() on JDK 17.
+   * Fixes UnsupportedOperationException on JDK 23+ (KNOX-3338).
+   */
+  @SuppressForbidden
+  private static void doSubjectAction(javax.security.auth.Subject subject,
+                                      Callable<Void> action) throws Exception {
+    if (SUBJECT_CALL_AS != null) {
+      try {
+        SUBJECT_CALL_AS.invoke(null, subject, action);
+      } catch (InvocationTargetException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof Exception) { throw (Exception) cause; }
+        throw new RuntimeException(cause);
+      }
+    } else {
+      // JDK 17 fallback — deprecated but functional on JDK 17
+      javax.security.auth.Subject.doAs(subject,
+          (PrivilegedExceptionAction<Void>) action::call);
+    }
+  }
 
   @Override
   public void init( FilterConfig filterConfig ) throws ServletException {
@@ -130,13 +176,11 @@ public class ShiroSubjectIdentityAdapter implements Filter {
     @SuppressWarnings("unchecked")
     @Override
     public Void call() throws Exception {
-      PrivilegedExceptionAction<Void> action = new PrivilegedExceptionAction<Void>() {
-        @Override
-        public Void run() throws Exception {
+      Callable<Void> action = () -> {
           chain.doFilter( request, response );
           return null;
-        }
       };
+
       Subject shiroSubject = SecurityUtils.getSubject();
 
       /**
@@ -158,7 +202,7 @@ public class ShiroSubjectIdentityAdapter implements Filter {
         AuditContext context = auditService.getContext();
         context.setUsername(principal);
         auditService.attachContext(context);
-        javax.security.auth.Subject.doAs(subject, action);
+        doSubjectAction(subject, action);
       } else {
 
         final String principal = shiroSubject.getPrincipal().toString();
@@ -211,7 +255,7 @@ public class ShiroSubjectIdentityAdapter implements Filter {
         // To modify the private credential Set, the caller must have AuthPermission("modifyPrivateCredentials").
         javax.security.auth.Subject subject = new javax.security.auth.Subject(
             true, principals, Collections.emptySet(), Collections.emptySet());
-        javax.security.auth.Subject.doAs(subject, action);
+        doSubjectAction(subject, action);
       }
 
       return null;

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
@@ -38,7 +38,11 @@ public class SubjectUtils {
    */
   @SuppressForbidden
   public static Subject getCurrentSubject() {
-    return Subject.getSubject( AccessController.getContext() );
+    try {
+      return (Subject) Subject.class.getMethod("current").invoke(null);
+    } catch (Exception e) {
+      return Subject.getSubject( AccessController.getContext() );
+    }
   }
 
   public static String getPrimaryPrincipalName(Subject subject) {

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
@@ -22,6 +22,7 @@ import de.thetaphi.forbiddenapis.SuppressForbidden;
 import javax.security.auth.Subject;
 
 import java.security.AccessController;
+import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.Optional;
@@ -36,13 +37,36 @@ public class SubjectUtils {
    * There is no option in JDK 17 other then suppressing.
    * For JDK 18+ use Subject.current() instead.
    */
+  /*
+   * Subject.current() was introduced in JDK 18 (JEP 411).
+   * Resolved once at class-load time to avoid per-request reflection overhead.
+   * On JDK 17, SUBJECT_CURRENT_METHOD will be null and we fall back to
+   * the deprecated Subject.getSubject() which still works on JDK 17.
+   * On JDK 23+, the fallback throws UnsupportedOperationException (KNOX-3338).
+   */
+  private static final Method SUBJECT_CURRENT_METHOD;
+
+  static {
+    Method m = null;
+    try {
+      m = Subject.class.getMethod("current"); // available since JDK 18
+    } catch (NoSuchMethodException | SecurityException e) {
+      // JDK 17 — fallback to Subject.getSubject() below
+    }
+    SUBJECT_CURRENT_METHOD = m;
+  }
+
   @SuppressForbidden
   public static Subject getCurrentSubject() {
-    try {
-      return (Subject) Subject.class.getMethod("current").invoke(null);
-    } catch (Exception e) {
-      return Subject.getSubject( AccessController.getContext() );
+    if (SUBJECT_CURRENT_METHOD != null) {
+      try {
+        return (Subject) SUBJECT_CURRENT_METHOD.invoke(null);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Subject.current() invocation failed", e);
+      }
     }
+    // JDK 17 fallback — deprecated but functional; throws on JDK 23+
+    return Subject.getSubject(AccessController.getContext());
   }
 
   public static String getPrimaryPrincipalName(Subject subject) {


### PR DESCRIPTION
[KNOX-3338] - A short description of the change

## Problem
On JDK 23+, Apache Knox throws `UnsupportedOperationException` at runtime 
because `Subject.getSubject(AccessController.getContext())` and 
`Subject.doAs()` were deprecated for removal in JDK 17 (JEP 411) and 
are now non-functional on JDK 23+.

Stack trace:
  at javax.security.auth.Subject.getSubject(Subject.java:277)
  at org.apache.knox.gateway.security.SubjectUtils.getCurrentSubject(SubjectUtils.java:41)
  at org.apache.knox.gateway.filter.ShiroSubjectIdentityAdapter$CallableChain.call(...)

## Solution
Migrate to the JDK 18+ replacement APIs (`Subject.current()` and 
`Subject.callAs()`) using cached reflection — resolved once at class-load 
time via a static initializer — with a graceful fallback to the legacy APIs 
on JDK 17. This keeps the code compilable on JDK 17 while being 
correct on JDK 23+.

## What changes were proposed in this pull request?

### SubjectUtils.java
- Replaced `Subject.getSubject(AccessController.getContext())` with 
  a cached reflection lookup for `Subject.current()` (JDK 18+)
- Static initializer resolves the method once at boot — zero per-request 
  reflection overhead
- Falls back to `Subject.getSubject()` on JDK 17
- Catches `NoSuchMethodException | SecurityException` in static block 
  to prevent `ExceptionInInitializerError`

### ShiroSubjectIdentityAdapter.java
- Added `SUBJECT_CALL_AS` static field — cached reflection lookup for 
  `Subject.callAs(Subject, Callable)` (JDK 18+)
- Added `doSubjectAction()` private helper method that routes to 
  `Subject.callAs()` on JDK 18+ or falls back to `Subject.doAs()` on JDK 17
- Replaced both `Subject.doAs()` call sites (anonymous path and 
  authenticated path) with `doSubjectAction()`
- Replaced `PrivilegedExceptionAction` anonymous class with `Callable` lambda

### gateway-provider-security-shiro/pom.xml
- Added `de.thetaphi:forbiddenapis` compile dependency required for 
  `@SuppressForbidden` annotation on `doSubjectAction()`

## How was this patch tested?

- Full build compiles cleanly on JDK 17
- `gateway-provider-security-shiro`: 26 tests run, 0 failures, 0 errors
- No new test failures introduced by this change

### Pre-existing failures on master (unrelated to this PR)
The following 30 test failures exist on master **before** this change 
and are confirmed by running `git stash` and reproducing the same failures 
on the unmodified codebase:
- `DefaultDispatchTest` (4 errors)
- `BCInterceptingOutputStreamTest` (8 errors)  
- `SSEDispatchTest` (5 errors)
- `KnoxImpersonationProviderTest` (13 errors)

Root cause: Mockito/ByteBuddy incompatibility (`Could not create type`) 
in the local build environment. These failures are not caused by any 
code change in this PR.

## JIRA
https://issues.apache.org/jira/browse/KNOX-3338

## UI changes
NA

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.