### PR TITLE
Knox security picks into v2.1.x

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AbstractJWTFilter.java
@@ -501,7 +501,7 @@ public abstract class AbstractJWTFilter implements Filter {
             final TokenMetadata tokenMetadata = tokenStateService == null ? null : tokenStateService.getTokenMetadata(tokenId);
             if (isTokenEnabled(tokenMetadata)) {
               if (isIdleTimeoutLimitNotExceeded(tokenMetadata)) {
-                if (hasSignatureBeenVerified(passcode) || validatePasscode(tokenId, passcode)) {
+                if (hasSignatureBeenVerified(passcodeVerificationCacheKey(tokenId, passcode)) || validatePasscode(tokenId, passcode)) {
                   markLastUsedAt(tokenId, tokenMetadata);
                   return true;
                 } else {
@@ -522,7 +522,7 @@ public abstract class AbstractJWTFilter implements Filter {
             // Explicitly evict the record of this token's signature verification (if present).
             // There is no value in keeping this record for expired tokens, and explicitly removing them may prevent
             // records for other valid tokens from being prematurely evicted from the cache.
-            removeSignatureVerificationRecord(passcode);
+            removeSignatureVerificationRecord(passcodeVerificationCacheKey(tokenId, passcode));
             handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED, "Token has expired");
           }
         } else {
@@ -548,7 +548,7 @@ public abstract class AbstractJWTFilter implements Filter {
     final byte[] storedPasscode = tokenMetadata == null ? null : tokenMetadata.getPasscode().getBytes(UTF_8);
     final boolean validPasscode = Arrays.equals(tokenMAC.hash(tokenId, issueTime, userName, passcode).getBytes(UTF_8), storedPasscode);
     if (validPasscode) {
-      recordSignatureVerification(passcode);
+      recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
     }
     return validPasscode;
   }
@@ -640,4 +640,7 @@ public abstract class AbstractJWTFilter implements Filter {
   protected abstract void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status,
                                                 String error) throws IOException;
 
+  private String passcodeVerificationCacheKey(final String tokenId, final String passcode) {
+    return tokenId + "::" + passcode;
+  }
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/AbstractJWTFilterTest.java
@@ -1519,4 +1519,7 @@ public abstract class AbstractJWTFilterTest  {
       }
   }
 
+  protected String passcodeVerificationCacheKey(final String tokenId, final String passcode) {
+    return tokenId + "::" + passcode;
+  }
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/ClientIdAndClientSecretFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/ClientIdAndClientSecretFederationFilterTest.java
@@ -110,7 +110,7 @@ public class ClientIdAndClientSecretFederationFilterTest extends TokenIDAsHTTPBa
 //        EasyMock.expectLastCall().once();
         EasyMock.replay(tokenStateService, tokenMetadata, request, response);
 
-        SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcode);
+        SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
 
         final TestFilterChain chain = new TestFilterChain();
         handler.doFilter(request, response, chain);
@@ -155,7 +155,7 @@ public class ClientIdAndClientSecretFederationFilterTest extends TokenIDAsHTTPBa
         EasyMock.expectLastCall().once();
         EasyMock.replay(tokenStateService, tokenMetadata, request, response);
 
-        SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcode);
+        SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
 
         final TestFilterChain chain = new TestFilterChain();
         handler.doFilter(request, response, chain);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTest.java
@@ -160,7 +160,7 @@ public class JWTFederationFilterTest extends AbstractJWTFilterTest {
     }
     EasyMock.replay(tokenStateService, tokenMetadata, request, response);
 
-    SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcode);
+    SignatureVerificationCache.getInstance(topologyName, filterConfig).recordSignatureVerification(passcodeVerificationCacheKey(tokenId, passcode));
 
     final TestFilterChain chain = new TestFilterChain();
     handler.doFilter(request, response, chain);

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/TokenIDAsHTTPBasicCredsFederationFilterTest.java
@@ -20,6 +20,7 @@ package org.apache.knox.gateway.provider.federation;
 
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.Instant;
@@ -259,6 +260,55 @@ public class TokenIDAsHTTPBasicCredsFederationFilterTest extends JWTAsHTTPBasicC
         } catch (ServletException se) {
             fail("Should NOT have thrown a ServletException.");
         }
+    }
+
+    @Test
+    public void testPasscodeCannotBeReplayedAgainstDifferentTokenId() throws Exception {
+        Properties props = getProperties();
+        handler.init(new TestFilterConfig(props));
+
+        final long issueTime = System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(5);
+        final Date expiry = new Date(System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+
+        final SignedJWT attackerJwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "attacker", expiry, privateKey);
+        final String attackerPasscode = (String) attackerJwt.getJWTClaimsSet().getClaims().get(PASSCODE_CLAIM);
+        addTokenState(attackerJwt, issueTime, "attacker", attackerPasscode);
+
+        final SignedJWT victimJwt = getJWT(AbstractJWTFilter.JWT_DEFAULT_ISSUER, "bob", expiry, privateKey);
+        final String victimPasscode = (String) victimJwt.getJWTClaimsSet().getClaims().get(PASSCODE_CLAIM);
+        addTokenState(victimJwt, issueTime, "bob", victimPasscode);
+        final String victimTokenId = getTokenId(victimJwt);
+
+        final TestFilterChain seedChain = new TestFilterChain();
+        handler.doFilter(newPasscodeRequest(generatePasscodeField(getTokenId(attackerJwt), attackerPasscode)),
+                newResponse(), seedChain);
+        Assert.assertTrue("Precondition: the attacker's own passcode should authenticate.", seedChain.doFilterCalled);
+
+        final TestFilterChain attackChain = new TestFilterChain();
+        handler.doFilter(newPasscodeRequest(generatePasscodeField(victimTokenId, attackerPasscode)),
+                newResponse(), attackChain);
+
+        Assert.assertFalse("A passcode must not authenticate when paired with a different token id "
+                + "(identity-assertion / authentication bypass).", attackChain.doFilterCalled);
+        Assert.assertNull("No subject should have been established for the replayed passcode.", attackChain.getSubject());
+    }
+
+    private HttpServletRequest newPasscodeRequest(final String passcodeField) {
+        final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+        setTokenOnRequest(request, JWTFederationFilter.PASSCODE, passcodeField);
+        EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+        EasyMock.expect(request.getPathInfo()).andReturn("resource").anyTimes();
+        EasyMock.expect(request.getQueryString()).andReturn(null).anyTimes();
+        EasyMock.replay(request);
+        return request;
+    }
+
+    private HttpServletResponse newResponse() throws IOException {
+        final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+        EasyMock.expect(response.encodeRedirectURL(SERVICE_URL)).andReturn(SERVICE_URL).anyTimes();
+        EasyMock.expect(response.getOutputStream()).andAnswer(DummyServletOutputStream::new).anyTimes();
+        EasyMock.replay(response);
+        return response;
     }
 
     @Override

--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealm.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealm.java
@@ -700,10 +700,10 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
               "(&(objectclass=%1$s)(%2$s=%3$s))",
               getUserObjectClass(),
               userSearchAttributeName,
-              expandTemplate( getUserSearchAttributeTemplate(), matchedPrincipal ) );
+              expandTemplate(getUserSearchAttributeTemplate(), matchedPrincipal, true));
         }
       } else {
-        searchFilter = expandTemplate( userSearchFilter, matchedPrincipal );
+        searchFilter = expandTemplate(userSearchFilter, matchedPrincipal, true);
       }
       SearchControls searchControls = getUserSearchControls();
 
@@ -749,17 +749,57 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
       return new SimpleAuthenticationInfo(token.getPrincipal(), credentialsHash.toHex(), credentialsHash.getSalt(), getName());
     }
 
-  private static String expandTemplate( final String template, final Matcher input ) {
+  private static String expandTemplate(final String template, final Matcher input) {
+    return expandTemplate(template, input, false);
+  }
+
+  private static String expandTemplate( final String template, final Matcher input, final boolean escapeForLdapFilter ) {
     String output = template;
     Matcher matcher = TEMPLATE_PATTERN.matcher( output );
     while( matcher.find() ) {
       String lookupStr = matcher.group( 1 );
       int lookupIndex = Integer.parseInt( lookupStr );
       String lookupValue = input.group( lookupIndex );
-      output = matcher.replaceFirst( lookupValue == null ? "" : lookupValue );
+      if (lookupValue == null) {
+          lookupValue = "";
+      } else if (escapeForLdapFilter) {
+          lookupValue = escapeLdapSearchFilterValue(lookupValue);
+      }
+      // quoteReplacement is required: replaceFirst treats '\' and '$' in the replacement specially
+      output = matcher.replaceFirst(Matcher.quoteReplacement(lookupValue));
       matcher = TEMPLATE_PATTERN.matcher( output );
     }
     return output;
+  }
+
+  private static String escapeLdapSearchFilterValue(final String value) {
+    if (value == null) {
+      return null;
+    }
+    final StringBuilder sb = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      final char c = value.charAt(i);
+      switch (c) {
+        case '\\':
+          sb.append("\\5c");
+          break;
+        case '*':
+          sb.append("\\2a");
+          break;
+        case '(':
+          sb.append("\\28");
+          break;
+        case ')':
+          sb.append("\\29");
+          break;
+        case '\0':
+          sb.append("\\00");
+          break;
+        default:
+          sb.append(c);
+      }
+    }
+    return sb.toString();
   }
 
 }

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmTest.java
@@ -19,12 +19,82 @@
 
 package org.apache.knox.gateway.shirorealm;
 
+import org.apache.shiro.realm.ldap.LdapContextFactory;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
 import org.junit.Test;
+
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class KnoxLdapRealmTest {
+
+  private static String captureSearchFilter(KnoxLdapRealm realm, String principal) throws Exception {
+    LdapContextFactory factory = EasyMock.createNiceMock(LdapContextFactory.class);
+    LdapContext ctx = EasyMock.createNiceMock(LdapContext.class);
+    NamingEnumeration<SearchResult> results = EasyMock.createNiceMock(NamingEnumeration.class);
+
+    EasyMock.expect(factory.getSystemLdapContext()).andReturn(ctx).anyTimes();
+    Capture<String> filter = EasyMock.newCapture();
+    EasyMock.expect(ctx.search(EasyMock.anyString(), EasyMock.capture(filter),
+        EasyMock.anyObject(SearchControls.class))).andReturn(results);
+    EasyMock.expect(results.hasMore()).andReturn(false).anyTimes();
+    EasyMock.replay(factory, ctx, results);
+
+    realm.setContextFactory(factory);
+    try {
+      realm.getUserDn(principal);
+    } catch (IllegalArgumentException expected) {
+      // mock returns no entry, so getUserDn throws after the search; we only need the filter
+    }
+    return filter.getValue();
+  }
+
+  private static KnoxLdapRealm searchModeRealm() {
+    KnoxLdapRealm realm = new KnoxLdapRealm();
+    realm.setSearchBase("dc=hadoop,dc=apache,dc=org");
+    realm.setUserSearchBase("ou=people,dc=hadoop,dc=apache,dc=org");
+    realm.setUserSearchAttributeName("uid");
+    realm.setUserObjectClass("person");
+    return realm;
+  }
+
+  @Test
+  public void getUserDnEscapesLdapFilterMetacharacters() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "*)(uid=admin");
+    assertEquals("(&(objectclass=person)(uid=\\2a\\29\\28uid=admin))", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesWildcard() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "*");
+    assertEquals("(&(objectclass=person)(uid=\\2a))", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesBackslash() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "a\\b");
+    assertEquals("(&(objectclass=person)(uid=a\\5cb))", filter);
+  }
+
+  @Test
+  public void getUserDnLeavesLegitimateUsernameUnchanged() throws Exception {
+    String filter = captureSearchFilter(searchModeRealm(), "sam");
+    assertEquals("(&(objectclass=person)(uid=sam))", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesValueButPreservesOperatorFilterStructure() throws Exception {
+    KnoxLdapRealm realm = searchModeRealm();
+    realm.setUserSearchFilter("(uid={0})");
+    String filter = captureSearchFilter(realm, "a)(b");
+    assertEquals("(uid=a\\29\\28b)", filter);
+  }
 
   @Test
   public void setGetSearchBase() {

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/topology/impl/DefaultTopologyService.java
@@ -299,13 +299,17 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
   public void deployTopology(Topology t){
 
     try {
+      File topology = new File(topologiesDirectory.getAbsolutePath() + "/" + t.getName() + ".xml");
+      if (!topology.getCanonicalFile().toPath().startsWith(topologiesDirectory.getCanonicalFile().toPath())) {
+        throw new IOException("Resolved topology path escapes managed directory: " + t.getName());
+      }
+
       File temp = new File(topologiesDirectory.getAbsolutePath() + "/" + t.getName() + ".xml.temp");
       Marshaller mr = jaxbContext.createMarshaller();
 
       mr.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
       mr.marshal(t, temp);
 
-      File topology = new File(topologiesDirectory.getAbsolutePath() + "/" + t.getName() + ".xml");
       if(!temp.renameTo(topology)) {
         FileUtils.forceDelete(temp);
         throw new IOException("Could not rename temp file");
@@ -709,8 +713,15 @@ public class DefaultTopologyService extends FileAlterationListenerAdaptor implem
 
     File destFile = new File(dest, name);
     try {
-      FileUtils.writeStringToFile(destFile, content, StandardCharsets.UTF_8);
-      log.wroteConfigurationFile(destFile.getAbsolutePath());
+      final File canonicalDest = dest.getCanonicalFile();
+      final File canonicalFile = destFile.getCanonicalFile();
+      if (!canonicalFile.toPath().startsWith(canonicalDest.toPath())) {
+        log.failedToWriteConfigurationFile(destFile.getAbsolutePath(),
+            new IOException("Resolved path escapes managed directory: " + name));
+        return false;
+      }
+      FileUtils.writeStringToFile(canonicalFile, content, StandardCharsets.UTF_8);
+      log.wroteConfigurationFile(canonicalFile.getAbsolutePath());
       result = true;
     } catch (IOException e) {
       log.failedToWriteConfigurationFile(destFile.getAbsolutePath(), e);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/ZkRemoteConfigurationMonitorService.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/topology/monitor/ZkRemoteConfigurationMonitorService.java
@@ -212,14 +212,14 @@ class ZkRemoteConfigurationMonitorService implements RemoteConfigurationMonitor 
 
     @Override
     public boolean createProvider(String name, String content) {
-        String entryPath = "/knox/config/shared-providers/" + name;
+        String entryPath = "/knox/config/shared-providers/" + FilenameUtils.getName(name);
         client.createEntry(entryPath, content);
         return (client.getEntryData(entryPath) != null);
     }
 
     @Override
     public boolean createDescriptor(String name, String content) {
-        String entryPath = "/knox/config/descriptors/" + name;
+        String entryPath = "/knox/config/descriptors/" + FilenameUtils.getName(name);
         client.createEntry(entryPath, content);
         return (client.getEntryData(entryPath) != null);
     }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/topology/DefaultTopologyServiceTest.java
@@ -596,6 +596,45 @@ public class DefaultTopologyServiceTest {
   }
 
   @Test
+  public void testDeployRejectsPathTraversal() throws Exception {
+    File dir = createDir();
+    File topologyDir = new File(dir, "topologies");
+    topologyDir.mkdirs();
+
+    File descriptorsDir = new File(dir, "descriptors");
+    descriptorsDir.mkdirs();
+
+    File sharedProvidersDir = new File(dir, "shared-providers");
+    sharedProvidersDir.mkdirs();
+
+    try {
+      TopologyService ts = new DefaultTopologyService();
+      Map<String, String> c = new HashMap<>();
+
+      GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+      EasyMock.expect(config.getReadOnlyOverrideTopologyNames()).andReturn(Collections.emptyList()).anyTimes();
+      EasyMock.expect(config.getGatewayTopologyDir()).andReturn(topologyDir.getAbsolutePath()).anyTimes();
+      EasyMock.expect(config.getGatewayConfDir()).andReturn(descriptorsDir.getParentFile().getAbsolutePath()).anyTimes();
+      EasyMock.replay(config);
+
+      ts.init(config, c);
+
+      final String traversalName = "../../evil.json";
+      final File escapeTarget = new File(dir.getParentFile(), "evil.json");
+      assertFalse("precondition: escape target must not pre-exist", escapeTarget.exists());
+
+      assertFalse("deployProviderConfiguration must reject a path-traversal name",
+                  ts.deployProviderConfiguration(traversalName, "malicious"));
+      assertFalse("deployDescriptor must reject a path-traversal name",
+                  ts.deployDescriptor(traversalName, "malicious"));
+
+      assertFalse("no file may be written outside the managed directory", escapeTarget.exists());
+    } finally {
+      FileUtils.deleteQuietly(dir);
+    }
+  }
+
+  @Test
   public void testProviderParamsOrderIsPreserved() {
 
     Provider provider = new Provider();

--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/TopologiesResource.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/TopologiesResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -55,8 +56,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -90,7 +89,7 @@ public class TopologiesResource {
   private static final String SINGLE_DESCRIPTOR_API_PATH = DESCRIPTORS_API_PATH + "/{name}";
 
   private static final int     RESOURCE_NAME_LENGTH_MAX = 100;
-  private static final Pattern RESOURCE_NAME_PATTERN    = Pattern.compile("^[\\w-/.]+$");
+  private static final Pattern RESOURCE_NAME_PATTERN    = Pattern.compile("^[\\w.-]+$");
 
   private static GatewaySpiMessages log = MessagesFactory.get(GatewaySpiMessages.class);
 
@@ -171,12 +170,6 @@ public class TopologiesResource {
   public Topology uploadTopology(@PathParam("id") String id, Topology t) {
     Topology result = null;
 
-    try {
-      id = URLDecoder.decode(id, StandardCharsets.UTF_8.name());
-    } catch (Exception e) {
-      // Ignore
-    }
-
     if (!isValidResourceName(id)) {
       log.invalidResourceName(id);
       throw new BadRequestException("Invalid topology name: " + id);
@@ -187,6 +180,17 @@ public class TopologiesResource {
 
     t.setName(id);
     TopologyService ts = gs.getService(ServiceType.TOPOLOGY_SERVICE);
+
+    GatewayConfig config =
+            (GatewayConfig) request.getServletContext().getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    if (config != null &&
+            config.getReadOnlyOverrideTopologyNames().contains(FilenameUtils.getBaseName(id))) {
+      log.disallowedOverwritingReadOnlyTopology(id);
+      throw new WebApplicationException(
+          status(Response.Status.FORBIDDEN)
+              .entity("{ \"error\" : \"Cannot overwrite read-only topology: " + id + "\" }")
+              .build());
+    }
 
     // Check for existing topology with the same name, to see if it had been generated
     boolean existingGenerated = false;
@@ -338,12 +342,6 @@ public class TopologiesResource {
   public Response uploadProviderConfiguration(@PathParam("name") String name, @Context HttpHeaders headers, String content) {
     Response response = null;
 
-    try {
-      name = URLDecoder.decode(name, StandardCharsets.UTF_8.name());
-    } catch (Exception e) {
-      // Ignore
-    }
-
     if (!isValidResourceName(name)) {
       log.invalidResourceName(name);
       throw new BadRequestException("Invalid provider configuration name: " + name);
@@ -392,12 +390,6 @@ public class TopologiesResource {
                                          @Context HttpHeaders headers,
                                          String content) {
     Response response = null;
-
-    try {
-      name = URLDecoder.decode(name, StandardCharsets.UTF_8.name());
-    } catch (Exception e) {
-      // Ignore
-    }
 
     if (!isValidResourceName(name)) {
       log.invalidResourceName(name);
@@ -554,8 +546,9 @@ public class TopologiesResource {
     return result;
   }
 
-  private static boolean isValidResourceName(final String name) {
+  static boolean isValidResourceName(final String name) {
     return name != null && name.length() <= RESOURCE_NAME_LENGTH_MAX &&
+        !name.contains("..") &&
         RESOURCE_NAME_PATTERN.matcher(name).matches();
   }
 

--- a/gateway-service-admin/src/test/java/org/apache/knox/gateway/service/admin/TopologyResourceTest.java
+++ b/gateway-service-admin/src/test/java/org/apache/knox/gateway/service/admin/TopologyResourceTest.java
@@ -19,7 +19,18 @@ package org.apache.knox.gateway.service.admin;
 
 import org.apache.knox.gateway.topology.Topology;
 import org.apache.knox.gateway.config.GatewayConfig;
+import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ServiceType;
+import org.apache.knox.gateway.services.topology.TopologyService;
+
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
 
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -27,6 +38,9 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TopologyResourceTest {
 
@@ -174,6 +188,28 @@ public class TopologyResourceTest {
 
   }
 
+  @Test
+  public void testResourceNameValidation() {
+    assertTrue(TopologiesResource.isValidResourceName("foo"));
+    assertTrue(TopologiesResource.isValidResourceName("foo.json"));
+    assertTrue(TopologiesResource.isValidResourceName("my-provider_1"));
+    assertTrue(TopologiesResource.isValidResourceName("a.b.c"));
+
+    assertFalse(TopologiesResource.isValidResourceName("../../etc/passwd"));
+    assertFalse(TopologiesResource.isValidResourceName(".."));
+    assertFalse(TopologiesResource.isValidResourceName("foo/bar"));
+    assertFalse(TopologiesResource.isValidResourceName("a/../../b"));
+    assertFalse(TopologiesResource.isValidResourceName("foo..bar"));
+
+    assertFalse(TopologiesResource.isValidResourceName("%2f"));
+    assertFalse(TopologiesResource.isValidResourceName("%252f"));
+
+    assertFalse(TopologiesResource.isValidResourceName(null));
+    assertFalse(TopologiesResource.isValidResourceName(""));
+    assertFalse(TopologiesResource.isValidResourceName("a".repeat(101)));
+    assertTrue(TopologiesResource.isValidResourceName("a".repeat(100)));
+  }
+
   private void setDefaultExpectations(HttpServletRequest request){
     EasyMock.expect( request.getPathInfo() ).andReturn( pathInfo ).anyTimes();
     EasyMock.expect( request.getContextPath() ).andReturn( reqContext ).anyTimes();
@@ -184,6 +220,78 @@ public class TopologyResourceTest {
 
   private void setMockRequestHeader(HttpServletRequest request, String header, String expected){
     EasyMock.expect( request.getHeader( header ) ).andReturn( expected ).anyTimes();
+  }
+
+  @Test
+  public void testUploadTopologyRefusesReadOnlyOverride() throws Exception {
+    TopologyService ts = EasyMock.createMock(TopologyService.class);
+
+    GatewayServices gs = EasyMock.createNiceMock(GatewayServices.class);
+    EasyMock.expect(gs.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
+
+    GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(config.getReadOnlyOverrideTopologyNames())
+        .andReturn(List.of("manager")).anyTimes();
+
+    HttpServletRequest request = mockRequest(gs, config);
+
+    EasyMock.replay(ts, gs, config, request);
+
+    TopologiesResource res = new TopologiesResource();
+    setRequestField(res, request);
+
+    try {
+      res.uploadTopology("manager", new org.apache.knox.gateway.service.admin.beans.Topology());
+      fail("Expected WebApplicationException for read-only override topology");
+    } catch (WebApplicationException e) {
+      assertEquals(Response.Status.FORBIDDEN.getStatusCode(), e.getResponse().getStatus());
+    }
+
+    EasyMock.verify(ts);
+  }
+
+  @Test
+  public void testUploadTopologyAllowedWhenNotReadOnly() throws Exception {
+    TopologyService ts = EasyMock.createMock(TopologyService.class);
+    EasyMock.expect(ts.getTopologies()).andReturn(Collections.emptyList()).anyTimes();
+    ts.deployTopology(EasyMock.anyObject(Topology.class));
+    EasyMock.expectLastCall().once();
+
+    GatewayServices gs = EasyMock.createNiceMock(GatewayServices.class);
+    EasyMock.expect(gs.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
+
+    GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(config.getReadOnlyOverrideTopologyNames())
+        .andReturn(Collections.emptyList()).anyTimes();
+
+    HttpServletRequest request = mockRequest(gs, config);
+
+    EasyMock.replay(ts, gs, config, request);
+
+    TopologiesResource res = new TopologiesResource();
+    setRequestField(res, request);
+
+    res.uploadTopology("sandbox", new org.apache.knox.gateway.service.admin.beans.Topology());
+
+    EasyMock.verify(ts);
+  }
+
+  private HttpServletRequest mockRequest(GatewayServices gs, GatewayConfig config) {
+    ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE))
+        .andReturn(gs).anyTimes();
+    EasyMock.expect(context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE))
+        .andReturn(config).anyTimes();
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getServletContext()).andReturn(context).anyTimes();
+    EasyMock.replay(context);
+    return request;
+  }
+
+  private void setRequestField(TopologiesResource res, HttpServletRequest request) throws Exception {
+    Field f = TopologiesResource.class.getDeclaredField("request");
+    f.setAccessible(true);
+    f.set(res, request);
   }
 
 }

--- a/gateway-service-admin/src/test/java/org/apache/knox/gateway/service/admin/TopologyResourceTest.java
+++ b/gateway-service-admin/src/test/java/org/apache/knox/gateway/service/admin/TopologyResourceTest.java
@@ -30,7 +30,6 @@ import javax.ws.rs.core.Response;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
-import java.util.List;
 
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -206,8 +205,8 @@ public class TopologyResourceTest {
 
     assertFalse(TopologiesResource.isValidResourceName(null));
     assertFalse(TopologiesResource.isValidResourceName(""));
-    assertFalse(TopologiesResource.isValidResourceName("a".repeat(101)));
-    assertTrue(TopologiesResource.isValidResourceName("a".repeat(100)));
+    assertFalse(TopologiesResource.isValidResourceName(repeat("a", 101)));
+    assertTrue(TopologiesResource.isValidResourceName(repeat("a", 100)));
   }
 
   private void setDefaultExpectations(HttpServletRequest request){
@@ -222,6 +221,14 @@ public class TopologyResourceTest {
     EasyMock.expect( request.getHeader( header ) ).andReturn( expected ).anyTimes();
   }
 
+  private static String repeat(String s, int count) {
+    StringBuilder sb = new StringBuilder(s.length() * count);
+    for (int i = 0; i < count; i++) {
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+
   @Test
   public void testUploadTopologyRefusesReadOnlyOverride() throws Exception {
     TopologyService ts = EasyMock.createMock(TopologyService.class);
@@ -231,7 +238,7 @@ public class TopologyResourceTest {
 
     GatewayConfig config = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(config.getReadOnlyOverrideTopologyNames())
-        .andReturn(List.of("manager")).anyTimes();
+        .andReturn(Collections.singletonList("manager")).anyTimes();
 
     HttpServletRequest request = mockRequest(gs, config);
 

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/KnoxSSOMessages.java
@@ -61,6 +61,10 @@ public interface KnoxSSOMessages {
       "not valid according to the configured whitelist: {1}. See documentation for KnoxSSO Whitelisting.")
   void whiteListMatchFail(String original, String whitelist);
 
+  @Message( level = MessageLevel.ERROR, text = "The original URL: {0} for redirecting back after authentication " +
+      "embeds userinfo (e.g. user@host) and is therefore rejected.")
+  void userInfoInOriginalURL(String original);
+
   @Message( level = MessageLevel.INFO, text = "Knox Token service ({0}) stored state for token {1} ({2})")
   void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 }

--- a/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
+++ b/gateway-service-knoxsso/src/main/java/org/apache/knox/gateway/service/knoxsso/WebSSOResource.java
@@ -259,20 +259,27 @@ public class WebSSOResource {
 
       boolean validRedirect = true;
 
-      // If there is a whitelist defined, then the original URL must be validated against it.
-      // If there is no whitelist, then everything is valid.
-      if (whitelist != null) {
-        try {
+      try {
+        // A redirect target embedding userinfo (e.g. https://knox-host:8443@evil/) is
+        // never legitimate; reject it before the host-only whitelist check.
+        if (Urls.containsUserInfo(original)) {
+          validRedirect = false;
+          LOGGER.userInfoInOriginalURL(Log4jAuditor.maskTokenFromURL(original));
+        } else if (whitelist != null) {
+          // If there is a whitelist defined, then the original URL must be validated against it.
+          // If there is no whitelist, then everything is valid.
           validRedirect = RegExUtils.checkBaseUrlAgainstWhitelist(whitelist, original);
-        } catch (MalformedURLException e) {
-          throw new WebApplicationException("Malformed original URL: " + original,
-                  Response.Status.BAD_REQUEST);
+          if (!validRedirect) {
+            LOGGER.whiteListMatchFail(Log4jAuditor.maskTokenFromURL(original), whitelist);
+          }
         }
+      } catch (MalformedURLException e) {
+        throw new WebApplicationException("Malformed original URL: " + original,
+                Response.Status.BAD_REQUEST);
       }
 
       if (!validRedirect) {
-        LOGGER.whiteListMatchFail(Log4jAuditor.maskTokenFromURL(original), whitelist);
-        throw new WebApplicationException("Original URL not valid according to the configured whitelist.",
+        throw new WebApplicationException("Original URL not valid for redirect.",
                                           Response.Status.BAD_REQUEST);
       }
     } else {

--- a/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
+++ b/gateway-service-knoxsso/src/test/java/org/apache/knox/gateway/service/knoxsso/WebSSOResourceTest.java
@@ -472,6 +472,49 @@ public class WebSSOResourceTest {
     }
   }
 
+  @Test
+  public void testUserInfoOriginalURLRejected() throws Exception {
+    ServletContext context = EasyMock.createNiceMock(ServletContext.class);
+    EasyMock.expect(context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE)).andReturn(expectGatewayConfig()).anyTimes();
+
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getParameter("originalUrl")).andReturn(
+        "https://localhost:8443%2f@malicious.link/");
+    EasyMock.expect(request.getAttribute("targetServiceRole")).andReturn("KNOXSSO").anyTimes();
+    EasyMock.expect(request.getParameterMap()).andReturn(Collections.emptyMap());
+    EasyMock.expect(request.getServletContext()).andReturn(context).anyTimes();
+    EasyMock.expect(request.getServerName()).andReturn("localhost").anyTimes();
+
+    Principal principal = EasyMock.createNiceMock(Principal.class);
+    EasyMock.expect(principal.getName()).andReturn("alice").anyTimes();
+    EasyMock.expect(request.getUserPrincipal()).andReturn(principal).anyTimes();
+
+    GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
+    EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services);
+
+    AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(services.getService(ServiceType.ALIAS_SERVICE)).andReturn(aliasService).anyTimes();
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(TokenUtils.SIGNING_HMAC_SECRET_ALIAS)).andReturn(null).anyTimes();
+
+    JWTokenAuthority authority = new TestJWTokenAuthority(gatewayPublicKey, gatewayPrivateKey);
+    EasyMock.expect(services.getService(ServiceType.TOKEN_SERVICE)).andReturn(authority);
+
+    HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
+    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
+    CookieResponseWrapper responseWrapper = new CookieResponseWrapper(response, outputStream);
+
+    EasyMock.replay(principal, services, context, request);
+
+    WebSSOResource webSSOResponse = new WebSSOResource();
+    webSSOResponse.request = request;
+    webSSOResponse.response = responseWrapper;
+    webSSOResponse.context = context;
+    webSSOResponse.init();
+
+    WebApplicationException e = Assert.assertThrows(WebApplicationException.class, webSSOResponse::doGet);
+    assertEquals(HttpStatus.SC_BAD_REQUEST, e.getResponse().getStatus());
+  }
+
   private GatewayConfig expectGatewayConfig() {
     return expectGatewayConfig(true);
   }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -487,6 +487,14 @@ public class TokenResource {
       final String createdBy = uriInfo.getQueryParameters().getFirst("createdBy");
       final String userNameOrCreatedBy = uriInfo.getQueryParameters().getFirst("userNameOrCreatedBy");
       final boolean allTokens = Boolean.parseBoolean(uriInfo.getQueryParameters().getFirst("allTokens"));
+
+      final String caller = SubjectUtils.getCurrentEffectivePrincipalName();
+      if (!isAuthorizedToSeeTokens(caller, userName, createdBy, userNameOrCreatedBy, allTokens)) {
+        log.unauthorizedGetUserTokensRequest(getTopologyName(), caller);
+        return Response.status(Response.Status.FORBIDDEN)
+            .entity("{\n  \"error\": \"Caller (" + caller + ") is not authorized to see other users' tokens.\"\n}\n").build();
+      }
+
       final Collection<KnoxToken> userTokens;
       if (allTokens) {
         userTokens = tokenStateService.getAllTokens();
@@ -518,6 +526,29 @@ public class TokenResource {
       }
       return Response.status(Response.Status.OK).entity(JsonUtils.renderAsJsonString(Collections.singletonMap("tokens", tokens))).build();
     }
+  }
+
+  private boolean isAuthorizedToSeeTokens(String caller, String userName, String createdBy, String userNameOrCreatedBy, boolean allTokens) {
+    if (StringUtils.isBlank(caller)) {
+      return false;
+    }
+    final GatewayConfig config = (GatewayConfig) context.getAttribute(GatewayConfig.GATEWAY_CONFIG_ATTRIBUTE);
+    if (config != null && config.canSeeAllTokens(caller)) {
+      return true;
+    }
+    if (allTokens) {
+      return false;
+    }
+    // an ordinary caller must scope the query to their own tokens
+    final boolean hasIdentifier = userName != null || createdBy != null || userNameOrCreatedBy != null;
+    return hasIdentifier
+        && requestedIsCallerIfPresent(caller, userName)
+        && requestedIsCallerIfPresent(caller, createdBy)
+        && requestedIsCallerIfPresent(caller, userNameOrCreatedBy);
+  }
+
+  private static boolean requestedIsCallerIfPresent(String caller, String requested) {
+    return requested == null || caller.equals(requested);
   }
 
   @GET

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -132,6 +133,7 @@ public class TokenResource {
   private static final String TOKEN_EXP_RENEWAL_MAX_LIFETIME = TOKEN_PARAM_PREFIX + "exp.max-lifetime";
   private static final String TOKEN_EXP_TOKENGEN_ALLOWED_TSS_BACKENDS = TOKEN_PARAM_PREFIX + "exp.tokengen.allowed.tss.backends";
   private static final String TOKEN_RENEWER_WHITELIST = TOKEN_PARAM_PREFIX + "renewer.whitelist";
+  private static final String TOKEN_RENEWER_GROUP_WHITELIST = TOKEN_PARAM_PREFIX + "renewer.group.whitelist";
   private static final String TSS_STATUS_IS_MANAGEMENT_ENABLED = "tokenManagementEnabled";
   private static final String TSS_STATUS_CONFIFURED_BACKEND = "configuredTssBackend";
   private static final String TSS_STATUS_ACTUAL_BACKEND = "actualTssBackend";
@@ -190,6 +192,7 @@ public class TokenResource {
   private UserLimitExceededAction userLimitExceededAction = UserLimitExceededAction.RETURN_ERROR;
 
   private List<String> allowedRenewers;
+  private Set<String> allowedRenewerGroups;
 
   @Context
   HttpServletRequest request;
@@ -333,6 +336,14 @@ public class TokenResource {
       } else {
         log.noRenewersConfigured(topologyName);
       }
+
+      final String renewerGroups = context.getInitParameter(TOKEN_RENEWER_GROUP_WHITELIST);
+      allowedRenewerGroups = StringUtils.isBlank(renewerGroups)
+              ? new HashSet<>()
+              : Arrays.stream(renewerGroups.split(","))
+              .map(String::trim)
+              .filter(s -> !s.isEmpty())
+              .collect(Collectors.toSet());
     }
     setTokenStateServiceStatusMap();
   }
@@ -551,8 +562,9 @@ public class TokenResource {
         errorCode = ErrorCode.INTERNAL_ERROR;
       }
     } else {
-      String renewer = SubjectUtils.getCurrentEffectivePrincipalName();
-      if (allowedRenewers.contains(renewer)) {
+      final String renewer = SubjectUtils.getCurrentEffectivePrincipalName();
+
+      if (tokenRenewalOrRevocationAuthorized(renewer)) {
         try {
           JWTToken jwt = new JWTToken(token);
           if (tokenStateService.isExpired(jwt)) {
@@ -590,6 +602,14 @@ public class TokenResource {
     }
 
     return resp;
+  }
+
+  private boolean tokenRenewalOrRevocationAuthorized(final String principalName) {
+    final boolean userAllowed = allowedRenewers.contains(principalName);
+    final boolean groupAllowed = SubjectUtils.getCurrentGroupPrincipals().stream()
+            .map(GroupPrincipal::getName)
+            .anyMatch(allowedRenewerGroups::contains);
+    return userAllowed || groupAllowed;
   }
 
   @DELETE
@@ -635,7 +655,7 @@ public class TokenResource {
           errorStatus = Response.Status.FORBIDDEN;
           error = "SSO cookie (" + Tokens.getTokenIDDisplayText(tokenId) + ") cannot not be revoked.";
           errorCode = ErrorCode.UNAUTHORIZED;
-        } else if (triesToRevokeOwnToken(tokenId, revoker) || allowedRenewers.contains(revoker)) {
+        } else if (triesToRevokeOwnToken(tokenId, revoker) || tokenRenewalOrRevocationAuthorized(revoker)) {
           tokenStateService.revokeToken(tokenId);
           log.revokedToken(getTopologyName(),
                   Tokens.getTokenDisplayText(token),

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -564,7 +564,7 @@ public class TokenResource {
     } else {
       final String renewer = SubjectUtils.getCurrentEffectivePrincipalName();
 
-      if (tokenRenewalOrRevocationAuthorized(renewer)) {
+      if (tokenStateChangeAuthorized(renewer)) {
         try {
           JWTToken jwt = new JWTToken(token);
           if (tokenStateService.isExpired(jwt)) {
@@ -604,7 +604,7 @@ public class TokenResource {
     return resp;
   }
 
-  private boolean tokenRenewalOrRevocationAuthorized(final String principalName) {
+  private boolean tokenStateChangeAuthorized(final String principalName) {
     final boolean userAllowed = allowedRenewers.contains(principalName);
     final boolean groupAllowed = SubjectUtils.getCurrentGroupPrincipals().stream()
             .map(GroupPrincipal::getName)
@@ -655,7 +655,7 @@ public class TokenResource {
           errorStatus = Response.Status.FORBIDDEN;
           error = "SSO cookie (" + Tokens.getTokenIDDisplayText(tokenId) + ") cannot not be revoked.";
           errorCode = ErrorCode.UNAUTHORIZED;
-        } else if (triesToRevokeOwnToken(tokenId, revoker) || tokenRenewalOrRevocationAuthorized(revoker)) {
+        } else if (triesToChangeOwnToken(tokenId, revoker) || tokenStateChangeAuthorized(revoker)) {
           tokenStateService.revokeToken(tokenId);
           log.revokedToken(getTopologyName(),
                   Tokens.getTokenDisplayText(token),
@@ -695,7 +695,7 @@ public class TokenResource {
     return metadata == null ? false : metadata.isKnoxSsoCookie();
   }
 
-  private boolean triesToRevokeOwnToken(String tokenId, String revoker) throws UnknownTokenException {
+  private boolean triesToChangeOwnToken(String tokenId, String revoker) throws UnknownTokenException {
     final TokenMetadata metadata = tokenStateService.getTokenMetadata(tokenId);
     final String tokenUserName = metadata == null ? "" : metadata.getUserName();
     final String tokenCreatedBy = metadata == null ? "" : metadata.getCreatedBy();
@@ -765,13 +765,19 @@ public class TokenResource {
   private Response setTokenEnabledFlag(String tokenId, boolean enable, boolean batch) {
     String error = "";
     ErrorCode errorCode = ErrorCode.UNKNOWN;
+    Response.Status responseStatus = Response.Status.BAD_REQUEST;
     if (tokenStateService == null) {
       error = "Unable to " + (enable ? "enable" : "disable") + " tokens because token management is not configured";
       errorCode = ErrorCode.CONFIGURATION_ERROR;
     } else {
       try {
         final TokenMetadata tokenMetadata = tokenStateService.getTokenMetadata(tokenId);
-        if (!batch && enable && tokenMetadata.isEnabled()) {
+        final String caller = SubjectUtils.getCurrentEffectivePrincipalName();
+        if (!(triesToChangeOwnToken(tokenId, caller) || tokenStateChangeAuthorized(caller))) {
+          responseStatus = Response.Status.FORBIDDEN;
+          error = "Caller (" + caller + ") not authorized to " + (enable ? "enable" : "disable") + " tokens.";
+          errorCode = ErrorCode.UNAUTHORIZED;
+        } else if (!batch && enable && tokenMetadata.isEnabled()) {
           error = "Token is already enabled";
           errorCode = ErrorCode.ALREADY_ENABLED;
         } else if (!batch && !enable && !tokenMetadata.isEnabled()) {
@@ -791,11 +797,12 @@ public class TokenResource {
     }
 
     if (error.isEmpty()) {
+      responseStatus = Response.Status.OK;
       log.setEnabledFlag(getTopologyName(), enable, Tokens.getTokenIDDisplayText(tokenId));
-      return Response.status(Response.Status.OK).entity("{\n  \"setEnabledFlag\": \"true\",\n  \"isEnabled\": \"" + enable + "\"\n}\n").build();
+      return Response.status(responseStatus).entity("{\n  \"setEnabledFlag\": \"true\",\n  \"isEnabled\": \"" + enable + "\"\n}\n").build();
     } else {
       log.badSetEnabledFlagRequest(getTopologyName(), Tokens.getTokenIDDisplayText(tokenId), error);
-      return Response.status(Response.Status.BAD_REQUEST).entity("{\n  \"setEnabledFlag\": \"false\",\n  \"error\": \"" + error + "\",\n  \"code\": " + errorCode.toInt() + "\n}\n").build();
+      return Response.status(responseStatus).entity("{\n  \"setEnabledFlag\": \"false\",\n  \"error\": \"" + error + "\",\n  \"code\": " + errorCode.toInt() + "\n}\n").build();
     }
   }
 

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -77,6 +77,9 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected a bad set enabled flag request for token {1}: {2}")
   void badSetEnabledFlagRequest(String topologyName, String tokenId, String error);
 
+  @Message( level = MessageLevel.ERROR, text = "Knox Token service ({0}) rejected an unauthorized getUserTokens request from caller ({1})")
+  void unauthorizedGetUserTokensRequest(String topologyName, String caller);
+
   @Message( level = MessageLevel.DEBUG, text = "Knox Token service ({0}) stored state for token {1} ({2})")
   void storedToken(String topologyName, String tokenDisplayText, String tokenId);
 

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenRenewalTestConfigs.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenRenewalTestConfigs.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import javax.security.auth.Subject;
+
+class TokenRenewalTestConfigs {
+    //true, if server-side token state management should be enabled in the service; Otherwise, false or null.
+    private final Boolean serviceLevelConfig;
+
+    //true, if server-side token state management should be enabled in the gateway-site.xml; Otherwise, false or null.
+    private final Boolean gatewayLevelConfig;
+
+    //A comma-delimited list of permitted renewer usernames
+    private final String renewers;
+
+    //A comma-delimited list of permitted renewer group names
+    private final String groupRenewers;
+
+    //The maximum duration (milliseconds) for a token's lifetime
+    private final Long maxTokenLifetime;
+
+    //The security subject who's making the request
+    private final Subject caller;
+
+    private TokenRenewalTestConfigs(Builder builder) {
+        this.serviceLevelConfig = builder.serviceLevelConfig;
+        this.gatewayLevelConfig = builder.gatewayLevelConfig;
+        this.renewers = builder.renewers;
+        this.groupRenewers = builder.groupRenewers;
+        this.maxTokenLifetime = builder.maxTokenLifetime;
+        this.caller = builder.caller;
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    Boolean getServiceLevelConfig() {
+        return serviceLevelConfig;
+    }
+
+    Boolean getGatewayLevelConfig() {
+        return gatewayLevelConfig;
+    }
+
+    boolean isTokenStateServerManaged() {
+        return Boolean.TRUE.equals(serviceLevelConfig) || Boolean.TRUE.equals(gatewayLevelConfig);
+    }
+
+    String getRenewers() {
+        return renewers;
+    }
+
+    String getGroupRenewers() {
+        return groupRenewers;
+    }
+
+    Long getMaxTokenLifetime() {
+        return maxTokenLifetime;
+    }
+
+    Subject getCaller() {
+        return caller;
+    }
+
+    static class Builder {
+        private Boolean serviceLevelConfig;
+        private Boolean gatewayLevelConfig;
+        private String renewers;
+        private String groupRenewers;
+        private Long maxTokenLifetime;
+        private Subject caller;
+
+        Builder serviceLevelConfig(boolean serviceLevelConfig) {
+            this.serviceLevelConfig = serviceLevelConfig;
+            return this;
+        }
+
+        Builder gatewayLevelConfig(boolean gatewayLevelConfig) {
+            this.gatewayLevelConfig = gatewayLevelConfig;
+            return this;
+        }
+
+        Builder renewers(String renewers) {
+            this.renewers = renewers;
+            return this;
+        }
+
+        Builder groupRenewers(String groupRenewers) {
+            this.groupRenewers = groupRenewers;
+            return this;
+        }
+
+        Builder maxTokenLifetime(Long maxTokenLifetime) {
+            this.maxTokenLifetime = maxTokenLifetime;
+            return this;
+        }
+
+        Builder caller(Subject caller) {
+            this.caller = caller;
+            return this;
+        }
+
+        @SuppressWarnings("PMD.AccessorClassGeneration")
+        TokenRenewalTestConfigs build() {
+            return new TokenRenewalTestConfigs(this);
+        }
+    }
+}

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -85,6 +85,7 @@ import org.apache.commons.codec.digest.HmacAlgorithms;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.context.ContextAttributes;
+import org.apache.knox.gateway.security.GroupPrincipal;
 import org.apache.knox.gateway.security.ImpersonatedPrincipal;
 import org.apache.knox.gateway.security.PrimaryPrincipal;
 import org.apache.knox.gateway.services.GatewayServices;
@@ -648,22 +649,37 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRenewal_ServerManagedStateConfiguredAtGatewayOnly() throws Exception {
     final String caller = "yarn";
-    Response renewalResponse = doTestTokenRenewal(null, true, caller, null, createTestSubject(caller)).getValue();
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .gatewayLevelConfig(true)
+            .renewers(caller)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateSuccessfulRenewalResponse(renewalResponse);
   }
 
   @Test
   public void testTokenRenewal_ServerManagedStateDisabledAtGatewayWithServiceOverride() throws Exception {
     final String caller = "yarn";
-    Response renewalResponse = doTestTokenRenewal(true, false, caller, null, createTestSubject(caller)).getValue();
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers(caller)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateSuccessfulRenewalResponse(renewalResponse);
   }
 
   @Test
   public void testTokenRenewal_ServerManagedStateEnabledAtGatewayWithServiceOverride() throws Exception {
     final String caller = "yarn";
-    Map.Entry<TestTokenStateService, Response> result =
-            doTestTokenRenewal(false, true, caller, null, createTestSubject(caller));
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .gatewayLevelConfig(true)
+            .serviceLevelConfig(false)
+            .renewers(caller)
+            .caller(createTestSubject(caller))
+            .build();
+    final Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(configs);
 
     // Make sure the expiration was not recorded by the TokenStateService, since it is disabled for this test
     TestTokenStateService tss = result.getKey();
@@ -680,7 +696,8 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRenewal_ServerManagedStateNotConfiguredAtAll() throws Exception {
-    Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(null, null, null, null, null);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder().build();
+    Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(configs);
 
     // Make sure the expiration was not recorded by the TokenStateService, since it is disabled for this test
     TestTokenStateService tss = result.getKey();
@@ -697,7 +714,10 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRenewal_Disabled() throws Exception {
-    Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(false, null, null, null);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(false)
+            .build();
+    final Map.Entry<TestTokenStateService, Response> result = doTestTokenRenewal(configs);
 
     // Make sure the expiration was not recorded by the TokenStateService, since it is disabled for this test
     TestTokenStateService tss = result.getKey();
@@ -714,14 +734,19 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRenewal_Enabled_NoRenewersNoSubject() throws Exception {
-    Response renewalResponse = doTestTokenRenewal(true, null, null);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder().gatewayLevelConfig(true).build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateRenewalResponse(renewalResponse, 403, false, "Caller (null) not authorized to renew tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
   }
 
   @Test
   public void testTokenRenewal_Enabled_NoRenewersWithSubject() throws Exception {
     final String caller = "yarn";
-    Response renewalResponse = doTestTokenRenewal(true, null, createTestSubject(caller));
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateRenewalResponse(renewalResponse,
                             403,
                             false,
@@ -730,7 +755,11 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRenewal_Enabled_WithRenewersNoSubject() throws Exception {
-    Response renewalResponse = doTestTokenRenewal(true, "larry, moe,  curly ", null);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("larry, moe,  curly ")
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateRenewalResponse(renewalResponse,
                             403,
                             false,
@@ -740,7 +769,12 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRenewal_Enabled_WithRenewersWithInvalidSubject() throws Exception {
     final String caller = "shemp";
-    Response renewalResponse = doTestTokenRenewal(true, "larry, moe,  curly ", createTestSubject(caller));
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("larry, moe,  curly ")
+            .caller(createTestSubject(caller))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateRenewalResponse(renewalResponse,
                             403,
                             false,
@@ -750,24 +784,59 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRenewal_Enabled_WithRenewersWithValidSubject() throws Exception {
     final String caller = "shemp";
-    Response renewalResponse =
-                      doTestTokenRenewal(true, ("larry, moe,  curly ," + caller), createTestSubject(caller));
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("larry, moe,  curly, " + caller)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
     validateSuccessfulRenewalResponse(renewalResponse);
+  }
+
+  @Test
+  public void testTokenRenewal_Enabled_WithoutUserRenewerAndWithCorrectGroup() throws Exception {
+    final String caller = "bob";
+    final String group = "devOps";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .groupRenewers(group)
+            .caller(createTestSubject(caller, group))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
+    validateSuccessfulRenewalResponse(renewalResponse);
+  }
+
+  @Test
+  public void testTokenRenewal_Enabled_WithoutUserRenewerOrCorrectGroup() throws Exception {
+    final String caller = "bob";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .groupRenewers("devOps")
+            .caller(createTestSubject(caller, "anotherGroup"))
+            .build();
+    final Response renewalResponse = doTestTokenRenewal(configs).getValue();
+    validateRenewalResponse(renewalResponse,
+            403,
+            false,
+            "Caller (" + caller + ") not authorized to renew tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
   }
 
   @Test
   public void testTokenRenewal_Enabled_WithDefaultMaxTokenLifetime() throws Exception {
     final String caller = "yarn";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers(caller)
+            .caller(createTestSubject(caller))
+            .build();
 
-    // Max lifetime duration is 10ms
-    Map.Entry<TestTokenStateService, Response> testResult =
-                  doTestTokenRenewal(true, caller, null, createTestSubject(caller));
+    final Map.Entry<TestTokenStateService, Response> testResult = doTestTokenRenewal(configs);
 
     TestTokenStateService tss = testResult.getKey();
     assertEquals(1, tss.issueTimes.size());
     String token = tss.issueTimes.keySet().iterator().next();
 
-    // Verify that the configured max lifetime was honored
+    // Verify that the default max lifetime was honored
     assertEquals(tss.getDefaultMaxLifetimeDuration(), tss.getMaxLifetime(token) - tss.getIssueTime(token));
   }
 
@@ -775,10 +844,14 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRenewal_Enabled_WithConfigurableMaxTokenLifetime() throws Exception {
     final String caller = "yarn";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers(caller)
+            .caller(createTestSubject(caller))
+            .maxTokenLifetime(10L) // Max lifetime duration is 10ms
+            .build();
 
-    // Max lifetime duration is 10ms
-    Map.Entry<TestTokenStateService, Response> testResult =
-                                              doTestTokenRenewal(true, caller, 10L, createTestSubject(caller));
+    final Map.Entry<TestTokenStateService, Response> testResult = doTestTokenRenewal(configs);
 
     TestTokenStateService tss = testResult.getKey();
     assertEquals(1, tss.issueTimes.size());
@@ -809,8 +882,9 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRevocation_ServerManagedStateNotConfigured() throws Exception {
-    Response renewalResponse = doTestTokenRevocation(null, null, null);
-    validateRevocationResponse(renewalResponse,
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder().build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
                                400,
                                false,
                                "Token revocation support is not configured", TokenResource.ErrorCode.CONFIGURATION_ERROR);
@@ -818,8 +892,9 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRevocation_Disabled() throws Exception {
-    Response renewalResponse = doTestTokenRevocation(false, null, null);
-    validateRevocationResponse(renewalResponse,
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder().gatewayLevelConfig(false).build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
                                400,
                                false,
                                "Token revocation support is not configured", TokenResource.ErrorCode.CONFIGURATION_ERROR);
@@ -827,8 +902,9 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRevocation_Enabled_NoRenewersNoSubject() throws Exception {
-    Response renewalResponse = doTestTokenRevocation(true, null, null);
-    validateRevocationResponse(renewalResponse,
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder().serviceLevelConfig(true).build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
                                403,
                                false,
                                "Caller (null) not authorized to revoke tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
@@ -837,8 +913,12 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRevocation_Enabled_NoRenewersWithSubject() throws Exception {
     final String caller = "yarn";
-    Response renewalResponse = doTestTokenRevocation(true, null, createTestSubject(caller));
-    validateRevocationResponse(renewalResponse,
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
                                403,
                                false,
                                "Caller (" + caller + ") not authorized to revoke tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
@@ -846,8 +926,12 @@ public class TokenServiceResourceTest {
 
   @Test
   public void testTokenRevocation_Enabled_WithRenewersNoSubject() throws Exception {
-    Response renewalResponse = doTestTokenRevocation(true, "larry, moe,  curly ", null);
-    validateRevocationResponse(renewalResponse,
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("larry, moe,  curly ")
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
                                403,
                                false,
                                "Caller (null) not authorized to revoke tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
@@ -856,8 +940,13 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRevocation_Enabled_WithRenewersWithInvalidSubject() throws Exception {
     final String caller = "shemp";
-    Response renewalResponse = doTestTokenRevocation(true, "larry, moe,  curly ", createTestSubject(caller));
-    validateRevocationResponse(renewalResponse,
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("larry, moe,  curly ")
+            .caller(createTestSubject(caller))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
                                403,
                                false,
                                "Caller (" + caller + ") not authorized to revoke tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
@@ -866,21 +955,61 @@ public class TokenServiceResourceTest {
   @Test
   public void testTokenRevocation_Enabled_WithRenewersWithValidSubject() throws Exception {
     final String caller = "shemp";
-    Response renewalResponse =
-        doTestTokenRevocation(true, ("larry, moe,  curly ," + caller), createTestSubject(caller));
-    validateSuccessfulRevocationResponse(renewalResponse);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("larry, moe,  curly ," + caller)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateSuccessfulRevocationResponse(revocationResponse);
   }
 
   @Test
   public void testTokenRevocation_Enabled_RevokeOwnToken() throws Exception {
-    final Response renewalResponse = doTestTokenRevocation(true, null, createTestSubject(USER_NAME));
-    validateSuccessfulRevocationResponse(renewalResponse);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(USER_NAME))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateSuccessfulRevocationResponse(revocationResponse);
   }
 
   @Test
   public void testTokenRevocation_Enabled_RevokeImpersonatedToken() throws Exception {
-    final Response renewalResponse = doTestTokenRevocation(true, null, createTestSubject(USER_NAME), "impersonatedUserName");
-    validateSuccessfulRevocationResponse(renewalResponse);
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(USER_NAME))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs, "impersonatedUserName");
+    validateSuccessfulRevocationResponse(revocationResponse);
+  }
+
+  @Test
+  public void testTokenRevocation_Enabled_WithoutUserRenewerAndWithCorrectGroup() throws Exception {
+    final String caller = "bob";
+    final String group = "devOps";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .groupRenewers(group)
+            .caller(createTestSubject(caller, group))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateSuccessfulRevocationResponse(revocationResponse);
+  }
+
+  @Test
+  public void testTokenRevocation_Enabled_WithoutUserRenewerOrCorrectGroup() throws Exception {
+    final String caller = "bob";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .groupRenewers("devOps")
+            .caller(createTestSubject(caller, "anotherGroup"))
+            .build();
+    final Response revocationResponse = doTestTokenRevocation(configs);
+    validateRevocationResponse(revocationResponse,
+            403,
+            false,
+            "Caller (" + caller + ") not authorized to revoke tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
   }
 
   @Test
@@ -1473,131 +1602,32 @@ public class TokenServiceResourceTest {
     }
   }
 
-  /**
-   *
-   * @param isTokenStateServerManaged true, if server-side token state management should be enabled; Otherwise, false or null.
-   * @param renewers A comma-delimited list of permitted renewer user names
-   * @param caller The user name making the request
-   *
-   * @return The Response from the token renewal request
-   *
-   * @throws Exception
-   */
-  private Response doTestTokenRenewal(final Boolean isTokenStateServerManaged,
-                                      final String  renewers,
-                                      final Subject caller) throws Exception {
-    return doTestTokenRenewal(isTokenStateServerManaged, renewers, null, caller).getValue();
-  }
 
   /**
-   *
-   * @param isTokenStateServerManaged true, if server-side token state management should be enabled; Otherwise, false or null.
-   * @param renewers                  A comma-delimited list of permitted renewer user names
-   * @param maxTokenLifetime          The maximum duration (milliseconds) for a token's lifetime
-   * @param caller                    The user name making the request
-   *
    * @return The Response from the token renewal request
-   *
-   * @throws Exception
    */
-  private Map.Entry<TestTokenStateService, Response> doTestTokenRenewal(final Boolean isTokenStateServerManaged,
-                                                                        final String  renewers,
-                                                                        final Long    maxTokenLifetime,
-                                                                        final Subject caller) throws Exception {
-    return doTestTokenRenewal(isTokenStateServerManaged,
-                              null,
-                              renewers,
-                              maxTokenLifetime,
-                              caller);
-  }
-
-  /**
-   *
-   * @param serviceLevelConfig true, if server-side token state management should be enabled; Otherwise, false or null.
-   * @param gatewayLevelConfig true, if server-side token state management should be enabled; Otherwise, false or null.
-   * @param renewers           A comma-delimited list of permitted renewer user names
-   * @param maxTokenLifetime   The maximum duration (milliseconds) for a token's lifetime
-   * @param caller             The user name making the request
-   *
-   * @return The Response from the token renewal request
-   *
-   * @throws Exception
-   */
-  private Map.Entry<TestTokenStateService, Response> doTestTokenRenewal(final Boolean serviceLevelConfig,
-                                                                        final Boolean gatewayLevelConfig,
-                                                                        final String  renewers,
-                                                                        final Long    maxTokenLifetime,
-                                                                        final Subject caller) throws Exception {
+  private Map.Entry<TestTokenStateService, Response> doTestTokenRenewal(final TokenRenewalTestConfigs configs) throws Exception {
     return doTestTokenLifecyle(TokenLifecycleOperation.Renew,
-                               serviceLevelConfig,
-                               gatewayLevelConfig,
-                               renewers,
-                               maxTokenLifetime,
-                               caller);
+            configs.getServiceLevelConfig(),
+            configs.getGatewayLevelConfig(),
+            configs.getRenewers(),
+            configs.getGroupRenewers(),
+            configs.getMaxTokenLifetime(),
+            configs.getCaller(),
+            null);
   }
 
 
   /**
-   *
-   * @param isTokenStateServerManaged true, if server-side token state management should be enabled; Otherwise, false or null.
-   * @param renewers A comma-delimited list of permitted renewer user names
-   * @param caller The user name making the request
-   *
    * @return The Response from the token revocation request
-   *
-   * @throws Exception
    */
-  private Response doTestTokenRevocation(final Boolean isTokenStateServerManaged,
-                                         final String  renewers,
-                                         final Subject caller) throws Exception {
-    return doTestTokenLifecyle(TokenLifecycleOperation.Revoke, isTokenStateServerManaged, renewers, caller);
+  private Response doTestTokenRevocation(final TokenRenewalTestConfigs configs) throws Exception {
+    return doTestTokenRevocation(configs, null);
   }
 
-  private Response doTestTokenRevocation(final Boolean isTokenStateServerManaged, final String renewers, final Subject caller, String impersonatedUser)
+  private Response doTestTokenRevocation(final TokenRenewalTestConfigs configs, String impersonatedUser)
       throws Exception {
-    return doTestTokenLifecyle(TokenLifecycleOperation.Revoke, isTokenStateServerManaged, null, renewers, null, caller, impersonatedUser).getValue();
-  }
-
-  /**
-   * @param operation     A TokenLifecycleOperation
-   * @param serverManaged true, if server-side token state management should be enabled; Otherwise, false or null.
-   * @param renewers      A comma-delimited list of permitted renewer user names
-   * @param caller        The user name making the request
-   *
-   * @return The Response from the token revocation request
-   *
-   * @throws Exception
-   */
-  private Response doTestTokenLifecyle(final TokenLifecycleOperation operation,
-                                       final Boolean                 serverManaged,
-                                       final String                  renewers,
-                                       final Subject                 caller) throws Exception {
-    return doTestTokenLifecyle(operation, serverManaged, renewers, null, caller).getValue();
-  }
-
-  /**
-   * @param operation          A TokenLifecycleOperation
-   * @param serviceLevelConfig true, if server-side token state management should be enabled at the service level;
-   *                           Otherwise, false or null.
-   * @param renewers           A comma-delimited list of permitted renewer user names
-   * @param maxTokenLifetime   The maximum lifetime duration for a token.
-   * @param caller             The user name making the request
-   *
-   * @return The Response from the token revocation request
-   *
-   * @throws Exception
-   */
-  private Map.Entry<TestTokenStateService, Response> doTestTokenLifecyle(final TokenLifecycleOperation operation,
-                                                                         final Boolean                 serviceLevelConfig,
-                                                                         final String                  renewers,
-                                                                         final Long                    maxTokenLifetime,
-                                                                         final Subject                 caller) throws Exception {
-    return doTestTokenLifecyle(operation, serviceLevelConfig, null, renewers, maxTokenLifetime, caller);
-  }
-
-  private Map.Entry<TestTokenStateService, Response> doTestTokenLifecyle(final TokenLifecycleOperation operation, final Boolean serviceLevelConfig,
-      final Boolean gatewayLevelConfig, final String renewers, final Long maxTokenLifetime, final Subject caller) throws Exception {
-    return doTestTokenLifecyle(operation, serviceLevelConfig, gatewayLevelConfig, renewers, maxTokenLifetime, caller, null);
+    return doTestTokenLifecyle(TokenLifecycleOperation.Revoke, configs.isTokenStateServerManaged(), null, configs.getRenewers(), configs.getGroupRenewers(), null, configs.getCaller(), impersonatedUser).getValue();
   }
 
   /**
@@ -1618,6 +1648,7 @@ public class TokenServiceResourceTest {
                                                                          final Boolean                 serviceLevelConfig,
                                                                          final Boolean                 gatewayLevelConfig,
                                                                          final String                  renewers,
+                                                                         final String                  groupRenewers,
                                                                          final Long                    maxTokenLifetime,
                                                                          final Subject                 caller,
                                                                          final String impersonatedUser) throws Exception {
@@ -1633,6 +1664,7 @@ public class TokenServiceResourceTest {
       }
     }
     contextExpectations.put("knox.token.renewer.whitelist", renewers);
+    contextExpectations.put("knox.token.renewer.group.whitelist", groupRenewers);
 
     if (StringUtils.isNotBlank(impersonatedUser)) {
       contextExpectations.put(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, "true");
@@ -1756,11 +1788,16 @@ public class TokenServiceResourceTest {
    *
    * @return A Subject
    */
-  private Subject createTestSubject(final String username) {
+  private Subject createTestSubject(final String username, final String... groups) {
     Subject s = new Subject();
 
     Set<Principal> principals = s.getPrincipals();
     principals.add(new PrimaryPrincipal(username));
+    if (groups != null) {
+      for (String group : groups) {
+        principals.add(new GroupPrincipal(group));
+      }
+    }
 
     return s;
   }

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -134,7 +134,9 @@ public class TokenServiceResourceTest {
 
   private enum TokenLifecycleOperation {
     Renew,
-    Revoke
+    Revoke,
+    Enable,
+    Disable
   }
 
   @BeforeClass
@@ -1013,6 +1015,104 @@ public class TokenServiceResourceTest {
   }
 
   @Test
+  public void testTokenDisable_Enabled_NoSubject() throws Exception {
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder().serviceLevelConfig(true).build();
+    final Response response = doTestSetTokenEnabledFlag(configs, false);
+    validateSetEnabledFlagResponse(response, 403, false,
+            "Caller (null) not authorized to disable tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_UnauthorizedCaller() throws Exception {
+    final String caller = "scott";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response response = doTestSetTokenEnabledFlag(configs, false);
+    validateSetEnabledFlagResponse(response, 403, false,
+            "Caller (" + caller + ") not authorized to disable tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_OwnToken() throws Exception {
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(USER_NAME))
+            .build();
+    final Response response = doTestSetTokenEnabledFlag(configs, false);
+    validateSuccessfulSetEnabledFlagResponse(response, false);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_WithRenewerWhitelist() throws Exception {
+    final String caller = "scott";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .renewers("tony, dany,  steve ," + caller)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response response = doTestSetTokenEnabledFlag(configs, false);
+    validateSuccessfulSetEnabledFlagResponse(response, false);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_WithGroupRenewerWhitelist() throws Exception {
+    final String caller = "scott";
+    final String group = "devOps";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .groupRenewers(group)
+            .caller(createTestSubject(caller, group))
+            .build();
+    final Response response = doTestSetTokenEnabledFlag(configs, false);
+    validateSuccessfulSetEnabledFlagResponse(response, false);
+  }
+
+  @Test
+  public void testTokenEnable_UnauthorizedCallerRejectedBeforeStateCheck() throws Exception {
+    final String caller = "scott";
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(caller))
+            .build();
+    final Response response = doTestSetTokenEnabledFlag(configs, true);
+    validateSetEnabledFlagResponse(response, 403, false,
+            "Caller (" + caller + ") not authorized to enable tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
+  }
+
+  @Test
+  public void testTokenEnable_AlreadyEnabled_OwnerGetsStateCheck() throws Exception {
+    final TokenRenewalTestConfigs configs = TokenRenewalTestConfigs.builder()
+            .serviceLevelConfig(true)
+            .caller(createTestSubject(USER_NAME))
+            .build();
+    final Response response = doTestSetTokenEnabledFlag(configs, true);
+    validateSetEnabledFlagResponse(response, 400, false,
+            "Token is already enabled", TokenResource.ErrorCode.ALREADY_ENABLED);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_ImpersonatorCanDisableCreatedToken() throws Exception {
+    final Response response = doTestImpersonatedTokenSetEnabledFlag(createTestSubject(USER_NAME), false);
+    validateSuccessfulSetEnabledFlagResponse(response, false);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_ImpersonatedUserCanDisableOwnToken() throws Exception {
+    final Response response = doTestImpersonatedTokenSetEnabledFlag(createTestSubject("impersonatedUserName"), false);
+    validateSuccessfulSetEnabledFlagResponse(response, false);
+  }
+
+  @Test
+  public void testTokenDisable_Enabled_UnauthorizedCallerCannotDisableImpersonatedToken() throws Exception {
+    final String caller = "scott";
+    final Response response = doTestImpersonatedTokenSetEnabledFlag(createTestSubject(caller), false);
+    validateSetEnabledFlagResponse(response, 403, false,
+            "Caller (" + caller + ") not authorized to disable tokens.", TokenResource.ErrorCode.UNAUTHORIZED);
+  }
+
+  @Test
   public void testKidJkuClaims() throws Exception {
     final Map<String, String> contextExpectations = new HashMap<>();
     contextExpectations.put("knox.token.ttl", "60000");
@@ -1630,6 +1730,42 @@ public class TokenServiceResourceTest {
     return doTestTokenLifecyle(TokenLifecycleOperation.Revoke, configs.isTokenStateServerManaged(), null, configs.getRenewers(), configs.getGroupRenewers(), null, configs.getCaller(), impersonatedUser).getValue();
   }
 
+  private Response doTestSetTokenEnabledFlag(final TokenRenewalTestConfigs configs, final boolean enable) throws Exception {
+    final TokenLifecycleOperation operation = enable ? TokenLifecycleOperation.Enable : TokenLifecycleOperation.Disable;
+    return doTestTokenLifecyle(operation, configs.isTokenStateServerManaged(), null, configs.getRenewers(), configs.getGroupRenewers(), null, configs.getCaller(), null).getValue();
+  }
+
+  /**
+   * Issues a token under an impersonating subject (so the persisted metadata has
+   * userName=impersonated user and createdBy=impersonator) and then attempts to flip its
+   * enabled flag as {@code caller}. Mirrors the impersonated-token creation flow in
+   * {@link #testCreateImpersonatedToken(boolean)}.
+   */
+  private Response doTestImpersonatedTokenSetEnabledFlag(final Subject caller, final boolean enable) throws Exception {
+    final String impersonatedUser = "impersonatedUserName";
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.exp.server-managed", Boolean.TRUE.toString());
+    contextExpectations.put(TokenResource.QUERY_PARAMETER_DOAS, impersonatedUser);
+    contextExpectations.put(AuthFilterUtils.PROXYUSER_PREFIX + "." + USER_NAME + ".users", impersonatedUser);
+    contextExpectations.put(AuthFilterUtils.PROXYUSER_PREFIX + "." + USER_NAME + ".hosts", "*");
+    contextExpectations.put(ContextAttributes.IMPERSONATION_ENABLED_ATTRIBUTE, Boolean.TRUE.toString());
+    configureCommonExpectations(contextExpectations, Boolean.TRUE);
+
+    final TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    final Subject issuer = createTestSubject(USER_NAME);
+    issuer.getPrincipals().add(new ImpersonatedPrincipal(impersonatedUser));
+    final Response issueResponse = Subject.doAs(issuer, (PrivilegedAction<Response>) () -> tr.doGet());
+    assertEquals(200, issueResponse.getStatus());
+    final String accessToken = getTagValue(issueResponse.getEntity().toString(), "access_token");
+    final String tokenId = TokenUtils.getTokenId(new JWTToken(accessToken));
+
+    return requestSetTokenEnabledFlag(tr, tokenId, enable, caller);
+  }
+
   /**
    * @param operation          A TokenLifecycleOperation
    * @param serviceLevelConfig true, if server-side token state management should be enabled at the service level;
@@ -1686,6 +1822,12 @@ public class TokenServiceResourceTest {
       case Revoke:
         response = requestTokenRevocation(tr, accessToken, caller);
         break;
+      case Enable:
+        response = requestSetTokenEnabledFlag(tr, TokenUtils.getTokenId(new JWTToken(accessToken)), true, caller);
+        break;
+      case Disable:
+        response = requestSetTokenEnabledFlag(tr, TokenUtils.getTokenId(new JWTToken(accessToken)), false, caller);
+        break;
       default:
         throw new Exception("Invalid operation: " + operation);
     }
@@ -1729,6 +1871,11 @@ public class TokenServiceResourceTest {
     return response;
   }
 
+  private static Response requestSetTokenEnabledFlag(final TokenResource tr, final String tokenId, final boolean enable, final Subject caller) {
+    final PrivilegedAction<Response> action = () -> enable ? tr.enable(tokenId) : tr.disable(tokenId);
+    return caller != null ? Subject.doAs(caller, action) : action.run();
+  }
+
   private static void validateSuccessfulRenewalResponse(final Response response) throws IOException {
     validateRenewalResponse(response, 200, true, null, null);
   }
@@ -1738,13 +1885,22 @@ public class TokenServiceResourceTest {
                                               final boolean  expectedResult,
                                               final String   expectedMessage,
                                               final TokenResource.ErrorCode expectedCode) throws IOException {
+    validateLifecycleResponse(response, "renewed", expectedStatusCode, expectedResult, expectedMessage, expectedCode);
+  }
+
+  private static void validateLifecycleResponse(final Response response,
+                                                final String   resultField,
+                                                final int      expectedStatusCode,
+                                                final boolean  expectedResult,
+                                                final String   expectedMessage,
+                                                final TokenResource.ErrorCode expectedCode) throws IOException {
     assertEquals(expectedStatusCode, response.getStatus());
     assertTrue(response.hasEntity());
     String responseContent = (String) response.getEntity();
     assertNotNull(responseContent);
     assertFalse(responseContent.isEmpty());
     Map<String, Object> json = parseJSONResponse(responseContent);
-    boolean result = Boolean.valueOf((String)json.get("renewed"));
+    boolean result = Boolean.parseBoolean((String) json.get(resultField));
     assertEquals(expectedResult, result);
     assertEquals(expectedMessage, json.get("error"));
     if (expectedCode != null) {
@@ -1761,18 +1917,21 @@ public class TokenServiceResourceTest {
                                                  final boolean  expectedResult,
                                                  final String   expectedMessage,
                                                  final TokenResource.ErrorCode expectedCode) throws IOException {
-    assertEquals(expectedStatusCode, response.getStatus());
-    assertTrue(response.hasEntity());
-    String responseContent = (String) response.getEntity();
-    assertNotNull(responseContent);
-    assertFalse(responseContent.isEmpty());
-    Map<String, Object> json = parseJSONResponse(responseContent);
-    boolean result = Boolean.valueOf((String)json.get("revoked"));
-    assertEquals(expectedResult, result);
-    assertEquals(expectedMessage, json.get("error"));
-    if (expectedCode != null) {
-      assertEquals(expectedCode.toInt(), json.get("code"));
-    }
+    validateLifecycleResponse(response, "revoked", expectedStatusCode, expectedResult, expectedMessage, expectedCode);
+  }
+
+  private static void validateSuccessfulSetEnabledFlagResponse(final Response response, final boolean enable) throws IOException {
+    validateSetEnabledFlagResponse(response, 200, true, null, null);
+    final Map<String, Object> json = parseJSONResponse((String) response.getEntity());
+    assertEquals(String.valueOf(enable), json.get("isEnabled"));
+  }
+
+  private static void validateSetEnabledFlagResponse(final Response response,
+                                                     final int      expectedStatusCode,
+                                                     final boolean  expectedResult,
+                                                     final String   expectedMessage,
+                                                     final TokenResource.ErrorCode expectedCode) throws IOException {
+    validateLifecycleResponse(response, "setEnabledFlag", expectedStatusCode, expectedResult, expectedMessage, expectedCode);
   }
 
 

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -109,6 +109,7 @@ import org.apache.knox.gateway.services.token.impl.JDBCTokenStateService;
 import org.apache.knox.gateway.util.AuthFilterUtils;
 import org.apache.knox.gateway.util.JsonUtils;
 import org.easymock.EasyMock;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -131,6 +132,7 @@ public class TokenServiceResourceTest {
   private JWTokenAuthority authority;
   private TestTokenStateService tss = new TestTokenStateService();
   private char[] hmacSecret;
+  private final Set<String> usersCanSeeAllTokens = new HashSet<>();
 
   private enum TokenLifecycleOperation {
     Renew,
@@ -147,6 +149,11 @@ public class TokenServiceResourceTest {
 
     publicKey = (RSAPublicKey) KPair.getPublic();
     privateKey = (RSAPrivateKey) KPair.getPrivate();
+  }
+
+  @After
+  public void cleanUp() {
+    this.usersCanSeeAllTokens.clear();
   }
 
   private void configureCommonExpectations(Map<String, String> contextExpectations) throws Exception {
@@ -203,6 +210,8 @@ public class TokenServiceResourceTest {
       EasyMock.expect(config.getServiceParameter(tokenStateServiceType, "impl")).andReturn(contextExpectations.get(tokenStateServiceType)).anyTimes();
     }
     EasyMock.expect(config.getKnoxTokenHashAlgorithm()).andReturn(HmacAlgorithms.HMAC_SHA_256.getName()).anyTimes();
+    EasyMock.expect(config.canSeeAllTokens(EasyMock.anyObject(String.class)))
+        .andAnswer(() -> usersCanSeeAllTokens.contains((String) EasyMock.getCurrentArguments()[0])).anyTimes();
     EasyMock.expect(config.getMaximumNumberOfTokensPerUser())
         .andReturn(contextExpectations.containsKey(KNOX_TOKEN_USER_LIMIT) ? Integer.parseInt(contextExpectations.get(KNOX_TOKEN_USER_LIMIT)) : -1).anyTimes();
     EasyMock.expect(services.getService(ServiceType.TOKEN_STATE_SERVICE)).andReturn(tss).anyTimes();
@@ -1309,12 +1318,86 @@ public class TokenServiceResourceTest {
   }
 
   private Response getUserTokensResponse(TokenResource tokenResource, boolean createdBy) {
+    return getUserTokensResponse(tokenResource, createTestSubject(USER_NAME),
+        Collections.singletonMap(createdBy ? "createdBy" : "userName", USER_NAME));
+  }
+
+  private Response getUserTokensResponse(TokenResource tokenResource, Subject caller, Map<String, String> queryParams) {
     final MultivaluedMap<String, String> queryParameters = new MultivaluedHashMap<>();
-    queryParameters.put(createdBy ? "createdBy" : "userName", Arrays.asList(USER_NAME));
+    queryParams.forEach((key, value) -> queryParameters.put(key, Arrays.asList(value)));
     final UriInfo uriInfo = EasyMock.createNiceMock(UriInfo.class);
     EasyMock.expect(uriInfo.getQueryParameters()).andReturn(queryParameters).anyTimes();
     EasyMock.replay(uriInfo);
-    return tokenResource.getUserTokens(uriInfo);
+    return Subject.doAs(caller, (PrivilegedAction<Response>) () -> tokenResource.getUserTokens(uriInfo));
+  }
+
+  private TokenResource createTokenResourceWithTokensFor(String... users) throws Exception {
+    configureCommonExpectations(new HashMap<>(), Boolean.TRUE);
+    final TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+    for (String user : users) {
+      Subject.doAs(createTestSubject(user), (PrivilegedAction<Response>) () -> tr.doGet());
+    }
+    return tr;
+  }
+
+  @SuppressWarnings("unchecked")
+  private int tokenCount(Response response) {
+    final Collection<Object> tokens = ((Map<String, Collection<Object>>) JsonUtils.getObjectFromJsonString(response.getEntity().toString()))
+        .get("tokens");
+    return tokens.size();
+  }
+
+  @Test
+  public void testGetUserTokensOwnerCanSeeOwnTokens() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject(USER_NAME), Collections.singletonMap("userName", USER_NAME));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(1, tokenCount(response));
+  }
+
+  @Test
+  public void testGetUserTokensUnauthorizedForOtherUser() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject("bob"), Collections.singletonMap("userName", USER_NAME));
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("not authorized"));
+  }
+
+  @Test
+  public void testGetUserTokensUnauthorizedForUserNameOrCreatedByOfOtherUser() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject("bob"), Collections.singletonMap("userNameOrCreatedBy", USER_NAME));
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("not authorized"));
+  }
+
+  @Test
+  public void testGetUserTokensAllTokensDeniedForOrdinaryUser() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    final Response response = getUserTokensResponse(tr, createTestSubject("bob"), Collections.singletonMap("allTokens", "true"));
+    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    assertTrue(response.getEntity().toString().contains("not authorized"));
+  }
+
+  @Test
+  public void testGetUserTokensAdminCanSeeAllTokens() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME, "bob");
+    usersCanSeeAllTokens.add("admin");
+    final Response response = getUserTokensResponse(tr, createTestSubject("admin"), Collections.singletonMap("allTokens", "true"));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(2, tokenCount(response));
+  }
+
+  @Test
+  public void testGetUserTokensAdminCanSeeOtherUsersTokens() throws Exception {
+    final TokenResource tr = createTokenResourceWithTokensFor(USER_NAME);
+    usersCanSeeAllTokens.add("admin");
+    final Response response = getUserTokensResponse(tr, createTestSubject("admin"), Collections.singletonMap("userName", USER_NAME));
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals(1, tokenCount(response));
   }
 
   @Test

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/i18n/GatewaySpiMessages.java
@@ -76,6 +76,9 @@ public interface GatewaySpiMessages {
   @Message( level = MessageLevel.ERROR, text = "Topology {0} cannot be manually overwritten because it was generated from a simple descriptor." )
   void disallowedOverwritingGeneratedTopology(String topologyName);
 
+  @Message( level = MessageLevel.INFO, text = "Read-only topology {0} cannot be overwritten." )
+  void disallowedOverwritingReadOnlyTopology(String topologyName);
+
   @Message( level = MessageLevel.INFO, text = "Read-only descriptor {0} cannot be overwritten." )
   void disallowedOverwritingGeneratedDescriptor(String name);
 

--- a/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
+++ b/gateway-spi/src/main/java/org/apache/knox/gateway/security/SubjectUtils.java
@@ -21,6 +21,7 @@ import javax.security.auth.Subject;
 
 import java.security.AccessController;
 import java.security.Principal;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -79,6 +80,11 @@ public class SubjectUtils {
   public static String getCurrentEffectivePrincipalName() {
     final Subject subject = getCurrentSubject();
     return subject == null ? null : getEffectivePrincipalName(subject);
+  }
+
+  public static Set<GroupPrincipal> getCurrentGroupPrincipals() {
+    final Subject subject = getCurrentSubject();
+    return subject == null ? Collections.emptySet() : getGroupPrincipals(subject);
   }
 
   public static Set<GroupPrincipal> getGroupPrincipals(Subject subject) {

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
@@ -1805,7 +1805,8 @@ public class GatewayAdminTopologyFuncTest {
     String newDescriptorJSON = createDescriptor(clusterName);
 
     // Attempt to PUT the descriptor
-    given().auth().preemptive().basic(username, password)
+    given().urlEncodingEnabled(false)
+           .auth().preemptive().basic(username, password)
            .header("Content-type", MediaType.APPLICATION_JSON)
            .body(newDescriptorJSON.getBytes(StandardCharsets.UTF_8.name()))
            .then()


### PR DESCRIPTION

[KNOX-3188](https://issues.apache.org/jira/browse/KNOX-3188) - Add group-based configuration parameter for KnoxToken renewer/revoker access control
[KNOX-3410](https://issues.apache.org/jira/browse/KNOX-3410) - KnoxToken enable/disable endpoints perform no caller authorization
[KNOX-3411](https://issues.apache.org/jira/browse/KNOX-3411) - KnoxToken getUserTokens returns every user's token metadata without a caller authorization check
[KNOX-3413](https://issues.apache.org/jira/browse/KNOX-3413) - KnoxToken passcode verification accepts a valid passcode for a different token
[KNOX-3416](https://issues.apache.org/jira/browse/KNOX-3416) - KnoxSSO redirects to untrusted site
[KNOX-3417](https://issues.apache.org/jira/browse/KNOX-3417) - A short description of the change
[KNOX-3418](https://issues.apache.org/jira/browse/KNOX-3418) - Path traversal → arbitrary file write/overwrite in the Apache Knox Admin API

## What changes were proposed in this pull request?

Backporting security fixes 

## How was this patch tested?

Did the same tested as specified in the parent PRs.