### PR TITLE
KNOX-3381: Fix HaDispatch unnecessary failover due to IOException dur…

### DIFF
--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasApiHaDispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasApiHaDispatch.java
@@ -71,12 +71,12 @@ public class AtlasApiHaDispatch extends DefaultHaDispatch {
                 failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, new Exception("Atlas HA redirection"));
             }
 
-            writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
-
         } catch (IOException e) {
             LOG.errorConnectingToServer(outboundRequest.getURI().toString(), e);
             failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, e);
+            return;
         }
+        writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
     }
 
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasApiTrustedProxyHaDispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasApiTrustedProxyHaDispatch.java
@@ -44,11 +44,11 @@ public class AtlasApiTrustedProxyHaDispatch extends DefaultHaDispatch {
         failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, new Exception("Atlas HA redirection"));
       }
 
-      writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
-
     } catch (IOException e) {
       LOG.errorConnectingToServer(outboundRequest.getURI().toString(), e);
       failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, e);
+      return;
     }
+    writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
   }
 }

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasHaDispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasHaDispatch.java
@@ -64,12 +64,12 @@ public class AtlasHaDispatch extends DefaultHaDispatch {
                 }
             }
 
-            writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
-
         } catch (IOException e) {
             LOG.errorConnectingToServer(outboundRequest.getURI().toString(), e);
             failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, e);
+            return;
         }
+        writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
     }
 
     private boolean isLoginRedirect(Header locationHeader) {

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasTrustedProxyHaDispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/AtlasTrustedProxyHaDispatch.java
@@ -50,12 +50,12 @@ public class AtlasTrustedProxyHaDispatch extends ConfigurableHADispatch {
         }
       }
 
-      writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
-
     } catch (IOException e) {
       LOG.errorConnectingToServer(outboundRequest.getURI().toString(), e);
       failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, e);
+      return;
     }
+    writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
   }
 
   private boolean isLoginRedirect(Header locationHeader) {

--- a/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
+++ b/gateway-provider-ha/src/main/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatch.java
@@ -113,7 +113,6 @@ public class ConfigurableHADispatch extends ConfigurableDispatch implements Comm
     HttpResponse inboundResponse = null;
     try {
       inboundResponse = executeOutboundRequest(outboundRequest);
-      writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
     } catch ( IOException e ) {
       /* if non-idempotent requests are not allowed to failover, unless it's a connection error */
       if(!isConnectionError(e.getCause()) && isNonIdempotentAndNonIdempotentFailoverDisabled(outboundRequest)) {
@@ -125,7 +124,9 @@ public class ConfigurableHADispatch extends ConfigurableDispatch implements Comm
         LOG.errorConnectingToServer(outboundRequest.getURI().toString(), e);
         failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, e);
       }
+      return;
     }
+    writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
   }
 
   protected void failoverRequest(HttpUriRequest outboundRequest, HttpServletRequest inboundRequest, HttpServletResponse outboundResponse, HttpResponse inboundResponse, Exception exception) throws IOException {

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatchTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/ConfigurableHADispatchTest.java
@@ -198,4 +198,90 @@ public class ConfigurableHADispatchTest {
     Assert.assertEquals(DigestUtils.sha256Hex(activeURL), captureCookieValue.getValue().getValue());
   }
 
+  /**
+   * Test that a failure while copying an already-received backend response to the client
+   * (e.g. a parse/rewrite error thrown from writeOutboundResponse) does NOT trigger a failover.
+   * The backend has already served the request, so replaying it against another node would be wrong.
+   */
+  @Test
+  public void testNoFailoverWhenResponseCopyFails() throws Exception {
+    String serviceName = "OOZIE";
+    HaDescriptor descriptor = HaDescriptorFactory.createDescriptor();
+    descriptor.addServiceConfig(HaDescriptorFactory.createServiceConfig(serviceName, "true", "1", "1000", null, null, null, null, null, null, null));
+    HaProvider provider = new DefaultHaProvider(descriptor);
+    URI uri1 = new URI( "http://host1.valid" );
+    URI uri2 = new URI( "http://host2.valid" );
+    ArrayList<String> urlList = new ArrayList<>();
+    urlList.add(uri1.toString());
+    urlList.add(uri2.toString());
+    provider.addHaService(serviceName, urlList);
+
+    BasicHttpParams params = new BasicHttpParams();
+
+    HttpUriRequest outboundRequest = EasyMock.createNiceMock(HttpRequestBase.class);
+    EasyMock.expect(outboundRequest.getMethod()).andReturn( "GET" ).anyTimes();
+    EasyMock.expect(outboundRequest.getURI()).andReturn( uri1 ).anyTimes();
+    EasyMock.expect(outboundRequest.getParams()).andReturn( params ).anyTimes();
+
+    HttpServletRequest inboundRequest = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(inboundRequest.getRequestURL()).andReturn( new StringBuffer(uri1.toString()) ).anyTimes();
+    EasyMock.expect(inboundRequest.getAttribute("dispatch.ha.failover.counter")).andReturn(new AtomicInteger(0)).anyTimes();
+
+    /* backend response */
+    CloseableHttpResponse inboundResponse = EasyMock.createNiceMock(CloseableHttpResponse.class);
+    final StatusLine statusLine = EasyMock.createNiceMock(StatusLine.class);
+    final HttpEntity entity = EasyMock.createNiceMock(HttpEntity.class);
+    final Header header = EasyMock.createNiceMock(Header.class);
+    final ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+    final GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+    final ByteArrayInputStream backendResponse = new ByteArrayInputStream("knox-backend".getBytes(
+            StandardCharsets.UTF_8));
+
+    EasyMock.expect(inboundResponse.getStatusLine()).andReturn(statusLine).anyTimes();
+    EasyMock.expect(statusLine.getStatusCode()).andReturn(HttpStatus.SC_OK).anyTimes();
+    EasyMock.expect(inboundResponse.getEntity()).andReturn(entity).anyTimes();
+    EasyMock.expect(inboundResponse.getAllHeaders()).andReturn(new Header[0]).anyTimes();
+    EasyMock.expect(inboundRequest.getServletContext()).andReturn(context).anyTimes();
+    EasyMock.expect(entity.getContent()).andReturn(backendResponse).anyTimes();
+    EasyMock.expect(entity.getContentType()).andReturn(header).anyTimes();
+    EasyMock.expect(header.getElements()).andReturn(new HeaderElement[]{}).anyTimes();
+    EasyMock.expect(entity.getContentLength()).andReturn(4L).anyTimes();
+    EasyMock.expect(context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(config).anyTimes();
+
+    HttpServletResponse outboundResponse = EasyMock.createNiceMock(HttpServletResponse.class);
+    EasyMock.expect(outboundResponse.getOutputStream()).andAnswer( new IAnswer<SynchronousServletOutputStreamAdapter>() {
+      @Override
+      public SynchronousServletOutputStreamAdapter answer() {
+        return new SynchronousServletOutputStreamAdapter() {
+          @Override
+          public void write( int b ) throws IOException {
+            throw new IOException( "response copy failed" );
+          }
+        };
+      }
+    }).once();
+
+    CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
+    EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).once();
+
+    EasyMock.replay(outboundRequest, inboundRequest, outboundResponse, mockHttpClient, inboundResponse,
+            statusLine, entity, header, context, config);
+
+    ConfigurableHADispatch dispatch = new ConfigurableHADispatch();
+    dispatch.setHttpClient(mockHttpClient);
+    dispatch.setHaProvider(provider);
+    dispatch.setServiceRole(serviceName);
+    dispatch.init();
+
+    try {
+      dispatch.executeRequestWrapper(outboundRequest, inboundRequest, outboundResponse);
+      Assert.fail("Expected the response-copy IOException to propagate");
+    } catch (IOException e) {
+      Assert.assertEquals("response copy failed", e.getMessage());
+    }
+
+    EasyMock.verify(mockHttpClient);
+    Assert.assertEquals(uri1.toString(), provider.getActiveURL(serviceName));
+  }
+
 }

--- a/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
+++ b/gateway-provider-ha/src/test/java/org/apache/knox/gateway/ha/dispatch/DefaultHaDispatchTest.java
@@ -828,17 +828,17 @@ public class DefaultHaDispatchTest {
 
     outboundResponse.setStatus(EasyMock.captureInt(statusCodeCapture));
 
-    EasyMock.expectLastCall().once();
+    EasyMock.expectLastCall().anyTimes();
     EasyMock.expect(outboundResponse.getOutputStream())
         .andAnswer((IAnswer<SynchronousServletOutputStreamAdapter>) () -> new SynchronousServletOutputStreamAdapter() {
           @Override
           public void write( int b ) throws IOException {
-            throw new IOException( "unreachable-host" ); // Fail-over condition
+            /* do nothing */
           }
-        }).atLeastOnce();
+        }).anyTimes();
 
     CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
-    EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).anyTimes();
+    EasyMock.expect(mockHttpClient.execute(outboundRequest)).andThrow(new IOException("unreachable-host")).andReturn(inboundResponse);
 
     EasyMock.replay(filterConfig,
         servletContext,
@@ -958,17 +958,17 @@ public class DefaultHaDispatchTest {
 
     outboundResponse.setStatus(EasyMock.captureInt(statusCodeCapture));
 
-    EasyMock.expectLastCall().once();
+    EasyMock.expectLastCall().anyTimes();
     EasyMock.expect(outboundResponse.getOutputStream())
         .andAnswer((IAnswer<SynchronousServletOutputStreamAdapter>) () -> new SynchronousServletOutputStreamAdapter() {
           @Override
           public void write( int b ) throws IOException {
-            throw new IOException( "unreachable-host" ); // Fail-over condition
+            /* do nothing */
           }
-        }).atLeastOnce();
+        }).anyTimes();
 
     CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
-    EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).anyTimes();
+    EasyMock.expect(mockHttpClient.execute(outboundRequest)).andThrow(new IOException("unreachable-host")).andReturn(inboundResponse);
 
     EasyMock.replay(filterConfig,
         servletContext,
@@ -1103,12 +1103,16 @@ public class DefaultHaDispatchTest {
             .andAnswer((IAnswer<SynchronousServletOutputStreamAdapter>) () -> new SynchronousServletOutputStreamAdapter() {
               @Override
               public void write( int b ) throws IOException {
-                throw new IOException( "unreachable-host" ); // Fail-over condition
+                /* do nothing */
               }
-            }).atLeastOnce();
+            }).anyTimes();
 
     CloseableHttpClient mockHttpClient = EasyMock.createNiceMock(CloseableHttpClient.class);
-    EasyMock.expect(mockHttpClient.execute(outboundRequest)).andReturn(inboundResponse).anyTimes();
+    if (withCookie) {
+      EasyMock.expect(mockHttpClient.execute(outboundRequest)).andThrow(new IOException("unreachable-host")).once();
+    } else {
+      EasyMock.expect(mockHttpClient.execute(outboundRequest)).andThrow(new IOException("unreachable-host")).andReturn(inboundResponse);
+    }
 
     EasyMock.replay(filterConfig,
                     servletContext,

--- a/gateway-service-nifi/src/main/java/org/apache/knox/gateway/dispatch/NiFiHaDispatch.java
+++ b/gateway-service-nifi/src/main/java/org/apache/knox/gateway/dispatch/NiFiHaDispatch.java
@@ -42,11 +42,12 @@ public class NiFiHaDispatch extends DefaultHaDispatch {
     try {
       outboundRequest = NiFiRequestUtil.modifyOutboundRequest(outboundRequest, inboundRequest);
       inboundResponse = executeOutboundRequest(outboundRequest);
-      writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
     } catch (IOException e) {
       LOG.errorConnectingToServer(outboundRequest.getURI().toString(), e);
       failoverRequest(outboundRequest, inboundRequest, outboundResponse, inboundResponse, e);
+      return;
     }
+    writeOutboundResponse(outboundRequest, inboundRequest, outboundResponse, inboundResponse);
   }
 
   /**


### PR DESCRIPTION
…ing writeOutboundResponse

[KNOX-3381](https://issues.apache.org/jira/browse/KNOX-3381) - HADispatch retries on IOException during writeOutboundResponse

## What changes were proposed in this pull request?

Failover dispatches wrapped both the backend call and the response-copy in one try, so an `IOException` while streaming an already-received response to the client (e.g. a parse/rewrite error) triggered a failover — replaying a request the backend had already served. Split the two phases so only backend-connection failures fail over; response-copy errors now propagate. Applied to `ConfigurableHADispatch` and the `Atlas/NiFi `HA dispatches, plus a new test.

Not touching `AbstractHdfsHaDispatch` in this PR because it fails over on other exceptions as well.

## How was this patch tested?

Unit tests, tested locally with custom REST endpoints

## Integration Tests
N/A

## UI changes
N/A