### PR TITLE
KNOX-3411: KnoxToken getUserTokens returns every user's token metadat…

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -507,6 +507,14 @@ public class TokenResource {
       final String createdBy = uriInfo.getQueryParameters().getFirst("createdBy");
       final String userNameOrCreatedBy = uriInfo.getQueryParameters().getFirst("userNameOrCreatedBy");
       final boolean allTokens = Boolean.parseBoolean(uriInfo.getQueryParameters().getFirst("allTokens"));
+
+      final String caller = SubjectUtils.getCurrentEffectivePrincipalName();
+      if (!isAuthorizedToSeeTokens(caller, userName, createdBy, userNameOrCreatedBy, allTokens)) {
+        log.unauthorizedGetUserTokensRequest(getTopologyName(), caller);
+        return Response.status(Response.Status.FORBIDDEN)
+            .entity("{\n  \"error\": \"Caller (" + caller + ") is not authorized to see other users' tokens.\"\n}\n").build();
+      }
+
       final Collection<KnoxToken> userTokens;
       if (allTokens) {
         userTokens = tokenStateService.getAllTokens();
@@ -538,6 +546,29 @@ public class TokenResource {
       }
       return Response.status(Response.Status.OK).entity(JsonUtils.renderAsJsonString(Collections.singletonMap("tokens", tokens))).build();
     }
+  }
+
+  private boolean isAuthorizedToSeeTokens(String caller, String userName, String createdBy, String userNameOrCreatedBy, boolean allTokens) {
+    if (StringUtils.isBlank(caller)) {
+      return false;
+    }
+    final GatewayConfig config = (GatewayConfig) context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    if (config != null && config.canSeeAllTokens(caller)) {
+      return true;
+    }
+    if (allTokens) {
+      return false;
+    }
+    // an ordinary caller must scope the query to their own tokens
+    final boolean hasIdentifier = userName != null || createdBy != null || userNameOrCreatedBy != null;
+    return hasIdentifier
+        && requestedIsCallerIfPresent(caller, userName)
+        && requestedIsCallerIfPresent(caller, createdBy)
+        && requestedIsCallerIfPresent(caller, userNameOrCreatedBy);
+  }
+
+  private static boolean requestedIsCallerIfPresent(String caller, String requested) {
+    return requested == null || caller.equals(requested);
   }
 
   @GET

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -77,6 +77,9 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad set enabled flag request for token {1}: {2}")
   void badSetEnabledFlagRequest(String topologyName, String tokenId, String error);
 
+  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected an unauthorized getUserTokens request from caller ({1})")
+  void unauthorizedGetUserTokensRequest(String topologyName, String caller);
+
   @Message( level = MessageLevel.DEBUG, text = "Knox Token service ({0}) stored state for token {1} ({2})")
   void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -135,6 +135,7 @@ public class TokenServiceResourceTest {
   private JWTokenAuthority authority;
   private TestTokenStateService tss = new TestTokenStateService();
   private char[] hmacSecret;
+  private final Set<String> usersCanSeeAllTokens = new HashSet<>();
 
   private enum TokenLifecycleOperation {
     Renew,
@@ -206,6 +207,8 @@ public class TokenServiceResourceTest {
       EasyMock.expect(config.getServiceParameter(tokenStateServiceType, "impl")).andReturn(contextExpectations.get(tokenStateServiceType)).anyTimes();
     }
     EasyMock.expect(config.getKnoxTokenHashAlgorithm()).andReturn(HmacAlgorithms.HMAC_SHA_256.getName()).anyTimes();
+    EasyMock.expect(config.canSeeAllTokens(EasyMock.anyObject(String.class)))
+        .andAnswer(() -> usersCanSeeAllTokens.contains((String) EasyMock.getCurrentArguments()[0])).anyTimes();
     EasyMock.expect(config.getMaximumNumberOfTokensPerUser())
         .andReturn(contextExpectations.containsKey(KNOX_TOKEN_USER_LIMIT) ? Integer.parseInt(contextExpectations.get(KNOX_TOKEN_USER_LIMIT)) : -1).anyTimes();
     EasyMock.expect(services.getService(ServiceType.TOKEN_STATE_SERVICE)).andReturn(tss).anyTimes();
@@ -1242,12 +1245,86 @@ public class TokenServiceResourceTest {
   }
 
   private Response getUserTokensResponse(TokenResource tokenResource, boolean createdBy) {
+    return getUserTokensResponse(tokenResource, createTestSubject(USER_NAME),
+        Collections.singletonMap(createdBy ? "createdBy" : "userName", USER_NAME));
+  }
+
+  private Response getUserTokensResponse(TokenResource tokenResource, Subject caller, Map<String, String> queryParams) {
     final MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
-    queryParameters.put(createdBy ? "createdBy" : "userName", Arrays.asList(USER_NAME));
+    queryParams.forEach((key, value) -> queryParameters.put(key, Arrays.asList(value)));
     final UriInfo uriInfo = EasyMock.createNiceMock(UriInfo.class);
     EasyMock.expect(uriInfo.getQueryParameters()).andReturn(queryParameters).anyTimes();
     EasyMock.replay(uriInfo);
-    return tokenResource.getUserTokens(uriInfo);
+    return Subject.doAs(caller, (PrivilegedAction<Response>) () -> tokenResource.getUserTokens(uriInfo));
+  }
+
+  private TokenResource createTokenResourceWithTokensFor(String... users) throws Exception {
+    configureCommonExpectations(new HashMap<>(), Boolean.TRUE);
+    final TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+    for (String user : users) {
+      Subject.doAs(createTestSubject(user), (PrivilegedAction<Response>) () -> tr.doGet());
+    }
+    return tr;
+  }
+
+  @SuppressWarnings("unchecked")
+  private int tokenCount(Response response) {
+    final Collection<Object> tokens = ((Map<String, Collection<Object>>) JsonUtils.getObjectFromJsonString(response.getEntity().toString()))
+        .get("tokens");
+    return tokens.size();
+  }
+
+  @Test
+  public void testGetUserTokensOwnerCanSeeOwnTokens() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject(USER_NAME), Collections.singletonMap("userName", USER_NAME));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(1, tokenCount(response));
+  }
+
+  @Test
+  public void testGetUserTokensUnauthorizedForOtherUser() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject("bob"), Collections.singletonMap("userName", USER_NAME));
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("not authorized"));
+  }
+
+  @Test
+  public void testGetUserTokensUnauthorizedForUserNameOrCreatedByOfOtherUser() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject("bob"), Collections.singletonMap("userNameOrCreatedBy", USER_NAME));
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("not authorized"));
+  }
+
+  @Test
+  public void testGetUserTokensAllTokensDeniedForOrdinaryUser() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject("bob"), Collections.singletonMap("allTokens", "true"));
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("not authorized"));
+  }
+
+  @Test
+  public void testGetUserTokensAdminCanSeeAllTokens() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME, "bob");
+    usersCanSeeAllTokens.add("admin");
+    final Response response = getUserTokensResponse(tr, createTestSubject("admin"), Collections.singletonMap("allTokens", "true"));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(2, tokenCount(response));
+  }
+
+  @Test
+  public void testGetUserTokensAdminCanSeeOtherUsersTokens() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    usersCanSeeAllTokens.add("admin");
+    final Response response = getUserTokensResponse(tr, createTestSubject("admin"), Collections.singletonMap("userName", USER_NAME));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(1, tokenCount(response));
   }
 
   @Test

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -113,6 +113,7 @@ import org.apache.knox.gateway.services.token.impl.JDBCTokenStateService;
 import org.apache.knox.gateway.util.AuthFilterUtils;
 import org.apache.knox.gateway.util.JsonUtils;
 import org.easymock.EasyMock;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -150,6 +151,11 @@ public class TokenServiceResourceTest {
 
     publicKey = (RSAPublicKey) KPair.getPublic();
     privateKey = (RSAPrivateKey) KPair.getPrivate();
+  }
+
+  @After
+  public void cleanUp() {
+    this.usersCanSeeAllTokens.clear();
   }
 
   private void configureCommonExpectations(Map<String, String> contextExpectations) throws Exception {


### PR DESCRIPTION
…a without a caller authorization check

[KNOX-3411](https://issues.apache.org/jira/browse/KNOX-3411) - KnoxToken getUserTokens returns every user's token metadata without a caller authorization check

## What changes were proposed in this pull request?

- Bug: any authenticated user could read any/all users' token metadata via ?userName=, ?createdBy=, ?userNameOrCreatedBy=, or ?allTokens=true. No caller check.
- Fix: in getUserTokens, admins (canSeeAllTokens) get everything; ordinary callers may only query their own tokens, else 403 + audit log.

## How was this patch tested?

Unit tests.
Locally tested by adding KNOXTOKEN to sandbox topology

```
curl -vku admin:admin-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token?lifespan=P0DT1H0M"
curl -vku tom:tom-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token?lifespan=P0DT1H0M"
curl -vku guest:guest-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token?lifespan=P0DT1H0M"
curl -vk -u guest:guest-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/getUserTokens?userNameOrCreatedBy=admin"
curl -vk -u tom:tom-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/getUserTokens?userName=guest"
curl -vk -u guest:guest-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/getUserTokens?userNameOrCreatedBy=tom"
curl -vk -u guest:guest-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/getUserTokens?allTokens=true"
curl -vk -u tom:tom-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/getUserTokens?allTokens=true"
curl -vk -u admin:admin-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token/getUserTokens?allTokens=true"
```

## Integration Tests
N/A

## UI changes
N/A
