### PR TITLE
KNOX-3406: LDAP Proxy backend improve error handling

### DIFF
--- a/.github/workflows/tests/test_knox_ldap_proxy_search.py
+++ b/.github/workflows/tests/test_knox_ldap_proxy_search.py
@@ -68,7 +68,7 @@ class TestKnoxLdapProxySearch(unittest.TestCase):
             knox_host(), port=KNOX_LDAP_PORT, use_ssl=True, tls=tls, get_info=ldap3.NONE
         )
         self.connection = ldap3.Connection(
-            server, user=BIND_DN, password=BIND_PASSWORD, auto_bind=True
+            server, user=BIND_DN, password=BIND_PASSWORD, auto_bind=True, raise_exceptions=True
         )
 
     def tearDown(self) -> None:

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
@@ -114,8 +114,8 @@ public interface LdapMessages {
     void ldapPagedSearchExceededMaxResultSetSize(int resultSetSize, int maxResultSetSize);
 
     @Message(level = MessageLevel.DEBUG,
-            text = "LDAP Paged Search Completed: {0} | {1}")
-    void ldapPagedSearchCompleted(String baseDn, String filter);
+            text = "LDAP Paged Search Completed: {0} | {1}. Found {2} entries")
+    void ldapPagedSearchCompleted(String baseDn, String filter, int numResults);
 
     @Message(level = MessageLevel.ERROR,
             text = "LDAP Search failed: {0} | {1}, {2}")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -28,7 +28,10 @@ import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapOperationException;
+import org.apache.directory.api.ldap.model.message.LdapResult;
 import org.apache.directory.api.ldap.model.message.Response;
+import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
 import org.apache.directory.api.ldap.model.message.SearchResultDone;
@@ -489,13 +492,15 @@ public class LdapProxyBackend implements LdapBackend {
             connection = getConnection();
             // Search for user using configurable attribute
             String filter = userSearchFilter.replace("{username}", username);
+            Entry sourceEntry = null;
             try (EntryCursor cursor = connection.search(remoteUserSearchBase, filter, SearchScope.SUBTREE, "*")) {
                 if (cursor.next()) {
-                    Entry sourceEntry = cursor.get();
-                    addGroupMemberships(sourceEntry, connection, createEntryCache(), createResolvedParentsCache());
-                    return remoteSchemaConverter.convertRemoteEntryToProxyEntry(sourceEntry, schemaManager);
-
+                    sourceEntry = cursor.get();
                 }
+            }
+            if (sourceEntry != null) {
+                addGroupMemberships(sourceEntry, connection, createEntryCache(), createResolvedParentsCache());
+                return remoteSchemaConverter.convertRemoteEntryToProxyEntry(sourceEntry, schemaManager);
             }
             return null;
         } finally {
@@ -563,7 +568,7 @@ public class LdapProxyBackend implements LdapBackend {
         }
     }
 
-    private void addGroupMemberships(Entry entry, LdapConnection connection, Map<String, Entry> entryCache, Map<String, Set<String>> resolvedParentsCache) throws Exception {
+    private void addGroupMemberships(Entry entry, LdapConnection connection, Map<String, Entry> entryCache, Map<String, Set<String>> resolvedParentsCache) throws LdapException, CursorException, IOException {
         // The memberOf attribute is already populated on the entry. Further work is only needed
         // when using recursive group resolution or non using memberOf to find groups
         if (recursiveGroupResolution || !useMemberOf) {
@@ -574,7 +579,7 @@ public class LdapProxyBackend implements LdapBackend {
         }
     }
 
-    private List<Entry> getUserGroupsEntries(LdapConnection connection, Entry user, Map<String, Entry> entryCache, Map<String, Set<String>> resolvedParentsCache) throws Exception {
+    private List<Entry> getUserGroupsEntries(LdapConnection connection, Entry user, Map<String, Entry> entryCache, Map<String, Set<String>> resolvedParentsCache) throws LdapException, CursorException, IOException {
         List<Entry> groups = new ArrayList<>();
         if (useMemberOf) {
             // Use memberOf attribute for efficient AD lookups
@@ -893,6 +898,11 @@ public class LdapProxyBackend implements LdapBackend {
                 }
                 if (cursor.isDone()) {
                     SearchResultDone done = cursor.getSearchResultDone();
+
+                    LdapResult ldapResult = done.getLdapResult();
+                    if (ldapResult.getResultCode() != ResultCodeEnum.SUCCESS) {
+                        throw new LdapOperationException(ldapResult.getResultCode(), ldapResult.getDiagnosticMessage());
+                    }
                     PagedResults responseControl = (PagedResults) done.getControl(PagedResults.OID);
 
                     if (responseControl != null) {
@@ -909,7 +919,7 @@ public class LdapProxyBackend implements LdapBackend {
         if (maxResultSetSize != 0 && results.size() >= maxResultSetSize) {
             LOG.ldapPagedSearchExceededMaxResultSetSize(results.size(), maxResultSetSize);
         } else {
-            LOG.ldapPagedSearchCompleted(baseDn, filter);
+            LOG.ldapPagedSearchCompleted(baseDn, filter, results.size());
         }
 
         return results;

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -899,16 +899,20 @@ public class LdapProxyBackend implements LdapBackend {
                 if (cursor.isDone()) {
                     SearchResultDone done = cursor.getSearchResultDone();
 
-                    LdapResult ldapResult = done.getLdapResult();
-                    if (ldapResult.getResultCode() != ResultCodeEnum.SUCCESS) {
-                        throw new LdapOperationException(ldapResult.getResultCode(), ldapResult.getDiagnosticMessage());
-                    }
-                    PagedResults responseControl = (PagedResults) done.getControl(PagedResults.OID);
+                    if (done != null) {
+                        LdapResult ldapResult = done.getLdapResult();
+                        if (ldapResult.getResultCode() != ResultCodeEnum.SUCCESS) {
+                            throw new LdapOperationException(ldapResult.getResultCode(), ldapResult.getDiagnosticMessage());
+                        }
+                        PagedResults responseControl = (PagedResults) done.getControl(PagedResults.OID);
 
-                    if (responseControl != null) {
-                        cookie = responseControl.getCookie();
+                        if (responseControl != null) {
+                            cookie = responseControl.getCookie();
+                        } else {
+                            cookie = null;
+                        }
                     } else {
-                        cookie = null;
+                        throw new LdapException("The LDAP search operation failed to complete fully.");
                     }
                 }
                 pageNumber++;

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import org.apache.directory.api.ldap.model.cursor.SearchCursor;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
+import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.exception.LdapOperationException;
 import org.apache.directory.api.ldap.model.message.BindRequest;
 import org.apache.directory.api.ldap.model.message.LdapResult;
@@ -869,6 +870,31 @@ public class LdapProxyBackendTest {
         assertEquals("test error message", exception.getMessage());
     }
 
+    @Test
+    public void testPerformPagedSearchThrowsOnNullSearchResultDone() throws Exception{
+        Map<String, String> config = new HashMap<>(ldapBackendConfig);
+        config.put("pageSize", Integer.toString(PAGE_SIZE));
+        ldapProxyBackend = new LdapProxyBackend("testbackend", config);
+
+        // Mock out unsuccessful paging result
+        LdapResult mockResult = createMock(LdapResult.class);
+        expect(mockResult.getResultCode()).andReturn(ResultCodeEnum.UNWILLING_TO_PERFORM).atLeastOnce();
+        expect(mockResult.getDiagnosticMessage()).andReturn("test error message");
+        SearchCursor mockCursor = createMock(SearchCursor.class);
+        expect(mockCursor.next()).andReturn(false);
+        expect(mockCursor.isDone()).andReturn(true);
+        expect(mockCursor.getSearchResultDone()).andReturn(null);
+        LdapConnection mockConnection = createMock(LdapConnection.class);
+        expect(mockConnection.search(anyObject(SearchRequest.class))).andReturn(mockCursor);
+        replay(mockResult,
+                mockCursor,
+                mockConnection);
+
+        LdapException exception = assertThrows(
+                LdapException.class,
+                () -> ldapProxyBackend.performPagedSearch(mockConnection, "ou=people,dc=proxy,dc=org", "(objectclass=inetOrgPerson)", SearchScope.SUBTREE, "*"));
+        assertEquals("The LDAP search operation failed to complete fully.", exception.getMessage());
+    }
     // Helper methods for refactoring
 
     private Map<String, String> createConfigWithUserAttr(String attr) {

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
@@ -17,19 +17,30 @@
  */
 package org.apache.knox.gateway.services.ldap.backend;
 
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.directory.api.ldap.model.cursor.SearchCursor;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
+import org.apache.directory.api.ldap.model.exception.LdapOperationException;
 import org.apache.directory.api.ldap.model.message.BindRequest;
+import org.apache.directory.api.ldap.model.message.LdapResult;
+import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchResultDone;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.ldap.client.api.LdapConnection;
 import org.apache.directory.server.core.api.CoreSession;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.api.InstanceLayout;
@@ -826,6 +837,36 @@ public class LdapProxyBackendTest {
         assertFalse(ldapProxyBackend.isSupportedSearchBase(null));
         assertFalse(ldapProxyBackend.isSupportedSearchBase(""));
         assertFalse(ldapProxyBackend.isSupportedSearchBase("dc=other,dc=base,dc=org"));
+    }
+
+    @Test
+    public void testPerformPagedSearchThrowsOnFailure() throws Exception{
+        Map<String, String> config = new HashMap<>(ldapBackendConfig);
+        config.put("pageSize", Integer.toString(PAGE_SIZE));
+        ldapProxyBackend = new LdapProxyBackend("testbackend", config);
+
+        // Mock out unsuccessful paging result
+        LdapResult mockResult = createMock(LdapResult.class);
+        expect(mockResult.getResultCode()).andReturn(ResultCodeEnum.UNWILLING_TO_PERFORM).atLeastOnce();
+        expect(mockResult.getDiagnosticMessage()).andReturn("test error message");
+        SearchResultDone mockDone = createMock(SearchResultDone.class);
+        expect(mockDone.getLdapResult()).andReturn(mockResult);
+        SearchCursor mockCursor = createMock(SearchCursor.class);
+        expect(mockCursor.next()).andReturn(false);
+        expect(mockCursor.isDone()).andReturn(true);
+        expect(mockCursor.getSearchResultDone()).andReturn(mockDone);
+        LdapConnection mockConnection = createMock(LdapConnection.class);
+        expect(mockConnection.search(anyObject(SearchRequest.class))).andReturn(mockCursor);
+        replay(mockResult,
+                mockDone,
+                mockCursor,
+                mockConnection);
+
+        LdapOperationException exception = assertThrows(
+                LdapOperationException.class,
+                () -> ldapProxyBackend.performPagedSearch(mockConnection, "ou=people,dc=proxy,dc=org", "(objectclass=inetOrgPerson)", SearchScope.SUBTREE, "*"));
+        assertEquals(ResultCodeEnum.UNWILLING_TO_PERFORM, exception.getResultCode());
+        assertEquals("test error message", exception.getMessage());
     }
 
     // Helper methods for refactoring


### PR DESCRIPTION
[KNOX-3406](https://issues.apache.org/jira/browse/KNOX-3406) - Fix LDAP Proxy error handling

## What changes were proposed in this pull request?

The LdapProxyBackend.getUser code was modified to ensure that the search cursor is closed before attempting to augment the entry with group memberships to avoid having simultaneously open cursors.

The error handling in performPagedSearch was improved such that unsuccessful paging calls will result in exceptions for the caller to handle.

## How was this patch tested?

Workflow was run repeatedly to try reproducing the intermittent failures in the JIRA. Through this, I discovered the paging issue that I've fixed in this PR. Unit tests were added to cover the paged search changes.

## Integration Tests

no tests added

## UI changes

no UI changes