### PR TITLE
KNOX-3416: KnoxSSO redirects to untrusted site

### DIFF
--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
@@ -61,6 +61,10 @@ public interface KnoxSSOMessages {
       "not valid according to the configured whitelist: {1}. See documentation for KnoxSSO Whitelisting.")
   void whiteListMatchFail(String original, String whitelist);
 
+  @Message( level = MessageLevel.ERROR, text = "The original URL: {0} for redirecting back after authentication " +
+      "embeds userinfo (e.g. user@host) and is therefore rejected.")
+  void userInfoInOriginalURL(String original);
+
   @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) stored state for token {1} ({2})")
   void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 }

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -264,15 +264,19 @@ public class WebSSOResource {
 
       boolean validRedirect = true;
 
-      // If there is a whitelist defined, then the original URL must be validated against it.
-      // If there is no whitelist, then everything is valid.
-      if (whitelist != null) {
-        try {
+      try {
+        // A redirect target embedding userinfo (e.g. https://knox-host:8443@evil/) is
+        // never legitimate; reject it before the host-only whitelist check.
+        if (Urls.containsUserInfo(original)) {
+          validRedirect = false;
+        } else if (whitelist != null) {
+          // If there is a whitelist defined, then the original URL must be validated against it.
+          // If there is no whitelist, then everything is valid.
           validRedirect = RegExUtils.checkBaseUrlAgainstWhitelist(whitelist, original);
-        } catch (MalformedURLException e) {
-          throw new WebApplicationException("Malformed original URL: " + original,
-                  Response.Status.BAD_REQUEST);
         }
+      } catch (MalformedURLException e) {
+        throw new WebApplicationException("Malformed original URL: " + original,
+                Response.Status.BAD_REQUEST);
       }
 
       if (!validRedirect) {

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -269,10 +269,14 @@ public class WebSSOResource {
         // never legitimate; reject it before the host-only whitelist check.
         if (Urls.containsUserInfo(original)) {
           validRedirect = false;
+          LOGGER.userInfoInOriginalURL(Log4jAuditor.maskTokenFromURL(original));
         } else if (whitelist != null) {
           // If there is a whitelist defined, then the original URL must be validated against it.
           // If there is no whitelist, then everything is valid.
           validRedirect = RegExUtils.checkBaseUrlAgainstWhitelist(whitelist, original);
+          if (!validRedirect) {
+            LOGGER.whiteListMatchFail(Log4jAuditor.maskTokenFromURL(original), whitelist);
+          }
         }
       } catch (MalformedURLException e) {
         throw new WebApplicationException("Malformed original URL: " + original,
@@ -280,8 +284,7 @@ public class WebSSOResource {
       }
 
       if (!validRedirect) {
-        LOGGER.whiteListMatchFail(Log4jAuditor.maskTokenFromURL(original), whitelist);
-        throw new WebApplicationException("Original URL not valid according to the configured whitelist.",
+        throw new WebApplicationException("Original URL not valid for redirect.",
                                           Response.Status.BAD_REQUEST);
       }
     } else {

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -473,6 +473,49 @@ public class WebSSOResourceTest {
     }
   }
 
+  @Test
+  public void testUserInfoOriginalURLRejected() throws Exception {
+    ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(expectGatewayConfig()).anyTimes();
+
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getParameter("originalUrl")).andReturn(
+        "https://localhost:8443%2f@malicious.link/");
+    EasyMock.expect(request.getAttribute("targetServiceRole")).andReturn("KNOXSSO").anyTimes();
+    EasyMock.expect(request.getParameterMap()).andReturn(Collections.emptyMap());
+    EasyMock.expect(request.getServletContext()).andReturn(context).anyTimes();
+    EasyMock.expect(request.getServerName()).andReturn("localhost").anyTimes();
+
+    Principal principal = EasyMock.createNiceMock(Principal.class);
+    EasyMock.expect(principal.getName()).andReturn("alice").anyTimes();
+    EasyMock.expect(request.getUserPrincipal()).andReturn(principal).anyTimes();
+
+    GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
+    EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
+
+    AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(TokenUtils.SIGNING_HMAC_SECRET_ALIAS)).andReturn(null).anyTimes();
+
+    JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
+
+    HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
+    CookieResponseWrapper responseWrapper = new CookieResponseWrapper(response, outputStream);
+
+    EasyMock.replay(principal, services, context, request);
+
+    WebSSOResource webSSOResponse = new WebSSOResource();
+    webSSOResponse.request = request;
+    webSSOResponse.response = responseWrapper;
+    webSSOResponse.context = context;
+    webSSOResponse.init();
+
+    WebApplicationException e = Assert.assertThrows(WebApplicationException.class, webSSOResponse::doGet);
+    assertEquals(HttpStatus.SC_BAD_REQUEST, e.getResponse().getStatus());
+  }
+
   private GatewayConfig expectGatewayConfig() {
     return expectGatewayConfig(true);
   }


### PR DESCRIPTION

[KNOX-3416](https://issues.apache.org/jira/browse/KNOX-3416) - KnoxSSO redirects to untrusted site

## What changes were proposed in this pull request?

KnoxSSO open redirect. `originalUrl=https://<knox-host>:443%252f@malicious.link/` bypassed the redirect whitelist — the whitelist check decoded the URL twice (seeing host <knox-host>), but the browser got the once-decoded Location and resolved the host to malicious.link. The `%2f@` trick hid the real host behind `userinfo`.

In `WebSSOResource`, reject any redirect target containing `userinfo` (user@host) — checked on original, the exact value emitted in the Location header. Malformed URLs and `userinfo` results in 400.

New unit tests for the scenario.

## How was this patch tested?

Unit tests

**Before:**

```
curl -iku guest:guest-password 'https://localhost:8443/gateway/knoxsso/api/v1/websso?originalUrl=https://localhost:8443%252f@malicious.link/'
HTTP/1.1 307 Temporary Redirect
Date: Wed, 12 Aug 2026 11:34:14 GMT
X-Frame-Options: DENY
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Location: https://localhost:8443%2f@malicious.link/
Content-Length: 0
```

**After:**

```
curl -iku guest:guest-password 'https://localhost:8443/gateway/knoxsso/api/v1/websso?originalUrl=https://localhost:8443%252f@malicious.link/'
HTTP/1.1 400 Bad Request
X-Frame-Options: DENY
Set-Cookie: KNOXSESSIONID=node01c8rf5xqxudkxxp4188wx0kg70.node0; Path=/gateway/knoxsso; Secure; HttpOnly
Set-Cookie: rememberMe=deleteMe; Path=/gateway/knoxsso; Max-Age=0; Expires=Tue, 11-Aug-2026 11:37:11 GMT; SameSite=lax
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: text/html;charset=iso-8859-1
Content-Length: 419

<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 400 Bad Request</title>
</head>
<body><h2>HTTP ERROR 400 Bad Request</h2>
<table>
<tr><th>URI:</th><td>/gateway/knoxsso/api/v1/websso</td></tr>
<tr><th>STATUS:</th><td>400</td></tr>
<tr><th>MESSAGE:</th><td>Bad Request</td></tr>
<tr><th>SERVLET:</th><td>knoxsso-knox-gateway-servlet</td></tr>
</table>

</body>
</html>
```

## Integration Tests
N/A

## UI changes
N/A
