### PR TITLE
KNOX-3423: Switch to JSON error messages in Knox token validation paths

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -34,6 +34,7 @@ import org.apache.knox.gateway.util.CertificateUtils;
 import org.apache.knox.gateway.util.CookieUtils;
 import org.apache.knox.gateway.util.ServletRequestUtils;
 import org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants;
+import org.apache.knox.gateway.util.knoxidf.KnoxIDFUtils;
 
 import javax.security.auth.Subject;
 import javax.servlet.FilterChain;
@@ -553,12 +554,31 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   @Override
   protected void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status,
                                        String error) throws IOException {
+    if (Boolean.TRUE.equals(request.getAttribute(TOKEN_EXCHANGE_REQUEST_ATTR))) {
+      handleValidationError(request, response, status, deriveOAuthError(status), error);
+      return;
+    }
     if (error != null) {
       response.sendError(status, error);
     }
     else {
       response.sendError(status);
     }
+  }
+
+  /**
+   * Emit an RFC 8693 / RFC 6749 §5.2 JSON error response ({@code {"error": ..., "error_description":
+   * ...}}) for a token-exchange request. Called directly by {@link TokenExchangeHandler} when it has
+   * an explicit OAuth error code (e.g. {@code invalid_request}, {@code unsupported_token_type}), and
+   * indirectly by the four-argument {@link #handleValidationError} for shared-path errors.
+   */
+  void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status,
+                             String error, String description) throws IOException {
+    KnoxIDFUtils.writeErrorResponse(response, status, error, description);
+  }
+
+  private static String deriveOAuthError(int status) {
+    return status == HttpServletResponse.SC_BAD_REQUEST ? "invalid_request" : "invalid_grant";
   }
 
   /**

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/JWTFederationFilter.java
@@ -555,7 +555,7 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   protected void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status,
                                        String error) throws IOException {
     if (Boolean.TRUE.equals(request.getAttribute(TOKEN_EXCHANGE_REQUEST_ATTR))) {
-      handleValidationError(request, response, status, deriveOAuthError(status), error);
+      handleValidationError(request, response, status, "invalid_request", error);
       return;
     }
     if (error != null) {
@@ -569,16 +569,12 @@ public class JWTFederationFilter extends AbstractJWTFilter {
   /**
    * Emit an RFC 8693 / RFC 6749 §5.2 JSON error response ({@code {"error": ..., "error_description":
    * ...}}) for a token-exchange request. Called directly by {@link TokenExchangeHandler} when it has
-   * an explicit OAuth error code (e.g. {@code invalid_request}, {@code unsupported_token_type}), and
-   * indirectly by the four-argument {@link #handleValidationError} for shared-path errors.
+   * an explicit OAuth error code (e.g. {@code invalid_request}), and indirectly by the four-argument
+   * {@link #handleValidationError} for shared-path errors.
    */
   void handleValidationError(HttpServletRequest request, HttpServletResponse response, int status,
                              String error, String description) throws IOException {
     KnoxIDFUtils.writeErrorResponse(response, status, error, description);
-  }
-
-  private static String deriveOAuthError(int status) {
-    return status == HttpServletResponse.SC_BAD_REQUEST ? "invalid_request" : "invalid_grant";
   }
 
   /**

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandler.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandler.java
@@ -92,35 +92,35 @@ class TokenExchangeHandler {
     // RFC 8693 section 2.1: subject_token and subject_token_type are REQUIRED.
     if (subjectTokenValue == null || subjectTokenValue.isEmpty()) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "invalid_request: the subject_token parameter is required");
+          "invalid_request", "the subject_token parameter is required");
       return;
     }
     if (subjectTokenType == null || subjectTokenType.isEmpty()) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "invalid_request: the subject_token_type parameter is required");
+          "invalid_request", "the subject_token_type parameter is required");
       return;
     }
     // RFC 8693 section 2.1: actor_token_type is REQUIRED when actor_token is present and MUST NOT
     // be present otherwise.
     if (hasActorToken && !hasActorTokenType) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "invalid_request: actor_token_type is required when actor_token is present");
+          "invalid_request", "actor_token_type is required when actor_token is present");
       return;
     }
     if (!hasActorToken && hasActorTokenType) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "invalid_request: actor_token_type must not be present without actor_token");
+          "invalid_request", "actor_token_type must not be present without actor_token");
       return;
     }
     // Only JWT-family token types are supported.
     if (isNotSupportedTokenType(subjectTokenType)) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "unsupported_token_type: unsupported subject_token_type " + subjectTokenType);
+          "unsupported_token_type", "unsupported subject_token_type " + subjectTokenType);
       return;
     }
     if (hasActorToken && isNotSupportedTokenType(actorTokenType)) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "unsupported_token_type: unsupported actor_token_type " + actorTokenType);
+          "unsupported_token_type", "unsupported actor_token_type " + actorTokenType);
       return;
     }
 
@@ -148,7 +148,7 @@ class TokenExchangeHandler {
       filter.continueWithEstablishedSecurityContext(subject, request, response, chain);
     } catch (ParseException | UnknownTokenException e) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED,
-          "Failed to parse token in token exchange: " + e.getMessage());
+          "invalid_grant", "Failed to parse token in token exchange: " + e.getMessage());
     }
   }
 

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandler.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandler.java
@@ -115,12 +115,12 @@ class TokenExchangeHandler {
     // Only JWT-family token types are supported.
     if (isNotSupportedTokenType(subjectTokenType)) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "unsupported_token_type", "unsupported subject_token_type " + subjectTokenType);
+          "invalid_request", "unsupported subject_token_type " + subjectTokenType);
       return;
     }
     if (hasActorToken && isNotSupportedTokenType(actorTokenType)) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_BAD_REQUEST,
-          "unsupported_token_type", "unsupported actor_token_type " + actorTokenType);
+          "invalid_request", "unsupported actor_token_type " + actorTokenType);
       return;
     }
 
@@ -148,7 +148,7 @@ class TokenExchangeHandler {
       filter.continueWithEstablishedSecurityContext(subject, request, response, chain);
     } catch (ParseException | UnknownTokenException e) {
       filter.handleValidationError(request, response, HttpServletResponse.SC_UNAUTHORIZED,
-          "invalid_grant", "Failed to parse token in token exchange: " + e.getMessage());
+          "invalid_request", "Failed to parse token in token exchange: " + e.getMessage());
     }
   }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTokenExchangeTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTokenExchangeTest.java
@@ -37,6 +37,9 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URI;
 import java.util.Date;
 import java.util.HashMap;
@@ -235,16 +238,16 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         subjectJwt.serialize(), buildContextWithIssuerService(issuerSvc));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(request, response, issuerSvc);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock, issuerSvc);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse(chain.doFilterCalled);
-    EasyMock.verify(mockAuth, issuerSvc, response);
+    Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    EasyMock.verify(mockAuth, issuerSvc);
   }
 
   /**
@@ -278,19 +281,20 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         expiredJwt.serialize(), buildContextWithIssuerService(issuerSvc));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token has expired");
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(request, response, issuerSvc);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock, issuerSvc);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse(chain.doFilterCalled);
     if (capturedJwt.hasCaptured()) {
       Assert.assertEquals(EXTERNAL_ISSUER, capturedJwt.getValue().getIssuer());
     }
-    EasyMock.verify(mockAuth, issuerSvc, response);
+    Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    Assert.assertTrue(response.body(), response.body().contains("Token has expired"));
+    EasyMock.verify(mockAuth, issuerSvc);
   }
 
   /**
@@ -324,19 +328,20 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         nbfJwt.serialize(), buildContextWithIssuerService(issuerSvc));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Bad request: the NotBefore check failed");
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(request, response, issuerSvc);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock, issuerSvc);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse(chain.doFilterCalled);
     if (capturedJwt.hasCaptured()) {
       Assert.assertEquals(EXTERNAL_ISSUER, capturedJwt.getValue().getIssuer());
     }
-    EasyMock.verify(mockAuth, issuerSvc, response);
+    Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
+    Assert.assertTrue(response.body(), response.body().contains("the NotBefore check failed"));
+    EasyMock.verify(mockAuth, issuerSvc);
   }
 
   /**
@@ -371,19 +376,20 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         subjectJwt.serialize(), buildContextWithIssuerService(issuerSvc));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Bad request: missing required token audience");
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(request, response, issuerSvc);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock, issuerSvc);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse(chain.doFilterCalled);
     if (capturedJwt.hasCaptured()) {
       Assert.assertEquals(EXTERNAL_ISSUER, capturedJwt.getValue().getIssuer());
     }
-    EasyMock.verify(mockAuth, issuerSvc, response);
+    Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
+    Assert.assertTrue(response.body(), response.body().contains("missing required token audience"));
+    EasyMock.verify(mockAuth, issuerSvc);
   }
 
   // ---------------------------------------------------------------------------
@@ -408,16 +414,16 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         subjectJwt.serialize(), buildContextWithIssuerService(issuerSvc));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(request, response, issuerSvc);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock, issuerSvc);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse(chain.doFilterCalled);
-    EasyMock.verify(issuerSvc, response);
+    Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    EasyMock.verify(issuerSvc);
   }
 
   /**
@@ -437,16 +443,15 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         subjectJwt.serialize(), buildServletContext(gws));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(request, response);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse(chain.doFilterCalled);
-    EasyMock.verify(response);
+    Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
   }
 
   /**
@@ -550,13 +555,15 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     final HttpServletRequest request = buildTokenExchangeRequest(
         subjectJwt.serialize(), buildContextWithIssuerService(issuerSvc));
-    final HttpServletResponse response = EasyMock.createNiceMock(HttpServletResponse.class);
-    EasyMock.replay(request, response, issuerSvc);
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock, issuerSvc);
 
     final TestFilterChain chain = new TestFilterChain();
-    handler.doFilter(request, response, chain);
+    handler.doFilter(request, response.mock, chain);
 
     Assert.assertFalse("Insecure (non-HTTPS) dynamic JWKS URI must be rejected OOTB", chain.doFilterCalled);
+    Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
     EasyMock.verify(mockAuth, issuerSvc);
   }
 
@@ -810,6 +817,33 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
     Assert.assertEquals(KNOX_ISSUER, capturedAttrs.get(KnoxIDFConstants.TOKEN_ISS_ATTRIBUTE));
   }
 
+  @Test
+  public void testTokenExchangeParamErrorEmitsRfcJsonError() throws Exception {
+    handler.init(new TestFilterConfig(getProperties()));
+
+    // grant_type marks a token-exchange dispatch, but subject_token is absent (niceMock returns null).
+    final HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getRequestURL()).andReturn(new StringBuffer(SERVICE_URL)).anyTimes();
+    EasyMock.expect(request.getParameter(GRANT_TYPE)).andReturn(JWTFederationFilter.TOKEN_EXCHANGE).anyTimes();
+    EasyMock.expect(request.getServletContext())
+        .andReturn(buildContextWithIssuerService(EasyMock.createNiceMock(TrustedOidcIssuerService.class))).anyTimes();
+    mockRequestAttributeStore(request);
+
+    final JsonErrorResponse response = new JsonErrorResponse();
+    EasyMock.replay(request, response.mock);
+
+    final TestFilterChain chain = new TestFilterChain();
+    handler.doFilter(request, response.mock, chain);
+
+    Assert.assertFalse(chain.doFilterCalled);
+    Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.status());
+    Assert.assertEquals("application/json; charset=UTF-8", response.contentType());
+    Assert.assertEquals("no-store", response.header("Cache-Control"));
+    Assert.assertEquals("no-cache", response.header("Pragma"));
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
+    Assert.assertTrue(response.body(), response.body().contains("subject_token"));
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
@@ -874,6 +908,44 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
     }).anyTimes();
     EasyMock.expect(request.getAttribute(EasyMock.anyString()))
         .andAnswer(() -> attrs.get(EasyMock.getCurrentArguments()[0])).anyTimes();
+  }
+
+  private static final class JsonErrorResponse {
+    private final HttpServletResponse mock;
+    private final StringWriter body = new StringWriter();
+    private final Capture<Integer> status = EasyMock.newCapture();
+    private final Capture<String> contentType = EasyMock.newCapture();
+    private final Map<String, String> headers = new HashMap<>();
+
+    JsonErrorResponse() throws IOException {
+      mock = EasyMock.createNiceMock(HttpServletResponse.class);
+      mock.setStatus(EasyMock.captureInt(status));
+      EasyMock.expectLastCall().anyTimes();
+      mock.setContentType(EasyMock.capture(contentType));
+      EasyMock.expectLastCall().anyTimes();
+      mock.setHeader(EasyMock.anyString(), EasyMock.anyString());
+      EasyMock.expectLastCall().andAnswer(() -> {
+        headers.put((String) EasyMock.getCurrentArguments()[0], (String) EasyMock.getCurrentArguments()[1]);
+        return null;
+      }).anyTimes();
+      EasyMock.expect(mock.getWriter()).andReturn(new PrintWriter(body)).anyTimes();
+    }
+
+    int status() {
+      return status.getValue();
+    }
+
+    String body() {
+      return body.toString();
+    }
+
+    String contentType() {
+      return contentType.hasCaptured() ? contentType.getValue() : null;
+    }
+
+    String header(String name) {
+      return headers.get(name);
+    }
   }
 
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTokenExchangeTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/JWTFederationFilterTokenExchangeTest.java
@@ -246,7 +246,7 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     Assert.assertFalse(chain.doFilterCalled);
     Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
-    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
     EasyMock.verify(mockAuth, issuerSvc);
   }
 
@@ -292,7 +292,7 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
       Assert.assertEquals(EXTERNAL_ISSUER, capturedJwt.getValue().getIssuer());
     }
     Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
-    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
     Assert.assertTrue(response.body(), response.body().contains("Token has expired"));
     EasyMock.verify(mockAuth, issuerSvc);
   }
@@ -422,7 +422,7 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     Assert.assertFalse(chain.doFilterCalled);
     Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
-    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
     EasyMock.verify(issuerSvc);
   }
 
@@ -451,7 +451,7 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     Assert.assertFalse(chain.doFilterCalled);
     Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
-    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
   }
 
   /**
@@ -563,7 +563,7 @@ public class JWTFederationFilterTokenExchangeTest extends AbstractJWTFilterTest 
 
     Assert.assertFalse("Insecure (non-HTTPS) dynamic JWKS URI must be rejected OOTB", chain.doFilterCalled);
     Assert.assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status());
-    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_grant\""));
+    Assert.assertTrue(response.body(), response.body().contains("\"error\":\"invalid_request\""));
     EasyMock.verify(mockAuth, issuerSvc);
   }
 

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandlerTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandlerTest.java
@@ -71,7 +71,8 @@ public class TokenExchangeHandlerTest {
   public void testSubjectTokenRequired() throws Exception {
     handler.handle(request(null, JWT_TYPE, null, null), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertTrue(filter.errorMessage.contains("subject_token"));
+    assertEquals("invalid_request", filter.error);
+    assertTrue(filter.errorDescription.contains("subject_token"));
     assertFalse(filter.continued);
   }
 
@@ -79,7 +80,8 @@ public class TokenExchangeHandlerTest {
   public void testSubjectTokenTypeRequired() throws Exception {
     handler.handle(request("subtok", null, null, null), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertTrue(filter.errorMessage.contains("subject_token_type"));
+    assertEquals("invalid_request", filter.error);
+    assertTrue(filter.errorDescription.contains("subject_token_type"));
     assertFalse(filter.continued);
   }
 
@@ -88,7 +90,8 @@ public class TokenExchangeHandlerTest {
     filter.valid.put("subtok", jwt("alice", "KNOXSSO"));
     handler.handle(request("subtok", JWT_TYPE, "acttok", null), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertTrue(filter.errorMessage.contains("actor_token_type is required"));
+    assertEquals("invalid_request", filter.error);
+    assertTrue(filter.errorDescription.contains("actor_token_type is required"));
     assertFalse(filter.continued);
   }
 
@@ -96,7 +99,8 @@ public class TokenExchangeHandlerTest {
   public void testActorTokenTypeForbiddenWithoutActor() throws Exception {
     handler.handle(request("subtok", JWT_TYPE, null, JWT_TYPE), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertTrue(filter.errorMessage.contains("must not be present"));
+    assertEquals("invalid_request", filter.error);
+    assertTrue(filter.errorDescription.contains("must not be present"));
     assertFalse(filter.continued);
   }
 
@@ -104,7 +108,8 @@ public class TokenExchangeHandlerTest {
   public void testUnsupportedSubjectTokenType() throws Exception {
     handler.handle(request("subtok", SAML2_TYPE, null, null), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertTrue(filter.errorMessage.contains("unsupported_token_type"));
+    assertEquals("unsupported_token_type", filter.error);
+    assertTrue(filter.errorDescription.contains("subject_token_type"));
     assertFalse(filter.continued);
   }
 
@@ -113,7 +118,8 @@ public class TokenExchangeHandlerTest {
     filter.valid.put("subtok", jwt("alice", "KNOXSSO"));
     handler.handle(request("subtok", JWT_TYPE, "acttok", SAML2_TYPE), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertTrue(filter.errorMessage.contains("unsupported_token_type"));
+    assertEquals("unsupported_token_type", filter.error);
+    assertTrue(filter.errorDescription.contains("actor_token_type"));
     assertFalse(filter.continued);
   }
 
@@ -228,7 +234,8 @@ public class TokenExchangeHandlerTest {
   private static final class RecordingFilter extends JWTFederationFilter {
     private final Map<String, JWT> valid = new HashMap<>();
     private int errorStatus = -1;
-    private String errorMessage;
+    private String error;
+    private String errorDescription;
     private boolean continued;
     private Subject establishedSubject;
 
@@ -254,10 +261,11 @@ public class TokenExchangeHandlerTest {
     }
 
     @Override
-    protected void handleValidationError(HttpServletRequest request, HttpServletResponse response,
-                                         int status, String error) {
+    void handleValidationError(HttpServletRequest request, HttpServletResponse response,
+                               int status, String error, String description) {
       this.errorStatus = status;
-      this.errorMessage = error == null ? "" : error;
+      this.error = error == null ? "" : error;
+      this.errorDescription = description == null ? "" : description;
     }
   }
 }

--- a/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandlerTest.java
+++ b/gateway-provider-security-jwt/src/test/java/org/apache/knox/gateway/provider/federation/jwt/filter/TokenExchangeHandlerTest.java
@@ -39,6 +39,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -108,7 +109,7 @@ public class TokenExchangeHandlerTest {
   public void testUnsupportedSubjectTokenType() throws Exception {
     handler.handle(request("subtok", SAML2_TYPE, null, null), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertEquals("unsupported_token_type", filter.error);
+    assertEquals("invalid_request", filter.error);
     assertTrue(filter.errorDescription.contains("subject_token_type"));
     assertFalse(filter.continued);
   }
@@ -118,7 +119,7 @@ public class TokenExchangeHandlerTest {
     filter.valid.put("subtok", jwt("alice", "KNOXSSO"));
     handler.handle(request("subtok", JWT_TYPE, "acttok", SAML2_TYPE), response, chain);
     assertEquals(HttpServletResponse.SC_BAD_REQUEST, filter.errorStatus);
-    assertEquals("unsupported_token_type", filter.error);
+    assertEquals("invalid_request", filter.error);
     assertTrue(filter.errorDescription.contains("actor_token_type"));
     assertFalse(filter.continued);
   }
@@ -192,6 +193,16 @@ public class TokenExchangeHandlerTest {
     assertFalse(filter.continued);
   }
 
+  @Test
+  public void testUnparseableSubjectTokenReturnsInvalidRequest() throws Exception {
+    filter.throwOnParse.add("subtok");
+    handler.handle(request("subtok", JWT_TYPE, null, null), response, chain);
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, filter.errorStatus);
+    assertEquals("invalid_request", filter.error);
+    assertTrue(filter.errorDescription.contains("Failed to parse token in token exchange"));
+    assertFalse(filter.continued);
+  }
+
   private static String primaryName(Subject subject) {
     return subject.getPrincipals(PrimaryPrincipal.class).iterator().next().getName();
   }
@@ -233,6 +244,7 @@ public class TokenExchangeHandlerTest {
    */
   private static final class RecordingFilter extends JWTFederationFilter {
     private final Map<String, JWT> valid = new HashMap<>();
+    private final Set<String> throwOnParse = new HashSet<>();
     private int errorStatus = -1;
     private String error;
     private String errorDescription;
@@ -243,6 +255,9 @@ public class TokenExchangeHandlerTest {
     JWT parseAndValidateJWT(HttpServletRequest request, HttpServletResponse response,
                             FilterChain chain, String tokenValue)
         throws ParseException, IOException, ServletException {
+      if (throwOnParse.contains(tokenValue)) {
+        throw new ParseException("cannot parse " + tokenValue, 0);
+      }
       return valid.get(tokenValue);
     }
 

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFUtils.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFUtils.java
@@ -22,13 +22,16 @@ import org.apache.knox.gateway.util.JsonUtils;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,6 +54,28 @@ public class KnoxIDFUtils {
         errorMap.put("error", error);
         errorMap.put("error_description", description);
         return Response.status(status).entity(JsonUtils.renderAsJsonString(errorMap)).build();
+    }
+
+    /**
+     * Writes an OAuth 2.0 error response (RFC 6749 §5.2 / RFC 8693 §2.2.2) directly to a servlet
+     * response as {@code {"error": ..., "error_description": ...}} with a JSON content type. Used by
+     * the filter layer, which works with {@link HttpServletResponse} rather than a JAX-RS
+     * {@link Response}. Uses {@link HttpServletResponse#setStatus(int)} (not {@code sendError}) so the
+     * JSON body is returned verbatim rather than replaced by the servlet container's HTML error page.
+     * The caller supplies the HTTP status; the {@code error_description} is omitted when {@code null}.
+     */
+    public static void writeErrorResponse(HttpServletResponse response, int status,
+                                          String error, String description) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json; charset=UTF-8");
+        response.setHeader("Cache-Control", "no-store");
+        response.setHeader("Pragma", "no-cache");
+        final Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", error);
+        if (description != null) {
+            body.put("error_description", description);
+        }
+        response.getWriter().write(JsonUtils.renderAsJsonString(body));
     }
 
     private static Response.Status statusForError(String error) {


### PR DESCRIPTION
[KNOX-3423](https://issues.apache.org/jira/browse/KNOX-3423) - Switch to JSON error messages in Knox token validation paths

## What changes were proposed in this pull request?

RFC 8693 §2.2.2 / RFC 6749 §5.2 require OAuth token-exchange errors to be a JSON
body (`{"error", "error_description"}`) with `Content-Type: application/json`.
`JWTFederationFilter` previously emitted plain-text/HTML (`sendError`) for every
path, breaking standards-compliant clients.

- Errors raised while handling a **token-exchange request** now return the RFC JSON
  body with `Cache-Control: no-store` / `Pragma: no-cache`. HTTP status codes are
  unchanged (400 for param/nbf/audience, 401 for signature/expiry/parse).
- Scope is the **whole exchange path**, keyed off the existing
  `TOKEN_EXCHANGE_REQUEST_ATTR`: both the direct param/parse errors in
  `TokenExchangeHandler` **and** the shared JWT-validation errors emitted by
  `AbstractJWTFilter` (expired / bad-signature / wrong-audience / …). The latter is
  the gap a handler-only fix would miss.
- The normal **bearer** auth path and the **SSO-cookie** path are untouched — still
  plain text.

## How was this patch tested?

Unit tests, local tests

```
curl -skiv -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
  --data 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange' \
  'https://localhost:8443/gateway/knoxidf/knoxidf/api/v1/token'

HTTP/1.1 400 Bad Request
Content-Type: application/json;charset=utf-8
{"error":"invalid_request","error_description":"the subject_token parameter is required"}
```

```
curl -skiv -H 'Authorization: Bearer not-a-real-jwt' \
  'https://localhost:8443/gateway/tokenconsumer/auth/api/v1/pre'

Content-Type: text/html;charset=iso-8859-1
<body><h2>HTTP ERROR 401 Bad request: missing token passcode.</h2>
```

```
curl -skiv -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
  --data 'grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=abc&subject_token_type=urn:ietf:params:oauth:token-type:saml2' \
  'https://localhost:8443/gateway/tokenconsumer/auth/api/v1/pre'

HTTP/1.1 400 Bad Request
Content-Type: application/json;charset=utf-8
{"error":"unsupported_token_type","error_description":"unsupported subject_token_type urn:ietf:params:oauth:token-type:saml2"}
```

## Integration Tests
N/A

## UI changes
N/A