### PR TITLE
KNOX-3388: Improve alias creation during EKU mode testing

### DIFF
--- a/.github/workflows/compose/single-eku/gateway-single-eku.sh
+++ b/.github/workflows/compose/single-eku/gateway-single-eku.sh
@@ -35,13 +35,16 @@ PASS="horton"
 #   - gateway-truststore-password             : server truststore password
 #   - gateway-identity-keystore-password      : server identity keystore password
 #   - gateway-identity-passphrase             : server identity key passphrase
-for alias in \
-    gateway-httpclient-keystore-password \
-    gateway-httpclient-truststore-password \
-    gateway-truststore-password \
-    gateway-identity-keystore-password \
-    gateway-identity-passphrase; do
-  /knox-runtime/bin/knoxcli.sh create-alias "$alias" --value "$PASS"
-done
+#
+# Use the batch create-aliases command so all five aliases are created in a
+# SINGLE knoxcli JVM boot. Creating them one-per-invocation cost ~6s of JVM
+# startup each (~30s total), which delayed the gateway bind past the CI wait
+# window and caused flaky "connection refused" failures in the mTLS suite.
+/knox-runtime/bin/knoxcli.sh create-aliases \
+    --alias gateway-httpclient-keystore-password --value "$PASS" \
+    --alias gateway-httpclient-truststore-password --value "$PASS" \
+    --alias gateway-truststore-password --value "$PASS" \
+    --alias gateway-identity-keystore-password --value "$PASS" \
+    --alias gateway-identity-passphrase --value "$PASS"
 
 exec java -jar /knox-runtime/bin/gateway.jar


### PR DESCRIPTION
[KNOX-3388](https://issues.apache.org/jira/browse/KNOX-3388) - Batch credential-store alias creation in single-EKU test entrypoint

## What changes were proposed in this pull request?

`gateway-single-eku.sh` created its 5 credential-store aliases via 5 separate `knoxcli.sh create-alias` calls. Each is a cold JVM boot (~6-8s), so ~30-40s was spent before the gateway JVM started. CI's `sleep 30` (measured from container start) was consumed by alias creation, so the gateway bound 8443 only after `pytest` connected → intermittent `Connection refused` in the single-EKU mTLS suite.

Replaced the loop with a single batch `knoxcli.sh create-aliases --alias ... --value ...` invocation (one JVM boot). Container-start → `Started gateway on port 8443` dropped from ~35s to ~9s, leaving comfortable margin under the existing wait.

## How was this patch tested?

- Recreated the single-EKU knox locally and timed startup: gateway bound 8443 in ~9s (was ~35s).
- Ran the single-EKU mTLS suite: `pytest test_single_eku_mtls.py` → 3 passed.

## Integration Tests

No test changes needed — this fixes flakiness in the existing `test_single_eku_mtls.py` suite under `.github/workflows/tests`.

## UI changes
N/A
