### PR TITLE
KNOX-3390 - Address comments for TrustedOidcIssuerService

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerService.java
@@ -195,6 +195,7 @@ public class JdbcTrustedOidcIssuerService implements TrustedOidcIssuerService {
       registrySnapshot.set(Collections.unmodifiableMap(fresh));
     } catch (Exception e) {
       LOG.errorReloadingRegistrySnapshot(e.getMessage(), e);
+      throw new RuntimeException("Error reloading trusted OIDC issuer registry snapshot", e);
     }
   }
 }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/TrustedOidcIssuerDatabase.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/TrustedOidcIssuerDatabase.java
@@ -44,8 +44,6 @@ class TrustedOidcIssuerDatabase extends KnoxDatabase {
       "DELETE FROM " + TABLE_NAME + " WHERE issuer_url = ?";
   private static final String SELECT_ALL_SQL =
       "SELECT issuer_url, dynamic_jwks, cluster_name, registered_at, registered_by FROM " + TABLE_NAME;
-  private static final String COUNT_SQL =
-      "SELECT COUNT(*) FROM " + TABLE_NAME;
 
   TrustedOidcIssuerDatabase(DataSource dataSource, String dbType) throws Exception {
     super(dataSource);
@@ -89,13 +87,5 @@ class TrustedOidcIssuerDatabase extends KnoxDatabase {
       }
     }
     return result;
-  }
-
-  int count() throws SQLException {
-    try (Connection connection = dataSource.getConnection();
-         PreparedStatement ps = connection.prepareStatement(COUNT_SQL);
-         ResultSet rs = ps.executeQuery()) {
-      return rs.next() ? rs.getInt(1) : 0;
-    }
   }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/knoxidf/trustedoidcissuer/JdbcTrustedOidcIssuerServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.services.knoxidf.trustedoidcissuer;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.config.impl.GatewayConfigImpl;
 import org.apache.knox.gateway.database.AbstractDataSourceFactory;
@@ -277,6 +278,45 @@ public class JdbcTrustedOidcIssuerServiceTest {
   @Test
   public void testRefreshJwksUriForUnregisteredIsNoOp() {
     service.refreshJwksUri("https://unknown.example.com"); // must not throw
+  }
+
+  // ------------------------------------------------------------------
+  // SQL exception error paths
+  // ------------------------------------------------------------------
+
+  @Test(expected = RuntimeException.class)
+  public void testDeregisterSqlExceptionOnDeleteThrowsRuntimeException() throws Exception {
+    final TrustedOidcIssuerDatabase mockDb = EasyMock.createMock(TrustedOidcIssuerDatabase.class);
+    mockDb.delete(EasyMock.anyString());
+    EasyMock.expectLastCall().andThrow(new java.sql.SQLException("delete failed"));
+    EasyMock.replay(mockDb);
+    FieldUtils.writeField(service, "database", mockDb, true);
+
+    service.deregister("https://any.example.com");
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testRegisterSqlExceptionOnSnapshotReloadPropagates() throws Exception {
+    final TrustedOidcIssuerDatabase mockDb = EasyMock.createMock(TrustedOidcIssuerDatabase.class);
+    mockDb.insert(EasyMock.anyObject(TrustedOidcIssuer.class));
+    EasyMock.expectLastCall();
+    EasyMock.expect(mockDb.selectAll()).andThrow(new java.sql.SQLException("selectAll failed"));
+    EasyMock.replay(mockDb);
+    FieldUtils.writeField(service, "database", mockDb, true);
+
+    service.register(issuer("https://any.example.com", false));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testDeregisterSqlExceptionOnSnapshotReloadPropagates() throws Exception {
+    final TrustedOidcIssuerDatabase mockDb = EasyMock.createMock(TrustedOidcIssuerDatabase.class);
+    mockDb.delete(EasyMock.anyString());
+    EasyMock.expectLastCall();
+    EasyMock.expect(mockDb.selectAll()).andThrow(new java.sql.SQLException("selectAll failed"));
+    EasyMock.replay(mockDb);
+    FieldUtils.writeField(service, "database", mockDb, true);
+
+    service.deregister("https://any.example.com");
   }
 
   // ------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -259,8 +259,8 @@
         <mina.version>2.2.8</mina.version>
         <netty.version>4.1.127.Final</netty.version>
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
-        <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
         <nodejs.version>v22.20.0</nodejs.version>
+        <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
         <okhttp.version>4.12.0</okhttp.version>
         <opensaml.version>5.2.2</opensaml.version>
         <pac4j.version>6.5.3</pac4j.version>


### PR DESCRIPTION
KNOX-3390 - Address comments for TrustedOidcIssuerService

Move the version declaration in pom.xml to alphabetical location.
Remove the count SQL helper as not used.
Ensure a DB snapshot reload failure is propagated to the caller.

Added unit tests for uncovered failure paths on snapshot reload.

