### PR TITLE
KNOX-3341: LDAP proxy general search — review fixes and hardening

### DIFF
--- a/.github/workflows/tests/requirements.txt
+++ b/.github/workflows/tests/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.32.4
 pytest==8.3.4
 pylint==4.0.5
+ldap3==2.9.1

--- a/.github/workflows/tests/test_knox_ldap_proxy_search.py
+++ b/.github/workflows/tests/test_knox_ldap_proxy_search.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for general LDAP search through the embedded Knox LDAP proxy.
+
+These exercise the LdapProxyBackend.search() path (KNOX-3341): clients can query
+the embedded Knox LDAP service - which proxies to the demo LDAP backend - by
+objectClass, cn and uid (including wildcards), not just by a single uid lookup.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from urllib.parse import urlparse
+
+import ldap3
+
+# The embedded Knox LDAP service port (see gateway-site.xml: gateway.ldap.port).
+KNOX_LDAP_PORT = 33390
+
+BASE_DN = "dc=hadoop,dc=apache,dc=org"
+PEOPLE_BASE = f"ou=people,{BASE_DN}"
+GROUPS_BASE = f"ou=groups,{BASE_DN}"
+
+# A valid backend user used to bind to the proxy before searching.
+BIND_DN = f"uid=guest,{PEOPLE_BASE}"
+BIND_PASSWORD = "guest-password"
+
+
+def knox_host() -> str:
+    """Derive the Knox host from KNOX_GATEWAY_URL (defaults to localhost)."""
+    url = os.environ.get("KNOX_GATEWAY_URL", "https://localhost:8443/")
+    return urlparse(url).hostname or "localhost"
+
+
+class TestKnoxLdapProxySearch(unittest.TestCase):
+    """Verify general search requests are proxied to the demo LDAP backend."""
+
+    def setUp(self) -> None:
+        server = ldap3.Server(knox_host(), port=KNOX_LDAP_PORT, get_info=ldap3.NONE)
+        self.connection = ldap3.Connection(
+            server, user=BIND_DN, password=BIND_PASSWORD, auto_bind=True
+        )
+
+    def tearDown(self) -> None:
+        self.connection.unbind()
+
+    def rdn_values(self, base: str, ldap_filter: str) -> list[str]:
+        """Run a subtree search and return the leading RDN value of each entry."""
+        self.connection.search(base, ldap_filter, search_scope=ldap3.SUBTREE)
+        values = []
+        for entry in self.connection.entries:
+            # entry_dn looks like "uid=guest,ou=people,..." or "cn=level1,ou=groups,..."
+            first_rdn = entry.entry_dn.split(",", 1)[0]
+            values.append(first_rdn.split("=", 1)[1])
+        return values
+
+    def test_search_all_users_by_objectclass(self) -> None:
+        """All inetOrgPerson entries under ou=people are returned."""
+        users = self.rdn_values(PEOPLE_BASE, "(objectClass=inetOrgPerson)")
+        for expected in ("guest", "admin", "sam", "tom", "recursiveUser"):
+            self.assertIn(expected, users)
+
+    def test_search_all_groups_by_objectclass(self) -> None:
+        """All groupOfNames entries under ou=groups are returned."""
+        groups = self.rdn_values(GROUPS_BASE, "(objectClass=groupOfNames)")
+        for expected in ("analyst", "scientist", "admin", "level1", "level2", "level3"):
+            self.assertIn(expected, groups)
+
+    def test_search_groups_by_cn_wildcard(self) -> None:
+        """A cn wildcard filter returns only the matching groups."""
+        groups = self.rdn_values(GROUPS_BASE, "(cn=level*)")
+        self.assertEqual({"level1", "level2", "level3"}, set(groups))
+
+    def test_search_user_by_uid(self) -> None:
+        """A single user can still be looked up by uid."""
+        users = self.rdn_values(PEOPLE_BASE, "(uid=sam)")
+        self.assertIn("sam", users)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/FileBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/FileBackend.java
@@ -153,7 +153,13 @@ public class FileBackend implements LdapBackend {
     public List<Entry> searchUsers(String filter, SchemaManager schemaManager) throws Exception {
         List<Entry> results = new ArrayList<>();
 
-        String userFilter = extractUser(filter).toLowerCase(Locale.ROOT);
+        final String extractedUser = extractUser(filter);
+        if (extractedUser == null) {
+            // The filter does not target a recognized user identifier (uid/cn/sAMAccountName),
+            // so there is nothing for this user-only backend to match.
+            return results;
+        }
+        String userFilter = extractedUser.toLowerCase(Locale.ROOT);
 
         // Simple filter matching - just check if username matches
         for (String username : users.keySet()) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -399,7 +399,7 @@ public class LdapProxyBackend implements LdapBackend {
                     results.add(remoteSchemaConverter.convertRemoteEntryToProxyEntry(entry, schemaManager));
                 }
             } catch (LdapException e) {
-                LOG.ldapAttributeCopyError(e);
+                LOG.ldapSearchFailed(remoteSearchBase, remoteFilter, e);
             }
             return results;
         } finally {
@@ -685,7 +685,6 @@ public class LdapProxyBackend implements LdapBackend {
         return null;
     }
 
-    // tODO reuse this method in recursive calls
     private List<Entry> getUserGroupsInternal(LdapConnection connection, Dn... dns) throws LdapException, CursorException, IOException {
         List<Entry> groups = new ArrayList<>();
         if (dns.length == 0) {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -502,7 +502,9 @@ public class LdapProxyBackend implements LdapBackend {
             groupEntry = entryCache.get((groupDn));
         } else {
             try {
-                groupEntry = connection.lookup(groupDn, "memberOf");
+                // Request "cn" alongside "memberOf" so the cached entry can be resolved to a
+                // group name later (e.g. by getUserGroups); a memberOf-only lookup omits it.
+                groupEntry = connection.lookup(groupDn, "cn", "memberOf");
             } catch (LdapException e) {
                 // assume group doesn't exist and has no parent groups
                 groupEntry = createSkeletonGroupEntry(groupDn);
@@ -736,6 +738,10 @@ public class LdapProxyBackend implements LdapBackend {
             Attribute cnAttr = entry.get("cn");
             if (cnAttr != null) {
                 cns.add(cnAttr.getString());
+            } else if (entry.getDn() != null && entry.getDn().getRdn() != null) {
+                // Fall back to the CN carried in the DN when the entry was fetched without the
+                // cn attribute, so resolved groups are not silently dropped from the result.
+                cns.add(entry.getDn().getRdn().getValue());
             }
         }
         return cns;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -506,12 +506,15 @@ public class LdapProxyBackend implements LdapBackend {
                 // group name later (e.g. by getUserGroups); a memberOf-only lookup omits it.
                 groupEntry = connection.lookup(groupDn, "cn", "memberOf");
             } catch (LdapException e) {
-                // assume group doesn't exist and has no parent groups
+                groupEntry = null;
+            }
+            if (groupEntry == null) {
+                // Entry not found or lookup failed — synthesise a skeleton so cn is still known.
                 groupEntry = createSkeletonGroupEntry(groupDn);
             }
             entryCache.put(groupDn, groupEntry);
         }
-        Attribute memberOf = groupEntry.get("memberOf");
+        Attribute memberOf = groupEntry == null ? null : groupEntry.get("memberOf");
         if (memberOf != null) {
             for (Value value : memberOf) {
                 parents.add(value.getNormalized());

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
@@ -30,6 +30,8 @@ import org.apache.knox.gateway.services.ldap.LdapMessages;
 
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class RemoteSchemaConverter {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
@@ -174,11 +176,14 @@ public class RemoteSchemaConverter {
      * @return the proxy search base
      */
     public String convertRemoteDnToProxyDn(String string) {
-        return string == null ?
-                null :
-                string.replaceAll("(?i)" + remoteGroupSearchBase, proxyGroupSearchBase)
-                .replaceAll("(?i)" + remoteUserSearchBase, proxyUserSearchBase)
-                .replaceAll("(?i)" + remoteBaseDn, proxyBaseDn);
+        if (string == null) {
+            return null;
+        }
+        // Replace the most specific bases first; they contain the base DN as a suffix.
+        String result = replaceIgnoreCase(string, remoteGroupSearchBase, proxyGroupSearchBase);
+        result = replaceIgnoreCase(result, remoteUserSearchBase, proxyUserSearchBase);
+        result = replaceIgnoreCase(result, remoteBaseDn, proxyBaseDn);
+        return result;
     }
 
     /**
@@ -187,10 +192,24 @@ public class RemoteSchemaConverter {
      * @return the remote search base
      */
     public String convertProxyDnToRemoteDn(String string) {
-        return string == null ?
-                null :
-                string.replaceAll("(?i)" + proxyGroupSearchBase, remoteGroupSearchBase)
-                .replaceAll("(?i)" + proxyUserSearchBase, remoteUserSearchBase)
-                .replaceAll("(?i)" + proxyBaseDn, remoteBaseDn);
+        if (string == null) {
+            return null;
+        }
+        // Replace the most specific bases first; they contain the base DN as a suffix.
+        String result = replaceIgnoreCase(string, proxyGroupSearchBase, remoteGroupSearchBase);
+        result = replaceIgnoreCase(result, proxyUserSearchBase, remoteUserSearchBase);
+        result = replaceIgnoreCase(result, proxyBaseDn, remoteBaseDn);
+        return result;
+    }
+
+    /**
+     * Case-insensitive literal replacement of all occurrences of {@code search} with
+     * {@code replacement}. Both operands are treated as literals (not regular expressions),
+     * so DNs containing regex metacharacters are handled safely.
+     */
+    private static String replaceIgnoreCase(String input, String search, String replacement) {
+        return Pattern.compile(Pattern.quote(search), Pattern.CASE_INSENSITIVE)
+                .matcher(input)
+                .replaceAll(Matcher.quoteReplacement(replacement));
     }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
@@ -28,8 +28,20 @@ import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ldap.LdapMessages;
 
+import java.util.Locale;
+import java.util.Set;
+
 public class RemoteSchemaConverter {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
+
+    // Credential-bearing attributes that must never be surfaced through the proxy entry.
+    private static final Set<String> SENSITIVE_ATTRIBUTES = Set.of(
+            "userpassword", "unicodepwd", "userpkcs12");
+
+    // Attributes whose values are distinguished names and therefore need remote->proxy
+    // DN rewriting. Other attribute values (mail, description, ...) are copied verbatim.
+    private static final Set<String> DN_VALUED_ATTRIBUTES = Set.of(
+            "member", "uniquemember", "memberof", "manager", "owner", "seealso");
 
     // Proxy configuration
     private final String proxyBaseDn;  // Base DN for proxy entries (e.g., dc=proxy,dc=com)
@@ -80,8 +92,12 @@ public class RemoteSchemaConverter {
         Entry entry = new DefaultEntry(schemaManager);
         entry.setDn(sourceEntry.getDn());
 
-        // Copy all known AttributeTypes as-is from backend response
+        // Copy attributes from the backend response, skipping credential-bearing ones so
+        // they are never exposed through the proxy.
         for (Attribute attribute : sourceEntry.getAttributes()) {
+            if (SENSITIVE_ATTRIBUTES.contains(attribute.getId().toLowerCase(Locale.ROOT))) {
+                continue;
+            }
             copyAttribute(sourceEntry, entry, attribute.getId());
         }
 
@@ -135,9 +151,12 @@ public class RemoteSchemaConverter {
     public void copyAttribute(Entry source, Entry target, String attributeName) {
         final Attribute attribute = source.get(attributeName);
         if (attribute != null) {
+            // Only rewrite DNs for DN-valued attributes; other values (e.g. mail, description)
+            // are copied verbatim so they are not corrupted if they happen to contain a base DN.
+            final boolean dnValued = DN_VALUED_ATTRIBUTES.contains(attributeName.toLowerCase(Locale.ROOT));
             // Copy all values of the attribute (important for multi-valued attributes like objectClass)
             for (Value value : attribute) {
-                String valueString = convertRemoteDnToProxyDn(value.toString());
+                String valueString = dnValued ? convertRemoteDnToProxyDn(value.toString()) : value.toString();
                 if (!target.contains(attributeName, valueString)) {
                     try {
                         target.add(attributeName, valueString);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
@@ -175,15 +175,15 @@ public class RemoteSchemaConverter {
 
     /**
      * Converts a remote dn string to a proxy dn string. This also works for search base strings.
-     * @param string the remote dn or search base
+     * @param attributeValue the remote dn or search base
      * @return the proxy search base
      */
-    public String convertRemoteDnToProxyDn(String string) {
-        if (string == null) {
+    private String convertRemoteDnToProxyDn(String attributeValue) {
+        if (attributeValue == null) {
             return null;
         }
         // Replace the most specific bases first; they contain the base DN as a suffix.
-        String result = replaceIgnoreCase(string, remoteGroupSearchBase, proxyGroupSearchBase);
+        String result = replaceIgnoreCase(attributeValue, remoteGroupSearchBase, proxyGroupSearchBase);
         result = replaceIgnoreCase(result, remoteUserSearchBase, proxyUserSearchBase);
         result = replaceIgnoreCase(result, remoteBaseDn, proxyBaseDn);
         return result;
@@ -191,15 +191,15 @@ public class RemoteSchemaConverter {
 
     /**
      * Converts a proxy dn string to a remote dn string. This also works for search base strings.
-     * @param string the proxy dn or search base
+     * @param attributeValue the proxy dn or search base
      * @return the remote search base
      */
-    public String convertProxyDnToRemoteDn(String string) {
-        if (string == null) {
+    public String convertProxyDnToRemoteDn(String attributeValue) {
+        if (attributeValue == null) {
             return null;
         }
         // Replace the most specific bases first; they contain the base DN as a suffix.
-        String result = replaceIgnoreCase(string, proxyGroupSearchBase, remoteGroupSearchBase);
+        String result = replaceIgnoreCase(attributeValue, proxyGroupSearchBase, remoteGroupSearchBase);
         result = replaceIgnoreCase(result, proxyUserSearchBase, remoteUserSearchBase);
         result = replaceIgnoreCase(result, proxyBaseDn, remoteBaseDn);
         return result;
@@ -210,7 +210,7 @@ public class RemoteSchemaConverter {
      * {@code replacement}. Both operands are treated as literals (not regular expressions),
      * so DNs containing regex metacharacters are handled safely.
      */
-    private static String replaceIgnoreCase(String input, String search, String replacement) {
+    private String replaceIgnoreCase(String input, String search, String replacement) {
         return Pattern.compile(Pattern.quote(search), Pattern.CASE_INSENSITIVE)
                 .matcher(input)
                 .replaceAll(Matcher.quoteReplacement(replacement));

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/RemoteSchemaConverter.java
@@ -28,6 +28,7 @@ import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ldap.LdapMessages;
 
+import java.text.ParseException;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -113,13 +114,15 @@ public class RemoteSchemaConverter {
 
         // replace userObjectClass and groupObjectClass object classes
         Attribute objectClassAttribute = sourceEntry.get("objectclass");
-        if (objectClassAttribute.contains(remoteGroupObjectClass)) {
-            entry.remove("objectclass", remoteGroupObjectClass);
-            entry.add("objectclass", "groupofnames");
-        }
-        if (objectClassAttribute.contains(remoteUserObjectClass)) {
-            entry.remove("objectclass", remoteUserObjectClass);
-            entry.add("objectclass", "inetOrgPerson");
+        if (objectClassAttribute != null) {
+            if (objectClassAttribute.contains(remoteGroupObjectClass)) {
+                entry.remove("objectclass", remoteGroupObjectClass);
+                entry.add("objectclass", "groupofnames");
+            }
+            if (objectClassAttribute.contains(remoteUserObjectClass)) {
+                entry.remove("objectclass", remoteUserObjectClass);
+                entry.add("objectclass", "inetOrgPerson");
+            }
         }
 
         return entry;
@@ -130,9 +133,9 @@ public class RemoteSchemaConverter {
      * @param filter the filter
      * @param schemaManager the schema manager
      * @return the converted filter
-     * @throws Exception if the filter cannot be parsed
+     * @throws ParseException if the filter cannot be parsed
      */
-    public String convertProxyFilterToRemoteFilter(String filter, SchemaManager schemaManager) throws Exception {
+    public String convertProxyFilterToRemoteFilter(String filter, SchemaManager schemaManager) throws ParseException {
         FilterMappingVisitor filterMappingVisitor = new FilterMappingVisitor(remoteUserIdentifierAttribute, remoteUserObjectClass, remoteGroupObjectClass, schemaManager);
 
         // Filter likely has already been annotated by other interceptors.

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/DisabledUserInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/DisabledUserInterceptor.java
@@ -71,8 +71,6 @@ public class DisabledUserInterceptor extends BaseInterceptor {
         } catch (IOException e) {
             // IOException would only occur after finishing iterating over results
             // we can ignore this exception and return the filtered entries
-        } catch (Exception e) {
-            throw e;
         }
         return new EntryFilteringCursorImpl(new ListCursor<>(filteredEntries), ctx, schemaManager);
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -95,14 +95,31 @@ public class UserSearchInterceptor extends BaseInterceptor {
         } catch (Exception e) {
             // If we get an error or no results, try the backends
         }
-        try {
-            entries.addAll(backend.search(baseDn, ctx.getScope(), filter, schemaManager));
-        } catch (Exception e) {
-            LOG.ldapSearchFailed(baseDn, filter, e);
+
+        // Only forward to the backend when the search base is under the backend's namespace.
+        // System/operational searches (ou=schema, cn=config, root-DSE) must not be forwarded.
+        if (isUnderBackendBaseDn(baseDn)) {
+            try {
+                entries.addAll(backend.search(baseDn, ctx.getScope(), filter, schemaManager));
+            } catch (Exception e) {
+                LOG.ldapSearchFailed(baseDn, filter, e);
+            }
         }
 
         // Return cursor with our results - use a simple approach
         return new EntryFilteringCursorImpl(new ListCursor<>(entries), ctx, schemaManager);
+    }
+
+    private boolean isUnderBackendBaseDn(String searchBase) {
+        if (searchBase == null || searchBase.isEmpty()) {
+            return false;
+        }
+        String backendBase = backend.getBaseDn();
+        if (backendBase == null || backendBase.isEmpty()) {
+            return false;
+        }
+        return searchBase.toLowerCase(java.util.Locale.ROOT)
+                .endsWith(backendBase.toLowerCase(java.util.Locale.ROOT));
     }
 
     @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -39,6 +39,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Locale.ROOT;
+
 /**
  * Interceptor for LDAP operations to proxy user searches to backends when not found locally
  */
@@ -111,15 +113,11 @@ public class UserSearchInterceptor extends BaseInterceptor {
     }
 
     private boolean isUnderBackendBaseDn(String searchBase) {
-        if (searchBase == null || searchBase.isEmpty()) {
+        final String backendBase = backend.getBaseDn();
+        if (searchBase == null || searchBase.isEmpty() || backendBase == null || backendBase.isEmpty()) {
             return false;
         }
-        String backendBase = backend.getBaseDn();
-        if (backendBase == null || backendBase.isEmpty()) {
-            return false;
-        }
-        return searchBase.toLowerCase(java.util.Locale.ROOT)
-                .endsWith(backendBase.toLowerCase(java.util.Locale.ROOT));
+        return searchBase.toLowerCase(ROOT).endsWith(backendBase.toLowerCase(ROOT));
     }
 
     @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
@@ -294,6 +294,33 @@ public class LdapProxyBackendTest {
     }
 
     @Test
+    public void testGetUserGroupsUseMemberOfRecursive() throws Exception {
+        Map<String, String> config = createRecursiveConfigForMemberOf(10);
+        config.put("useMemberOf", "true");
+        ldapProxyBackend = new LdapProxyBackend("testbackend", config);
+
+        List<String> userGroups = ldapProxyBackend.getUserGroups("memberOfUser", schemaManager);
+        assertTrue(userGroups.contains("memberOflevel1"));
+        assertTrue(userGroups.contains("memberOflevel2"));
+        assertTrue(userGroups.contains("memberOflevel3"));
+        assertTrue(userGroups.contains("memberOflevel4"));
+        assertTrue(userGroups.contains("memberOfCycleA"));
+        assertTrue(userGroups.contains("memberOfCycleB"));
+    }
+
+    @Test
+    public void testGetUserGroupsUseMemberOfRecursiveDepth2() throws Exception {
+        Map<String, String> config = createRecursiveConfigForMemberOf(2);
+        config.put("useMemberOf", "true");
+        ldapProxyBackend = new LdapProxyBackend("testbackend", config);
+
+        List<String> userGroups = ldapProxyBackend.getUserGroups("memberOfUser", schemaManager);
+        assertTrue(userGroups.contains("memberOflevel1"));
+        assertTrue(userGroups.contains("memberOflevel2"));
+        assertFalse("Level 3 should not appear at max depth 2", userGroups.contains("memberOflevel3"));
+    }
+
+    @Test
     public void testSearchUsers() throws Exception {
         ldapProxyBackend = new LdapProxyBackend("testbackend", ldapBackendConfig);
         validateUserSearch("*", 3, Set.of("ldaptest1", "ldaptest2", "guest"));

--- a/gateway-server/src/test/resources/ldap-recursive-test.ldif
+++ b/gateway-server/src/test/resources/ldap-recursive-test.ldif
@@ -143,10 +143,10 @@ member: uid=memberOfUser2,ou=recursiveMemberOfPeople,dc=hadoop,dc=apache,dc=org
 dn: cn=memberOflevel2,ou=recursiveMemberOfGroups,dc=hadoop,dc=apache,dc=org
 objectclass:top
 objectclass: groupofnames
-cn: memberOflevel2level2
+cn: memberOflevel2
 memberOf: cn=memberOflevel3,ou=recursiveMemberOfGroups,dc=hadoop,dc=apache,dc=org
 memberOf: cn=memberOfCycleA,ou=recursiveMemberOfGroups,dc=hadoop,dc=apache,dc=org
-member: cn=memberOflevel1,ou=recursiveGroups,dc=hadoop,dc=apache,dc=org
+member: cn=memberOflevel1,ou=recursiveMemberOfGroups,dc=hadoop,dc=apache,dc=org
 
 # memberOf Level 3 Group (Member is Level 2)
 dn: cn=memberOflevel3,ou=recursiveMemberOfGroups,dc=hadoop,dc=apache,dc=org

--- a/knox-site/docs/service_ldap_server.md
+++ b/knox-site/docs/service_ldap_server.md
@@ -108,7 +108,7 @@ remains available with its default credentials.
 
 | Property | Default Value | Description |
 | :--- | :--- | :--- |
-| `gateway.ldap.interceptor.<name>.interceptorType` | N/A | The type of interceptor to use (`backend` or `duplicateuserfilter`). |
+| `gateway.ldap.interceptor.<name>.interceptorType` | N/A | The type of interceptor to use (`backend`, `duplicateuserfilter`, `disableduserfilter`, or `rolesLookup`). |
 
 #### User Search Interceptor (`backend`)
 
@@ -197,7 +197,6 @@ The proxy backend delegates lookups to a remote LDAP or Active Directory server.
 | `gateway.ldap.interceptor.<name>.groupObjectClass` | `groupOfNames` | Objectclass for identifying groups in remote server (e.g., `group` for AD). |
 | `gateway.ldap.interceptor.<name>.groupMemberAttribute` | `memberUid` | Attribute used for group membership (e.g., `member` for AD). |
 | `gateway.ldap.interceptor.<name>.useMemberOf` | `false` | If `true`, use the `memberOf` attribute for efficient group lookups. |
-| `gateway.ldap.interceptor.<name>.proxy.poolMaxActive` | `8` | Maximum number of active connections in the pool. |
 | `gateway.ldap.interceptor.<name>.proxy.poolMaxActive` | `8` | Maximum number of active connections in the pool. |
 
 ## Active Directory (AD) Integration


### PR DESCRIPTION
[KNOX-3341](https://issues.apache.org/jira/browse/KNOX-3341) - LDAP proxy general search: review follow-ups and hardening

## What changes were proposed in this pull request?

This is a follow-up to #1274 (KNOX-3341, "LDAP proxy backend handles general searches"). A post-merge review surfaced a few correctness gaps and some hardening/cleanup opportunities in the new proxy/search code.

**Correctness fixes**

- **`FileBackend.searchUsers` NPE on non-user filters.** `extractUser()` returns `null` when a filter targets no recognized user identifier (e.g. `(objectclass=inetOrgPerson)`). Since `FileBackend.search()` now delegates every filter to
 `searchUsers()`, such general searches threw an NPE on `toLowerCase()`. The null is now guarded (the user-only backend matches nothing for filters it cannot satisfy).
- **Group CNs dropped in recursive `memberOf` resolution.** `getUserGroups()` with `useMemberOf=true` and `recursiveGroupResolution=true` returned an incomplete list: parent groups were looked up requesting only the `memberOf` attribute, so the cached entries carried no `cn` and `getCnsFromEntries` silently dropped them. The lookup now requests `cn` as well, and `getCnsFromEntries` falls back to the CN in the entry's DN. Also fixes an NPE when `LdapConnection.lookup()` returns `null` (rather than throwing) for a missing entry.

**Hardening**

- **Don't expose secrets or corrupt non-DN values when proxying entries.** `convertRemoteEntryToProxyEntry` copied every remote attribute verbatim (including credential-bearing ones such as `userPassword`) and ran the remote→proxy DN rewrite on every value, which could mangle non-DN values (`mail`, `description`) containing a base-DN substring. Sensitive attributes are now skipped, and DN rewriting is applied only to known DN-valued attributes (`member`, `uniqueMember
`, `memberOf`, `manager`, `owner`, `seeAlso`).
- **Regex-safe DN conversion.** `convertRemoteDnToProxyDn`/`convertProxyDnToRemoteDn` used the base DNs directly as regex patterns and the targets as replacement strings. They now use `Pattern.quote`/`Matcher.quoteReplacement` (case-insensitive, most-specific-first) so a DN with regex metacharacters can't break the conversion.
- **Only forward searches under the backend's namespace.** `UserSearchInterceptor.search` forwarded every search to the backend, including ApacheDS internal/operational searches (`ou=schema`, `cn=config`, root-DSE). It now skips the backend call when the search base is not under the backend's base DN.

**Cleanups**

- Removed a dead `catch (Exception e) { throw e; }` in `DisabledUserInterceptor`
- dropped a stale `tODO` comment
- null-checked the `objectclass` attribute before use
- narrowed `convertProxyFilterToRemoteFilter` from `throws Exception` to `throws ParseException`
- and switched a misleading `ldapAttributeCopyError` log in `search()` to `ldapSearchFailed`.

**Docs**

- Fixed `knox-site/docs/service_ldap_server.md`: removed a duplicated `proxy.poolMaxActive` table row and completed the `interceptorType` value list (`disableduserfilter`, `rolesLookup`).

## How was this patch tested?

- **Unit tests** (`gateway-server`): the full `org.apache.knox.gateway.services.ldap.**` suite passes.
Added `testGetUserGroupsUseMemberOfRecursive` and `testGetUserGroupsUseMemberOfRecursiveDepth2` to cover the previously-untested `use MemberOf` + recursive `getUserGroups()` path, and fixed two data bugs in `ldap-recursive-test.ldif` (a mismatched `cn` and a wrong-OU `member` reference) that had masked the dropped-CN bug.
- **Docker integration tests**: the full compose suite passes (`32 passed`), including the new LDAP search test, and `pylint` rates the test sources `10.00/10`.

## Integration Tests

Added `.github/workflows/tests/test_knox_ldap_proxy_search.py` (and `ldap3` to `requirements.txt`). 

The existing integration coverage only exercised bind and recursive group resolution (Shiro authenticates via a `userDnTemplate` bind, not a search) so the new `LdapProxyBackend.search()` path had no end-to-end coverage.

The new test binds to the embedded Knox LDAP service (which proxies to the demo LDAP backend) and searches by `objectClass`, `cn` wildcard, and `uid`, validating that general searches are proxied and converted correctly.

## UI changes
N/A