### PR TITLE
KNOX-3369: Bump requests from 2.32.4 to 2.33.0 and pytest from 8.3.4 to 9.0.3 in /.github/workflows/tests

### DIFF
--- a/.github/workflows/tests/requirements.txt
+++ b/.github/workflows/tests/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.32.4
-pytest==8.3.4
+requests==2.33.0
+pytest==9.0.3
 pylint==4.0.5
 ldap3==2.9.1


### PR DESCRIPTION
[KNOX-3369](https://issues.apache.org/jira/browse/KNOX-3369) - Bump Python-related versions in Docker-based integration tests

## What changes were proposed in this pull request?

Bumps [pytest](https://github.com/pytest-dev/pytest) from 8.3.4 to 9.0.3. (see #1199 )
Bumps [requests](https://github.com/psf/requests) from 2.32.4 to 2.33.0. (see #1186 )

## How was this patch tested?

Running the integration tests manually on my local test ENV:
```
tests-1  | Installing collected packages: urllib3, typing-extensions, tomlkit, tomli, pygments, pyasn1, pluggy, platformdirs, packaging, mccabe, isort, iniconfig, idna, dill, charset_normalizer, certifi, requests, ldap3, exceptiongroup, astroid, pytest, pylint
tests-1  | Successfully installed astroid-4.0.4 certifi-2026.6.17 charset_normalizer-3.4.7 dill-0.4.1 exceptiongroup-1.3.1 idna-3.18 iniconfig-2.3.0 isort-8.0.1 ldap3-2.9.1 mccabe-0.7.0 packaging-26.2 platformdirs-4.10.0 pluggy-1.6.0 pyasn1-0.6.3 pygments-2.20.0 pylint-4.0.5 pytest-9.0.3 requests-2.33.0 tomli-2.4.1 tomlkit-0.15.0 typing-extensions-4.15.0 urllib3-2.7.0
tests-1  | WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
tests-1  | 
tests-1  | [notice] A new release of pip is available: 23.0.1 -> 26.1.2
tests-1  | [notice] To update, run: pip install --upgrade pip
tests-1  | 
tests-1  | ------------------------------------
tests-1  | Your code has been rated at 10.00/10
tests-1  | 
tests-1  | Waiting for knox...
tests-1  | ============================= test session starts ==============================
tests-1  | platform linux -- Python 3.10.20, pytest-9.0.3, pluggy-1.6.0
tests-1  | rootdir: /tests
tests-1  | collected 32 items
tests-1  | 
tests-1  | test_health.py .....                                                     [ 15%]
tests-1  | test_k8s_serviceaccount_validation.py ......                             [ 34%]
tests-1  | test_knox_auth_service_and_ldap.py ...                                   [ 43%]
tests-1  | test_knox_configs.py .                                                   [ 46%]
tests-1  | test_knox_ldap_proxy_search.py ....                                      [ 59%]
tests-1  | test_knoxauth_preauth_and_paths.py ......                                [ 78%]
tests-1  | test_remote_auth.py ...                                                  [ 87%]
tests-1  | test_remoteauth_extauthz_additional_path.py ....                         [100%]
tests-1  | 
tests-1  | =============================== warnings summary ===============================
tests-1  | ../usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50
tests-1  |   /usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50: DeprecationWarning: tagMap is deprecated. Please use TAG_MAP instead.
tests-1  |     from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
tests-1  | 
tests-1  | ../usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50
tests-1  |   /usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50: DeprecationWarning: typeMap is deprecated. Please use TYPE_MAP instead.
tests-1  |     from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
tests-1  | 
tests-1  | test_health.py: 5 warnings
tests-1  | test_k8s_serviceaccount_validation.py: 6 warnings
tests-1  | test_knox_auth_service_and_ldap.py: 3 warnings
tests-1  | test_knox_configs.py: 1 warning
tests-1  | test_knoxauth_preauth_and_paths.py: 6 warnings
tests-1  | test_remote_auth.py: 3 warnings
tests-1  | test_remoteauth_extauthz_additional_path.py: 4 warnings
tests-1  |   /usr/local/lib/python3.10/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning: Unverified HTTPS request is being made to host 'knox'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
tests-1  |     warnings.warn(
tests-1  | 
tests-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
tests-1  | ----------------- generated xml file: /tests/test-results.xml ------------------
tests-1  | ======================= 32 passed, 30 warnings in 1.43s ========================

```

## Integration Tests
N/A

## UI changes
N/A