### PR TITLE
KNOX-3403: RFC 8693 token exchange: use the impersonated subject as the token sub on non-server-managed topologies

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -920,18 +920,19 @@ public class TokenResource {
   protected UserContext buildUserContext(HttpServletRequest request) {
     String userName = request.getUserPrincipal().getName();
     String createdBy = null;
-    // checking the doAs user only makes sense if tokens are managed (this is where we store the userName/createdBy information)
-    // and if impersonation was enabled before (on HadoopAuth or identity-assertion level) so the the current subject has at least one ImpersonatedPrincipal principal
-    if (tokenStateService != null) {
-      final Subject subject = SubjectUtils.getCurrentSubject();
-      if (subject != null && SubjectUtils.isImpersonating(subject)) {
-        String primaryPrincipalName = SubjectUtils.getPrimaryPrincipalName(subject);
-        String impersonatedPrincipalName = SubjectUtils.getImpersonatedPrincipalName(subject);
-        if (!primaryPrincipalName.equals(impersonatedPrincipalName)) {
-          createdBy = primaryPrincipalName;
-          userName = impersonatedPrincipalName;
-          log.tokenImpersonationSuccess(createdBy, userName);
-        }
+    // When impersonation is in effect, the issued token's subject must be the effective (impersonated)
+    // identity, not the primary principal. This applies to traditional doAs as well as RFC 8693 token
+    // exchange (where the actor is the primary principal and the subject is the impersonated one).
+    // This is independent of server-managed state: createdBy is only persisted for managed tokens (see
+    // persistTokenDetails), so computing it here is harmless when there is no token state service.
+    final Subject subject = SubjectUtils.getCurrentSubject();
+    if (subject != null && SubjectUtils.isImpersonating(subject)) {
+      String primaryPrincipalName = SubjectUtils.getPrimaryPrincipalName(subject);
+      String impersonatedPrincipalName = SubjectUtils.getImpersonatedPrincipalName(subject);
+      if (!primaryPrincipalName.equals(impersonatedPrincipalName)) {
+        createdBy = primaryPrincipalName;
+        userName = impersonatedPrincipalName;
+        log.tokenImpersonationSuccess(createdBy, userName);
       }
     }
     return new UserContext(userName, createdBy);

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -2220,4 +2220,55 @@ public class TokenServiceResourceTest {
 
     EasyMock.verify(request, context);
   }
+
+  /**
+   * KNOX-3403: On a NON-server-managed topology, an impersonated request (traditional doAs or RFC 8693
+   * token exchange, where the actor is the primary principal and the subject is the impersonated one)
+   * must still issue a token whose {@code sub} is the impersonated subject. Previously buildUserContext
+   * only applied the impersonated identity when {@code tokenStateService != null}, so on a non-managed
+   * topology the {@code sub} incorrectly fell back to the primary principal (the actor).
+   */
+  @Test
+  @SuppressForbidden
+  public void testImpersonatedTokenSubjectOnNonServerManagedTopology() throws Exception {
+    final String primaryUser = "admin";      // primary principal (authenticated caller / actor)
+    final String impersonatedUser = "bob";  // impersonated subject (distinct from USER_NAME)
+
+    // No serverManagedTssEnabled argument -> token state service is absent (non-server-managed).
+    configureCommonExpectations(createDelegatedAuthContextExpectations(true, true));
+    Subject subject = createSubjectWithOptionalImpersonation(primaryUser, impersonatedUser);
+    JWTToken parsedToken = getTokenWithSubject(subject);
+
+    // The token subject must be the impersonated user, not the primary.
+    assertEquals("Non-server-managed impersonated token must use the impersonated subject as sub",
+            impersonatedUser, parsedToken.getSubject());
+
+    // The 'act' claim still records the primary user (delegated auth enabled).
+    Object actClaim = parsedToken.getClaimAsObject(JWTToken.ACT_CLAIM);
+    assertNotNull("RFC 8693 'act' claim should be present", actClaim);
+    assertTrue("'act' claim should be a Map", actClaim instanceof Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> actClaimMap = (Map<String, Object>) actClaim;
+    assertEquals("'act' claim should contain the primary user's subject", primaryUser, actClaimMap.get("sub"));
+
+    EasyMock.verify(request, context);
+  }
+
+  /**
+   * KNOX-3403: sanity check that decoupling the impersonated-sub from server-managed does not change
+   * the non-impersonating case - the token {@code sub} remains the authenticated (primary) user on a
+   * non-server-managed topology.
+   */
+  @Test
+  @SuppressForbidden
+  public void testNonImpersonatedTokenSubjectOnNonServerManagedTopology() throws Exception {
+    configureCommonExpectations(createDelegatedAuthContextExpectations(true, false));
+    Subject subject = createSubjectWithOptionalImpersonation(USER_NAME, null);
+    JWTToken parsedToken = getTokenWithSubject(subject);
+
+    assertEquals(USER_NAME, parsedToken.getSubject());
+    assertNull("'act' claim should NOT be present without impersonation", parsedToken.getClaimAsObject(JWTToken.ACT_CLAIM));
+
+    EasyMock.verify(request, context);
+  }
 }


### PR DESCRIPTION
[KNOX-3403](https://issues.apache.org/jira/browse/KNOX-3403) - Token exchange issues the wrong `sub` on non-server-managed topologies

## What changes were proposed in this pull request?

When a token was issued under impersonation via an RFC 8693 token exchange (`subject_token` + `actor_token`) on a topology that is **not** server-managed, the issued JWT's `sub` was set to the **actor** (the primary principal / authenticated caller) instead of the **subject** (the impersonated end user) - so the token represented the acting party rather than the user, defeating the on-behalf-of semantics. (The `act` claim was already correct; only `sub` was wrong.)

**Root cause:** `TokenResource.buildUserContext(...)` only replaced the default username (the primary principal, from `request.getUserPrincipal()`) with the impersonated principal inside an `if (tokenStateService != null)` block - i.e. only when the topology is server-managed. That gate predates token exchange and was intended only to guard *metadata* storage (`userName`/`createdBy` persisted to the token state service), not to control the issued token's `sub`.

This PR moves the impersonation -> `userName` resolution out of that gate, so the issued token's `sub` is the effective (impersonated) identity whenever `SubjectUtils.isImpersonating(subject)` is true, independent of server-managed state. `createdBy` continues to be persisted only for managed tokens (`persistTokenDetails` already guards on `tokenStateService != null`, so computing it otherwise is harmless). The stale comment was updated.

**Scope:** only the non-server-managed impersonation path changes. Traditional `doAs` was already correct (the identity-assertion request wrapper exposes the impersonated user via `getUserPrincipal()`), server-managed topologies are unchanged, and non-impersonating requests are unchanged.

## How was this patch tested?

* Reproduced end-to-end on a live gateway: an RFC 8693 exchange on a non-server-managed topology returned `sub = <actor>` (wrong); the same exchange on a server-managed topology returned the correct `sub`, isolating the cause to this gate.
* Added unit tests in `TokenServiceResourceTest`:
  * `testImpersonatedTokenSubjectOnNonServerManagedTopology`: non-server-managed + impersonation (actor `admin`, subject `bob`) asserts `sub == bob` and `act == { sub: admin }`.
  * `testNonImpersonatedTokenSubjectOnNonServerManagedTopology`: non-server-managed, no impersonation asserts `sub == <primary>` and no `act` claim (no regression).
* Confirmed both new tests **fail without the fix** (`expected:<bob> but was:<alice>`) and pass with it; full `TokenServiceResourceTest` passes (73 tests) with 0 Checkstyle violations.

**Manual testing:**

__Step 1__ - mint two DISTINCT Knox tokens from sandbox (subject ≠ actor, so act populates)
```
export SUBJ=$(curl -sku tom:tom-password  "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token" | jq -r .access_token)
export ACTOR=$(curl -sku sam:sam-password "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token" | jq -r .access_token)
```

__Step 2__ - create a NON‑server‑managed exchange topology obo

All tokens here are Knox‑issued (iss=KNOXSSO, typ=JWT), so no JWKS/CA/typ‑ignore needed — Knox verifies them with its own key; `conf/topologies/obo.xml` looks like this:
```
<topology>
  <gateway>
    <provider><role>federation</role><name>JWTProvider</name><enabled>true</enabled></provider>
    <provider><role>identity-assertion</role><name>Default</name><enabled>true</enabled></provider>
  </gateway>
  <service>
    <role>KNOXTOKEN</role>
    <param><name>knox.token.enable.delegated.auth</name><value>true</value></param>
  </service>
</topology>
```
Notes:
 * NO server-managed -> the external‑style validation path
 * Default identity‑assertion is required - it's what maps the exchange subject to the impersonated principal
 * `enable.delegated.auth` adds the `act `claim.)

__Step 3__ - verification

Verified these combinations:
| Change on `obo` | subject/actor | Expected result | What it validates |
|---|---|---|---|
| baseline (non-managed, `enable.delegated.auth=true`) | tom / sam | `sub=tom`, `act={sub:sam}` | the fix |
| `enable.delegated.auth=false` | tom / sam | `sub=tom`, no `act` | `act` gated on delegated auth |
| same identity (both `$SUBJ`) | tom / tom | `sub=tom`, no `act` | actor==subject equality guard |
| `knox.token.exp.server-managed=true` on the **KNOXTOKEN service** | tom / sam | `sub=tom`, `act={sub:sam}` | issued-token tracking makes `tokenStateService != null`, so the correct subject is used (works even without the fix) |
| `knox.token.exp.server-managed=true` on the **JWTProvider** | tom / sam | `401 "Unknown token"` | incoming-token validation does a state-store lookup; untracked tokens are rejected (why the exchange topology's JWTProvider must be non-managed) |

I used the following `curl` command and its variations:
```
curl -sk -X POST "https://localhost:8443/gateway/obo/knoxtoken/api/v2/token" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
  -d "subject_token=$SUBJ" -d "subject_token_type=urn:ietf:params:oauth:token-type:jwt" \
  -d "actor_token=$ACTOR" -d "actor_token_type=urn:ietf:params:oauth:token-type:jwt" \
  | jq -r .access_token | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null | jq '{sub, act}'
```

__Step 4__ - `doAs` sanity check on `sandbox` (should be unchanged by this PR to confirm no regression):
```
# token management ON
$ curl -sku admin:admin-password "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token?doAs=bob"   | jq -r .access_token | cut -d. -f2 | tr '_-' '/+' | base64 -d 
{"sub":"bob","jku":"https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/jwks.json","kid":"GpOl8XfsNAOFzROVhb-HM7vJ5CRqR1GMM7pXHdQ29VQ","iss":"KNOXSSO","exp":1795815685,"managed.token":"true","knox.id":"aa9a0ee1-5b15-4d19-a3bc-2da431dec7cc"}

# token management OFF
$ curl -sku admin:admin-password "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token?doAs=bob"   | jq -r .access_token | cut -d. -f2 | tr '_-' '/+' | base64 -d 
{"sub":"bob","jku":"https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/jwks.json","kid":"GpOl8XfsNAOFzROVhb-HM7vJ5CRqR1GMM7pXHdQ29VQ","iss":"KNOXSSO","exp":1795815670,"managed.token":"false","knox.id":"d6391a02-b0a8-4c5d-aa11-d4f44630c2b1"}
```

## Integration Tests
N/A

## UI changes
N/A