### PR TITLE
KNOX-3417: KnoxLdapRealm builds the LDAP search filter from the clien…

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealm.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealm.java
@@ -700,10 +700,10 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
               "(&(objectclass=%1$s)(%2$s=%3$s))",
               getUserObjectClass(),
               userSearchAttributeName,
-              expandTemplate( getUserSearchAttributeTemplate(), matchedPrincipal ) );
+              expandTemplate(getUserSearchAttributeTemplate(), matchedPrincipal, true));
         }
       } else {
-        searchFilter = expandTemplate( userSearchFilter, matchedPrincipal );
+        searchFilter = expandTemplate(userSearchFilter, matchedPrincipal, true);
       }
       SearchControls searchControls = getUserSearchControls();
 
@@ -749,17 +749,57 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
       return new SimpleAuthenticationInfo(token.getPrincipal(), credentialsHash.toHex(), credentialsHash.getSalt(), getName());
     }
 
-  private static String expandTemplate( final String template, final Matcher input ) {
+  private static String expandTemplate(final String template, final Matcher input) {
+    return expandTemplate(template, input, false);
+  }
+
+  private static String expandTemplate( final String template, final Matcher input, final boolean escapeForLdapFilter ) {
     String output = template;
     Matcher matcher = TEMPLATE_PATTERN.matcher( output );
     while( matcher.find() ) {
       String lookupStr = matcher.group( 1 );
       int lookupIndex = Integer.parseInt( lookupStr );
       String lookupValue = input.group( lookupIndex );
-      output = matcher.replaceFirst( lookupValue == null ? "" : lookupValue );
+      if (lookupValue == null) {
+          lookupValue = "";
+      } else if (escapeForLdapFilter) {
+          lookupValue = escapeLdapSearchFilterValue(lookupValue);
+      }
+      // quoteReplacement is required: replaceFirst treats '\' and '$' in the replacement specially
+      output = matcher.replaceFirst(Matcher.quoteReplacement(lookupValue));
       matcher = TEMPLATE_PATTERN.matcher( output );
     }
     return output;
+  }
+
+  private static String escapeLdapSearchFilterValue(final String value) {
+    if (value == null) {
+      return null;
+    }
+    final StringBuilder sb = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      switch (c) {
+        case '\\':
+          sb.append("\\5c");
+          break;
+        case '*':
+          sb.append("\\2a");
+          break;
+        case '(':
+          sb.append("\\28");
+          break;
+        case ')':
+          sb.append("\\29");
+          break;
+        case '\0':
+          sb.append("\\00");
+          break;
+        default:
+          sb.append(c);
+      }
+    }
+    return sb.toString();
   }
 
 }

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmTest.java
@@ -19,12 +19,82 @@
 
 package org.apache.knox.gateway.shirorealm;
 
+import org.apache.shiro.realm.ldap.LdapContextFactory;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
 import org.junit.Test;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class KnoxLdapRealmTest {
+
+  private static String captureSearchFilter(KnoxLdapRealm realm, String principal) throws Exception {
+    LdapContextFactory factory = EasyMock.createNiceMock(LdapContextFactory.class);
+    LdapContext ctx = EasyMock.createNiceMock(LdapContext.class);
+    NamingEnumeration<SearchResult> results = EasyMock.createNiceMock(NamingEnumeration.class);
+
+    EasyMock.expect(factory.getSystemLdapContext()).andReturn(ctx).anyTimes();
+    Capture<String> filter = EasyMock.newCapture();
+    EasyMock.expect(ctx.search(EasyMock.anyString(), EasyMock.capture(filter),
+        EasyMock.anyObject(SearchControls.class))).andReturn(results);
+    EasyMock.expect(results.hasMore()).andReturn(false).anyTimes();
+    EasyMock.replay(factory, ctx, results);
+
+    realm.setContextFactory(factory);
+    try {
+      realm.getUserDn(principal);
+    } catch (IllegalArgumentException expected) {
+      // mock returns no entry, so getUserDn throws after the search; we only need the filter
+    }
+    return filter.getValue();
+  }
+
+  private static KnoxLdapRealm searchModeRealm() {
+    KnoxLdapRealm realm = new KnoxLdapRealm();
+    realm.setSearchBase("dc=hadoop,dc=apache,dc=org");
+    realm.setUserSearchBase("ou=people,dc=hadoop,dc=apache,dc=org");
+    realm.setUserSearchAttributeName("uid");
+    realm.setUserObjectClass("person");
+    return realm;
+  }
+
+  @Test
+  public void getUserDnEscapesLdapFilterMetacharacters() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "*)(uid=admin");
+    assertEquals("(&(objectclass=person)(uid=\\2a\\29\\28uid=admin))", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesWildcard() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "*");
+    assertEquals("(&(objectclass=person)(uid=\\2a))", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesBackslash() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "a\\b");
+    assertEquals("(&(objectclass=person)(uid=a\\5cb))", filter);
+  }
+
+  @Test
+  public void getUserDnLeavesLegitimateUsernameUnchanged() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "sam");
+    assertEquals("(&(objectclass=person)(uid=sam))", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesValueButPreservesOperatorFilterStructure() throws Exception {
+    KnoxLdapRealm realm = searchModeRealm();
+    realm.setUserSearchFilter("(uid={0})");
+    String filter = captureSearchFilter(realm, "a)(b");
+    assertEquals("(uid=a\\29\\28b)", filter);
+  }
 
   @Test
   public void setGetSearchBase() {


### PR DESCRIPTION
…t username without RFC-4515 escaping

[KNOX-3417](https://issues.apache.org/jira/browse/KNOX-3417) - A short description of the change

## What changes were proposed in this pull request?

In search-then-bind LDAP mode, Knox dropped the login username straight into an LDAP search filter with no escaping. Typing username `*)(uid=admin` turned the intended filter `(&(objectclass=person)(uid=<user>))` into `(&(objectclass=person)(uid=*)(uid=admin))`.

The fix (`KnoxLdapRealm.java`):
- New `escapeLdapSearchFilterValue()` — RFC 4515 escaping (* ( ) \ NUL → \2a \28 \29 \5c \00).
- New `expandTemplate(..., escapeForLdapFilter)` overload (escapes the value + Matcher.quoteReplacement), switched on at the two filter sites.
- Now `*)(uid=admin` becomes inert literal `uid=\2a\29\28uid=admin `— no longer alters the query.

New unit tests

## How was this patch tested?

Unit tests, manually tested

Log level to `DEBUG`
New topology:
```
<param>
   <name>main.ldapRealm.userSearchBase</name>
   <value>ou=people,dc=hadoop,dc=apache,dc=org</value>
</param>
<param>
    <name>main.ldapRealm.userSearchAttributeName</name>
    <value>uid</value>
</param>
<param>
    <name>main.ldapRealm.userObjectClass</name>
    <value>person</value>
</param>
```
**Before**:

```
curl -sivk -u '*)(uid=admin:admin-password' 'https://localhost:8443/gateway/injtest/v1/gateway-status'

HTTP/1.1 200 OK

DEBUG knox.gateway (KnoxLdapRealm.java:getUserDn(715)) - Searching from ou=people,dc=hadoop,dc=apache,dc=org where (&(objectclass=person)(uid=admin)) scope subtree
```

**After**:

```
curl -sivk -u '*)(uid=admin:admin-password' 'https://localhost:8443/gateway/injtest/v1/gateway-status'

HTTP/1.1 401 Unauthorized

DEBUG knox.gateway (KnoxLdapRealm.java:getUserDn(715)) - Searching from ou=people,dc=hadoop,dc=apache,dc=org where (&(objectclass=person)(uid=\2a\29\28uid=admin)) scope subtree
```

```
<param>
    <name>main.ldapRealm.userSearchBase</name>
    <value>ou=people,dc=hadoop,dc=apache,dc=org</value>
</param>
<param>
    <name>main.ldapRealm.userSearchFilter</name>
    <value>(&amp;(objectclass=person)(uid={0}))</value>
</param>
```

**Before**:

```
curl -ik -u '*)(uid=admin:admin-password' 'https://localhost:8443/gateway/injtestfilter/v1/gateway-status'
HTTP/1.1 200 OK
DEBUG knox.gateway (KnoxLdapRealm.java:getUserDn(715)) - Searching from ou=people,dc=hadoop,dc=apache,dc=org where (&(objectclass=person)(uid=*)(uid=admin)) scope subtree
```

**After**:

```
curl -ik -u '*)(uid=admin:admin-password' 'https://localhost:8443/gateway/injtestfilter/v1/gateway-status'
HTTP/1.1 401 Unauthorized
DEBUG knox.gateway (KnoxLdapRealm.java:getUserDn(715)) - Searching from ou=people,dc=hadoop,dc=apache,dc=org where (&(objectclass=person)(uid=\2a\29\28uid=admin)) scope subtree
```



## Integration Tests
N/A

## UI changes
N/A
