### PR TITLE
KNOX-3385: Ldap Proxy accepts search using either proxy or remote base dn

### DIFF
--- a/.github/workflows/build/conf/topologies/knoxldap.xml
+++ b/.github/workflows/build/conf/topologies/knoxldap.xml
@@ -31,7 +31,7 @@ limitations under the License.
 			</param>
 			<param>
 				<name>main.ldapRealm.userDnTemplate</name>
-				<value>uid={0},ou=people,dc=hadoop,dc=apache,dc=org</value>
+				<value>uid={0},ou=people,dc=proxy,dc=org</value>
 			</param>
 			<param>
 				<name>main.ldapRealm.contextFactory.url</name>

--- a/.github/workflows/build/gateway-site.xml
+++ b/.github/workflows/build/gateway-site.xml
@@ -143,7 +143,7 @@ limitations under the License.
     </property>
     <property>
         <name>gateway.ldap.base.dn</name>
-        <value>dc=hadoop,dc=apache,dc=org</value>
+        <value>dc=proxy,dc=org</value>
     </property>
     <property>
         <name>gateway.ldap.recursive.group.resolution</name>

--- a/.github/workflows/compose/single-eku-no-mtls/gateway-site.xml
+++ b/.github/workflows/compose/single-eku-no-mtls/gateway-site.xml
@@ -155,7 +155,7 @@ limitations under the License.
     </property>
     <property>
         <name>gateway.ldap.base.dn</name>
-        <value>dc=hadoop,dc=apache,dc=org</value>
+        <value>dc=proxy,dc=org</value>
     </property>
     <property>
         <name>gateway.ldap.recursive.group.resolution</name>

--- a/.github/workflows/compose/single-eku/gateway-site.xml
+++ b/.github/workflows/compose/single-eku/gateway-site.xml
@@ -209,7 +209,7 @@ limitations under the License.
     </property>
     <property>
         <name>gateway.ldap.base.dn</name>
-        <value>dc=hadoop,dc=apache,dc=org</value>
+        <value>dc=proxy,dc=org</value>
     </property>
     <property>
         <name>gateway.ldap.recursive.group.resolution</name>

--- a/.github/workflows/tests/test_knox_ldap_proxy_search.py
+++ b/.github/workflows/tests/test_knox_ldap_proxy_search.py
@@ -43,6 +43,10 @@ BASE_DN = "dc=hadoop,dc=apache,dc=org"
 PEOPLE_BASE = f"ou=people,{BASE_DN}"
 GROUPS_BASE = f"ou=groups,{BASE_DN}"
 
+PROXY_BASE_DN = "dc=proxy,dc=org"
+PROXY_PEOPLE_BASE = f"ou=people,{PROXY_BASE_DN}"
+PROXY_GROUPS_BASE = f"ou=groups,{PROXY_BASE_DN}"
+
 # A valid backend user used to bind to the proxy before searching.
 BIND_DN = f"uid=guest,{PEOPLE_BASE}"
 BIND_PASSWORD = "guest-password"
@@ -100,6 +104,28 @@ class TestKnoxLdapProxySearch(unittest.TestCase):
     def test_search_user_by_uid(self) -> None:
         """A single user can still be looked up by uid."""
         users = self.rdn_values(PEOPLE_BASE, "(uid=sam)")
+        self.assertIn("sam", users)
+
+    def test_search_all_users_by_objectclass_proxy_dn(self) -> None:
+        """All inetOrgPerson entries under ou=people are returned."""
+        users = self.rdn_values(PROXY_PEOPLE_BASE, "(objectClass=inetOrgPerson)")
+        for expected in ("guest", "admin", "sam", "tom", "recursiveUser"):
+            self.assertIn(expected, users)
+
+    def test_search_all_groups_by_objectclass_proxy_dn(self) -> None:
+        """All groupOfNames entries under ou=groups are returned."""
+        groups = self.rdn_values(PROXY_GROUPS_BASE, "(objectClass=groupOfNames)")
+        for expected in ("analyst", "scientist", "admin", "level1", "level2", "level3"):
+            self.assertIn(expected, groups)
+
+    def test_search_groups_by_cn_wildcard_proxy_dn(self) -> None:
+        """A cn wildcard filter returns only the matching groups."""
+        groups = self.rdn_values(PROXY_GROUPS_BASE, "(cn=level*)")
+        self.assertEqual({"level1", "level2", "level3"}, set(groups))
+
+    def test_search_user_by_uid_proxy_dn(self) -> None:
+        """A single user can still be looked up by uid."""
+        users = self.rdn_values(PROXY_PEOPLE_BASE, "(uid=sam)")
         self.assertIn("sam", users)
 
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/FileBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/FileBackend.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.ldap.backend;
 
+import static java.util.Locale.ROOT;
+
 import com.google.gson.Gson;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
@@ -54,6 +56,7 @@ public class FileBackend implements LdapBackend {
     private Map<String, UserData> users = new HashMap<>();
     private final String dataFile;
     private final String baseDn;
+    private final String userSearchBase;
     private final String name;
 
     static class UserData {
@@ -73,6 +76,7 @@ public class FileBackend implements LdapBackend {
         this.name = name;
         dataFile = config.getOrDefault("dataFile", "ldap-users.json");
         baseDn = config.getOrDefault("baseDn", "dc=proxy,dc=com");
+        userSearchBase = "ou=people," + baseDn;
         loadData();
     }
 
@@ -89,6 +93,11 @@ public class FileBackend implements LdapBackend {
     @Override
     public String getBaseDn() {
         return baseDn;
+    }
+
+    @Override
+    public boolean isSupportedSearchBase(String searchBase) {
+        return searchBase != null && searchBase.toLowerCase(ROOT).endsWith(userSearchBase.toLowerCase(ROOT));
     }
 
     private void loadData() throws Exception {
@@ -119,7 +128,7 @@ public class FileBackend implements LdapBackend {
         }
 
         Entry entry = new DefaultEntry(schemaManager);
-        entry.setDn("uid=" + userData.username + ",ou=Users," + baseDn);
+        entry.setDn("uid=" + userData.username + "," + userSearchBase);
         entry.add("objectClass", "top");
         entry.add("objectClass", "person");
         entry.add("objectClass", "organizationalPerson");

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapBackend.java
@@ -50,7 +50,7 @@ public interface LdapBackend {
     String getBaseDn();
 
     /**
-     * Returns whether the a search base is supported by this backend
+     * Returns whether a search base is supported by this backend
      * @param searchBase the base dn for a search
      * @return True if the base dn is supported by this backend
      */

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapBackend.java
@@ -50,6 +50,13 @@ public interface LdapBackend {
     String getBaseDn();
 
     /**
+     * Returns whether the a search base is supported by this backend
+     * @param searchBase the base dn for a search
+     * @return True if the base dn is supported by this backend
+     */
+    boolean isSupportedSearchBase(String searchBase);
+
+    /**
      * Get a user entry by username
      * @param username The username to look up
      * @param schemaManager Schema manager for creating entries

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -17,6 +17,8 @@
  */
 package org.apache.knox.gateway.services.ldap.backend;
 
+import static java.util.Locale.ROOT;
+
 import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
 import org.apache.directory.api.ldap.model.entry.Attribute;
@@ -225,6 +227,20 @@ public class LdapProxyBackend implements LdapBackend {
     @Override
     public String getBaseDn() {
         return remoteBaseDn;
+    }
+
+    @Override
+    public boolean isSupportedSearchBase(String searchBase) {
+        // System/operational searches (ou=schema, cn=config, root-DSE) must not be forwarded.
+        // Only support user and group searches against either the proxy or remote base Dn.
+        if (searchBase == null) {
+            return false;
+        }
+        String searchBaseLowerCase = searchBase.toLowerCase(ROOT);
+        return searchBaseLowerCase.endsWith(proxyUserSearchBase.toLowerCase(ROOT)) ||
+                searchBaseLowerCase.endsWith(proxyGroupSearchBase.toLowerCase(ROOT)) ||
+                searchBaseLowerCase.endsWith(remoteUserSearchBase.toLowerCase(ROOT)) ||
+                searchBaseLowerCase.endsWith(remoteGroupSearchBase.toLowerCase(ROOT));
     }
 
     /**

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -237,10 +237,8 @@ public class LdapProxyBackend implements LdapBackend {
             return false;
         }
         String searchBaseLowerCase = searchBase.toLowerCase(ROOT);
-        return searchBaseLowerCase.endsWith(proxyUserSearchBase.toLowerCase(ROOT)) ||
-                searchBaseLowerCase.endsWith(proxyGroupSearchBase.toLowerCase(ROOT)) ||
-                searchBaseLowerCase.endsWith(remoteUserSearchBase.toLowerCase(ROOT)) ||
-                searchBaseLowerCase.endsWith(remoteGroupSearchBase.toLowerCase(ROOT));
+        return searchBaseLowerCase.endsWith(proxyBaseDn.toLowerCase(ROOT)) ||
+                searchBaseLowerCase.endsWith(remoteBaseDn.toLowerCase(ROOT));
     }
 
     /**

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -39,8 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Locale.ROOT;
-
 /**
  * Interceptor for LDAP operations to proxy user searches to backends when not found locally
  */

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -100,7 +100,7 @@ public class UserSearchInterceptor extends BaseInterceptor {
 
         // Only forward to the backend when the search base is under the backend's namespace.
         // System/operational searches (ou=schema, cn=config, root-DSE) must not be forwarded.
-        if (isUnderBackendBaseDn(baseDn)) {
+        if (backend.isSupportedSearchBase(baseDn)) {
             try {
                 entries.addAll(backend.search(baseDn, ctx.getScope(), filter, schemaManager));
             } catch (Exception e) {
@@ -110,14 +110,6 @@ public class UserSearchInterceptor extends BaseInterceptor {
 
         // Return cursor with our results - use a simple approach
         return new EntryFilteringCursorImpl(new ListCursor<>(entries), ctx, schemaManager);
-    }
-
-    private boolean isUnderBackendBaseDn(String searchBase) {
-        final String backendBase = backend.getBaseDn();
-        if (searchBase == null || searchBase.isEmpty() || backendBase == null || backendBase.isEmpty()) {
-            return false;
-        }
-        return searchBase.toLowerCase(ROOT).endsWith(backendBase.toLowerCase(ROOT));
     }
 
     @Override

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
@@ -662,6 +662,32 @@ public class LdapProxyBackendTest {
         assertTrue(ldapProxyBackend.authenticate(dn, "memberOfUser2-password"));
     }
 
+    @Test
+    public void testIsSupportedSearchBase() {
+        Map<String, String> config = new HashMap<>(ldapBackendConfig);
+        config.put("baseDn", "dc=proxy,dc=org");
+        ldapProxyBackend = new LdapProxyBackend("testbackend", config);
+
+        // Test searching remote dn
+        assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=people,dc=hadoop,dc=apache,dc=org"));
+        assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=groups,dc=hadoop,dc=apache,dc=org"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=hadoop,dc=apache,dc=org"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("ou=schema,dc=hadoop,dc=apache,dc=org"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("cn=config,dc=hadoop,dc=apache,dc=org"));
+
+        // Test searching proxy dn
+        assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=people,dc=proxy,dc=org"));
+        assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=groups,dc=proxy,dc=org"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=proxy,dc=org"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("ou=schema,dc=proxy,dc=org"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("cn=config,dc=proxy,dc=org"));
+
+        // Test searching arbitrary dn
+        assertFalse(ldapProxyBackend.isSupportedSearchBase(null));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase(""));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=other,dc=base,dc=org"));
+    }
+
     // Helper methods for refactoring
 
     private Map<String, String> createConfigWithUserAttr(String attr) {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
@@ -671,18 +671,14 @@ public class LdapProxyBackendTest {
         // Test searching remote dn
         assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=people,dc=hadoop,dc=apache,dc=org"));
         assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=groups,dc=hadoop,dc=apache,dc=org"));
-        assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=hadoop,dc=apache,dc=org"));
-        assertFalse(ldapProxyBackend.isSupportedSearchBase("ou=schema,dc=hadoop,dc=apache,dc=org"));
-        assertFalse(ldapProxyBackend.isSupportedSearchBase("cn=config,dc=hadoop,dc=apache,dc=org"));
 
         // Test searching proxy dn
         assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=people,dc=proxy,dc=org"));
         assertTrue(ldapProxyBackend.isSupportedSearchBase("ou=groups,dc=proxy,dc=org"));
-        assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=proxy,dc=org"));
-        assertFalse(ldapProxyBackend.isSupportedSearchBase("ou=schema,dc=proxy,dc=org"));
-        assertFalse(ldapProxyBackend.isSupportedSearchBase("cn=config,dc=proxy,dc=org"));
 
         // Test searching arbitrary dn
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("cn=schema"));
+        assertFalse(ldapProxyBackend.isSupportedSearchBase("cn=config"));
         assertFalse(ldapProxyBackend.isSupportedSearchBase(null));
         assertFalse(ldapProxyBackend.isSupportedSearchBase(""));
         assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=other,dc=base,dc=org"));

--- a/knox-site/docs/service_ldap_server.md
+++ b/knox-site/docs/service_ldap_server.md
@@ -135,7 +135,7 @@ The interceptor will skip role mapping for a search request if the RolesLookupBy
 | Byte | Value | Description |
 | :--- | :--- | :--- |
 | Tag | 0x01 | The Boolean Tag value |
-| Length | 0x03 | The length of the value in bytes |
+| Length | 0x01 | The length of the value in bytes |
 | Bypass | 0x00 or Oxff | 0x00 corresponds to `false` and 0xff corresponds to `true |
 
 


### PR DESCRIPTION
[KNOX-3385](https://issues.apache.org/jira/browse/KNOX-3385) - Ldap Proxy accepts search using either proxy or remote base dn

## What changes were proposed in this pull request?

A method is added to the LdapBackend to indicate whether a given search base is applicable to that backend. The LdapProxyBackend implements this to accept searches against either the proxy dn or remote dn. Searches are limited to the specified user and group search bases to reject searches for schema, config, etc.

## How was this patch tested?

Unit tests were added to the LdapProxyBackendTest class to verify that the new method returns true for both the proxy and remote DNs.

## Integration Tests

gateway-site.xml was updated to have a different proxy base dn. Workflow tests were added to `test_knox_ldap_proxy_search.py` to search by proxy dn.

## UI changes
none

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
