### PR TITLE
KNOX-3371: Fix broken error message on login page

### DIFF
--- a/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/js/knoxauth.js
@@ -86,14 +86,15 @@ var login = function() {
 					}
 					redirect(redirectUrl);
 				} else {
-					$('#errorBox').show();
-					$('#signInLoading').css('visibility', 'hidden');
-					$('#signIn').removeAttr('disabled');
 					if (request.status == 401) {
 						$('#errorBox .errorMsg').text("The username or password you entered is incorrect.");
 					} else {
 						$('#errorBox .errorMsg').text("Response from " + request.responseURL + " - " + request.status + ": " + request.statusText);
 					}
+					$('#errorBox').show();
+					$('#signInLoading').css('visibility', 'hidden');
+					$('#signIn').removeAttr('disabled');
+					$(window).trigger('resize');
 				}
 			}
 		};

--- a/gateway-applications/src/main/resources/applications/knoxauth/app/login.html
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/login.html
@@ -102,9 +102,10 @@
                         <label><i class="bi bi-lock"></i> Password:</label>
                         <input type="password" name="password" id="password" tabindex="2" autocomplete="off" onkeypress=keypressed(event)>
                     </div>
-                    <span id="errorBox" class="help-inline" style="color:white;display:none;"><span class="errorMsg"></span>
-                        <i class="bi bi-exclamation-triangle" style="color:#ae2817;"></i>
-                    </span>
+                    <div id="errorBox" style="display:none;" role="alert">
+                        <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
+                        <span class="errorMsg"></span>
+                    </div>
                     <button type="button" class="btn btn-primary w-100" id="signIn" tabindex="4" onkeypress="keypressed(event)" onclick="login();" style="position: relative; text-align: center;">
                         <span>Sign In</span>
                         <i id="signInLoading" class="bi bi-arrow-repeat icon-sign-in"></i>

--- a/gateway-applications/src/main/resources/applications/knoxauth/app/styles/knox.css
+++ b/gateway-applications/src/main/resources/applications/knoxauth/app/styles/knox.css
@@ -1732,6 +1732,28 @@ body.login {
   box-shadow: none !important;
   outline: none !important;
 }
+.login #errorBox {
+  margin-top: 12px;
+  padding: 10px 12px;
+  background-color: rgba(174, 40, 23, 0.15);
+  border: 1px solid #ae2817;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  box-sizing: border-box;
+  width: 100%;
+}
+.login #errorBox i {
+  color: #ae2817;
+  margin-right: 8px;
+  vertical-align: text-top;
+}
+.login #errorBox .errorMsg {
+  display: inline;
+}
 .label-yellow{
     background-color: #f3a139;
 }


### PR DESCRIPTION
[KNOX-3371](https://issues.apache.org/jira/browse/KNOX-3371) - Error message is broken on login page

## What changes were proposed in this pull request?

- Fixed the broken error message for invalid username/password inputs

## How was this patch tested?

On a locally running knox

## UI changes

UI with the fix
<img width="429" height="678" alt="image" src="https://github.com/user-attachments/assets/e9b105a0-e166-4410-a408-d8a1e2640597" />

<img width="494" height="648" alt="image" src="https://github.com/user-attachments/assets/37524c86-c04a-4182-848d-7512af60976a" />
