### PR TITLE
KNOX-3380: hive_metastore_enable_ssl config should be used to determine if SSL is enabled on HMS

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGenerator.java
@@ -36,7 +36,7 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
   static final String HTTP_PORT = "hive_metastore_catalog_servlet_port";
   static final String HTTP_PATH = "hive_metastore_catalog_servlet_path";
   static final String REST_CATALOG_ENABLED = "hive_rest_catalog_enabled";
-  static final String SSL_ENABLED    = "hiveserver2_enable_ssl";
+  static final String SSL_ENABLED    = "hive_metastore_enable_ssl";
 
   static final String DEFAULT_HTTP_PATH = "icecli";
 


### PR DESCRIPTION


[KNOX-3380](https://issues.apache.org/jira/browse/KNOX-3380) - Using the correct HMS service-level config to determine of SSL is enabled on HMS

## What changes were proposed in this pull request?

Checking `hive_metastore_enable_ssl` instead of `hiveserver2_enable_ssl` when discovering ICEBERG-REST in Cloudera Manager.

## How was this patch tested?

Manually on a live CM cluster:

SSL disabled:
```
# grep -A 3 -B 1 "<role>ICEBERG-REST</role>" /var/lib/knox/gateway/conf/topologies/iceberg-rest-topology.xml
    <service>
        <role>ICEBERG-REST</role>
        <url>http://MY_ICEBERG_REST_HOST1:8090/icecli</url>
        <url>http://MY_ICEBERG_REST_HOST2:8090/icecli</url>
    </service>
```

SSL enabled:
```
# grep -A 3 -B 1 "<role>ICEBERG-REST</role>" /var/lib/knox/gateway/conf/topologies/iceberg-rest-topology.xml
    <service>
        <role>ICEBERG-REST</role>
        <url>MY_ICEBERG_REST_HOST1:8090/icecli</url>
        <url>MY_ICEBERG_REST_HOST2:8090/icecli</url>
    </service>
```

## Integration Tests
N/A

## UI changes
N/A
