### PR TITLE
KNOX-3366:Upgrade Mina-core to 2.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <metrics.version>4.1.16</metrics.version>
-        <mina.version>2.2.7</mina.version>
+        <mina.version>2.2.8</mina.version>
         <netty.version>4.1.127.Final</netty.version>
         <nimbus-jose-jwt.version>10.5</nimbus-jose-jwt.version>
         <nodejs.version>v22.20.0</nodejs.version>


### PR DESCRIPTION
(It is very **important** that you created an Apache Knox JIRA for this change and that the PR title/commit message includes the Apache Knox JIRA ID!)

[KNOX-3366](https://issues.apache.org/jira/browse/KNOX-3366) - Upgrade mina-core to 2.2.8

## What changes were proposed in this pull request?

Upgrade mina-core to 2.2.8 to target CVEs.
CVE-2026-47065: Critical Deserialization Allow-list Bypass via resolveProxyClass - ZDRES-232
CVE-2026-47321: Unbounded Decompression Amplification DoS in Apache Mina Zlib.inflate - ZDRES-231
https://mina.apache.org/mina-project/news

## How was this patch tested?
Built Locally , relying on precommits.

## Integration Tests
No additional tests added , as this is a minor change.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
