### PR TITLE
KNOX-3382: Bump Netty to 1.135.Final due to CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <metrics.version>4.1.16</metrics.version>
         <mina.version>2.2.8</mina.version>
-        <netty.version>4.1.127.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
         <nodejs.version>v22.20.0</nodejs.version>
         <okhttp.version>4.12.0</okhttp.version>


### PR DESCRIPTION
[KNOX-3382](https://issues.apache.org/jira/browse/KNOX-3382) - Bump Netty to 1.135.Final

## What changes were proposed in this pull request?

Bumped Netty version to 1.135.Final

## How was this patch tested?

Built and deployed locally.
Relying on unit tests and Docker-based integration tests.

## Integration Tests
N/A

## UI changes
N/A