### PR TITLE
KNOX-3376: Use DeafultAliasService in Knox OOTB

### DIFF
--- a/gateway-release/home/conf/gateway-site.xml
+++ b/gateway-release/home/conf/gateway-site.xml
@@ -17,11 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <configuration>
-
-    <property>
-        <name>gateway.service.alias.impl</name>
-        <value>org.apache.knox.gateway.services.security.impl.RemoteAliasService</value>
-    </property>
+    
     <property>
         <name>gateway.port</name>
         <value>8443</value>


### PR DESCRIPTION
[KNOX-3376](https://issues.apache.org/jira/browse/KNOX-3376) - Use DeafultAliasService in Knox OOTB

## What changes were proposed in this pull request?

Remove the incomplete OOTB configuration of `RemoteAliasService` from `gateway-site.xml`.

## How was this patch tested?

Built and started Knox. Relevant logs:
```
2026-07-13 13:33:48,889  INFO  knox.gateway (AbstractServiceFactory.java:logServiceUsage(105)) - Using default implementation for AliasService
...
2026-07-13 13:33:51,812  INFO  knox.gateway (AbstractGatewayServices.java:start(60)) - Starting service: org.apache.knox.gateway.services.security.impl.DefaultAliasService
```

## Integration Tests
N/A

## UI changes
N/A