### PR TITLE
KNOX-3396: Return 4xx for type-mismatched register bodies and issuer-limit-reached instead of 500

### DIFF
--- a/gateway-service-knoxidf/pom.xml
+++ b/gateway-service-knoxidf/pom.xml
@@ -77,10 +77,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>

--- a/gateway-service-knoxidf/pom.xml
+++ b/gateway-service-knoxidf/pom.xml
@@ -73,6 +73,10 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>

--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/RegisterIssuerRequest.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/RegisterIssuerRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.service.knoxidf;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request body for registering a trusted OIDC issuer via {@link TrustedOidcIssuersResource#registerIssuer(String)}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RegisterIssuerRequest {
+
+  private String issuerUrl;
+  private boolean dynamicJwks;
+  private String clusterName;
+
+  public String getIssuerUrl() {
+    return issuerUrl;
+  }
+
+  public void setIssuerUrl(String issuerUrl) {
+    this.issuerUrl = issuerUrl;
+  }
+
+  public boolean isDynamicJwks() {
+    return dynamicJwks;
+  }
+
+  public void setDynamicJwks(boolean dynamicJwks) {
+    this.dynamicJwks = dynamicJwks;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public void setClusterName(String clusterName) {
+    this.clusterName = clusterName;
+  }
+}

--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResource.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResource.java
@@ -16,7 +16,6 @@
  */
 package org.apache.knox.gateway.service.knoxidf;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
@@ -90,14 +89,15 @@ public class TrustedOidcIssuersResource {
     String outcome = ActionOutcome.FAILURE;
 
     try {
-      final Map<String, Object> parsed;
+      final RegisterIssuerRequest parsed;
       try {
-        parsed = MAPPER.readValue(body, new TypeReference<Map<String, Object>>() {});
+        parsed = MAPPER.readValue(body, RegisterIssuerRequest.class);
       } catch (IOException e) {
-        return errorResponse(Response.Status.BAD_REQUEST, "invalid_request", "Malformed JSON body");
+        return errorResponse(Response.Status.BAD_REQUEST, "invalid_request",
+            "Malformed or invalid JSON body");
       }
 
-      final String rawUrl = (String) parsed.get("issuerUrl");
+      final String rawUrl = parsed.getIssuerUrl();
       issuerUrl = (rawUrl != null && !rawUrl.isEmpty()) ? rawUrl : "UNKNOWN_ISSUER";
 
       if (rawUrl == null || rawUrl.isEmpty()) {
@@ -112,13 +112,17 @@ public class TrustedOidcIssuersResource {
             "Issuer already registered: " + rawUrl);
       }
 
-      final boolean dynamicJwks = Boolean.TRUE.equals(parsed.get("dynamicJwks"));
-      final String clusterName = (String) parsed.get("clusterName");
-
-      trustedIssuers.register(new TrustedOidcIssuer(rawUrl, dynamicJwks, clusterName,
-          Instant.now(), operatorId));
+      trustedIssuers.register(new TrustedOidcIssuer(rawUrl, parsed.isDynamicJwks(),
+          parsed.getClusterName(), Instant.now(), operatorId));
       outcome = ActionOutcome.SUCCESS;
       return Response.status(Response.Status.CREATED).build();
+    } catch (IllegalStateException e) {
+      // The service throws IllegalStateException when the configured maximum number of
+      // registered issuers (MAX_TRUSTED_ISSUERS) is reached. This is an operator-facing
+      // capacity condition, distinct from an internal storage failure, so report it as a
+      // 409 rather than lumping it into the generic 500 storage_error path below.
+      return errorResponse(Response.Status.CONFLICT, "issuer_limit_reached",
+          "Maximum number of registered trusted issuers reached");
     } catch (RuntimeException e) {
       return errorResponse(Response.Status.INTERNAL_SERVER_ERROR, "storage_error",
           "Failed to register issuer");

--- a/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResourceTest.java
+++ b/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResourceTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.knox.gateway.service.knoxidf;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.knox.gateway.audit.api.Action;
 import org.apache.knox.gateway.audit.api.ActionOutcome;
@@ -567,8 +566,9 @@ public class TrustedOidcIssuersResourceTest {
         body.contains(expectedError));
   }
 
+  @SuppressWarnings("unchecked")
   private static List<Map<String, Object>> parseJsonList(String json) throws Exception {
-    return new ObjectMapper().readValue(json, new TypeReference<List<Map<String, Object>>>() {});
+    return new ObjectMapper().readValue(json, List.class);
   }
 
   private static Map<String, Object> findByIssuerUrl(List<Map<String, Object>> list,

--- a/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResourceTest.java
+++ b/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResourceTest.java
@@ -251,6 +251,42 @@ public class TrustedOidcIssuersResourceTest {
     EasyMock.verify(mockService, mockAuditor);
   }
 
+  @Test
+  public void testRegisterWrongTypeFieldReturnsBadRequest() {
+    // A syntactically valid JSON body with a type-mismatched field (clusterName as an
+    // array instead of a string). Binding to the typed RegisterIssuerRequest bean makes
+    // Jackson reject this during deserialization, so it is a 400 invalid_request rather
+    // than a ClassCastException surfacing as a 500. No service calls are expected; audit
+    // fires with the INVALID_REQUEST sentinel because parsing failed before the URL was read.
+    expectAudit("INVALID_REQUEST", ActionOutcome.FAILURE, "issuer_registered");
+    EasyMock.replay(mockService, mockAuditor);
+
+    final Response response = resource.registerIssuer(
+        "{\"issuerUrl\":\"" + ISSUER_A + "\",\"clusterName\":[1,2,3]}");
+
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    assertErrorField(response, "invalid_request");
+    EasyMock.verify(mockService, mockAuditor);
+  }
+
+  @Test
+  public void testRegisterIssuerLimitReached() {
+    // The service throws IllegalStateException when MAX_TRUSTED_ISSUERS is reached. This is
+    // an operator-facing capacity condition and must map to 409 issuer_limit_reached, not
+    // the generic 500 storage_error used for genuine storage failures.
+    EasyMock.expect(mockService.isTrusted(ISSUER_A)).andReturn(false).once();
+    mockService.register(EasyMock.anyObject(TrustedOidcIssuer.class));
+    EasyMock.expectLastCall().andThrow(new IllegalStateException("MAX_TRUSTED_ISSUERS (100) reached")).once();
+    expectAudit(ISSUER_A, ActionOutcome.FAILURE, "issuer_registered");
+    EasyMock.replay(mockService, mockAuditor);
+
+    final Response response = resource.registerIssuer(buildRegisterBody(ISSUER_A, false, null));
+
+    assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+    assertErrorField(response, "issuer_limit_reached");
+    EasyMock.verify(mockService, mockAuditor);
+  }
+
   // ---------------------------------------------------------------------------
   // DELETE /
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
[KNOX-3396](https://issues.apache.org/jira/browse/KNOX-3396) - Fix trusted-OIDC-issuer register API returning 500 for client-actionable errors

## What changes were proposed in this pull request?

Follow-up to KNOX-3368 (#1327), hardening the `POST` register endpoint of the trusted-OIDC-issuer admin API so that client-actionable conditions return the correct `4xx` status instead of a misleading `500`:

1. **Typed request bean.** `registerIssuer` now deserializes the body into a new `RegisterIssuerRequest` DTO instead of a generic `Map<String, Object>` with blind casts.
2. **Differentiated exception handling.** The service throws `IllegalStateException` when the configured `MAX_TRUSTED_ISSUERS` limit is reached: an operator-facing capacity condition. This is now caught separately and mapped to `409 issuer_limit_reached`, so it is distinguishable from a genuine storage failure (still `500 storage_error`).

Parsing remains inside the `try` block, so the audit-on-every-path behavior and the malformed-JSON handling are unchanged. Validation ordering, the SSRF/HTTPS gate, the error-response contract, and the other endpoints `GET`/`DELETE`/`refresh-jwks`) are untouched.

## How was this patch tested?

Automated unit tests in `TrustedOidcIssuersResourceTest` (module `gateway-service-knoxidf`). Two cases were added:
- `testRegisterWrongTypeFieldReturnsBadRequest`: an array-valued `clusterName` now returns `400 invalid_request` (was `500` before the fix).
- `testRegisterIssuerLimitReached`: the service throwing `IllegalStateException` now returns `409 issuer_limit_reached`.

## Integration Tests
N/A

## UI changes
N/A