### PR TITLE
KNOX-3387: Forward proxy-namespace searches to the LDAP backend when proxy and remote base DNs differ

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/FileBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/FileBackend.java
@@ -91,6 +91,11 @@ public class FileBackend implements LdapBackend {
         return baseDn;
     }
 
+    @Override
+    public String getProxyBaseDn() {
+        return baseDn;
+    }
+
     private void loadData() throws Exception {
         Path path = Paths.get(dataFile);
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapBackend.java
@@ -45,9 +45,22 @@ public interface LdapBackend {
     String getType();
 
     /**
-     * Get the base dn of this backend
+     * Get the base dn of this backend.
+     * <p>
+     * For proxying backends this is the <em>remote</em> base DN (the namespace of the
+     * upstream LDAP server). For non-proxying backends it is the same as
+     * {@link #getProxyBaseDn()}.
      */
     String getBaseDn();
+
+    /**
+     * Get the proxy (client-facing) base DN this backend is mounted at in the embedded
+     * LDAP server, i.e. the namespace incoming searches are expressed in.
+     * <p>
+     * Proxying backends translate this namespace to {@link #getBaseDn()} internally. For
+     * non-proxying backends this is the same as {@link #getBaseDn()}.
+     */
+    String getProxyBaseDn();
 
     /**
      * Get a user entry by username

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -227,6 +227,11 @@ public class LdapProxyBackend implements LdapBackend {
         return remoteBaseDn;
     }
 
+    @Override
+    public String getProxyBaseDn() {
+        return proxyBaseDn;
+    }
+
     /**
      * Initializes the LDAP connection pool with configurable parameters.
      * Uses a validating pool to ensure connections remain healthy.

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -113,11 +113,20 @@ public class UserSearchInterceptor extends BaseInterceptor {
     }
 
     private boolean isUnderBackendBaseDn(String searchBase) {
-        final String backendBase = backend.getBaseDn();
-        if (searchBase == null || searchBase.isEmpty() || backendBase == null || backendBase.isEmpty()) {
+        if (searchBase == null || searchBase.isEmpty()) {
             return false;
         }
-        return searchBase.toLowerCase(ROOT).endsWith(backendBase.toLowerCase(ROOT));
+        // Incoming searches are expressed in the proxy (client-facing) namespace, which the
+        // backend translates to its remote namespace internally. Accept a search base under
+        // either namespace: for non-proxying backends the two are identical, and the embedded
+        // server registers both the proxy and remote base DNs as partitions.
+        final String lowerSearchBase = searchBase.toLowerCase(ROOT);
+        return endsWithBaseDn(lowerSearchBase, backend.getProxyBaseDn())
+                || endsWithBaseDn(lowerSearchBase, backend.getBaseDn());
+    }
+
+    private boolean endsWithBaseDn(String lowerSearchBase, String baseDn) {
+        return baseDn != null && !baseDn.isEmpty() && lowerSearchBase.endsWith(baseDn.toLowerCase(ROOT));
     }
 
     @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.ldap.interceptor;
+
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
+import org.apache.directory.server.core.api.interceptor.context.SearchOperationContext;
+import org.apache.knox.gateway.security.ldap.SimpleDirectoryService;
+import org.apache.knox.gateway.services.ldap.SchemaManagerFactory;
+import org.apache.knox.gateway.services.ldap.backend.LdapBackend;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link UserSearchInterceptor}, focused on when the interceptor forwards a
+ * search to its backend.
+ */
+public class UserSearchInterceptorTest {
+
+    private static final String TEST_INTERCEPTOR = "TEST";
+    private static final String NEXT_INTERCEPTOR = "NEXT";
+
+    private static final String PROXY_BASE_DN = "dc=proxy,dc=com";
+    private static final String REMOTE_BASE_DN = "dc=example,dc=com";
+
+    private DirectoryService directoryService;
+    private SchemaManager schemaManager;
+    private ConfigurableEntriesTestInterceptor nextInterceptor;
+    private RecordingBackend backend;
+    private UserSearchInterceptor interceptor;
+
+    @Before
+    public void setUp() throws Exception {
+        directoryService = new SimpleDirectoryService();
+        directoryService.setShutdownHookEnabled(false);
+        schemaManager = SchemaManagerFactory.createSchemaManager();
+        directoryService.setSchemaManager(schemaManager);
+
+        // Proxy namespace (dc=proxy,dc=com) intentionally differs from the remote namespace
+        // (dc=example,dc=com), which is the configuration that exposed the original bug.
+        backend = new RecordingBackend(PROXY_BASE_DN, REMOTE_BASE_DN);
+
+        interceptor = new UserSearchInterceptor(TEST_INTERCEPTOR, backend);
+        interceptor.init(directoryService);
+        directoryService.addLast(interceptor);
+
+        nextInterceptor = new ConfigurableEntriesTestInterceptor(NEXT_INTERCEPTOR);
+        nextInterceptor.init(directoryService);
+        directoryService.addLast(nextInterceptor);
+        // The local partition never resolves the proxied users, mirroring production.
+        nextInterceptor.setEntries(List.of());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        directoryService.shutdown();
+    }
+
+    private SearchOperationContext newSearchContext(String baseDn) throws Exception {
+        SearchOperationContext ctx = new SearchOperationContext(directoryService.getSession());
+        // The interceptor list holds only the interceptors that next() should traverse
+        // downstream of the one under test. Including the interceptor under test here would
+        // make its next() call re-enter itself (currentInterceptor starts at index 0).
+        ctx.setInterceptors(new ArrayList<>(List.of(NEXT_INTERCEPTOR)));
+        ctx.setDn(new Dn(schemaManager, baseDn));
+        ctx.setScope(SearchScope.SUBTREE);
+        return ctx;
+    }
+
+    /**
+     * Regression test for the case where the proxy base DN differs from the remote base DN.
+     * A search issued in the proxy namespace must still be forwarded to the backend.
+     */
+    @Test
+    public void testForwardsProxyNamespaceSearchWhenBaseDnsDiffer() throws Exception {
+        Entry user = new DefaultEntry(schemaManager);
+        user.add("uid", "admin");
+        backend.setSearchResult(List.of(user));
+
+        List<String> uids = new ArrayList<>();
+        try (EntryFilteringCursor results = interceptor.search(newSearchContext(PROXY_BASE_DN))) {
+            while (results.next()) {
+                uids.add(results.get().get("uid").getString());
+            }
+        }
+
+        assertEquals("The backend entry should be returned exactly once", List.of("admin"), uids);
+        assertEquals("Backend should have been queried with the proxy-namespace base",
+                PROXY_BASE_DN, backend.getLastSearchBase());
+    }
+
+    /**
+     * The embedded server also registers the remote base DN as a partition, so a search in the
+     * remote namespace must be forwarded as well.
+     */
+    @Test
+    public void testForwardsRemoteNamespaceSearch() throws Exception {
+        backend.setSearchResult(List.of());
+
+        try (EntryFilteringCursor results = interceptor.search(newSearchContext(REMOTE_BASE_DN))) {
+            assertFalse(results.next());
+        }
+
+        assertEquals(REMOTE_BASE_DN, backend.getLastSearchBase());
+    }
+
+    /**
+     * A sub-tree search below the proxy namespace (e.g. ou=people) is forwarded.
+     */
+    @Test
+    public void testForwardsSearchUnderProxyBaseDn() throws Exception {
+        final String subtree = "ou=people," + PROXY_BASE_DN;
+        backend.setSearchResult(List.of());
+
+        try (EntryFilteringCursor results = interceptor.search(newSearchContext(subtree))) {
+            assertFalse(results.next());
+        }
+
+        assertEquals(subtree, backend.getLastSearchBase());
+    }
+
+    /**
+     * Operational / system searches (schema, config, ...) are outside both namespaces and must
+     * never be forwarded to the backend.
+     */
+    @Test
+    public void testDoesNotForwardOperationalSearch() throws Exception {
+        try (EntryFilteringCursor results = interceptor.search(newSearchContext("ou=schema"))) {
+            assertFalse(results.next());
+        }
+
+        assertNull("Backend must not be queried for operational searches", backend.getLastSearchBase());
+    }
+
+    /**
+     * A minimal backend that records the search base it was invoked with and returns a
+     * configurable result set.
+     */
+    private static final class RecordingBackend implements LdapBackend {
+        private final String proxyBaseDn;
+        private final String remoteBaseDn;
+        private List<Entry> searchResult = new ArrayList<>();
+        private String lastSearchBase;
+
+        RecordingBackend(String proxyBaseDn, String remoteBaseDn) {
+            this.proxyBaseDn = proxyBaseDn;
+            this.remoteBaseDn = remoteBaseDn;
+        }
+
+        void setSearchResult(List<Entry> entries) {
+            this.searchResult = entries;
+        }
+
+        String getLastSearchBase() {
+            return lastSearchBase;
+        }
+
+        @Override
+        public String getName() {
+            return "recording";
+        }
+
+        @Override
+        public String getType() {
+            return "recording";
+        }
+
+        @Override
+        public String getBaseDn() {
+            return remoteBaseDn;
+        }
+
+        @Override
+        public String getProxyBaseDn() {
+            return proxyBaseDn;
+        }
+
+        @Override
+        public Entry getUser(String username, SchemaManager schemaManager) {
+            return null;
+        }
+
+        @Override
+        public List<String> getUserGroups(String username, SchemaManager schemaManager) {
+            return List.of();
+        }
+
+        @Override
+        public List<Entry> searchUsers(String filter, SchemaManager schemaManager) {
+            return List.of();
+        }
+
+        @Override
+        public List<Entry> search(String searchBase, SearchScope searchScope, String filter, SchemaManager schemaManager) {
+            this.lastSearchBase = searchBase;
+            return searchResult;
+        }
+
+        @Override
+        public boolean authenticate(Dn userDn, String password) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
[KNOX-3387](https://issues.apache.org/jira/browse/KNOX-3387) - HadoopGroupProvider returns no groups when the embedded LDAP proxy base DN differs from the remote base DN

## What changes were proposed in this pull request?

When the embedded Knox LDAP service (`gateway.ldap.enabled=true`) is configured with an LDAP proxy backend whose proxy base DN (`gateway.ldap.base.dn`) differs from the backend's `remoteBaseDn`, group lookups via the HadoopGroupProvider (`use.ldap.service=true`) always returned an empty group list, even when the user is a member of groups on the remote LDAP server.

**Root cause:** group lookups (`KnoxLDAPServerManager.getUserGroups()`) search under the proxy base DN and flow through `UserSearchInterceptor.search()`, which only forwards to the backend when `isUnderBackendBaseDn()` passes. That check compared the proxy-namespace search base against `LdapProxyBackend.getBaseDn()`, which returns the remote base DN, so `"dc=proxy,dc=com".endsWith("dc=example,dc=com")` was `false`, the backend was never queried, and no `memberOf` values were found. This contradicts the backend's own contract: `LdapProxyBackend.search()` expects a proxy-namespace base and translates it to the remote namespace internally via `RemoteSchemaConverter`.

**Changes:**
- Added `getProxyBaseDn()` to the `LdapBackend` interface. `FileBackend` returns its single base DN (proxy and remote are identical for non-proxying backends); LdapProxyBackend returns `proxyBaseDn` (existing already).
- Updated `UserSearchInterceptor.isUnderBackendBaseDn()` to forward a search when the base is under the proxy base DN or the remote base DN. Both namespaces are registered as partitions by `KnoxLDAPServerManager`, and `LdapProxyBackend.search()` handles either.

No new configuration is introduced: `getProxyBaseDn()` exposes the already-existing value derived from `gateway.ldap.base.dn`.

## How was this patch tested?

- Added `UserSearchInterceptorTest` (4 cases) exercising a backend where `proxyBaseDn != remoteBaseDn`:
  - proxy-namespace search is forwarded and the entry is returned exactly once (regression guard);
  - sub-tree search below the proxy base DN is forwarded;
  - remote-namespace search is still forwarded;
  - operational searches (e.g. ou=schema) are not forwarded.
- Verified the tests fail against the pre-fix code (backend never queried → empty results) and pass with the fix.
- Ran the full `org.apache.knox.gateway.services.ldap.**` suite (132 tests) — all green, checkstyle included.
- Manually verified end-to-end: with `gateway.ldap.base.dn = dc=proxy,dc=com` and `remoteBaseDn = dc=example,dc=com`, HadoopGroupProvider now resolves the user's groups from the remote server; previously it logged 
```
Found groups for principal admin : [].
```
now:
```
Found groups for principal admin : [engineering, operations]
```