### PR TITLE
KNOX-3344: Upgrade pac4j to 6.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <commons-pool2.version>2.7.0</commons-pool2.version>
         <commons-text.version>1.10.0</commons-text.version>
         <cors-filter.version>2.9.1</cors-filter.version>
-        <cryptacular.version>1.2.7</cryptacular.version>
+        <cryptacular.version>1.3.0</cryptacular.version>
         <curator.version>5.4.0</curator.version>
         <dependency-check-maven.version>6.0.3</dependency-check-maven.version>
         <derby.db.version>10.14.2.0</derby.db.version> <!-- 10.15.1.3 requires Java 9 -->
@@ -199,6 +199,7 @@
         <easymock.version>5.2.0</easymock.version>
         <eclipselink.version>2.7.8</eclipselink.version>
         <ehcache.version>3.3.1</ehcache.version>
+        <error_prone_annotations.version>2.41.0</error_prone_annotations.version>
         <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
         <fastinfoset.version>1.2.18</fastinfoset.version>
         <forbiddenapis.version>3.9</forbiddenapis.version>
@@ -233,7 +234,7 @@
         <java-support.version>8.3.1</java-support.version>
         <javassist.version>3.27.0-GA</javassist.version>
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
-        <jee-pac4j.version>8.0.1</jee-pac4j.version>
+        <jee-pac4j.version>8.0.3</jee-pac4j.version>
         <jericho-html.version>3.4</jericho-html.version>
         <jersey.version>2.47</jersey.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
@@ -255,11 +256,11 @@
         <metrics.version>4.1.16</metrics.version>
         <mina.version>2.2.7</mina.version>
         <netty.version>4.1.127.Final</netty.version>
-        <nimbus-jose-jwt.version>10.5</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
         <nodejs.version>v22.20.0</nodejs.version>
         <okhttp.version>4.12.0</okhttp.version>
-        <opensaml.version>5.1.6</opensaml.version>
-        <pac4j.version>6.3.0</pac4j.version>
+        <opensaml.version>5.2.2</opensaml.version>
+        <pac4j.version>6.5.3</pac4j.version>
         <postgresql.version>42.7.11</postgresql.version>
         <mysql.version>8.0.28</mysql.version>
         <mariadb.connector.version>3.3.0</mariadb.connector.version>
@@ -1775,6 +1776,11 @@
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${error_prone_annotations.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>com.kstruct</groupId>
@@ -2402,7 +2408,6 @@
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bcpkix-jdk18on.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
@@ -2625,12 +2630,6 @@
                 <groupId>org.pac4j</groupId>
                 <artifactId>javaee-pac4j</artifactId>
                 <version>${jee-pac4j.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.pac4j</groupId>
-                        <artifactId>pac4j-javaee</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <!-- harmonize pac4j-saml dependencies -->
@@ -2747,10 +2746,6 @@
                     <exclusion>
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker-qual</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
[KNOX-3344](https://issues.apache.org/jira/browse/KNOX-3344) - Upgrade pac4j to 6.5.3

## What changes were proposed in this pull request?

upgraded 
- pac4j.version to 6.5.3
- jee-pac4j.version to 8.0.3
- cryptacular to 1.3.0
- nimbus-jose-jwt.version to 10.9.1 
- opensaml.version to 5.2.2 

pinned 
- com.google.errorprone:error_prone_annotations to 2.41.0

Note: [KNOX-3348](https://issues.apache.org/jira/browse/KNOX-3348) already upgraded BouncyCastle to 1.84.

## How was this patch tested?
Manual tests using keycloak as IDP (OIDC, SAML), plus auth0 and azure ad 2 oidc login test.

## Integration Tests
None added. Will create a separate ticket for Pac4j OIDC and SAML integration tests.

