### PR TITLE
KNOX-3397: Add preauth.auth.header.actor.groups to set actor groups header name explicitly

### DIFF
--- a/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
+++ b/gateway-service-auth/src/main/java/org/apache/knox/gateway/service/auth/AbstractAuthResource.java
@@ -43,6 +43,7 @@ import static javax.ws.rs.core.Response.status;
 
 public abstract class AbstractAuthResource {
   public static final String AUTH_ACTOR_ID_HEADER_NAME = "preauth.auth.header.actor.id.name";
+  public static final String AUTH_ACTOR_GROUPS_HEADER_NAME = "preauth.auth.header.actor.groups";
   public static final String AUTH_ACTOR_GROUPS_HEADER_PREFIX = "preauth.auth.header.actor.groups.prefix";
   public static final String GROUP_HEADER_LENGTH_LIMIT = "preauth.auth.header.groups.length.limit";
   public static final String GROUP_HEADER_SIZE_LIMIT = "preauth.auth.header.groups.size.limit";
@@ -60,6 +61,7 @@ public abstract class AbstractAuthResource {
   private static final String ACTOR_GROUPS_HEADER_FORMAT = "%s-%d";
 
   protected String authHeaderActorIDName;
+  protected String authHeaderActorGroupsName;
   protected String authHeaderActorGroupsPrefix;
   private int groupHeaderLengthLimit;
   private int groupHeaderSizeLimit;
@@ -69,6 +71,7 @@ public abstract class AbstractAuthResource {
 
   protected void initialize() {
     authHeaderActorIDName = getInitParameter(AUTH_ACTOR_ID_HEADER_NAME, DEFAULT_AUTH_ACTOR_ID_HEADER_NAME);
+    authHeaderActorGroupsName = getInitParameter(AUTH_ACTOR_GROUPS_HEADER_NAME, null);
     authHeaderActorGroupsPrefix = getInitParameter(AUTH_ACTOR_GROUPS_HEADER_PREFIX, DEFAULT_AUTH_ACTOR_GROUPS_HEADER_PREFIX);
     groupHeaderLengthLimit = Integer.parseInt(getInitParameter(GROUP_HEADER_LENGTH_LIMIT, DEFAULT_GROUP_HEADER_LENGTH_LIMIT));
     groupHeaderSizeLimit = Integer.parseInt(getInitParameter(GROUP_HEADER_SIZE_LIMIT, DEFAULT_GROUP_HEADER_SIZE_LIMIT));
@@ -114,11 +117,21 @@ public abstract class AbstractAuthResource {
       final boolean useRoles = !roles.isEmpty();
       final List<String> groupStrings = GroupUtils.getGroupStrings(useRoles ? roles : matchingGroupNames, groupHeaderLengthLimit, groupHeaderSizeLimit);
       for (int i = 0; i < groupStrings.size(); i++) {
-        final String headerName = useRoles || rolesLookupExecuted() ? authHeaderActorGroupsPrefix : String.format(Locale.ROOT, ACTOR_GROUPS_HEADER_FORMAT, authHeaderActorGroupsPrefix, i + 1);
-        getResponse().addHeader(headerName, groupStrings.get(i));
+        getResponse().addHeader(createGroupsHeaderName(useRoles, i), groupStrings.get(i));
       }
     }
     return ok().build();
+  }
+
+  private String createGroupsHeaderName(boolean useRoles, int index) {
+    if (authHeaderActorGroupsName != null) {
+      // explicit groups header takes precedence over the prefix and is used directly, without an index suffix
+      return authHeaderActorGroupsName;
+    } else if (useRoles || rolesLookupExecuted()) {
+      return authHeaderActorGroupsPrefix;
+    } else {
+      return String.format(Locale.ROOT, ACTOR_GROUPS_HEADER_FORMAT, authHeaderActorGroupsPrefix, index + 1);
+    }
   }
 
   private Collection<String> lookupRoles(String userName, Collection<String> groups) {

--- a/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/PreAuthResourceTest.java
+++ b/gateway-service-auth/src/test/java/org/apache/knox/gateway/service/auth/PreAuthResourceTest.java
@@ -170,6 +170,33 @@ public class PreAuthResourceTest {
   }
 
   @Test
+  public void testExplicitGroupsHeaderTakesPrecedenceOverPrefix() throws Exception {
+    final String explicitGroupsHeader = "X-Knox-Actor-Groups";
+    subject.getPrincipals().add(new GroupPrincipal("group1"));
+
+    context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getInitParameter(PreAuthResource.AUTH_ACTOR_GROUPS_HEADER_NAME)).andReturn(explicitGroupsHeader).anyTimes();
+    // a prefix is configured as well, to prove the explicit header wins and no index suffix is appended
+    EasyMock.expect(context.getInitParameter(PreAuthResource.AUTH_ACTOR_GROUPS_HEADER_PREFIX)).andReturn("X-Knox-Prefixed-Groups").anyTimes();
+    request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getAttribute(AbstractIdentityAssertionBase.ROLES_LOOKUP_EXECUTED)).andReturn(false).anyTimes();
+    response = EasyMock.createNiceMock(HttpServletResponse.class);
+    response.setHeader(PreAuthResource.DEFAULT_AUTH_ACTOR_ID_HEADER_NAME, USER_NAME);
+    EasyMock.expectLastCall();
+    // the explicit header name is used directly, without an index suffix
+    response.addHeader(EasyMock.eq(explicitGroupsHeader), EasyMock.anyString());
+    EasyMock.expectLastCall().times(1);
+    EasyMock.replay(context, request, response);
+
+    final PreAuthResource preAuthResource = new PreAuthResource();
+    preAuthResource.context = context;
+    preAuthResource.response = response;
+    preAuthResource.request = request;
+    executeResourceWithSubject(preAuthResource);
+    EasyMock.verify(response);
+  }
+
+  @Test
   public void testPopulatingGroupsWithRoles() throws Exception {
     final String rolesHeader = "X-Knox-Roles";
     final GatewayServices gatewayServices = configureLdapRolesLookupExpectations(false);


### PR DESCRIPTION
[KNOX-3397](https://issues.apache.org/jira/browse/KNOX-3397) - Allow the actor groups header name to be configured explicitly

## What changes were proposed in this pull request?

[KNOX-3354](https://issues.apache.org/jira/browse/KNOX-3354) removed the index suffix from the actor groups header when roles are resolved at the resource layer (rather than in the LDAP interceptors), so that the configured actor groups header is not postfixed. This is useful in environments where role lookup is configured locally.

However, a topology may instead use the RemoteAuthFilter to authenticate requests, where the remote counterpart is configured for role lookup. In that case remote.auth.group.header returns roles rather than groups, but the `KNOX-AUTH-SERVICE` configured in the topology still emits the suffixed version of `preauth.auth.header.actor.groups.prefix`, causing a mismatch.

To give operators explicit control over this, this PR introduces a new configuration parameter in AbstractAuthResource: `preauth.auth.header.actor.groups`. When declared, it takes precedence over the existing `preauth.auth.header.actor.groups.prefix` parameter and is used directly as the groups header name in the response, without any index suffix.

When the new parameter is not set, behavior is unchanged (fully backward compatible). The header-name selection logic was also extracted into a small private `createGroupsHeaderName(...)` helper for readability.

## How was this patch tested?

- Added a unit test (PreAuthResourceTest#testExplicitGroupsHeaderTakesPrecedenceOverPrefix) that configures both the explicit header and a prefix, and verifies the explicit header is emitted directly, exactly once, with no index suffix.
- Ran the full PreAuthResourceTest suite: Tests run: 9, Failures: 0, Errors: 0, Skipped: 0.

## Integration Tests
N/A

## UI changes
N/A