### PR TITLE
KNOX-3362 - Fix 307 redirect issue for Yarn

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/yarnui/2.7.0/service.xml
@@ -25,7 +25,6 @@
     <routes>
         <route path="/yarn/ws/**">
             <rewrite apply="YARNUI/yarn/inbound/ws" to="request.url"/>
-            <dispatch contributor-name="http-client" />
         </route>
         <route path="/yarn/proxy/**">
             <rewrite apply="YARNUI/yarn/outbound/headers/jobhistory/job" to="response.headers"/>


### PR DESCRIPTION
[KNOX-3362](https://issues.apache.org/jira/browse/KNOX-3362) - Fix 307 redirect issue for Yarn

## Description
Knox should be handle 307, this was contributed way back [KNOX-719](https://issues.apache.org/jira/browse/KNOX-719) Knox support for Yarn Resource Manager HA - ASF Jira

Currently it is not working for Yarn is because of `<dispatch contributor-name="http-client" />` property. 
Even though the HA class name configured is RMUIHaDispatch it is not getting pulled in.  specific 307 handling.

Note: This works for yarnv2 the problem is yarn.

## What changes were proposed in this pull request?

Remove the offending `<dispatch contributor-name="http-client" />` property.

## How was this patch tested?

This feature was tested locally.

## Integration Tests
NA

## UI changes
NA