### PR TITLE
KNOX-3374: Fix inherited roles missing from auth headers when LDAP ro…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -45,6 +45,7 @@ import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
+import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlImpl;
 import org.apache.knox.gateway.services.ldap.interceptor.InterceptorFactory;
 import org.apache.knox.gateway.services.security.AliasService;
 
@@ -376,6 +377,10 @@ public class KnoxLDAPServerManager {
         searchRequest.setScope(SearchScope.SUBTREE);
         searchRequest.setFilter("(uid=" + username + ")");
         searchRequest.addAttributes("*");
+
+        RolesLookupBypassControlImpl bypassControl = new RolesLookupBypassControlImpl();
+        bypassControl.setBypassRolesLookup(true);
+        searchRequest.addControl(bypassControl);
 
         List<String> groups = new ArrayList<>();
         try (Cursor<Entry> cursor = directoryService.getAdminSession().search(searchRequest)) {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -19,16 +19,21 @@ package org.apache.knox.gateway.services.ldap;
 
 import org.apache.directory.api.ldap.codec.api.ControlFactory;
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapAuthenticationException;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.message.Control;
 import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.ldap.client.api.LdapConnection;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
+import org.apache.knox.gateway.services.ldap.interceptor.ConfigurableEntriesTestInterceptor;
+import org.apache.knox.gateway.services.ldap.interceptor.LDAPRolesLookupInterceptor;
 import org.apache.knox.gateway.services.ldap.model.constants.SchemaConstants;
 import org.easymock.EasyMock;
 import org.apache.directory.api.ldap.model.name.Dn;
@@ -40,12 +45,15 @@ import org.junit.After;
 import java.io.File;
 import java.net.ServerSocket;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
@@ -406,6 +414,45 @@ public class KnoxLDAPServerManagerTest {
         Map<String, ControlFactory<? extends Control>> controlFactoryMap = serverManager.directoryService.getLdapCodecService().getRequestControlFactories();
         assertTrue(controlFactoryMap.containsKey(SchemaConstants.ROLES_LOOKUP_BYPASS_CONTROL_OID));
         assertTrue(controlFactoryMap.get(SchemaConstants.ROLES_LOOKUP_BYPASS_CONTROL_OID) instanceof RolesLookupBypassControlFactory);
+    }
+
+    @Test
+    public void testGetUserGroupsReturnsRawGroupsEvenWhenRolesInterceptorRewritesMemberOf() throws Exception {
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of()).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
+        serverManager.start();
+
+        SchemaManager schemaManager = serverManager.directoryService.getSchemaManager();
+        Entry userEntry = new DefaultEntry(schemaManager);
+        userEntry.setDn("uid=admin,ou=people,dc=test,dc=com");
+        userEntry.add("uid", "admin");
+        userEntry.add("memberOf", "cn=me-test-group-a,ou=groups,dc=test,dc=com");
+        userEntry.add("memberOf", "cn=me-test-group-b,ou=groups,dc=test,dc=com");
+        ConfigurableEntriesTestInterceptor entriesInterceptor = new ConfigurableEntriesTestInterceptor("testEntries");
+        entriesInterceptor.setEntries(List.of(userEntry));
+        entriesInterceptor.init(serverManager.directoryService);
+
+        LDAPRolesLookupService mockRolesService = EasyMock.createNiceMock(LDAPRolesLookupService.class);
+        expect(mockRolesService.lookupRoles(anyString(), anyObject()))
+                .andReturn(Arrays.asList("console:admin", "ws-1:viewer", "ws-2:user")).anyTimes();
+        replay(mockRolesService);
+        LDAPRolesLookupInterceptor rolesInterceptor = new LDAPRolesLookupInterceptor(mockRolesService);
+        rolesInterceptor.init(serverManager.directoryService);
+
+        List<Interceptor> chain = new ArrayList<>(serverManager.directoryService.getInterceptors());
+        chain.add(0, rolesInterceptor);
+        chain.add(1, entriesInterceptor);
+        serverManager.directoryService.setInterceptors(chain);
+
+        List<String> groups = serverManager.getUserGroups("admin");
+
+        assertEquals(Arrays.asList("me-test-group-a", "me-test-group-b"), groups);
     }
 
     @Test(expected = LdapException.class)

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableEntriesTestInterceptor.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableEntriesTestInterceptor.java
@@ -35,7 +35,7 @@ public class ConfigurableEntriesTestInterceptor extends BaseInterceptor {
     private List<Entry> entries;
     private EntryFilteringCursor cursor;
 
-    ConfigurableEntriesTestInterceptor(String name) {
+    public ConfigurableEntriesTestInterceptor(String name) {
         super(name);
     }
 


### PR DESCRIPTION
…les-lookup interceptor is active

[KNOX-3374](https://issues.apache.org/jira/browse/KNOX-3374) - Inherited roles missing from auth headers when LDAP roles-lookup interceptor is active

## What changes were proposed in this pull request?

- `KnoxLDAPServerManager.getUserGroups()` now attaches a `RolesLookupBypassControl` to its LDAP search, so it returns raw group names instead of interceptor-rewritten role names.
- Eliminates a double roles-lookup: `LDAPRolesLookupInterceptor` was rewriting memberOf to roles, and `AbstractAuthResource` then called the roles API again with those roles-as-groups — which returned only the user's direct roles, dropping inherited ones.
- External LDAP-proxy clients are unaffected; the interceptor still rewrites memberOf on their searches.
- New `KnoxLDAPServerManagerTest#testGetUserGroupsReturnsRawGroupsEvenWhenRolesInterceptorRewritesMemberOf` — installs the real roles interceptor over a test entries interceptor serving a user with memberOf group DNs; asserts getUserGroups returns raw group names, not the mocked roles.

## How was this patch tested?

Unit tests
E2Etests:

Roles:
```
[
  { "id": "admin", "type": "user",
    "roles": [ { "scope": "console", "name": "admin" } ] },
  { "id": "me-test-group-a", "type": "group",
    "roles": [ { "scope": "ws-1", "name": "viewer" } ] },
  { "id": "me-test-group-b", "type": "group",
    "roles": [ { "scope": "ws-2", "name": "user" } ] }
]
```


Without changes:
```
ldapsearch -x -H ldap://localhost:10389 \
  -D "uid=admin,ou=people,dc=hadoop,dc=apache,dc=org" -w admin-password \
  -b "dc=hadoop,dc=apache,dc=org" "(uid=admin)" memberOf

# admin, people, hadoop.apache.org
dn: uid=admin,ou=people,dc=hadoop,dc=apache,dc=org
memberOf: cn=ws-1:viewer,ou=groups,ou=groups,dc=hadoop,dc=apache,dc=org
memberOf: cn=ws-2:user,ou=groups,ou=groups,dc=hadoop,dc=apache,dc=org
```

```
curl -kvs -u admin:admin-password \
  https://localhost:8443/gateway/sandbox/auth/api/v1/extauthz/anything

< username: admin
< roles: console:admin
```

With the fix:
```
ldapsearch -x -H ldap://localhost:10389 \
  -D "uid=admin,ou=people,dc=hadoop,dc=apache,dc=org" -w admin-password \
  -b "dc=hadoop,dc=apache,dc=org" "(uid=admin)" memberOf

# admin, people, hadoop.apache.org
dn: uid=admin,ou=people,dc=hadoop,dc=apache,dc=org
memberOf: cn=ws-1:viewer,ou=groups,ou=groups,dc=hadoop,dc=apache,dc=org
memberOf: cn=ws-2:user,ou=groups,ou=groups,dc=hadoop,dc=apache,dc=org
```

```
curl -kvs -u admin:admin-password \
  https://localhost:8443/gateway/sandbox/auth/api/v1/extauthz/anything

< username: admin
< roles: ws-1:viewer,console:admin,ws-2:user
```

## Integration Tests
N/A

## UI changes
N/A
