### PR TITLE
KNOX-3375: Wire in gatewayservices for LDAPRolesLookupInterceptorFact…

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/LdapServiceFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/factory/LdapServiceFactory.java
@@ -38,6 +38,7 @@ public class LdapServiceFactory extends AbstractServiceFactory {
         if (shouldCreateService(implementation)) {
             service = new KnoxLDAPService();
             service.setAliasService(getAliasService(gatewayServices));
+            service.setGatewayServices(gatewayServices);
             GatewayServer.registerConfigChangeListener(service);
             logServiceUsage(service.getClass().getName(), serviceType);
         }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -44,6 +44,7 @@ import org.apache.directory.server.ldap.LdapServer;
 import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlImpl;
 import org.apache.knox.gateway.services.ldap.interceptor.InterceptorFactory;
@@ -67,6 +68,7 @@ public class KnoxLDAPServerManager {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
     private static final String LDAP_BIND_PASSWORD_ALIAS = "gateway_ldap_bind_password";
     private final AliasService aliasService;
+    private final GatewayServices gatewayServices;
 
     @VisibleForTesting
     DirectoryService directoryService;
@@ -81,7 +83,12 @@ public class KnoxLDAPServerManager {
     private Set<String> baseDns;
 
     KnoxLDAPServerManager(AliasService aliasService) {
+        this(aliasService, null);
+    }
+
+    KnoxLDAPServerManager(AliasService aliasService, GatewayServices gatewayServices) {
         this.aliasService = aliasService;
+        this.gatewayServices = gatewayServices;
     }
 
     /**
@@ -133,7 +140,7 @@ public class KnoxLDAPServerManager {
                 }
             }
 
-            interceptors.add(InterceptorFactory.createInterceptor(config, interceptorName, interceptorConfig));
+            interceptors.add(InterceptorFactory.createInterceptor(config, gatewayServices, interceptorName, interceptorConfig));
         }
         this.interceptors = interceptors;
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPService.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.services.ldap;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.GatewayConfigChangeListener;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.Service;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.security.AliasService;
@@ -36,6 +37,7 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
 
     KnoxLDAPServerManager ldapServerManager;
     AliasService aliasService;
+    private GatewayServices gatewayServices;
     private boolean enabled;
 
     @Override
@@ -48,7 +50,7 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
 
         try {
             // Initialize the LDAP server manager with configuration
-            ldapServerManager = new KnoxLDAPServerManager(aliasService);
+            ldapServerManager = new KnoxLDAPServerManager(aliasService, gatewayServices);
             ldapServerManager.initialize(config);
         } catch (Exception e) {
             throw new ServiceLifecycleException("Failed to initialize LDAP service", e);
@@ -57,6 +59,10 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
 
     public void setAliasService(AliasService aliasService) {
         this.aliasService = aliasService;
+    }
+
+    public void setGatewayServices(GatewayServices gatewayServices) {
+        this.gatewayServices = gatewayServices;
     }
 
     @Override
@@ -95,7 +101,7 @@ public class KnoxLDAPService implements Service, GatewayConfigChangeListener {
             this.enabled = config.isLDAPEnabled();
 
             if (this.enabled) {
-                this.ldapServerManager = this.ldapServerManager == null ? new KnoxLDAPServerManager(aliasService) : this.ldapServerManager;
+                this.ldapServerManager = this.ldapServerManager == null ? new KnoxLDAPServerManager(aliasService, gatewayServices) : this.ldapServerManager;
                 ldapServerManager.stop();
                 ldapServerManager.initialize(config);
                 ldapServerManager.start();

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/DisabledUserInterceptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/DisabledUserInterceptorFactory.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.ldap.interceptor;
 
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
 
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public class DisabledUserInterceptorFactory implements KnoxLdapInterceptorFactor
     public static final String TYPE = "disableduserfilter";
 
     @Override
-    public Interceptor create(GatewayConfig gatewayConfig, String name, Map<String, String> config) {
+    public Interceptor create(GatewayConfig gatewayConfig, GatewayServices gatewayServices, String name, Map<String, String> config) {
         return new DisabledUserInterceptor(name, config);
     }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/DuplicateUserFilteringInterceptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/DuplicateUserFilteringInterceptorFactory.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.ldap.interceptor;
 
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
 
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public class DuplicateUserFilteringInterceptorFactory implements KnoxLdapInterce
     public static final String TYPE = "duplicateuserfilter";
 
     @Override
-    public Interceptor create(GatewayConfig gatewayConfig, String name, Map<String, String> interceptorConfig) {
+    public Interceptor create(GatewayConfig gatewayConfig, GatewayServices gatewayServices, String name, Map<String, String> interceptorConfig) {
         return new DuplicateUserFilteringInterceptor(name);
     }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/InterceptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/InterceptorFactory.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.services.ldap.interceptor;
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ldap.LdapMessages;
 
 import java.util.Map;
@@ -33,7 +34,8 @@ import java.util.ServiceLoader;
 public class InterceptorFactory {
     private static final LdapMessages LOG = MessagesFactory.get(LdapMessages.class);
 
-    public static Interceptor createInterceptor(final GatewayConfig gatewayConfig, final String interceptorName,
+    public static Interceptor createInterceptor(final GatewayConfig gatewayConfig, final GatewayServices gatewayServices,
+                                                final String interceptorName,
                                                 final Map<String, String> interceptorConfig) throws Exception {
         final String interceptorType = interceptorConfig.get("interceptorType");
         if (interceptorType == null) {
@@ -49,7 +51,7 @@ public class InterceptorFactory {
         for (KnoxLdapInterceptorFactory interceptorFactory : loader) {
             if (interceptorFactory.getType().equalsIgnoreCase(interceptorType)) {
                 LOG.ldapInterceptorCreating(interceptorType, "ServiceLoader");
-                return interceptorFactory.create(gatewayConfig, interceptorName, interceptorConfig);
+                return interceptorFactory.create(gatewayConfig, gatewayServices, interceptorName, interceptorConfig);
             }
         }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/KnoxLdapInterceptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/KnoxLdapInterceptorFactory.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.ldap.interceptor;
 
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
 
 import java.util.Map;
 
@@ -27,13 +28,14 @@ import java.util.Map;
  */
 public interface KnoxLdapInterceptorFactory {
     /**
-     * Instantiate and interceptor
+     * Instantiate an interceptor
      * @param gatewayConfig the Knox Gateway configuration
+     * @param gatewayServices the active GatewayServices registry (may be null)
      * @param name the name of the interceptor
      * @param interceptorConfig the configuration for the interceptor
      * @return the interceptor
      */
-    Interceptor create(GatewayConfig gatewayConfig, String name, Map<String, String> interceptorConfig) throws Exception;
+    Interceptor create(GatewayConfig gatewayConfig, GatewayServices gatewayServices, String name, Map<String, String> interceptorConfig) throws Exception;
 
     /**
      * Get the type of interceptor this factory creates

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/LDAPRolesLookupInterceptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/LDAPRolesLookupInterceptorFactory.java
@@ -30,17 +30,17 @@ public class LDAPRolesLookupInterceptorFactory implements KnoxLdapInterceptorFac
     private static final String TYPE = "rolesLookup";
 
     @Override
-    public Interceptor create(GatewayConfig gatewayConfig, String name, Map<String, String> interceptorConfig) throws Exception {
-        final LDAPRolesLookupService ldapRolesLookupService = getLDAPRolesLookupService();
+    public Interceptor create(GatewayConfig gatewayConfig, GatewayServices gatewayServices, String name, Map<String, String> interceptorConfig) throws Exception {
+        final LDAPRolesLookupService ldapRolesLookupService = getLDAPRolesLookupService(gatewayServices);
         if (ldapRolesLookupService == null || !ldapRolesLookupService.enabled()) {
             throw new ServiceLifecycleException("LDAP roles lookup service not found or disabled");
         }
         return new LDAPRolesLookupInterceptor(ldapRolesLookupService);
     }
 
-    protected LDAPRolesLookupService getLDAPRolesLookupService() {
-        final GatewayServices gatewayServices = GatewayServer.getGatewayServices();
-        return gatewayServices.getService(ServiceType.LDAP_ROLES_LOOKUP_SERVICE);
+    protected LDAPRolesLookupService getLDAPRolesLookupService(GatewayServices gatewayServices) {
+        final GatewayServices services = gatewayServices != null ? gatewayServices : GatewayServer.getGatewayServices();
+        return services == null ? null : services.getService(ServiceType.LDAP_ROLES_LOOKUP_SERVICE);
     }
 
     @Override

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorFactory.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorFactory.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.ldap.interceptor;
 
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
 
 import java.util.Map;
 
@@ -26,7 +27,7 @@ public class UserSearchInterceptorFactory implements KnoxLdapInterceptorFactory 
     public static final String TYPE = "backend";
 
     @Override
-    public Interceptor create(GatewayConfig gatewayConfig, String name, Map<String, String> interceptorConfig) throws Exception {
+    public Interceptor create(GatewayConfig gatewayConfig, GatewayServices gatewayServices, String name, Map<String, String> interceptorConfig) throws Exception {
         return new UserSearchInterceptor(name, interceptorConfig);
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/LDAPRolesLookupInterceptorFactoryTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/LDAPRolesLookupInterceptorFactoryTest.java
@@ -18,6 +18,7 @@ package org.apache.knox.gateway.services.ldap.interceptor;
 
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
 import org.apache.knox.gateway.services.ServiceLifecycleException;
 import org.apache.knox.gateway.services.ldap.LDAPRolesLookupService;
 import org.easymock.EasyMock;
@@ -38,7 +39,7 @@ public class LDAPRolesLookupInterceptorFactoryTest {
 
         LDAPRolesLookupInterceptorFactory factory = new LDAPRolesLookupInterceptorFactory() {
             @Override
-            protected LDAPRolesLookupService getLDAPRolesLookupService() {
+            protected LDAPRolesLookupService getLDAPRolesLookupService(GatewayServices gatewayServices) {
                 return mockService;
             }
         };
@@ -46,7 +47,7 @@ public class LDAPRolesLookupInterceptorFactoryTest {
         GatewayConfig mockConfig = EasyMock.createMock(GatewayConfig.class);
         EasyMock.replay(mockConfig);
 
-        Interceptor interceptor = factory.create(mockConfig, "test", Collections.emptyMap());
+        Interceptor interceptor = factory.create(mockConfig, null, "test", Collections.emptyMap());
         assertNotNull(interceptor);
         assertTrue(interceptor instanceof LDAPRolesLookupInterceptor);
     }
@@ -59,7 +60,7 @@ public class LDAPRolesLookupInterceptorFactoryTest {
 
         LDAPRolesLookupInterceptorFactory factory = new LDAPRolesLookupInterceptorFactory() {
             @Override
-            protected LDAPRolesLookupService getLDAPRolesLookupService() {
+            protected LDAPRolesLookupService getLDAPRolesLookupService(GatewayServices gatewayServices) {
                 return mockService;
             }
         };
@@ -67,14 +68,14 @@ public class LDAPRolesLookupInterceptorFactoryTest {
         GatewayConfig mockConfig = EasyMock.createMock(GatewayConfig.class);
         EasyMock.replay(mockConfig);
 
-        factory.create(mockConfig, "test", Collections.emptyMap());
+        factory.create(mockConfig, null, "test", Collections.emptyMap());
     }
 
     @Test(expected = ServiceLifecycleException.class)
     public void testCreateWithNullService() throws Exception {
         LDAPRolesLookupInterceptorFactory factory = new LDAPRolesLookupInterceptorFactory() {
             @Override
-            protected LDAPRolesLookupService getLDAPRolesLookupService() {
+            protected LDAPRolesLookupService getLDAPRolesLookupService(org.apache.knox.gateway.services.GatewayServices gatewayServices) {
                 return null;
             }
         };
@@ -82,6 +83,6 @@ public class LDAPRolesLookupInterceptorFactoryTest {
         GatewayConfig mockConfig = EasyMock.createMock(GatewayConfig.class);
         EasyMock.replay(mockConfig);
 
-        factory.create(mockConfig, "test", Collections.emptyMap());
+        factory.create(mockConfig, null, "test", Collections.emptyMap());
     }
 }


### PR DESCRIPTION
…ory so KnoxCLI is able to load it

[KNOX-3375](https://issues.apache.org/jira/browse/KNOX-3375) - KnoxCLI fails if rolesLookupInterceptor is enabled

## What changes were proposed in this pull request?

- Threaded the active `GatewayServices` instance from `LdapServiceFactory` through `KnoxLDAPService` → `KnoxLDAPServerManager` → `InterceptorFactory` → `LDAPRolesLookupInterceptorFactory`, so the factory no longer depends on the null-under-knoxcli static `GatewayServer.getGatewayServices()`. This lets knoxcli commands succeed when rolesLookup is configured, since `CLIGatewayServices` already registers `LDAP_ROLES_LOOKUP_SERVICE`.

## How was this patch tested?

Enabled rolesLookupInterceptor and tested knoxcli, unit tests

## Integration Tests
N/A

## UI changes
N/A
