### PR TITLE
KNOX-3390: Address review feedback for TrustedOidcIssuerService

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerService.java
@@ -130,18 +130,18 @@ public class JdbcTrustedOidcIssuerService implements TrustedOidcIssuerService {
 
   @Override
   public boolean isTrusted(String issuerUrl) {
-    return registrySnapshot.get().containsKey(issuerUrl);
+    return registrySnapshot.get().containsKey(normalizeIssuerUrl(issuerUrl));
   }
 
   @Override
   public boolean isDynamicJwks(String issuerUrl) {
-    final TrustedOidcIssuer entry = registrySnapshot.get().get(issuerUrl);
+    final TrustedOidcIssuer entry = registrySnapshot.get().get(normalizeIssuerUrl(issuerUrl));
     return entry != null && entry.isDynamicJwks();
   }
 
   @Override
   public Optional<String> resolveJwksUri(String issuerUrl) {
-    return discoveryHelper.discoverJwksUri(issuerUrl);
+    return discoveryHelper.discoverJwksUri(normalizeIssuerUrl(issuerUrl));
   }
 
   @Override
@@ -150,31 +150,34 @@ public class JdbcTrustedOidcIssuerService implements TrustedOidcIssuerService {
       throw new IllegalStateException(
           "Cannot register issuer: MAX_TRUSTED_ISSUERS (" + maxTrustedIssuers + ") reached");
     }
+    final TrustedOidcIssuer normalized = normalizeIssuer(issuer);
     try {
-      database.insert(issuer);
+      database.insert(normalized);
     } catch (SQLException e) {
-      LOG.errorRegisteringIssuer(issuer.getIssuerUrl(), e.getMessage(), e);
-      throw new RuntimeException("Error registering trusted OIDC issuer: " + issuer.getIssuerUrl(), e);
+      LOG.errorRegisteringIssuer(normalized.getIssuerUrl(), e.getMessage(), e);
+      throw new RuntimeException("Error registering trusted OIDC issuer: " + normalized.getIssuerUrl(), e);
     }
     reloadRegistrySnapshot();
   }
 
   @Override
   public synchronized void deregister(String issuerUrl) {
+    final String normalizedUrl = normalizeIssuerUrl(issuerUrl);
     try {
-      database.delete(issuerUrl);
+      database.delete(normalizedUrl);
     } catch (SQLException e) {
-      LOG.errorDeregisteringIssuer(issuerUrl, e.getMessage(), e);
-      throw new RuntimeException("Error deregistering trusted OIDC issuer: " + issuerUrl, e);
+      LOG.errorDeregisteringIssuer(normalizedUrl, e.getMessage(), e);
+      throw new RuntimeException("Error deregistering trusted OIDC issuer: " + normalizedUrl, e);
     }
     reloadRegistrySnapshot();
-    discoveryHelper.invalidate(issuerUrl);
+    discoveryHelper.invalidate(normalizedUrl);
   }
 
   @Override
   public void refreshJwksUri(String issuerUrl) {
-    if (isDynamicJwks(issuerUrl)) {
-      discoveryHelper.invalidate(issuerUrl);
+    final String normalizedUrl = normalizeIssuerUrl(issuerUrl);
+    if (isDynamicJwks(normalizedUrl)) {
+      discoveryHelper.invalidate(normalizedUrl);
     }
   }
 
@@ -187,6 +190,10 @@ public class JdbcTrustedOidcIssuerService implements TrustedOidcIssuerService {
    * Rebuilds the registry snapshot from the current DB state.
    * Called on init, after register, and after deregister.
    * Synchronized on this to prevent concurrent rebuilds from interleaving with mutations.
+   * <p>
+   * Propagates any failure rather than swallowing it: a reload that fails after a committed
+   * write would otherwise leave the in-memory snapshot silently diverged from the DB while
+   * the mutating call returned success. Callers (init/register/deregister) surface the error.
    */
   private synchronized void reloadRegistrySnapshot() {
     try {
@@ -195,6 +202,35 @@ public class JdbcTrustedOidcIssuerService implements TrustedOidcIssuerService {
       registrySnapshot.set(Collections.unmodifiableMap(fresh));
     } catch (Exception e) {
       LOG.errorReloadingRegistrySnapshot(e.getMessage(), e);
+      throw new RuntimeException("Error reloading trusted OIDC issuer registry snapshot", e);
     }
+  }
+
+  /**
+   * Canonicalizes an issuer URL for registry storage and lookup by stripping a single
+   * trailing slash, so that {@code https://issuer.example.com/} and
+   * {@code https://issuer.example.com} are treated as the same issuer. This matches the
+   * trailing-slash stripping {@link OIDCDiscoveryHelper} already applies when building the
+   * discovery URL. Null-safe.
+   */
+  private static String normalizeIssuerUrl(String issuerUrl) {
+    if (issuerUrl == null) {
+      return null;
+    }
+    return issuerUrl.endsWith("/") ? issuerUrl.substring(0, issuerUrl.length() - 1) : issuerUrl;
+  }
+
+  /**
+   * Returns a copy of the given issuer with its URL normalized via
+   * {@link #normalizeIssuerUrl(String)}, or the original instance if the URL is already
+   * canonical.
+   */
+  private static TrustedOidcIssuer normalizeIssuer(TrustedOidcIssuer issuer) {
+    final String normalizedUrl = normalizeIssuerUrl(issuer.getIssuerUrl());
+    if (normalizedUrl != null && normalizedUrl.equals(issuer.getIssuerUrl())) {
+      return issuer;
+    }
+    return new TrustedOidcIssuer(normalizedUrl, issuer.isDynamicJwks(),
+        issuer.getClusterName(), issuer.getRegisteredAt(), issuer.getRegisteredBy());
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/TrustedOidcIssuerDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/TrustedOidcIssuerDatabase.java
@@ -44,8 +44,6 @@ class TrustedOidcIssuerDatabase extends KnoxDatabase {
       "DELETE FROM " + TABLE_NAME + " WHERE issuer_url = ?";
   private static final String SELECT_ALL_SQL =
       "SELECT issuer_url, dynamic_jwks, cluster_name, registered_at, registered_by FROM " + TABLE_NAME;
-  private static final String COUNT_SQL =
-      "SELECT COUNT(*) FROM " + TABLE_NAME;
 
   TrustedOidcIssuerDatabase(DataSource dataSource, String dbType) throws Exception {
     super(dataSource);
@@ -89,13 +87,5 @@ class TrustedOidcIssuerDatabase extends KnoxDatabase {
       }
     }
     return result;
-  }
-
-  int count() throws SQLException {
-    try (Connection connection = dataSource.getConnection();
-         PreparedStatement ps = connection.prepareStatement(COUNT_SQL);
-         ResultSet rs = ps.executeQuery()) {
-      return rs.next() ? rs.getInt(1) : 0;
-    }
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerServiceTest.java
@@ -112,6 +112,31 @@ public class JdbcTrustedOidcIssuerServiceTest {
     assertFalse(service.isTrusted("https://other.example.com"));
   }
 
+  /**
+   * An issuer registered with a trailing slash must match a lookup without one, and
+   * vice versa: the URL is canonicalized (single trailing slash stripped) on both write
+   * and lookup.
+   */
+  @Test
+  public void testIssuerUrlTrailingSlashNormalized() {
+    service.register(issuer("https://issuer.example.com/", true));
+
+    // Registered with slash, looked up without
+    assertTrue(service.isTrusted("https://issuer.example.com"));
+    assertTrue(service.isDynamicJwks("https://issuer.example.com"));
+    // Registered with slash, looked up with slash
+    assertTrue(service.isTrusted("https://issuer.example.com/"));
+
+    // Canonical form is persisted (no trailing slash)
+    assertEquals(1, service.list().size());
+    assertEquals("https://issuer.example.com", service.list().get(0).getIssuerUrl());
+
+    // Deregister using the non-canonical form still removes it
+    service.deregister("https://issuer.example.com/");
+    assertFalse(service.isTrusted("https://issuer.example.com"));
+    assertTrue(service.list().isEmpty());
+  }
+
   @Test
   public void testDeregisterClearsSnapshot() {
     service.register(issuer("https://issuer.example.com", false));

--- a/pom.xml
+++ b/pom.xml
@@ -259,8 +259,8 @@
         <mina.version>2.2.8</mina.version>
         <netty.version>4.1.127.Final</netty.version>
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
-        <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
         <nodejs.version>v22.20.0</nodejs.version>
+        <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
         <okhttp.version>4.12.0</okhttp.version>
         <opensaml.version>5.2.2</opensaml.version>
         <pac4j.version>6.5.3</pac4j.version>


### PR DESCRIPTION
[KNOX-3390](https://issues.apache.org/jira/browse/KNOX-3390) - Address review feedback for TrustedOidcIssuerService

## What changes were proposed in this pull request?

Follow-up to #1315 addressing review comments on the `TrustedOidcIssuerService` implementation. Four items:

1. Surface registry-reload failures instead of swallowing them (`JdbcTrustedOidcIssuerService). reloadRegistrySnapshot()` previously caught, logged, and discarded any exception. Because it runs after a committed insert/delete, a reload failure would leave the in-memory snapshot silently diverged from the database while register/deregister still returned success. It now logs and re-throws as a `RuntimeException`, which register/deregister propagate (matching the interface's documented "throws RuntimeException on storage error") and which `init()` continues to wrap into `ServiceLifecycleException` so startup still fails cleanly.
2. Canonicalize issuer URLs on write and lookup (`JdbcTrustedOidcIssuerService`). Added trailing-slash normalization (a single trailing / stripped, null-safe, consistent with the stripping OIDCDiscoveryHelper already applies when building the discovery URL). `register` now persists the canonical form, and all lookup paths (`isTrusted`, `isDynamicJwks`, `resolveJwksUri`, `refreshJwksUri`, `deregister`) normalize their argument. This prevents a registration of `https://idp.example.com/` from failing to match an `iss` claim of `https://idp.example.com` (and vice versa).
3. Remove dead code: dropped the unused `count()` method and `COUNT_SQL` constant from `TrustedOidcIssuerDatabase` (the max-issuers check uses the in-memory snapshot size, so `count()` had no callers).
4. Restore alphabetical ordering in `pom.xml`: moved the `oauth2-oidc-sdk.version` property after `nodejs.version`.

## How was this patch tested?

Existing unit tests plus a new one, run via Maven:
```
mvn -pl gateway-server test -Dtest='JdbcTrustedOidcIssuerServiceTest,\
  TrustedOidcIssuerServiceFactoryTest,OIDCDiscoveryHelperTest,\
  EmptyTrustedOidcIssuerServiceTest,TrustedOidcIssuersSchemaTest'

Result: 46 tests, 0 failures, 0 errors (JdbcTrustedOidcIssuerServiceTest 17, OIDCDiscoveryHelperTest 12, TrustedOidcIssuerServiceFactoryTest 8, EmptyTrustedOidcIssuerServiceTest 7, TrustedOidcIssuersSchemaTest 2).
```

Added `JdbcTrustedOidcIssuerServiceTest#testIssuerUrlTrailingSlashNormalized`, which verifies: registering with a trailing slash and looking up without one (and vice versa) matches; the canonical (slash-stripped) form is what gets persisted; and deregistering via the non-canonical form still removes the entry.


## Integration Tests
N/A

## UI changes
N/A