### PR TITLE
KNOX-3398: Enable Iceberg REST catalog SSL only when ENCRYPT_ALL_PORTS is set

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGenerator.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGenerator.java
@@ -37,6 +37,7 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
   static final String HTTP_PATH = "hive_metastore_catalog_servlet_path";
   static final String REST_CATALOG_ENABLED = "hive_rest_catalog_enabled";
   static final String SSL_ENABLED    = "hive_metastore_enable_ssl";
+  static final String ENCRYPT_ALL_PORTS_ENV_VAR_NAME = "ENCRYPT_ALL_PORTS";
 
   static final String DEFAULT_HTTP_PATH = "icecli";
 
@@ -75,7 +76,9 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
                                       ApiRole role,
                                       ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig) throws ApiException {
     String hostname = role.getHostRef().getHostname();
-    boolean sslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));
+    final boolean hmsSslEnabled = Boolean.parseBoolean(getServiceConfigValue(serviceConfig, SSL_ENABLED));
+    final boolean encryptAllPorts = isEncryptAllPorts();
+    final boolean sslEnabled = hmsSslEnabled && encryptAllPorts;
     String scheme = sslEnabled ? "https" : "http";
     String port = getHttpPort(serviceConfig);
     String httpPath = getHttpPath(serviceConfig);
@@ -86,12 +89,17 @@ public class IcebergRestServiceModelGenerator extends AbstractServiceModelGenera
 
     ServiceModel model =
         createServiceModel(String.format(Locale.getDefault(), "%s://%s:%s/%s", scheme, hostname, port, httpPath));
-    model.addServiceProperty(HTTP_PORT, getHttpPort(serviceConfig));
-    model.addServiceProperty(HTTP_PATH, getHttpPath(serviceConfig));
+    model.addServiceProperty(HTTP_PORT, port);
+    model.addServiceProperty(HTTP_PATH, httpPath);
     model.addServiceProperty(REST_CATALOG_ENABLED, getRestCatalogEnabled(serviceConfig));
-    model.addServiceProperty(SSL_ENABLED, Boolean.toString(sslEnabled));
+    model.addServiceProperty(SSL_ENABLED, Boolean.toString(hmsSslEnabled));
+    model.addServiceProperty(ENCRYPT_ALL_PORTS_ENV_VAR_NAME, Boolean.toString(encryptAllPorts));
 
     return model;
+  }
+
+  boolean isEncryptAllPorts() {
+    return Boolean.parseBoolean(System.getenv(ENCRYPT_ALL_PORTS_ENV_VAR_NAME));
   }
 
   protected String getHttpPort(ApiServiceConfig serviceConfig) {

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/AbstractServiceModelGeneratorTest.java
@@ -79,9 +79,13 @@ public abstract class AbstractServiceModelGeneratorTest extends AbstractCMDiscov
 
 
   protected ServiceModel createServiceModel(Map<String, String> serviceConfig, Map<String, String> roleConfig) {
+    return createServiceModel(newGenerator(), serviceConfig, roleConfig);
+  }
+
+  protected ServiceModel createServiceModel(ServiceModelGenerator generator, Map<String, String> serviceConfig, Map<String, String> roleConfig) {
     ServiceModel model = null;
     try {
-      model = newGenerator().generateService(createApiServiceMock(getServiceType()),
+      model = generator.generateService(createApiServiceMock(getServiceType()),
                                              createApiServiceConfigMock(serviceConfig),
                                              createApiRoleMock(getRoleType()),
                                              createApiConfigListMock(roleConfig),

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGeneratorTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/model/hive/IcebergRestServiceModelGeneratorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.knox.gateway.topology.discovery.cm.model.hive;
 
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.AbstractServiceModelGeneratorTest;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -54,6 +56,7 @@ public class IcebergRestServiceModelGeneratorTest extends AbstractServiceModelGe
     serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PATH, "icecli");
     serviceConfig.put(IcebergRestServiceModelGenerator.REST_CATALOG_ENABLED, "true");
     serviceConfig.put(IcebergRestServiceModelGenerator.SSL_ENABLED, "false");
+    serviceConfig.put(IcebergRestServiceModelGenerator.ENCRYPT_ALL_PORTS_ENV_VAR_NAME, "false");
 
     final Map<String, String> roleConfig = Collections.emptyMap();
 
@@ -62,15 +65,36 @@ public class IcebergRestServiceModelGeneratorTest extends AbstractServiceModelGe
 
   @Test
   public void testServiceModelSslEnabled() {
+    testServiceModelSsl(true);
+  }
+
+  @Test
+  public void testServiceModelSslDisabledWhenEncryptionDisabled() {
+    testServiceModelSsl(false);
+  }
+
+  private void testServiceModelSsl(boolean encryptionEnabled) {
     final Map<String, String> serviceConfig = new HashMap<>();
     serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PORT, "8091");
     serviceConfig.put(IcebergRestServiceModelGenerator.HTTP_PATH, "icecli2");
     serviceConfig.put(IcebergRestServiceModelGenerator.REST_CATALOG_ENABLED, "false");
     serviceConfig.put(IcebergRestServiceModelGenerator.SSL_ENABLED, "true");
+    serviceConfig.put(IcebergRestServiceModelGenerator.ENCRYPT_ALL_PORTS_ENV_VAR_NAME, Boolean.toString(encryptionEnabled));
 
     final Map<String, String> roleConfig = Collections.emptyMap();
 
-    validateServiceModel(createServiceModel(serviceConfig, roleConfig), serviceConfig, roleConfig);
+    final ServiceModel model = createServiceModel(new IcebergRestServiceModelGenerator() {
+      @Override
+      boolean isEncryptAllPorts() {
+        return encryptionEnabled;
+      }
+    }, serviceConfig, roleConfig);
+
+    validateServiceModel(model, serviceConfig, roleConfig);
+
+    // HTTPS is only used when HMS SSL is enabled AND all ports are encrypted.
+    final String expectedScheme = encryptionEnabled ? "https" : "http";
+    assertEquals(expectedScheme + "://localhost:8091/icecli2", model.getServiceUrl());
   }
 
   @Override


### PR DESCRIPTION
[KNOX-3398](https://issues.apache.org/jira/browse/KNOX-3398) - Enable Iceberg REST catalog SSL only when ENCRYPT_ALL_PORTS is set

## What changes were proposed in this pull request?

The Iceberg REST catalog URL now uses https only when HMS SSL (`hive_metastore_enable_ssl`) is enabled and the `ENCRYPT_ALL_PORTS` env var is set. The raw `HMS SSL flag` and the new `ENCRYPT_ALL_PORTS` flag are exposed as separate service properties.

## How was this patch tested?

Unit tests in `IcebergRestServiceModelGeneratorTest`- parameterized over both `ENCRYPT_ALL_PORTS` states, asserting the resulting scheme (http/https), URL, and service properties.

## Integration Tests
N/A

## UI changes
N/A