### PR TITLE
KNOX-3383: Bump Jackson to 2.18.9 due to CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
         <httpclient5.version>5.4.3</httpclient5.version>
         <httpcore.version>4.4.14</httpcore.version>
         <httpcore5.version>5.3.6</httpcore5.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <jansi.version>1.18</jansi.version>
         <jakarta.activation-api.version>1.2.1</jakarta.activation-api.version>


### PR DESCRIPTION
[KNOX-3383](https://issues.apache.org/jira/browse/KNOX-3383) - Bump Jackson to 2.18.9 due to CVEs

## What changes were proposed in this pull request?

Bumped Jackson version to 2.18.9

## How was this patch tested?

Built and deployed locally.
Relying on unit tests and Docker-based integration tests.

## Integration Tests
N/A

## UI changes
N/A
