### PR TITLE
KNOX-3389: Embedded LDAP getUserGroups drops roles-lookup roles that have no backing group

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -470,6 +470,13 @@ public class KnoxLDAPServerManager {
                             int commaIdx = groupDn.indexOf(',');
                             if (commaIdx > 0) {
                                 groups.add(groupDn.substring(3, commaIdx));
+                            } else if (hasRolesLookupInterceptor) {
+                                // When the roles lookup interceptor is active and no template
+                                // group DN was available, roles are stored as a bare RDN
+                                // (cn=role) with no trailing DN components (see
+                                // LDAPRolesLookupInterceptor#addRoleAttribute). Take everything
+                                // after "cn=".
+                                groups.add(groupDn.substring(3));
                             }
                         }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -27,6 +27,7 @@ import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchScope;
@@ -56,7 +57,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -465,21 +465,19 @@ public class KnoxLDAPServerManager {
                 Attribute memberOf = entry.get("memberOf");
                 if (memberOf != null) {
                     for (Value value : memberOf) {
-                        String groupDn = value.getString();
-                        if (groupDn.toLowerCase(Locale.ROOT).startsWith("cn=")) {
-                            int commaIdx = groupDn.indexOf(',');
-                            if (commaIdx > 0) {
-                                groups.add(groupDn.substring(3, commaIdx));
-                            } else if (hasRolesLookupInterceptor) {
-                                // When the roles lookup interceptor is active and no template
-                                // group DN was available, roles are stored as a bare RDN
-                                // (cn=role) with no trailing DN components (see
-                                // LDAPRolesLookupInterceptor#addRoleAttribute). Take everything
-                                // after "cn=".
-                                groups.add(groupDn.substring(3));
+                        try {
+                            Dn groupDn = new Dn(value.getString());
+                            String groupName = LdapUtils.extractGroupName(groupDn);
+                            // A full group DN (cn=role,ou=groups,...) is always resolved. A bare
+                            // RDN (cn=role) is only produced by the roles lookup interceptor when
+                            // no template group DN was available (see LDAPRolesLookupInterceptor#addRoleAttribute),
+                            // so only accept it when that interceptor is active.
+                            if (groupName != null && (groupDn.size() > 1 || hasRolesLookupInterceptor)) {
+                                groups.add(groupName);
                             }
+                        } catch (LdapInvalidDnException e) {
+                            // Skip memberOf values that are not valid DNs
                         }
-
                     }
                 }
             }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -33,7 +33,10 @@ import org.apache.knox.gateway.services.security.AliasService;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
 import org.apache.knox.gateway.services.ldap.model.constants.SchemaConstants;
 import org.easymock.EasyMock;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.knox.gateway.services.ldap.interceptor.UserSearchInterceptor;
 import org.junit.Test;
 import org.junit.Before;
@@ -46,6 +49,7 @@ import javax.net.ssl.X509TrustManager;
 
 import java.io.File;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.security.KeyPair;
@@ -427,6 +431,40 @@ public class KnoxLDAPServerManagerTest {
         assertTrue(controlFactoryMap.get(SchemaConstants.ROLES_LOOKUP_BYPASS_CONTROL_OID) instanceof RolesLookupBypassControlFactory);
     }
 
+    @Test
+    public void testGetUserGroupsResolvesBareRdnRolesWhenRolesLookupActive() throws Exception {
+        serverManager.initialize(createNoInterceptorConfig());
+        serverManager.start();
+
+        // The roles lookup interceptor stores roles that have no template group DN as a bare
+        // RDN (cn=role) with no trailing DN components - exactly the "no groups at all" case.
+        addUserWithMemberOf("sam", "cn=platform:admin-sam", "cn=ml-workspace-abc:viewer-sam");
+        setRolesLookupInterceptorFlag(true);
+
+        List<String> groups = serverManager.getUserGroups("sam");
+
+        assertEquals("Both bare-RDN roles should be resolved as groups", 2, groups.size());
+        assertTrue("Expected platform:admin-sam among " + groups, groups.contains("platform:admin-sam"));
+        assertTrue("Expected ml-workspace-abc:viewer-sam among " + groups, groups.contains("ml-workspace-abc:viewer-sam"));
+    }
+
+    @Test
+    public void testGetUserGroupsIgnoresBareRdnWhenRolesLookupInactive() throws Exception {
+        serverManager.initialize(createNoInterceptorConfig());
+        serverManager.start();
+
+        // A real group DN (with a comma) alongside a bare cn= RDN. Without the roles lookup
+        // interceptor a bare RDN is unexpected data and must be skipped, while the full DN
+        // group is still resolved.
+        addUserWithMemberOf("sam", "cn=analysts,ou=groups,dc=test,dc=com", "cn=platform:admin-sam");
+        setRolesLookupInterceptorFlag(false);
+
+        List<String> groups = serverManager.getUserGroups("sam");
+
+        assertEquals("Only the full-DN group should be resolved when roles lookup is inactive",
+                List.of("analysts"), groups);
+    }
+
     @Test(expected = LdapException.class)
     public void testBindRequiredRejectsAnonymous() throws Exception {
         useBindPassword(BIND_PASSWORD);
@@ -624,6 +662,38 @@ public class KnoxLDAPServerManagerTest {
                 .andReturn(password == null ? null : password.toCharArray()).anyTimes();
         replay(aliasService);
         return aliasService;
+    }
+
+    /** A minimal config that starts the embedded server with base partitions and no interceptors. */
+    private GatewayConfig createNoInterceptorConfig() {
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of()).anyTimes();
+        replay(mockConfig);
+        return mockConfig;
+    }
+
+    /** Add a user under ou=people,dc=test,dc=com carrying the given memberOf values. */
+    private void addUserWithMemberOf(String uid, String... memberOf) throws Exception {
+        SchemaManager schemaManager = serverManager.directoryService.getSchemaManager();
+        Entry entry = new DefaultEntry(schemaManager, new Dn(schemaManager, "uid=" + uid + ",ou=people,dc=test,dc=com"));
+        entry.add("objectClass", "top", "person", "organizationalPerson", "inetOrgPerson");
+        entry.add("cn", uid);
+        entry.add("sn", uid);
+        entry.add("uid", uid);
+        for (String value : memberOf) {
+            entry.add("memberOf", value);
+        }
+        serverManager.directoryService.getAdminSession().add(entry);
+    }
+
+    /** Toggle the private flag that gates lenient bare-RDN parsing in getUserGroups. */
+    private void setRolesLookupInterceptorFlag(boolean value) throws Exception {
+        Field field = KnoxLDAPServerManager.class.getDeclaredField("hasRolesLookupInterceptor");
+        field.setAccessible(true);
+        field.setBoolean(serverManager, value);
     }
 
     private Map<String, String> createFileBackendInterceptorConfig() {


### PR DESCRIPTION
[KNOX-3389](https://issues.apache.org/jira/browse/KNOX-3389) - Embedded LDAP getUserGroups drops roles-lookup roles that have no backing group

## What changes were proposed in this pull request?

`KnoxLDAPServerManager.getUserGroups` failed to return roles-lookup roles as groups when the user had no backing group.

When the roles lookup interceptor is enabled, resolved roles are written onto the user entry as `memberOf` values. If the user has no existing group, `LDAPRolesLookupInterceptor.addRoleAttribute` has no template group DN to build a
full DN from and stores each role as a bare RDN (e.g. `memberOf: cn=platform:admin-sam`) with no trailing DN components. `getUserGroups` extracted the group name as the substring between `cn=` and the first comma; a bare RDN has no comma, so the value was silently dropped and the roles never surfaced as groups.

This PR reworks the `memberOf` parsing in `getUserGroups`:
- Parses each `memberOf` value as a `Dn` and extracts the group name via the existing `LdapUtils.extractGroupName(Dn)` helper (leading RDN, `cn`-typed, `rdn.getValue()`) instead of manual string splitting. This is the same helper `LDAPRolesLookupInterceptor.fetchGroups` already uses, so the two `memberOf`-parsing paths are now consistent and resilient to RDN formatting (case, escaping, spacing).
- A full group DN (`cn=role,ou=groups,...`, i.e. `dn.size() > 1`) is always resolved. A bare RDN (`cn=role`) is only ever produced by the roles lookup interceptor, so it is accepted only when that interceptor is active (`hasRolesLookupInterceptor`); otherwise it is treated as unexpected data and skipped.
- Values that are not valid DNs are caught and skipped per-value, so a single malformed entry no longer aborts the whole group lookup.

## How was this patch tested?

Added two unit tests to `KnoxLDAPServerManagerTest` that start the embedded server, seed a user via the admin session, and call `getUserGroups` directly:
- `testGetUserGroupsResolvesBareRdnRolesWhenRolesLookupActive` - user with `memberOf: cn=platform:awc-admin-sam` and `cn=ml-workspace-abc:viewer-sam`, interceptor flag on: both roles resolve as groups (reproduces the reported scenario).
- `testGetUserGroupsIgnoresBareRdnWhenRolesLookupInactive` - a full-DN group plus a bare RDN, interceptor flag off: only the full-DN group resolves, proving the lenient parse is scoped to the roles-lookup case.

Manually tested as well (using the same setup as described in the JIRA). After my changes applied, I could see the resolved groups:
```
~ $ curl -iku sam:sam-password http://localhost:8443/gateway/sandbox/auth/api/v1/pre
HTTP/1.1 200 OK
Date: Wed, 22 Jul 2026 11:10:35 GMT
Set-Cookie: KNOXSESSIONID=node01qag1cyt0x3sat9xtybpnjtlb0.node0; Path=/gateway/sandbox; Secure; HttpOnly
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Set-Cookie: rememberMe=deleteMe; Path=/gateway/sandbox; Max-Age=0; Expires=Tue, 21-Jul-2026 11:10:35 GMT; SameSite=lax
x-knox-username: sam
x-knox-roles: ml-workspace-abc:viewer-sam,platform:awc-admin-sam
Content-Length: 0
```

## Integration Tests
N/A

## UI changes
N/A