### PR TITLE
KNOX-3413: KnoxToken passcode verification accepts a valid passcode f…

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -568,7 +568,7 @@ public abstract class AbstractJWTFilter implements Filter {
             final TokenMetadata tokenMetadata = tokenStateService == null ? null : tokenStateService.getTokenMetadata(tokenId);
             if (isTokenEnabled(tokenMetadata)) {
               if (isIdleTimeoutLimitNotExceeded(tokenMetadata)) {
-                if (hasSignatureBeenVerified(passcode) || validatePasscode(tokenId, passcode)) {
+                if (hasSignatureBeenVerified(passcodeVerificationCacheKey(tokenId, passcode)) || validatePasscode(tokenId, passcode)) {
                   markLastUsedAt(tokenId, tokenMetadata);
                   return true;
                 } else {
@@ -589,7 +589,7 @@ public abstract class AbstractJWTFilter implements Filter {
             // Explicitly evict the record of this token's signature verification (if present).
             // There is no value in keeping this record for expired tokens, and explicitly removing them may prevent
             // records for other valid tokens from being prematurely evicted from the cache.
-            removeSignatureVerificationRecord(passcode);
+            removeSignatureVerificationRecord(passcodeVerificationCacheKey(tokenId, passcode));
             handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED, "Token has expired");
           }
         } else {
@@ -615,7 +615,7 @@ public abstract class AbstractJWTFilter implements Filter {
     final byte[] storedPasscode = tokenMetadata == null ? null : tokenMetadata.getPasscode().getBytes(UTF_8);
     final boolean validPasscode = Arrays.equals(tokenMAC.hash(tokenId, issueTime, userName, passcode).getBytes(UTF_8), storedPasscode);
     if (validPasscode) {
-      recordSignatureVerification(passcode);
+      recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
     }
     return validPasscode;
   }
@@ -707,4 +707,7 @@ public abstract class AbstractJWTFilter implements Filter {
   protected abstract void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status,
                                                 String error) throws IOException;
 
+  private String passcodeVerificationCacheKey(final String tokenId, final String passcode) {
+    return tokenId + "::" + passcode;
+  }
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -1520,4 +1520,7 @@ public abstract class AbstractJWTFilterTest  {
       }
   }
 
+  protected String passcodeVerificationCacheKey(final String tokenId, final String passcode) {
+    return tokenId + "::" + passcode;
+  }
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -195,7 +195,7 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
     }
     EasyMock.replay(tokenStateService, tokenMetadata, request, response);
 
-    SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcode);
+    SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
 
     final TestFilterChain chain = new TestFilterChain();
     handler.doFilter(request, response, chain);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/OAuthFlowsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/OAuthFlowsFederationFilterTest.java
@@ -278,7 +278,7 @@ public class OAuthFlowsFederationFilterTest extends TokenIDAsHTTPBasicCredsFeder
         // Wrap the request to simulate real-world scenario where wrappers hide parameter access
         final HttpServletRequest request = new TestServletRequestWrapper(mockRequest);
 
-        SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcode);
+        SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
 
         final TestFilterChain chain = new TestFilterChain();
         handler.doFilter(request, response, chain);
@@ -387,6 +387,11 @@ public class OAuthFlowsFederationFilterTest extends TokenIDAsHTTPBasicCredsFeder
     public void testUnableToParseJWT() throws Exception {
     }
 
+    @Override
+    @Test
+    public void testPasscodeCannotBeReplayedAgainstDifferentTokenId() {
+    }
+
     @Test
     public void testGetWireTokenUsingRefreshTokenFlow() throws Exception {
       final String refreshToken = "WTJ4cFpXNTBMV2xrTFRFeU16UTE6OlkyeHBaVzUwTFhObFkzSmxkQzB4TWpNME5RPT0=";
@@ -470,7 +475,7 @@ public class OAuthFlowsFederationFilterTest extends TokenIDAsHTTPBasicCredsFeder
         // Wrap the request to simulate real-world scenario where wrappers hide parameter access
         final HttpServletRequest request = new TestServletRequestWrapper(mockRequest);
 
-        SignatureVerificationCache.getInstance("jwt-topology", filterConfig).recordSignatureVerification(passcode);
+        SignatureVerificationCache.getInstance("jwt-topology", filterConfig).recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
 
         final TestFilterChain chain = new TestFilterChain();
         handler.doFilter(request, response, chain);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.provider.federation;
 
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.Instant;
@@ -263,6 +264,55 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
         } catch (ServletException se) {
             fail("Should NOT have thrown a ServletException.");
         }
+    }
+
+    @Test
+    public void testPasscodeCannotBeReplayedAgainstDifferentTokenId() throws Exception {
+        Properties props = getProperties();
+        handler.init(new TestFilterConfig(props));
+
+        final long issueTime = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);
+        final Date expiry = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+
+        final SignedJWT attackerJwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "attacker", expiry, privateKey);
+        final String attackerPasscode = (String) attackerJwt.getJWTClaimsSet().getClaims().get(PASSCODE_CLAIM);
+        addTokenState(attackerJwt, issueTime, "attacker", attackerPasscode);
+
+        final SignedJWT victimJwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob", expiry, privateKey);
+        final String victimPasscode = (String) victimJwt.getJWTClaimsSet().getClaims().get(PASSCODE_CLAIM);
+        addTokenState(victimJwt, issueTime, "bob", victimPasscode);
+        final String victimTokenId = getTokenId(victimJwt);
+
+        final TestFilterChain seedChain = new TestFilterChain();
+        handler.doFilter(newPasscodeRequest(generatePasscodeField(getTokenId(attackerJwt), attackerPasscode)),
+                newResponse(), seedChain);
+        Assert.assertTrue("Precondition: the attacker's own passcode should authenticate.", seedChain.doFilterCalled);
+
+        final TestFilterChain attackChain = new TestFilterChain();
+        handler.doFilter(newPasscodeRequest(generatePasscodeField(victimTokenId, attackerPasscode)),
+                newResponse(), attackChain);
+
+        Assert.assertFalse("A passcode must not authenticate when paired with a different token id "
+                + "(identity-assertion / authentication bypass).", attackChain.doFilterCalled);
+        Assert.assertNull("No subject should have been established for the replayed passcode.", attackChain.getSubject());
+    }
+
+    private HttpServletRequest newPasscodeRequest(final String passcodeField) {
+        final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+        setTokenOnRequest(request, JWTFederationFilter.PASSCODE, passcodeField);
+        EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+        EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+        EasyMock.expect(request.getQueryString()).andReturn(null).anyTimes();
+        EasyMock.replay(request);
+        return request;
+    }
+
+    private HttpServletResponse newResponse() throws IOException {
+        final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+        EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
+        EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+        EasyMock.replay(response);
+        return response;
     }
 
     @Override


### PR DESCRIPTION
…or a different token

[KNOX-3413](https://issues.apache.org/jira/browse/KNOX-3413) - KnoxToken passcode verification accepts a valid passcode for a different token

## What changes were proposed in this pull request?

The cache abstraction conflates two token models. For JWTs the key is the entire serialized JWT (self-authenticating, and identity is derived from that same token). For passcodes, validity is a property of the `(tokenId, passcode)` pair, but the cache stored only the passcode while identity came from a separately supplied `tokenId`.

The only check that binds the passcode to the token identifier is `validatePasscode(tokenId, passcode)`, which compares `tokenMAC.hash(tokenId, issueTime, userName, passcode)` against the passcode stored for that specific tokenId. On success it records the verification in a shared, per-topology cache (`SignatureVerificationCache`) keyed on the passcode string alone.

Because the guard at `AbstractJWTFilter.java:571` is `hasSignatureBeenVerified(passcode) || validatePasscode(tokenId, passcode)`, and tokenId/passcode are two independently attacker-controlled fields (parsed from Base64(tokenId)::Base64(passcode) at JWTFederationFilter.java:213-215), a caller who has verified its own passcode once can then present that same passcode paired with a different, victim tokenId.

Key the passcode verification cache on the `(tokenId, passcode)` pairing instead of the passcode
alone. Introduce one private helper and update the three passcode-path call sites. The JWT path
(`verifyTokenSignature`, keyed on `serializedJWT`) is unchanged.

Also adds new regression test for the scenario.

## How was this patch tested?

Unit tests
Tested locally with two new topologies (tokenissuer, tokenconsumer)

```
curl -vku admin:admin-password -X "GET" "https://localhost:8443/gateway/tokenissuer/knoxtoken/api/v2/token?lifespan=P0DT1H0M"
curl -vku tom:tom-password -X "GET" "https://localhost:8443/gateway/sandbox/knoxtoken/api/v2/token?lifespan=P0DT1H0M"
curl -vk -H "Authorization: Basic replaced_tokenid_token" -X "GET" "https://localhost:8443/gateway/tokenconsumer/auth/api/v1/pre"
```

## Integration Tests
N/A

## UI changes
N/A
