### PR TITLE
KNOX-3368 - Switch KNOXIDF_ADMIN pattern for PathAclsAuthz

### DIFF
--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResource.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/TrustedOidcIssuersResource.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 @Produces(MediaType.APPLICATION_JSON)
 public class TrustedOidcIssuersResource {
 
-  static final String RESOURCE_PATH = "knoxidf/issuers-admin/v1/trusted-oidc-issuers";
+  static final String RESOURCE_PATH = "knoxidf/admin/v1/trusted-oidc-issuers";
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/deploy/KnoxIDFAdminServiceDeploymentContributor.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/deploy/KnoxIDFAdminServiceDeploymentContributor.java
@@ -19,13 +19,17 @@ package org.apache.knox.gateway.service.knoxidf.deploy;
 import org.apache.knox.gateway.jersey.JerseyServiceDeploymentContributorBase;
 
 /**
- * Deployment contributor for the KNOXIDF_ADMIN service role, which hosts the
- * trusted OIDC issuer admin REST API. This contributor registers
- * {@link org.apache.knox.gateway.service.knoxidf.TrustedOidcIssuersResource}
- * under the {@code knoxidf/issuers-admin/**?**} pattern, which is disjoint from
- * the KNOXIDF role's {@code knoxidf/api/**?**} pattern. This ensures the KNOXIDF
- * role cannot serve admin endpoints, and that per-role AclsAuthz authorization
- * ({@code KNOXIDF_ADMIN.acl}) applies only to trusted-issuer admin requests.
+ * Deployment contributor for the KNOXIDF_ADMIN service role, which hosts all
+ * KnoxIDF admin REST APIs under a single {@code knoxidf/admin/**?**} URL pattern.
+ * Current resources: {@link org.apache.knox.gateway.service.knoxidf.TrustedOidcIssuersResource}.
+ *
+ * <p>The {@code knoxidf/admin/**?**} pattern is disjoint from the KNOXIDF role's
+ * {@code knoxidf/api/**?**} pattern, preventing KNOXIDF from serving admin endpoints.</p>
+ *
+ * <p>Authorization: use {@code PathAclsAuthz} in the topology to assign independent
+ * ACLs to each admin endpoint (e.g., {@code KNOXIDF_ADMIN.rule_issuers.path.acl}
+ * for trusted-issuers). Alternatively, {@code AclsAuthz} with {@code KNOXIDF_ADMIN.acl}
+ * applies a single ACL to all endpoints under this role.</p>
  */
 public class KnoxIDFAdminServiceDeploymentContributor extends JerseyServiceDeploymentContributorBase {
 
@@ -46,6 +50,6 @@ public class KnoxIDFAdminServiceDeploymentContributor extends JerseyServiceDeplo
 
   @Override
   protected String[] getPatterns() {
-    return new String[] { "knoxidf/issuers-admin/**?**" };
+    return new String[] { "knoxidf/admin/**?**" };
   }
 }

--- a/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/deploy/KnoxIDFAdminServiceDeploymentContributorTest.java
+++ b/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/deploy/KnoxIDFAdminServiceDeploymentContributorTest.java
@@ -72,11 +72,12 @@ public class KnoxIDFAdminServiceDeploymentContributorTest {
         new KnoxIDFAdminServiceDeploymentContributor();
     final String[] patterns = c.getPatterns();
     assertNotNull(patterns);
-    // Distinct from KnoxIDFServiceDeploymentContributor's "knoxidf/api/**?**" so that the
-    // KNOXIDF role cannot accidentally serve admin endpoints, and so that per-role AclsAuthz
-    // params (KNOXIDF_ADMIN.acl) apply only to trusted-issuer admin requests.
-    assertTrue("Expected knoxidf/issuers-admin/**?** in patterns",
-        Arrays.asList(patterns).contains("knoxidf/issuers-admin/**?**"));
+    // Single broad pattern covers all KnoxIDF admin resources (trusted-issuers, delegation-policies, etc.).
+    // Disjoint from KnoxIDFServiceDeploymentContributor's "knoxidf/api/**?**" so the KNOXIDF role
+    // cannot serve admin endpoints. Per-endpoint ACLs are configured via PathAclsAuthz rules in
+    // the topology descriptor (e.g., KNOXIDF_ADMIN.rule_issuers.path.acl).
+    assertTrue("Expected knoxidf/admin/**?** in patterns",
+        Arrays.asList(patterns).contains("knoxidf/admin/**?**"));
   }
 
   @Test
@@ -140,6 +141,6 @@ public class KnoxIDFAdminServiceDeploymentContributorTest {
     contributor.contributeService(context, service);
 
     assertEquals("KNOXIDF_ADMIN", capturedRole.getValue());
-    assertEquals("knoxidf/issuers-admin/**?**", capturedPattern.getValue());
+    assertEquals("knoxidf/admin/**?**", capturedPattern.getValue());
   }
 }


### PR DESCRIPTION
KNOX-3368 - Switch KNOXIDF_ADMIN pattern for PathAclsAuthz

## What changes were proposed in this pull request?

Remove redundant admin URL paths, still allowing separate ACLs for different
knox idf admin APIs using PathAclAuthz.

## How was this patch tested?

Unit tests updated for new path.

## Integration Tests
None. Will add later once flow is implemented.

