### PR TITLE
KNOX-3424: Dynamic audience handling in the KNOXTOKEN service

### DIFF
--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidationContext.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidationContext.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import java.util.Collections;
+import java.util.List;
+
+record AudienceValidationContext(List<String> requestedAudiences, List<String> configuredAudiences) {
+    AudienceValidationContext(List<String> requestedAudiences, List<String> configuredAudiences) {
+        this.requestedAudiences = requestedAudiences == null ? Collections.emptyList() : requestedAudiences;
+        this.configuredAudiences = configuredAudiences == null ? Collections.emptyList() : configuredAudiences;
+    }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidationException.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidationException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import org.apache.knox.gateway.service.knoxtoken.TokenResource.ErrorCode;
+
+/**
+ * Thrown when an {@code audience} requested on a token request cannot be honored, e.g. because no
+ * whitelist is configured or a requested value is not part of the configured {@code knox.token.audiences}.
+ */
+class AudienceValidationException extends Exception {
+  private final ErrorCode errorCode;
+
+  AudienceValidationException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidator.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidator.java
@@ -38,7 +38,11 @@ interface AudienceValidator {
         if (WhitelistAudienceValidator.NAME.equalsIgnoreCase(selected)) {
             return new WhitelistAudienceValidator();
         }
+        if (PassthroughAudienceValidator.NAME.equalsIgnoreCase(selected)) {
+            return new PassthroughAudienceValidator();
+        }
         throw new IllegalArgumentException("Unknown audience validator '" + selected + "'. Supported validators: "
-                + StaticAudienceValidator.NAME + ", " + WhitelistAudienceValidator.NAME + '.');
+                + StaticAudienceValidator.NAME + ", " + WhitelistAudienceValidator.NAME + ", "
+                + PassthroughAudienceValidator.NAME + '.');
     }
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidator.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/AudienceValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import java.util.List;
+
+
+interface AudienceValidator {
+
+    String name();
+
+    default boolean requiresConfiguredAudiences() {
+        return false;
+    }
+
+    List<String> validateAndResolve(AudienceValidationContext context) throws RequestedAudienceValidationException;
+
+    static AudienceValidator forName(String name) {
+        final String selected = (name == null || name.trim().isEmpty()) ? StaticAudienceValidator.NAME : name.trim();
+        if (StaticAudienceValidator.NAME.equalsIgnoreCase(selected)) {
+            return new StaticAudienceValidator();
+        }
+        if (WhitelistAudienceValidator.NAME.equalsIgnoreCase(selected)) {
+            return new WhitelistAudienceValidator();
+        }
+        throw new IllegalArgumentException("Unknown audience validator '" + selected + "'. Supported validators: "
+                + StaticAudienceValidator.NAME + ", " + WhitelistAudienceValidator.NAME + '.');
+    }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/PassthroughAudienceValidator.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/PassthroughAudienceValidator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import java.util.List;
+
+class PassthroughAudienceValidator implements AudienceValidator {
+
+    static final String NAME = "passthrough";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<String> validateAndResolve(AudienceValidationContext context) {
+        return context.requestedAudiences();
+    }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/RequestedAudienceValidationException.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/RequestedAudienceValidationException.java
@@ -19,14 +19,10 @@ package org.apache.knox.gateway.service.knoxtoken;
 
 import org.apache.knox.gateway.service.knoxtoken.TokenResource.ErrorCode;
 
-/**
- * Thrown when an {@code audience} requested on a token request cannot be honored, e.g. because no
- * whitelist is configured or a requested value is not part of the configured {@code knox.token.audiences}.
- */
-class AudienceValidationException extends Exception {
+class RequestedAudienceValidationException extends Exception {
   private final ErrorCode errorCode;
 
-  AudienceValidationException(String message, ErrorCode errorCode) {
+  RequestedAudienceValidationException(String message, ErrorCode errorCode) {
     super(message);
     this.errorCode = errorCode;
   }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/StaticAudienceValidator.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/StaticAudienceValidator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import java.util.List;
+
+class StaticAudienceValidator implements AudienceValidator {
+
+    static final String NAME = "static";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<String> validateAndResolve(AudienceValidationContext context) {
+        return context.configuredAudiences();
+    }
+}

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -907,7 +907,7 @@ public class TokenResource {
     final List<String> audiences;
     try {
       audiences = resolveAudiences();
-    } catch (AudienceValidationException e) {
+    } catch (RequestedAudienceValidationException e) {
       log.rejectedAudienceRequest(e.getMessage());
       return new TokenResponseContext(null,
           "{\n  \"error\": \"" + e.getMessage() + "\",\n  \"code\": " + e.getErrorCode().toInt() + "\n}\n",
@@ -1149,7 +1149,7 @@ public class TokenResource {
     }
   }
 
-  private List<String> resolveAudiences() throws AudienceValidationException {
+  private List<String> resolveAudiences() throws RequestedAudienceValidationException {
     final Map<String, String[]> parameterMap = request.getParameterMap();
     final String[] rawValues = parameterMap == null ? null : parameterMap.get(AUDIENCE_QUERY_PARAM);
     final List<String> requested = new ArrayList<>();
@@ -1174,13 +1174,13 @@ public class TokenResource {
 
     // Secure by default: with no configured whitelist there is nothing to validate against, so refuse.
     if (targetAudiences.isEmpty()) {
-      throw new AudienceValidationException("No audiences are configured; cannot honor a requested audience.",
+      throw new RequestedAudienceValidationException("No allowed audiences are configured in 'knox.token.audiences'; cannot honor a requested audience.",
           ErrorCode.INVALID_AUDIENCE);
     }
 
     for (String audience : requested) {
       if (!targetAudiences.contains(audience)) {
-        throw new AudienceValidationException("The requested audience '" + audience + "' is not allowed.",
+        throw new RequestedAudienceValidationException("The requested audience '" + audience + "' is not allowed.",
             ErrorCode.INVALID_AUDIENCE);
       }
     }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -125,6 +125,7 @@ public class TokenResource {
   protected static final String TOKEN_TTL_PARAM = TOKEN_PARAM_PREFIX + "ttl";
   public static final String TOKEN_TYPE_PARAM = TOKEN_PARAM_PREFIX + "type";
   private static final String TOKEN_AUDIENCES_PARAM = TOKEN_PARAM_PREFIX + "audiences";
+  static final String AUDIENCE_QUERY_PARAM = "audience";
   public static final String TOKEN_INCLUDE_GROUPS_IN_JWT_ALLOWED = TOKEN_PARAM_PREFIX + "include.groups.allowed";
   private static final String TOKEN_TARGET_URL = TOKEN_PARAM_PREFIX + "target.url";
   static final String TOKEN_CLIENT_DATA = TOKEN_PARAM_PREFIX + "client.data";
@@ -217,7 +218,8 @@ public class TokenResource {
     ALREADY_DISABLED(60),
     ALREADY_ENABLED(70),
     DISABLED_KNOXSSO_COOKIE(80),
-    TOKEN_EXPIRED(90);
+    TOKEN_EXPIRED(90),
+    INVALID_AUDIENCE(100);
 
     private final int code;
 
@@ -901,9 +903,20 @@ public class TokenResource {
     long expires = getExpiry();
     setupPublicCertPEM();
     String jku = getJku();
+
+    final List<String> audiences;
+    try {
+      audiences = resolveAudiences();
+    } catch (AudienceValidationException e) {
+      log.rejectedAudienceRequest(e.getMessage());
+      return new TokenResponseContext(null,
+          "{\n  \"error\": \"" + e.getMessage() + "\",\n  \"code\": " + e.getErrorCode().toInt() + "\n}\n",
+          Response.status(Response.Status.BAD_REQUEST));
+    }
+
     try
     {
-      JWT token = getJWT(context, issueTime, expires, jku);
+      JWT token = getJWT(context, issueTime, expires, jku, audiences);
       if (token != null) {
         ResponseMap result = buildResponseMap(token, expires);
         String jsonResponse = JsonUtils.renderAsJsonString(result.map);
@@ -1136,7 +1149,45 @@ public class TokenResource {
     }
   }
 
-  private JWT getJWT(UserContext userContext, long issueTime, long expires, String jku) throws TokenServiceException {
+  private List<String> resolveAudiences() throws AudienceValidationException {
+    final Map<String, String[]> parameterMap = request.getParameterMap();
+    final String[] rawValues = parameterMap == null ? null : parameterMap.get(AUDIENCE_QUERY_PARAM);
+    final List<String> requested = new ArrayList<>();
+    if (rawValues != null) {
+      for (String rawValue : rawValues) {
+        if (rawValue == null) {
+          continue;
+        }
+        for (String value : rawValue.split(",")) {
+          final String trimmed = value.trim();
+          if (!trimmed.isEmpty()) {
+            requested.add(trimmed);
+          }
+        }
+      }
+    }
+
+    // No audience requested: keep the historical behavior (use the configured audiences).
+    if (requested.isEmpty()) {
+      return targetAudiences;
+    }
+
+    // Secure by default: with no configured whitelist there is nothing to validate against, so refuse.
+    if (targetAudiences.isEmpty()) {
+      throw new AudienceValidationException("No audiences are configured; cannot honor a requested audience.",
+          ErrorCode.INVALID_AUDIENCE);
+    }
+
+    for (String audience : requested) {
+      if (!targetAudiences.contains(audience)) {
+        throw new AudienceValidationException("The requested audience '" + audience + "' is not allowed.",
+            ErrorCode.INVALID_AUDIENCE);
+      }
+    }
+    return requested;
+  }
+
+  private JWT getJWT(UserContext userContext, long issueTime, long expires, String jku, List<String> audiences) throws TokenServiceException {
     JWTokenAttributes jwtAttributes;
     JWT token;
     JWTokenAuthority ts = getGatewayServices().getService(ServiceType.TOKEN_SERVICE);
@@ -1151,8 +1202,8 @@ public class TokenResource {
         .setManaged(managedToken)
         .setJku(jku)
         .setType(tokenType);
-    if (!targetAudiences.isEmpty()) {
-      jwtAttributesBuilder.setAudiences(targetAudiences);
+    if (audiences != null && !audiences.isEmpty()) {
+      jwtAttributesBuilder.setAudiences(audiences);
     }
     if (shouldIncludeGroups()) {
       jwtAttributesBuilder.setGroups(groups());

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenResource.java
@@ -126,6 +126,7 @@ public class TokenResource {
   public static final String TOKEN_TYPE_PARAM = TOKEN_PARAM_PREFIX + "type";
   private static final String TOKEN_AUDIENCES_PARAM = TOKEN_PARAM_PREFIX + "audiences";
   static final String AUDIENCE_QUERY_PARAM = "audience";
+  private static final String TOKEN_AUDIENCE_VALIDATOR_PARAM = TOKEN_PARAM_PREFIX + "audience.validator";
   public static final String TOKEN_INCLUDE_GROUPS_IN_JWT_ALLOWED = TOKEN_PARAM_PREFIX + "include.groups.allowed";
   private static final String TOKEN_TARGET_URL = TOKEN_PARAM_PREFIX + "target.url";
   static final String TOKEN_CLIENT_DATA = TOKEN_PARAM_PREFIX + "client.data";
@@ -173,6 +174,7 @@ public class TokenResource {
   private String tokenType;
   private String tokenTTLAsText;
   private List<String> targetAudiences = new ArrayList<>();
+  private AudienceValidator audienceValidator;
   private String tokenTargetUrl;
   private Map<String, Object> tokenClientDataMap;
   private List<String> allowedDNs = new ArrayList<>();
@@ -246,6 +248,18 @@ public class TokenResource {
       for (String aud : auds) {
         targetAudiences.add(aud.trim());
       }
+    }
+
+    try {
+      audienceValidator = AudienceValidator.forName(context.getInitParameter(TOKEN_AUDIENCE_VALIDATOR_PARAM));
+    } catch (IllegalArgumentException e) {
+      throw new ServiceLifecycleException(e.getMessage(), e);
+    }
+
+    if (audienceValidator.requiresConfiguredAudiences() && targetAudiences.isEmpty()) {
+      throw new ServiceLifecycleException("The '" + audienceValidator.name()
+          + "' audience validator requires audiences to be configured in '" + TOKEN_AUDIENCES_PARAM
+          + "', but none are set. Configure the allowed audiences or select a different audience validator.");
     }
 
     String clientCert = context.getInitParameter(TOKEN_CLIENT_CERT_REQUIRED);
@@ -906,7 +920,7 @@ public class TokenResource {
 
     final List<String> audiences;
     try {
-      audiences = resolveAudiences();
+      audiences = audienceValidator.validateAndResolve(new AudienceValidationContext(parseRequestedAudiences(), targetAudiences));
     } catch (RequestedAudienceValidationException e) {
       log.rejectedAudienceRequest(e.getMessage());
       return new TokenResponseContext(null,
@@ -1149,7 +1163,7 @@ public class TokenResource {
     }
   }
 
-  private List<String> resolveAudiences() throws RequestedAudienceValidationException {
+  private List<String> parseRequestedAudiences() {
     final Map<String, String[]> parameterMap = request.getParameterMap();
     final String[] rawValues = parameterMap == null ? null : parameterMap.get(AUDIENCE_QUERY_PARAM);
     final List<String> requested = new ArrayList<>();
@@ -1164,24 +1178,6 @@ public class TokenResource {
             requested.add(trimmed);
           }
         }
-      }
-    }
-
-    // No audience requested: keep the historical behavior (use the configured audiences).
-    if (requested.isEmpty()) {
-      return targetAudiences;
-    }
-
-    // Secure by default: with no configured whitelist there is nothing to validate against, so refuse.
-    if (targetAudiences.isEmpty()) {
-      throw new RequestedAudienceValidationException("No allowed audiences are configured in 'knox.token.audiences'; cannot honor a requested audience.",
-          ErrorCode.INVALID_AUDIENCE);
-    }
-
-    for (String audience : requested) {
-      if (!targetAudiences.contains(audience)) {
-        throw new RequestedAudienceValidationException("The requested audience '" + audience + "' is not allowed.",
-            ErrorCode.INVALID_AUDIENCE);
       }
     }
     return requested;

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceMessages.java
@@ -105,4 +105,7 @@ public interface TokenServiceMessages {
   @Message( level = MessageLevel.DEBUG, text = "Adding RFC 8693 'act' claim to token: actor={0}, subject={1}" )
   void addingActorClaimToToken(String actor, String subject);
 
+  @Message( level = MessageLevel.WARN, text = "Rejected token request due to invalid audience: {0}" )
+  void rejectedAudienceRequest(String reason);
+
 }

--- a/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/WhitelistAudienceValidator.java
+++ b/gateway-service-knoxtoken/src/main/java/org/apache/knox/gateway/service/knoxtoken/WhitelistAudienceValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import java.util.List;
+
+import org.apache.knox.gateway.service.knoxtoken.TokenResource.ErrorCode;
+
+class WhitelistAudienceValidator implements AudienceValidator {
+
+    static final String NAME = "whitelist";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public boolean requiresConfiguredAudiences() {
+        return true;
+    }
+
+    @Override
+    public List<String> validateAndResolve(AudienceValidationContext context) throws RequestedAudienceValidationException {
+        final List<String> requested = context.requestedAudiences();
+        final List<String> configured = context.configuredAudiences();
+
+        // No audience requested: keep the historical behavior (use the configured audiences).
+        if (requested.isEmpty()) {
+            return configured;
+        }
+
+        for (String audience : requested) {
+            if (!configured.contains(audience)) {
+                throw new RequestedAudienceValidationException(
+                        "The requested audience '" + audience + "' is not allowed.", ErrorCode.INVALID_AUDIENCE);
+            }
+        }
+        return requested;
+    }
+}

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/PassthroughAudienceValidatorTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/PassthroughAudienceValidatorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class PassthroughAudienceValidatorTest {
+
+  private final PassthroughAudienceValidator validator = new PassthroughAudienceValidator();
+
+  @Test
+  public void requestedAudiencesAreReturnedAsIsWithoutWhitelistCheck() throws Exception {
+    final List<String> requested = Arrays.asList("service-a", "not-configured");
+    final List<String> result = validator.validateAndResolve(
+        new AudienceValidationContext(requested, Collections.singletonList("service-b")));
+    assertSame(requested, result);
+  }
+
+  @Test
+  public void noRequestedAudienceReturnsEmptyWithoutFallbackToConfigured() throws Exception {
+    final List<String> result = validator.validateAndResolve(
+        new AudienceValidationContext(Collections.emptyList(), Arrays.asList("a", "b")));
+    assertEquals(Collections.emptyList(), result);
+  }
+
+  @Test
+  public void doesNotRequireConfiguredAudiences() {
+    assertFalse(validator.requiresConfiguredAudiences());
+  }
+}

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/StaticAudienceValidatorTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/StaticAudienceValidatorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class StaticAudienceValidatorTest {
+
+  private final StaticAudienceValidator validator = new StaticAudienceValidator();
+
+  @Test
+  public void requestedAudiencesAreIgnoredAndConfiguredAreReturned() throws Exception {
+    final List<String> configured = Arrays.asList("a", "b");
+    final List<String> result = validator.validateAndResolve(
+        new AudienceValidationContext(Collections.singletonList("requested"), configured));
+    assertSame(configured, result);
+  }
+
+  @Test
+  public void noConfiguredAudiencesReturnsEmpty() throws Exception {
+    final List<String> result = validator.validateAndResolve(
+        new AudienceValidationContext(Collections.singletonList("requested"), Collections.emptyList()));
+    assertEquals(Collections.emptyList(), result);
+  }
+
+  @Test
+  public void doesNotRequireConfiguredAudiences() {
+    assertFalse(validator.requiresConfiguredAudiences());
+  }
+}

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -133,6 +133,7 @@ public class TokenServiceResourceTest {
 
   private ServletContext context;
   private HttpServletRequest request;
+  private String[] audienceParamValues;
   private JWTokenAuthority authority;
   private TestTokenStateService tss = new TestTokenStateService();
   private char[] hmacSecret;
@@ -198,6 +199,11 @@ public class TokenServiceResourceTest {
       EasyMock.expect(request.getParameter(TokenResource.QUERY_PARAMETER_DOAS)).andReturn(contextExpectations.get(TokenResource.QUERY_PARAMETER_DOAS)).anyTimes();
     }
     EasyMock.expect(request.getParameterNames()).andReturn(Collections.emptyEnumeration()).anyTimes();
+    final Map<String, String[]> parameterMap = new HashMap<>();
+    if (audienceParamValues != null) {
+      parameterMap.put(TokenResource.AUDIENCE_QUERY_PARAM, audienceParamValues);
+    }
+    EasyMock.expect(request.getParameterMap()).andReturn(parameterMap).anyTimes();
 
     GatewayServices services = EasyMock.createNiceMock(GatewayServices.class);
     EasyMock.expect(context.getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE)).andReturn(services).anyTimes();
@@ -428,6 +434,103 @@ public class TokenServiceResourceTest {
     assertEquals(2, audiences.size());
     assertTrue(audiences.contains("recipient1"));
     assertTrue(audiences.contains("recipient2"));
+  }
+
+  @Test
+  public void testDynamicAudienceNoParamUsesConfigured() throws Exception {
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response retResponse = tr.doGet();
+    assertEquals(200, retResponse.getStatus());
+
+    JWT parsedToken = new JWTToken(getTagValue(retResponse.getEntity().toString(), "access_token"));
+    List<String> audiences = Arrays.asList(parsedToken.getAudienceClaims());
+    assertEquals(2, audiences.size());
+    assertTrue(audiences.contains("recipient1"));
+    assertTrue(audiences.contains("recipient2"));
+  }
+
+  @Test
+  public void testDynamicAudienceRejectedWhenNoWhitelistConfigured() throws Exception {
+    audienceParamValues = new String[] { "recipient1" };
+    final Map<String, String> contextExpectations = new HashMap<>();
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response retResponse = tr.doGet();
+    assertEquals(400, retResponse.getStatus());
+  }
+
+  @Test
+  public void testDynamicAudienceAllowedWhenWhitelisted() throws Exception {
+    audienceParamValues = new String[] { "recipient1" };
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response retResponse = tr.doGet();
+    assertEquals(200, retResponse.getStatus());
+
+    JWT parsedToken = new JWTToken(getTagValue(retResponse.getEntity().toString(), "access_token"));
+    List<String> audiences = Arrays.asList(parsedToken.getAudienceClaims());
+    assertEquals(1, audiences.size());
+    assertTrue(audiences.contains("recipient1"));
+    assertFalse(audiences.contains("recipient2"));
+  }
+
+  @Test
+  public void testDynamicAudienceRejectedWhenNotWhitelisted() throws Exception {
+    audienceParamValues = new String[] { "recipient1", "intruder" };
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response retResponse = tr.doGet();
+    assertEquals(400, retResponse.getStatus());
+  }
+
+  @Test
+  public void testDynamicAudienceMultipleValuesAndCommaSeparated() throws Exception {
+    audienceParamValues = new String[] { "recipient1", " recipient2 , recipient3" };
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audiences", "recipient1,recipient2,recipient3");
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+
+    Response retResponse = tr.doGet();
+    assertEquals(200, retResponse.getStatus());
+
+    JWT parsedToken = new JWTToken(getTagValue(retResponse.getEntity().toString(), "access_token"));
+    List<String> audiences = Arrays.asList(parsedToken.getAudienceClaims());
+    assertEquals(3, audiences.size());
+    assertTrue(audiences.contains("recipient1"));
+    assertTrue(audiences.contains("recipient2"));
+    assertTrue(audiences.contains("recipient3"));
   }
 
   @Test

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/TokenServiceResourceTest.java
@@ -439,6 +439,7 @@ public class TokenServiceResourceTest {
   @Test
   public void testDynamicAudienceNoParamUsesConfigured() throws Exception {
     final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audience.validator", "whitelist");
     contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
     configureCommonExpectations(contextExpectations);
 
@@ -458,9 +459,12 @@ public class TokenServiceResourceTest {
   }
 
   @Test
-  public void testDynamicAudienceRejectedWhenNoWhitelistConfigured() throws Exception {
+  public void testDynamicAudienceIgnoredWithDefaultStaticValidator() throws Exception {
+    // With no validator configured the default 'static' validator is used: a requested audience must
+    // be ignored and the configured audiences used unchanged (historical behavior).
     audienceParamValues = new String[] { "recipient1" };
     final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
     configureCommonExpectations(contextExpectations);
 
     TokenResource tr = new TokenResource();
@@ -469,13 +473,47 @@ public class TokenServiceResourceTest {
     tr.init();
 
     Response retResponse = tr.doGet();
-    assertEquals(400, retResponse.getStatus());
+    assertEquals(200, retResponse.getStatus());
+
+    JWT parsedToken = new JWTToken(getTagValue(retResponse.getEntity().toString(), "access_token"));
+    List<String> audiences = Arrays.asList(parsedToken.getAudienceClaims());
+    assertEquals(2, audiences.size());
+    assertTrue(audiences.contains("recipient1"));
+    assertTrue(audiences.contains("recipient2"));
+  }
+
+  @Test(expected = ServiceLifecycleException.class)
+  public void testDeploymentFailsWhenWhitelistValidatorWithoutWhitelist() throws Exception {
+    // Selecting the whitelist validator with no configured audiences must fail the deployment rather
+    // than start up unable to honor any request.
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audience.validator", "whitelist");
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
+  }
+
+  @Test(expected = ServiceLifecycleException.class)
+  public void testDeploymentFailsWhenUnknownAudienceValidatorConfigured() throws Exception {
+    final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audiences", "recipient1");
+    contextExpectations.put("knox.token.audience.validator", "does-not-exist");
+    configureCommonExpectations(contextExpectations);
+
+    TokenResource tr = new TokenResource();
+    tr.request = request;
+    tr.context = context;
+    tr.init();
   }
 
   @Test
   public void testDynamicAudienceAllowedWhenWhitelisted() throws Exception {
     audienceParamValues = new String[] { "recipient1" };
     final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audience.validator", "whitelist");
     contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
     configureCommonExpectations(contextExpectations);
 
@@ -498,6 +536,7 @@ public class TokenServiceResourceTest {
   public void testDynamicAudienceRejectedWhenNotWhitelisted() throws Exception {
     audienceParamValues = new String[] { "recipient1", "intruder" };
     final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audience.validator", "whitelist");
     contextExpectations.put("knox.token.audiences", "recipient1,recipient2");
     configureCommonExpectations(contextExpectations);
 
@@ -514,6 +553,7 @@ public class TokenServiceResourceTest {
   public void testDynamicAudienceMultipleValuesAndCommaSeparated() throws Exception {
     audienceParamValues = new String[] { "recipient1", " recipient2 , recipient3" };
     final Map<String, String> contextExpectations = new HashMap<>();
+    contextExpectations.put("knox.token.audience.validator", "whitelist");
     contextExpectations.put("knox.token.audiences", "recipient1,recipient2,recipient3");
     configureCommonExpectations(contextExpectations);
 

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/WhitelistAudienceValidatorTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/WhitelistAudienceValidatorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.knoxtoken;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class WhitelistAudienceValidatorTest {
+
+  private final WhitelistAudienceValidator validator = new WhitelistAudienceValidator();
+
+  @Test
+  public void noRequestedAudienceReturnsConfigured() throws Exception {
+    final List<String> configured = Arrays.asList("a", "b");
+    final List<String> result = validator.validateAndResolve(new AudienceValidationContext(Collections.emptyList(), configured));
+    assertSame(configured, result);
+  }
+
+  @Test
+  public void requestedSubsetIsHonored() throws Exception {
+    final List<String> result = validator.validateAndResolve(
+        new AudienceValidationContext(Collections.singletonList("a"), Arrays.asList("a", "b")));
+    assertEquals(Collections.singletonList("a"), result);
+  }
+
+  @Test
+  public void requestedValueNotInWhitelistIsRejected() {
+    try {
+      validator.validateAndResolve(new AudienceValidationContext(Arrays.asList("a", "intruder"), Arrays.asList("a", "b")));
+      fail("Expected RequestedAudienceValidationException for a non-whitelisted audience");
+    } catch (RequestedAudienceValidationException e) {
+      assertEquals(TokenResource.ErrorCode.INVALID_AUDIENCE, e.getErrorCode());
+    }
+  }
+
+  @Test
+  public void requestedAudienceWithNoWhitelistIsRejected() {
+    try {
+      validator.validateAndResolve(new AudienceValidationContext(Collections.singletonList("a"), Collections.emptyList()));
+      fail("Expected RequestedAudienceValidationException when no whitelist is configured");
+    } catch (RequestedAudienceValidationException e) {
+      assertEquals(TokenResource.ErrorCode.INVALID_AUDIENCE, e.getErrorCode());
+    }
+  }
+
+  @Test
+  public void requiresConfiguredAudiences() {
+    assertTrue(validator.requiresConfiguredAudiences());
+  }
+
+  @Test
+  public void forNameDefaultsToStatic() {
+    assertTrue(AudienceValidator.forName(null) instanceof StaticAudienceValidator);
+    assertTrue(AudienceValidator.forName("  ") instanceof StaticAudienceValidator);
+    assertTrue(AudienceValidator.forName("static") instanceof StaticAudienceValidator);
+    assertTrue(AudienceValidator.forName("whitelist") instanceof WhitelistAudienceValidator);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void forNameRejectsUnknownValidator() {
+    AudienceValidator.forName("nope");
+  }
+}

--- a/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/WhitelistAudienceValidatorTest.java
+++ b/gateway-service-knoxtoken/src/test/java/org/apache/knox/gateway/service/knoxtoken/WhitelistAudienceValidatorTest.java
@@ -77,6 +77,7 @@ public class WhitelistAudienceValidatorTest {
     assertTrue(AudienceValidator.forName("  ") instanceof StaticAudienceValidator);
     assertTrue(AudienceValidator.forName("static") instanceof StaticAudienceValidator);
     assertTrue(AudienceValidator.forName("whitelist") instanceof WhitelistAudienceValidator);
+    assertTrue(AudienceValidator.forName("passthrough") instanceof PassthroughAudienceValidator);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/knox-site/docs/config_knox_token.md
+++ b/knox-site/docs/config_knox_token.md
@@ -47,7 +47,7 @@ The Knox Token Service configuration can be configured in any descriptor/topolog
 Parameter                        | Description | Default    |
 -------------------------------- |------------ |----------- |
 knox.token.ttl                | This indicates the lifespan (milliseconds) of the token. Once it expires a new token must be acquired from KnoxToken service. The 36000000 in the topology above gives you 10 hrs. | 30000 (30 seconds) |
-knox.token.audiences          | This is a comma-separated list of audiences to add to the JWT token. This is used to ensure that a token received by a participating application knows that the token was intended for use with that application. It is optional. In the event that an endpoint has expected audiences and they are not present the token must be rejected. In the event where the token has audiences and the endpoint has none expected then the token is accepted.| empty |
+knox.token.audiences          | This is a comma-separated list of audiences to add to the JWT token. This is used to ensure that a token received by a participating application knows that the token was intended for use with that application. It is optional. In the event that an endpoint has expected audiences and they are not present the token must be rejected. In the event where the token has audiences and the endpoint has none expected then the token is accepted. This list additionally acts as the whitelist of audiences a caller is permitted to request per request via the `audience` query parameter (see below).| empty |
 knox.token.target.url         | This is an optional configuration parameter to indicate the intended endpoint for which the token may be used. The KnoxShell token credential collector can pull this URL from a knoxtokencache file to be used in scripts. This eliminates the need to prompt for or hardcode endpoints in your scripts. | n/a |
 knox.token.exp.server-managed | This is an optional configuration parameter to enable/disable server-managed token state, to support the associated token renewal and revocation APIs. | false |
 knox.token.renewer.whitelist  | This is an optional configuration parameter to authorize the comma-separated list of users to invoke the associated token renewal and revocation APIs. |  |
@@ -98,6 +98,21 @@ This feature is enabled by default. If you want to disable it, add the following
             <name>knox.token.include.groups.allowed</name> <!-- default = true -->
             <value>false</value>
         </param>
+
+#### Requesting a token audience dynamically
+
+By default the `aud` claim of an issued token is fixed to the value(s) configured in `knox.token.audiences`. A caller may instead request the audience(s) per request using the `audience` query parameter. Multiple audiences may be supplied either comma-separated in a single parameter or as repeated parameters; surrounding whitespace is trimmed.
+
+    curl -u admin:admin-password -k "https://localhost:8443/gateway/homepage/knoxtoken/api/v1/token?audience=service-a"
+
+To prevent audience (token) spoofing, requested audiences are validated against `knox.token.audiences`, which acts as a whitelist. The behavior is:
+
+*   the request does not contain an `audience` parameter -> the statically configured `knox.token.audiences` are used, exactly as before (unchanged default behavior)
+*   the request contains an `audience` parameter but `knox.token.audiences` is not configured -> the request is rejected with `400 Bad Request` (secure by default: there is no whitelist to validate against)
+*   the request contains an `audience` parameter and every requested audience is present in `knox.token.audiences` -> only the requested audience(s) are placed in the token's `aud` claim
+*   the request contains an `audience` parameter and any requested audience is not present in `knox.token.audiences` -> the request is rejected with `400 Bad Request`
+
+Only exact matches against the whitelist are honored.
 
 #### KnoxToken Renewal, Revocation and Enable/Disable actions
 

--- a/knox-site/docs/config_knox_token.md
+++ b/knox-site/docs/config_knox_token.md
@@ -109,6 +109,7 @@ Which requested audiences are allowed is decided by a pluggable *audience valida
 
 *   `static` (the default) preserves the historical behavior: the `audience` query parameter is ignored and the statically configured `knox.token.audiences` are always used. No configuration beyond `knox.token.audiences` is needed and nothing new is exposed to callers.
 *   `whitelist` validates requested audiences against `knox.token.audiences`, treating it as a whitelist.
+*   `passthrough` accepts whatever audience(s) the caller requests without any local whitelist. It requires no configured `knox.token.audiences`; when the request contains no `audience` parameter the token is issued with no `aud` claim (it does not fall back to `knox.token.audiences`).
 
 Selecting the `whitelist` validator enables per-request audiences:
 
@@ -125,15 +126,17 @@ With the `whitelist` validator its behavior is:
 
 Only exact matches against the whitelist are honored.
 
-To avoid deploying a topology that cannot authorize any request, the deployment fails at startup when the `whitelist` validator is selected but no `knox.token.audiences` are configured. This guard is specific to validators that require a configured audience list (the `whitelist` validator cannot authorize anything without one); it is expressed through the validator's own `requiresConfiguredAudiences()` contract rather than by inspecting the topology. The default `static` validator has no such requirement.
+The `passthrough` validator instead stamps the requested audience(s) into the token's `aud` claim verbatim, without any whitelist check, and rejects nothing. If the request contains no `audience` parameter the token is issued with no `aud` claim. Because it performs no local authorization, `passthrough` relies on a downstream JWTProvider to reject tokens whose `aud` does not match the consumer topology's expected audiences, deferring enforcement to the point of consumption. Use it only when such consumption-time validation is in place.
 
-Additional validators can be added and selected through `knox.token.audience.validator` without changing the `static` or `whitelist` behavior described above. Because a validator runs when the token is *issued*, it decides only which `aud` value(s) may be stamped into the new token; it does not and cannot consult the JWTProvider filter, which validates an already-issued token at *consumption* time on the topology fronting the target service. A conceivable future validator could, for example, honor requested audiences without a local whitelist and rely on a downstream JWTProvider to reject tokens whose `aud` does not match that consumer topology's expected audiences (deferring enforcement to the point of consumption), or delegate the decision to an external policy service. Neither is implemented today.
+To avoid deploying a topology that cannot authorize any request, the deployment fails at startup when the `whitelist` validator is selected but no `knox.token.audiences` are configured. This guard is specific to validators that require a configured audience list (the `whitelist` validator cannot authorize anything without one); it is expressed through the validator's own `requiresConfiguredAudiences()` contract rather than by inspecting the topology. The `static` and `passthrough` validators have no such requirement.
+
+Additional validators can be added and selected through `knox.token.audience.validator` without changing the behavior described above. Because a validator runs when the token is *issued*, it decides only which `aud` value(s) may be stamped into the new token; it does not and cannot consult the JWTProvider filter, which validates an already-issued token at *consumption* time on the topology fronting the target service. A conceivable future validator could, for example, delegate the decision to an external policy service. That is not implemented today.
 
 Audience validator configuration parameters:
 
 Parameter                        | Description | Default    |
 -------------------------------- |------------ |----------- |
-knox.token.audience.validator | Selects the audience validator strategy. `static` ignores the per-request `audience` parameter and uses `knox.token.audiences`; `whitelist` honors requested audiences that appear in `knox.token.audiences`. | static |
+knox.token.audience.validator | Selects the audience validator strategy. `static` ignores the per-request `audience` parameter and uses `knox.token.audiences`; `whitelist` honors requested audiences that appear in `knox.token.audiences`; `passthrough` accepts any requested audience without a whitelist (no `aud` when the parameter is absent). | static |
 
 #### KnoxToken Renewal, Revocation and Enable/Disable actions
 

--- a/knox-site/docs/config_knox_token.md
+++ b/knox-site/docs/config_knox_token.md
@@ -101,18 +101,39 @@ This feature is enabled by default. If you want to disable it, add the following
 
 #### Requesting a token audience dynamically
 
-By default the `aud` claim of an issued token is fixed to the value(s) configured in `knox.token.audiences`. A caller may instead request the audience(s) per request using the `audience` query parameter. Multiple audiences may be supplied either comma-separated in a single parameter or as repeated parameters; surrounding whitespace is trimmed.
+By default the `aud` claim of an issued token is fixed to the value(s) configured in `knox.token.audiences`, and the per-request `audience` query parameter is ignored. To let a caller request the audience(s) per request instead, select an *audience validator* that honors the parameter. Multiple audiences may be supplied either comma-separated in a single parameter or as repeated parameters; surrounding whitespace is trimmed.
 
     curl -u admin:admin-password -k "https://localhost:8443/gateway/homepage/knoxtoken/api/v1/token?audience=service-a"
 
-To prevent audience (token) spoofing, requested audiences are validated against `knox.token.audiences`, which acts as a whitelist. The behavior is:
+Which requested audiences are allowed is decided by a pluggable *audience validator*, selected with `knox.token.audience.validator`:
+
+*   `static` (the default) preserves the historical behavior: the `audience` query parameter is ignored and the statically configured `knox.token.audiences` are always used. No configuration beyond `knox.token.audiences` is needed and nothing new is exposed to callers.
+*   `whitelist` validates requested audiences against `knox.token.audiences`, treating it as a whitelist.
+
+Selecting the `whitelist` validator enables per-request audiences:
+
+        <param>
+            <name>knox.token.audience.validator</name>
+            <value>whitelist</value>
+        </param>
+
+With the `whitelist` validator its behavior is:
 
 *   the request does not contain an `audience` parameter -> the statically configured `knox.token.audiences` are used, exactly as before (unchanged default behavior)
-*   the request contains an `audience` parameter but `knox.token.audiences` is not configured -> the request is rejected with `400 Bad Request` (secure by default: there is no whitelist to validate against)
 *   the request contains an `audience` parameter and every requested audience is present in `knox.token.audiences` -> only the requested audience(s) are placed in the token's `aud` claim
 *   the request contains an `audience` parameter and any requested audience is not present in `knox.token.audiences` -> the request is rejected with `400 Bad Request`
 
 Only exact matches against the whitelist are honored.
+
+To avoid deploying a topology that cannot authorize any request, the deployment fails at startup when the `whitelist` validator is selected but no `knox.token.audiences` are configured. This guard is specific to validators that require a configured audience list (the `whitelist` validator cannot authorize anything without one); it is expressed through the validator's own `requiresConfiguredAudiences()` contract rather than by inspecting the topology. The default `static` validator has no such requirement.
+
+Additional validators can be added and selected through `knox.token.audience.validator` without changing the `static` or `whitelist` behavior described above. Because a validator runs when the token is *issued*, it decides only which `aud` value(s) may be stamped into the new token; it does not and cannot consult the JWTProvider filter, which validates an already-issued token at *consumption* time on the topology fronting the target service. A conceivable future validator could, for example, honor requested audiences without a local whitelist and rely on a downstream JWTProvider to reject tokens whose `aud` does not match that consumer topology's expected audiences (deferring enforcement to the point of consumption), or delegate the decision to an external policy service. Neither is implemented today.
+
+Audience validator configuration parameters:
+
+Parameter                        | Description | Default    |
+-------------------------------- |------------ |----------- |
+knox.token.audience.validator | Selects the audience validator strategy. `static` ignores the per-request `audience` parameter and uses `knox.token.audiences`; `whitelist` honors requested audiences that appear in `knox.token.audiences`. | static |
 
 #### KnoxToken Renewal, Revocation and Enable/Disable actions
 


### PR DESCRIPTION
[KNOX-3424](https://issues.apache.org/jira/browse/KNOX-3424) - Dynamic audience handling in the KNOXTOKEN service

## What changes were proposed in this pull request?

Callers can now request a token's `aud` claim per request via an `audience` query parameter. Requested values are validated by a pluggable audience validator, selected with the new `knox.token.audience.validator` init param, so operators opt into dynamic audiences explicitly and untrusted callers can't spoof arbitrary audiences.

**Validators**

Selected per topology via `knox.token.audience.validator`:

- `static` (default) — preserves the existing behavior. The `audience` query parameter is ignored and the statically configured `knox.token.audiences` are always used. No config change needed for existing deployments.
- `whitelist` — honors the `audience` query parameter, validated against the `knox.token.audiences` whitelist.
- `passthrough` — accepts whatever audience(s) the caller requests, with no local whitelist. Enforcement is deferred to the consumption-time JWTProvider on the topology fronting the target service.

**Behavior (whitelist)**

- No `audience` param → the configured `knox.token.audiences` are used (unchanged).
- `audience` param, all values in the whitelist → only the requested audience(s) land in `aud`.
- `audience` param, any value not whitelisted → `400`.
- Multiple audiences allowed (comma-separated and/or repeated params); exact match only, whitespace trimmed.

**Behavior (passthrough)**

- `audience` param present → the requested audience(s) are stamped into `aud` verbatim; no whitelist check, never rejected.
- No `audience` param → the token is issued with no `aud` claim (no fallback to `knox.token.audiences`, unlike `static`/`whitelist`).
- Multiple audiences allowed (comma-separated and/or repeated params); whitespace trimmed.
- Use only where a downstream JWTProvider validates `aud` at consumption time.

**Fail-fast**

`whitelist` requires `knox.token.audiences` to be configured — a validator that needs a whitelist but has nothing to validate against fails deployment (`ServiceLifecycleException`) rather than silently accepting anything. An unknown validator name also fails deployment.

**Extensibility**

`AudienceValidator.validateAndResolve(...)` is a small strategy interface; new validators can be added and selected through `knox.token.audience.validator` without touching `TokenResource`.

## How was this patch tested?

Unit tests, local tests

```
<param>
    <name>knox.token.audiences</name>
    <value>test1,test2</value>
</param>
<param>
    <name>knox.token.audience.validator</name>
    <value>whitelist</value>
</param>
```

```
curl -sku guest:guest-password -X GET \
  "https://localhost:8443/gateway/tokenissuer/knoxtoken/api/v2/token?lifespan=P0DT1H0M" \
| jq -r '.access_token' \
| cut -d. -f2 \
| { read p; pad=$(( (4 - ${#p} % 4) % 4 )); printf '%s%s' "$p" "$(printf '%*s' "$pad" '' | tr ' ' '=')" | tr '_-' '/+' | base64 -d; } \
| jq '{aud}'
{
  "aud": [
    "test1",
    "test2"
  ]
}
```

```
curl -sku guest:guest-password -X GET \
  "https://localhost:8443/gateway/tokenissuer/knoxtoken/api/v2/token?lifespan=P0DT1H0M&audience=test1,test2" \
| jq -r '.access_token' \
| cut -d. -f2 \
| { read p; pad=$(( (4 - ${#p} % 4) % 4 )); printf '%s%s' "$p" "$(printf '%*s' "$pad" '' | tr ' ' '=')" | tr '_-' '/+' | base64 -d; } \
| jq '{aud}'
{
  "aud": [
    "test1",
    "test2"
  ]
}

```

```
curl -sku guest:guest-password -X GET \
  "https://localhost:8443/gateway/tokenissuer/knoxtoken/api/v2/token?lifespan=P0DT1H0M&audience=test1" \
| jq -r '.access_token' \
| cut -d. -f2 \
| { read p; pad=$(( (4 - ${#p} % 4) % 4 )); printf '%s%s' "$p" "$(printf '%*s' "$pad" '' | tr ' ' '=')" | tr '_-' '/+' | base64 -d; } \
| jq '{aud}'
{
  "aud": "test1"
}
```

```
curl -sku guest:guest-password -X GET \
  "https://localhost:8443/gateway/tokenissuer/knoxtoken/api/v2/token?lifespan=P0DT1H0M&audience=test1,bad"
{
  "error": "The requested audience 'bad' is not allowed.",
  "code": 100
}
```

```
curl -sku guest:guest-password -X GET \
  "https://localhost:8443/gateway/tokenissuer/knoxtoken/api/v2/token?lifespan=P0DT1H0M&audience=bad"
{
  "error": "The requested audience 'bad' is not allowed.",
  "code": 100
}
```

## Integration Tests
N/A

## UI changes
N/A
