### PR TITLE
KNOX-3364: New loadAliasesFromK8sSecrets method in entrypoint.sh to l…

### DIFF
--- a/gateway-docker/src/main/resources/docker/Dockerfile
+++ b/gateway-docker/src/main/resources/docker/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update && \
        libnss3 \
        bash \
        passwd \
-       curl && \
+       curl \
+       jq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
+++ b/gateway-docker/src/main/resources/docker/gateway-entrypoint.sh
@@ -35,6 +35,8 @@
 #   TRUSTSTORE_IMPORTS="myRootCA:/mountedpath/enterprise_root_cert.pem myBizPartnerCA:/mountedpath/mybiz_partner_cert.pem"
 #   Description:
 #   This will import the specified certificates into the truststore JKS with the provided alias name(s) during the container startup process.
+# - KNOX_ALIAS_LABEL - (optional) label selector used to discover Knox alias
+#   Secrets in the pod's namespace, default 'knox.apache.org/alias=true'.
 
 
 set -e
@@ -92,6 +94,49 @@ saveAlias() {
   fi
 }
 
+## Helper function to load Knox aliases from labeled Kubernetes Secrets.
+loadAliasesFromK8sSecrets() {
+  local sa_token_file="/var/run/secrets/kubernetes.io/serviceaccount/token"
+  local sa_ca_file="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+  local sa_ns_file="/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+  local label="${KNOX_ALIAS_LABEL:-knox.apache.org/alias=true}"
+
+  if [[ ! -r ${sa_token_file} || ! -r ${sa_ca_file} || ! -r ${sa_ns_file} ]]; then
+    echo "ServiceAccount token not mounted; skipping k8s-sourced Knox aliases"
+    return 0
+  fi
+
+  echo "Loading Knox aliases from labeled k8s Secrets (label: ${label}) ..."
+  local namespace token resp_file http_code secret_names
+  namespace=$(/bin/cat "${sa_ns_file}")
+  token=$(/bin/cat "${sa_token_file}")
+  resp_file=$(mktemp)
+
+  http_code=$(curl -sS \
+    --cacert "${sa_ca_file}" \
+    -H "Authorization: Bearer ${token}" \
+    -o "${resp_file}" -w "%{http_code}" \
+    "https://kubernetes.default.svc/api/v1/namespaces/${namespace}/secrets?labelSelector=${label}") || http_code="000"
+
+  if [[ ${http_code} != "200" ]]; then
+    echo "WARN: failed to list Knox alias Secrets from k8s API (HTTP ${http_code}); continuing without k8s aliases"
+    /bin/rm -f "${resp_file}"
+    return 0
+  fi
+
+  secret_names=$(jq -r '.items[].metadata.name' "${resp_file}" | tr '\n' ' ') || secret_names=""
+  /bin/rm -f "${resp_file}"
+
+  if [[ -z ${secret_names} ]]; then
+    echo "No labeled Knox alias Secrets found"
+    return 0
+  fi
+
+  # shellcheck disable=SC2086
+  /home/knox/knox/bin/knoxcli.sh create-k8s-alias ${secret_names} --namespace "${namespace}"
+  echo "Knox aliases loaded from k8s Secrets: ${secret_names}"
+}
+
 export GATEWAY_SERVER_RUN_IN_FOREGROUND=true
 
 
@@ -130,6 +175,8 @@ else
   echo "Generating knox.token.hash.key alias ..."
   /home/knox/knox/bin/knoxcli.sh generate-jwk --saveAlias knox.token.hash.key
 fi
+
+loadAliasesFromK8sSecrets
 
 # If keystore dir is empty use default one
 if [[ -z ${KEYSTORE_DIR} ]]


### PR DESCRIPTION
…oad aliases from k8s secrets. Install jq in the container as well.

[KNOX-3364](https://issues.apache.org/jira/browse/KNOX-3364) - Bootstrap Knox aliases from labeled Kubernetes Secrets on container startup

## What changes were proposed in this pull request?

Helper function to load Knox aliases from labeled Kubernetes Secrets. Uses the pod's mounted ServiceAccount token to list Secrets in the pod's namespace that carry KNOX_ALIAS_LABEL and feeds the names to `knoxcli create-k8s-alias`, so aliases are restored on every pod restart. Skips silently when no ServiceAccount token is mounted (non-k8s runs); logs a warning and continues on API errors so Knox startup isn't blocked by transient cluster issues. Requires: jq in the image; the pod's ServiceAccount must have list on Secrets in its namespace.

- Installs jq on the container

## How was this patch tested?

Tested on a local kind cluster, tested by just running without k8s, tested with no secrets, tested with different labels

Secrets:

```
---
apiVersion: v1
kind: Secret
metadata:
  name: stringdatasecret
  namespace: knox
  labels:
    knox.apache.org/alias: "true"
type: Opaque
stringData:
  alias.name: my-alias2
  topology: sandbox
  alias.value: s3cr3t
---
apiVersion: v1
kind: Secret
metadata:
  name: datasecret
  namespace: knox
  labels:
    knox.apache.org/alias: "true"
type: Opaque
data:
  alias.name: bXktYWxpYXM=
  alias.value: czNjcjN0
```

`./bin/knoxcli.sh list-alias --cluster __gateway,sandbox`
