### PR TITLE
KNOX-3422: Ldap Proxy used in-memory bind user

### DIFF
--- a/.github/workflows/build/gateway-site.xml
+++ b/.github/workflows/build/gateway-site.xml
@@ -146,6 +146,10 @@ limitations under the License.
         <value>dc=proxy,dc=org</value>
     </property>
     <property>
+        <name>gateway.ldap.bind.user</name>
+        <value>uid=bind,ou=people,dc=proxy,dc=org</value>
+    </property>
+    <property>
         <name>gateway.ldap.max.size.limit</name>
         <value>1000</value>
     </property>

--- a/.github/workflows/build/gateway.sh
+++ b/.github/workflows/build/gateway.sh
@@ -43,6 +43,11 @@ keytool -importcert -noprompt -alias knox-ldaps \
   -file /tmp/ldaps-cert.pem
 rm -f /tmp/ldaps-cert.pem
 
+# 4) Store a password for the LDAP Proxy bind user
+LDAP_BIND_PASSWORD=bind-password
+LDAP_BIND_PASSWORD_ALIAS=gateway_ldap_bind_password
+/knox-runtime/bin/knoxcli.sh create-alias "$LDAP_BIND_PASSWORD_ALIAS" --value "$LDAP_BIND_PASSWORD"
+
 # Start Knox. Endpoint (hostname) identification is disabled for the embedded LDAPS
 # connection - the dev cert is self-signed - but trust is still enforced via cacerts.
 java -Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true \

--- a/.github/workflows/compose/single-eku-no-mtls/gateway-site.xml
+++ b/.github/workflows/compose/single-eku-no-mtls/gateway-site.xml
@@ -158,6 +158,10 @@ limitations under the License.
         <value>dc=proxy,dc=org</value>
     </property>
     <property>
+        <name>gateway.ldap.bind.user</name>
+        <value>uid=bind,ou=people,dc=proxy,dc=org</value>
+    </property>
+    <property>
         <name>gateway.ldap.max.size.limit</name>
         <value>1000</value>
     </property>

--- a/.github/workflows/compose/single-eku/gateway-site.xml
+++ b/.github/workflows/compose/single-eku/gateway-site.xml
@@ -212,6 +212,10 @@ limitations under the License.
         <value>dc=proxy,dc=org</value>
     </property>
     <property>
+        <name>gateway.ldap.bind.user</name>
+        <value>uid=bind,ou=people,dc=proxy,dc=org</value>
+    </property>
+    <property>
         <name>gateway.ldap.max.size.limit</name>
         <value>1000</value>
     </property>

--- a/.github/workflows/tests/test_knox_ldap_proxy_search.py
+++ b/.github/workflows/tests/test_knox_ldap_proxy_search.py
@@ -48,8 +48,8 @@ PROXY_PEOPLE_BASE = f"ou=people,{PROXY_BASE_DN}"
 PROXY_GROUPS_BASE = f"ou=groups,{PROXY_BASE_DN}"
 
 # A valid backend user used to bind to the proxy before searching.
-BIND_DN = f"uid=guest,{PEOPLE_BASE}"
-BIND_PASSWORD = "guest-password"
+BIND_DN = f"uid=bind,{PROXY_PEOPLE_BASE}"
+BIND_PASSWORD = "bind-password"
 
 
 def knox_host() -> str:
@@ -83,6 +83,23 @@ class TestKnoxLdapProxySearch(unittest.TestCase):
             first_rdn = entry.entry_dn.split(",", 1)[0]
             values.append(first_rdn.split("=", 1)[1])
         return values
+
+    def test_anonymous_search_rejected(self) -> None:
+        """Anonymous search not allowed when bind user configured."""
+        # Self-signed dev certificate in CI: connect over TLS but skip validation.
+        tls = ldap3.Tls(validate=ssl.CERT_NONE)
+        server = ldap3.Server(
+            knox_host(), port=KNOX_LDAP_PORT, use_ssl=True, tls=tls, get_info=ldap3.NONE
+        )
+        with self.assertRaises(ldap3.core.exceptions.LDAPInvalidCredentialsResult):
+            try:
+                connection = ldap3.Connection(
+                    server, auto_bind=ldap3.AUTO_BIND_NONE, raise_exceptions=True
+                )
+                connection.bind()
+            finally:
+                if connection.bound:
+                    connection.unbind()
 
     def test_search_all_users_by_objectclass(self) -> None:
         """All inetOrgPerson entries under ou=people are returned."""

--- a/gateway-server/pom.xml
+++ b/gateway-server/pom.xml
@@ -505,6 +505,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-interceptors-authn</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-jdbm-partition</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -37,8 +37,11 @@ import org.apache.directory.server.core.DefaultDirectoryService;
 import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.api.DnFactory;
 import org.apache.directory.server.core.api.InstanceLayout;
+import org.apache.directory.server.core.api.InterceptorEnum;
 import org.apache.directory.server.core.api.interceptor.Interceptor;
 import org.apache.directory.server.core.api.schema.SchemaPartition;
+import org.apache.directory.server.core.authn.AuthenticationInterceptor;
+import org.apache.directory.server.core.authn.Authenticator;
 import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition;
 import org.apache.directory.server.core.partition.ldif.LdifPartition;
 import org.apache.directory.server.ldap.LdapServer;
@@ -46,6 +49,7 @@ import org.apache.directory.server.protocol.shared.transport.TcpTransport;
 import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 import org.apache.knox.gateway.services.GatewayServices;
+import org.apache.knox.gateway.services.ldap.authn.InMemoryBindAuthenticator;
 import org.apache.knox.gateway.services.ldap.control.RolesLookupBypassControlFactory;
 import org.apache.knox.gateway.services.ldap.interceptor.InterceptorFactory;
 import org.apache.knox.gateway.services.ldap.interceptor.LDAPRolesLookupInterceptor;
@@ -56,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -116,6 +121,7 @@ public class KnoxLDAPServerManager {
         this.port = config.getLDAPPort();
         this.baseDn = config.getLDAPBaseDN();
         this.bindUser = config.getLDAPBindUser();
+        validateBindUser();
 
         maxSizeLimit = config.getLDAPMaxSizeLimit();
         maxTimeLimit = config.getLDAPMaxTimeLimit();
@@ -143,6 +149,19 @@ public class KnoxLDAPServerManager {
         }
 
         workDir.mkdirs();
+    }
+
+    /**
+     * Validates that the bind dn, if configured, matches the base dn for the embedded
+     * LDAP service (e.g. {@code ou=system} or {@code ou=people,<baseDn>}).
+     */
+    private void validateBindUser() throws Exception {
+        if (!StringUtils.isBlank(bindUser)) {
+            Dn bindUserDn = new Dn(bindUser);
+            if (!(bindUserDn.isDescendantOf("ou=system") || bindUserDn.isDescendantOf("ou=people," + this.baseDn))) {
+                throw new IllegalArgumentException("Bind user must be a descendant of ou=system or ou=people" + this.baseDn);
+            }
+        }
     }
 
     private void createInterceptors(GatewayConfig config) throws Exception {
@@ -233,17 +252,16 @@ public class KnoxLDAPServerManager {
         final String bindPassword = bindPasswordChars == null ? null : new String(bindPasswordChars);
         final boolean requireBind = StringUtils.isNotBlank(bindUser) && StringUtils.isNotBlank(bindPassword);
         directoryService.setAllowAnonymousAccess(!requireBind);
+        if (requireBind) {
+            configureInMemoryBindUser(bindPassword);
+            LOG.ldapBindUserConfigured(bindUser);
+        }
 
         // Start the service
         directoryService.startup();
 
         // Add base entries to the partitions
         createBaseEntries(baseDns, schemaManager);
-
-        if (requireBind) {
-            createBindUser(schemaManager, bindPassword);
-            LOG.ldapBindUserConfigured(bindUser);
-        }
 
         // Create LDAP server on configured port
         ldapServer = new LdapServer();
@@ -435,22 +453,24 @@ public class KnoxLDAPServerManager {
     }
 
     /**
-     * Create the entry used by external clients to bind against the embedded LDAP server.
-     * The bind DN's parent container (e.g. {@code ou=system} or {@code ou=people,<baseDn>})
-     * must already exist. The entry is added using the privileged admin session, which is
-     * unaffected by the anonymous-access setting.
+     * Configure the Authenticator used by external clients to bind against the embedded LDAP server.
      */
-    private void createBindUser(SchemaManager schemaManager, String bindPassword) throws Exception {
-        Dn bindDn = new Dn(schemaManager, bindUser);
-        if (!directoryService.getAdminSession().exists(bindDn)) {
-            String rdnValue = bindDn.getRdn().getValue();
-            Entry bindEntry = new DefaultEntry(schemaManager);
-            bindEntry.setDn(bindDn);
-            bindEntry.add("objectClass", "top", "person", "organizationalPerson", "inetOrgPerson");
-            bindEntry.add("cn", rdnValue);
-            bindEntry.add("sn", rdnValue);
-            bindEntry.add("userPassword", bindPassword);
-            directoryService.getAdminSession().add(bindEntry);
+    private void configureInMemoryBindUser(String bindPassword) throws Exception {
+        String id = "inmemoryuser";
+        Dn bindDn = new Dn(directoryService.getSchemaManager(), bindUser);
+
+        Interceptor interceptor = directoryService.getInterceptor(InterceptorEnum.AUTHENTICATION_INTERCEPTOR.getName());
+        if (interceptor instanceof AuthenticationInterceptor authInterceptor) {
+            InMemoryBindAuthenticator inMemoryBindAuthenticator = new InMemoryBindAuthenticator(bindDn,  bindPassword);
+
+            // Create an ordered set so that in-memory authenticator will have priority over
+            // the default SIMPLE authenticator.
+            Set<Authenticator> authenticators = new LinkedHashSet<>();
+            authenticators.add(inMemoryBindAuthenticator);
+            authenticators.addAll(authInterceptor.getAuthenticators());
+            authInterceptor.setAuthenticators(authenticators);
+        } else {
+            throw new IllegalStateException("Unable to configure AuthenticationInterceptor for bind user");
         }
     }
 

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManager.java
@@ -159,7 +159,7 @@ public class KnoxLDAPServerManager {
         if (!StringUtils.isBlank(bindUser)) {
             Dn bindUserDn = new Dn(bindUser);
             if (!(bindUserDn.isDescendantOf("ou=system") || bindUserDn.isDescendantOf("ou=people," + this.baseDn))) {
-                throw new IllegalArgumentException("Bind user must be a descendant of ou=system or ou=people" + this.baseDn);
+                throw new IllegalArgumentException("Bind user must be a descendant of ou=system or ou=people," + this.baseDn);
             }
         }
     }
@@ -456,7 +456,6 @@ public class KnoxLDAPServerManager {
      * Configure the Authenticator used by external clients to bind against the embedded LDAP server.
      */
     private void configureInMemoryBindUser(String bindPassword) throws Exception {
-        String id = "inmemoryuser";
         Dn bindDn = new Dn(directoryService.getSchemaManager(), bindUser);
 
         Interceptor interceptor = directoryService.getInterceptor(InterceptorEnum.AUTHENTICATION_INTERCEPTOR.getName());

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticator.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticator.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.ldap.authn;
+
+import org.apache.directory.api.ldap.model.constants.AuthenticationLevel;
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.server.core.api.LdapPrincipal;
+import org.apache.directory.server.core.api.interceptor.context.BindOperationContext;
+import org.apache.directory.server.core.authn.AbstractAuthenticator;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Authenticator for an in-memory user.
+ */
+public class InMemoryBindAuthenticator extends AbstractAuthenticator {
+
+    private final Dn bindDn;
+    private final String bindPassword;
+
+    public InMemoryBindAuthenticator(Dn bindDn, String bindPassword)
+        throws LdapException {
+        super(AuthenticationLevel.SIMPLE, bindDn);
+        this.bindDn = bindDn;
+        this.bindPassword = bindPassword;
+    }
+
+    @Override
+    public LdapPrincipal authenticate(BindOperationContext bindContext) throws LdapException {
+        Dn dn = bindContext.getDn();
+
+        // Check if authenticating as the configured in-memory user
+        if (bindDn.equals(dn)) {
+            byte[] passwordBytes = bindContext.getCredentials();
+            String password = new String(passwordBytes, StandardCharsets.UTF_8);
+            if (bindPassword.equals(password)) {
+                return new LdapPrincipal(getDirectoryService().getSchemaManager(), dn, AuthenticationLevel.SIMPLE);
+            }
+        }
+
+        // Pass-through to default authenticators if it's a normal directory user
+        return null;
+    }
+}

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticator.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticator.java
@@ -18,6 +18,7 @@
 package org.apache.knox.gateway.services.ldap.authn;
 
 import org.apache.directory.api.ldap.model.constants.AuthenticationLevel;
+import org.apache.directory.api.ldap.model.exception.LdapAuthenticationException;
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.server.core.api.LdapPrincipal;
@@ -51,6 +52,8 @@ public class InMemoryBindAuthenticator extends AbstractAuthenticator {
             String password = new String(passwordBytes, StandardCharsets.UTF_8);
             if (bindPassword.equals(password)) {
                 return new LdapPrincipal(getDirectoryService().getSchemaManager(), dn, AuthenticationLevel.SIMPLE);
+            } else {
+                throw new LdapAuthenticationException("Failed to authenticate: " + dn.getName());
             }
         }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/KnoxLDAPServerManagerTest.java
@@ -82,6 +82,7 @@ public class KnoxLDAPServerManagerTest {
     private static final String BIND_PASSWORD = "knox-password";
     private static final String KEYSTORE_PASSWORD = "keystore-password";
     private static final String SSL_KEYSTORE_ALIAS = "gateway_ldap_ssl_keystore_password";
+    public static final String BASE_DN = "dc=test,dc=com";
 
     private KnoxLDAPServerManager serverManager;
     private File tempWorkDir;
@@ -133,7 +134,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         Map<String, String> backendConfig = createFileBackendInterceptorConfig();
@@ -143,7 +144,7 @@ public class KnoxLDAPServerManagerTest {
         serverManager.initialize(mockConfig);
 
         assertEquals("Port should be set correctly", port, serverManager.getPort());
-        assertEquals("Base DN should be set correctly", "dc=test,dc=com", serverManager.getBaseDn());
+        assertEquals("Base DN should be set correctly", BASE_DN, serverManager.getBaseDn());
         assertFalse("Should not be running after initialize", serverManager.isRunning());
     }
 
@@ -152,7 +153,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("ldapbackend")).anyTimes();
         Map<String, String> backendConfig = createLdapBackendInterceptorConfig();
         expect(mockConfig.getLDAPInterceptorConfig("ldapbackend")).andReturn(backendConfig).anyTimes();
@@ -161,7 +162,7 @@ public class KnoxLDAPServerManagerTest {
         serverManager.initialize(mockConfig);
 
         assertEquals("Port should be set correctly", port, serverManager.getPort());
-        assertEquals("Base DN should be set correctly", "dc=test,dc=com", serverManager.getBaseDn());
+        assertEquals("Base DN should be set correctly", BASE_DN, serverManager.getBaseDn());
         assertFalse("Should not be running after initialize", serverManager.isRunning());
     }
 
@@ -183,7 +184,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend", "ldapbackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         Map<String, String> fileBackendConfig = createFileBackendInterceptorConfig();
@@ -195,8 +196,40 @@ public class KnoxLDAPServerManagerTest {
         serverManager.initialize(mockConfig);
 
         assertEquals("Port should be set correctly", port, serverManager.getPort());
-        assertEquals("Base DN should be set correctly", "dc=test,dc=com", serverManager.getBaseDn());
+        assertEquals("Base DN should be set correctly", BASE_DN, serverManager.getBaseDn());
         assertFalse("Should not be running after initialize", serverManager.isRunning());
+    }
+
+    @Test
+    public void testInitializeWithBindConfig() throws Exception {
+        useBindPassword(BIND_PASSWORD);
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
+        expect(mockConfig.getLDAPBindUser()).andReturn(BIND_DN).anyTimes();
+        expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPInterceptorConfig("filebackend")).andReturn(createFileBackendInterceptorConfig()).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitializeWithBadBindDn() throws Exception {
+        useBindPassword(BIND_PASSWORD);
+        GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
+        expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
+        expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
+        expect(mockConfig.getLDAPBindUser()).andReturn("uid=bad,dc=unknown,dc=com").anyTimes();
+        expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
+        expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
+        expect(mockConfig.getLDAPInterceptorConfig("filebackend")).andReturn(createFileBackendInterceptorConfig()).anyTimes();
+        replay(mockConfig);
+
+        serverManager.initialize(mockConfig);
     }
 
     @Test
@@ -278,7 +311,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         Map<String, String> backendConfig = createFileBackendInterceptorConfig();
@@ -328,7 +361,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend", "ldapbackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         Map<String, String> fileBackendConfig = createFileBackendInterceptorConfig();
@@ -380,7 +413,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("ldapbackend", "ldap backend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         Map<String, String> ldapBackendConfig = createLdapBackendInterceptorConfig();
@@ -418,7 +451,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of()).anyTimes();
         replay(mockConfig);
 
@@ -473,7 +506,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of()).anyTimes();
         expect(mockConfig.getLDAPMaxSizeLimit()).andReturn(expectedMaxSize).anyTimes();
         expect(mockConfig.getLDAPMaxTimeLimit()).andReturn(expectedMaxTime).anyTimes();
@@ -508,7 +541,7 @@ public class KnoxLDAPServerManagerTest {
             connection.bind(BIND_DN, BIND_PASSWORD);
             assertTrue("Connection should be authenticated", connection.isAuthenticated());
             // An authenticated client should be able to search.
-            try (EntryCursor cursor = connection.search("dc=test,dc=com", "(objectClass=*)", SearchScope.SUBTREE)) {
+            try (EntryCursor cursor = connection.search(BASE_DN, "(objectClass=*)", SearchScope.SUBTREE)) {
                 assertTrue("Authenticated search should return at least one entry", cursor.next());
             }
         }
@@ -530,7 +563,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         expect(mockConfig.getLDAPInterceptorConfig("filebackend")).andReturn(createFileBackendInterceptorConfig()).anyTimes();
@@ -542,7 +575,7 @@ public class KnoxLDAPServerManagerTest {
         // No bind credentials configured -> anonymous access remains allowed (backward compatible).
         try (LdapConnection connection = new LdapNetworkConnection("localhost", port)) {
             connection.bind();
-            try (EntryCursor cursor = connection.search("dc=test,dc=com", "(objectClass=*)", SearchScope.SUBTREE)) {
+            try (EntryCursor cursor = connection.search(BASE_DN, "(objectClass=*)", SearchScope.SUBTREE)) {
                 assertTrue("Anonymous search should return at least one entry", cursor.next());
             }
         }
@@ -581,7 +614,7 @@ public class KnoxLDAPServerManagerTest {
         try (LdapNetworkConnection connection = new LdapNetworkConnection("localhost", port)) {
             connection.setTimeOut(5000);
             connection.bind();
-            try (EntryCursor cursor = connection.search("dc=test,dc=com", "(objectClass=*)", SearchScope.SUBTREE)) {
+            try (EntryCursor cursor = connection.search(BASE_DN, "(objectClass=*)", SearchScope.SUBTREE)) {
                 cursor.next();
             }
             fail("Plaintext access against an LDAPS-only transport should fail");
@@ -600,7 +633,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
         expect(mockConfig.getLDAPInterceptorConfig("filebackend")).andReturn(createFileBackendInterceptorConfig()).anyTimes();
@@ -662,7 +695,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getParent()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPBindUser()).andReturn(BIND_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of("filebackend")).anyTimes();
         expect(mockConfig.getLDAPBackendDataFile()).andReturn(tempLdapFile.getAbsolutePath()).anyTimes();
@@ -690,7 +723,7 @@ public class KnoxLDAPServerManagerTest {
         GatewayConfig mockConfig = EasyMock.createNiceMock(GatewayConfig.class);
         expect(mockConfig.getGatewayDataDir()).andReturn(tempWorkDir.getAbsolutePath()).anyTimes();
         expect(mockConfig.getLDAPPort()).andReturn(port).anyTimes();
-        expect(mockConfig.getLDAPBaseDN()).andReturn("dc=test,dc=com").anyTimes();
+        expect(mockConfig.getLDAPBaseDN()).andReturn(BASE_DN).anyTimes();
         expect(mockConfig.getLDAPInterceptorNames()).andReturn(List.of()).anyTimes();
         replay(mockConfig);
         return mockConfig;

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticatorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticatorTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.ldap.authn;
+
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.server.core.DefaultDirectoryService;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.LdapPrincipal;
+import org.apache.directory.server.core.api.interceptor.context.BindOperationContext;
+import org.apache.knox.gateway.services.ldap.SchemaManagerFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class InMemoryBindAuthenticatorTest {
+    private static final String BIND_DN = "uid=bind-user,dc=test,dc=com";
+    private static final String BIND_PASSWORD = "test-password";
+
+    Dn bindDn;
+    SchemaManager schemaManager;
+    DirectoryService directoryService;
+    InMemoryBindAuthenticator authenticator;
+
+    @Before
+    public void setUp() throws Exception {
+        directoryService = new DefaultDirectoryService();
+        schemaManager = SchemaManagerFactory.createSchemaManager();
+        directoryService.setSchemaManager(schemaManager);
+
+        bindDn = new Dn(schemaManager, BIND_DN);
+        authenticator = new InMemoryBindAuthenticator(bindDn,  BIND_PASSWORD);
+        authenticator.init(directoryService);
+    }
+
+    @Test
+    public void testAuthenticate() throws Exception {
+        BindOperationContext context = mock(BindOperationContext.class);
+        expect(context.getDn()).andReturn(bindDn).once();
+        expect(context.getCredentials()).andReturn(BIND_PASSWORD.getBytes(StandardCharsets.UTF_8)).once();
+        replay(context);
+
+        LdapPrincipal principal = authenticator.authenticate(context);
+        assertNotNull(principal);
+        assertEquals(bindDn, principal.getDn());
+    }
+
+    @Test
+    public void testAuthenticateBadDn() throws Exception {
+        Dn badDn = new Dn(schemaManager, "uid=bad-user,dc=test,dc=com");
+        BindOperationContext context = mock(BindOperationContext.class);
+        expect(context.getDn()).andReturn(badDn).anyTimes();
+        replay(context);
+
+        LdapPrincipal principal = authenticator.authenticate(context);
+        assertNull(principal);
+    }
+
+    @Test
+    public void testAuthenticateBadPassword() throws Exception {
+        BindOperationContext context = mock(BindOperationContext.class);
+        expect(context.getDn()).andReturn(bindDn).once();
+        expect(context.getCredentials()).andReturn("bad-password".getBytes(StandardCharsets.UTF_8)).once();
+        replay(context);
+
+        LdapPrincipal principal = authenticator.authenticate(context);
+        assertNull(principal);
+    }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticatorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/authn/InMemoryBindAuthenticatorTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.knox.gateway.services.ldap.authn;
 
+import org.apache.directory.api.ldap.model.exception.LdapAuthenticationException;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.server.core.DefaultDirectoryService;
@@ -79,14 +80,13 @@ public class InMemoryBindAuthenticatorTest {
         assertNull(principal);
     }
 
-    @Test
+    @Test(expected = LdapAuthenticationException.class)
     public void testAuthenticateBadPassword() throws Exception {
         BindOperationContext context = mock(BindOperationContext.class);
         expect(context.getDn()).andReturn(bindDn).once();
         expect(context.getCredentials()).andReturn("bad-password".getBytes(StandardCharsets.UTF_8)).once();
         replay(context);
 
-        LdapPrincipal principal = authenticator.authenticate(context);
-        assertNull(principal);
+        authenticator.authenticate(context);
     }
 }

--- a/knox-site/docs/service_ldap_server.md
+++ b/knox-site/docs/service_ldap_server.md
@@ -39,7 +39,7 @@ The service is configured in `gateway-site.xml`.
 | `gateway.ldap.enabled` | `false` | Enables or disables the embedded LDAP service. |
 | `gateway.ldap.port` | `3890` | The port on which the LDAP server listens. |
 | `gateway.ldap.base.dn` | `dc=proxy,dc=com` | The base DN for the LDAP server. |
-| `gateway.ldap.bind.user` | N/A | Full bind DN (e.g. `uid=knox,ou=system`) that clients must authenticate as. When set together with the `gateway_ldap_bind_password` credential store alias, anonymous access is disabled. The bind DN's parent container must already exist (`ou=system` always exists; `ou=people,{base.dn}` and `ou=groups,{base.dn}` are created automatically). |
+| `gateway.ldap.bind.user` | N/A | Full bind DN (e.g. `uid=knox,dc=proxy,dc=com`) that clients must authenticate as. When set together with the `gateway_ldap_bind_password` credential store alias, anonymous access is disabled. The bind DN's parent container must already exist (`ou=system` always exists; `ou=people,{base.dn}` and `ou=groups,{base.dn}` are created automatically). |
 | `gateway.ldap.interceptor.names` | N/A | A comma separated list of interceptors to use. A separate interceptor configuration block will be used for each name. |
 | `gateway.ldap.roles.lookup.strategy` | N/A | The LDAP roles lookup strategy (`file` or `rest`). |
 | `gateway.ldap.roles.lookup.rest.api.endpoint` | N/A | The LDAP roles lookup REST API endpoint. |
@@ -99,10 +99,18 @@ Clients then bind with the full DN, e.g.:
 ldapsearch -x -H ldap://localhost:3890 -D "uid=knox,ou=people,dc=hadoop,dc=apache,dc=org" -w knoxsecret -b "" "(uid=admin)"
 ```
 
-The bind entry is created as an `inetOrgPerson`, so either a `uid`-based RDN
-(`uid=knox,...`) or a `cn`-based RDN (`cn=bind,...`) is valid. Use a dedicated identity
-(e.g. `uid=knox`) rather than the built-in ApacheDS admin `uid=admin,ou=system`, which
+Either a `uid`-based RDN (`uid=knox,...`) or a `cn`-based RDN (`cn=bind,...`) are accepted as valid Bind DNs.
+Use a dedicated identity (e.g. `uid=knox`) rather than the built-in ApacheDS admin `uid=admin,ou=system`, which
 remains available with its default credentials.
+
+#### Rotating bind credentials
+
+Knox keeps the bind dn and credentials in-memory for authentication. The bind credentials can be rotated by
+changing the `gateway.ldap.bind.user` property in the gateway configuration and aliased password. The bind
+user will be updated when the gateway is reloaded.
+
+NOTE: Knox 3.0.0 created the bind user in the embedded LDAP server. These users need to be manually deleted to disable
+access using the old credentials.
 
 ### Interceptor Types
 

--- a/pom.xml
+++ b/pom.xml
@@ -2271,6 +2271,11 @@
                 <artifactId>apacheds-jdbm-partition</artifactId>
                 <version>${apacheds.directory.server.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-interceptors-authn</artifactId>
+                <version>${apacheds.directory.server.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.directory.api</groupId>


### PR DESCRIPTION
[KNOX-3422](https://issues.apache.org/jira/browse/KNOX-3422) - Create LDAP Proxy bind user in-memory instead of in embedded LDAP

## What changes were proposed in this pull request?

The bind user created from the gateway configuration is now created in-memory instead of being added to the embedded ldap server. This provides the benefit of being able to rotate the user just by changing the configuration. Previously, since the configured user is not tracked, there wasn't a way to automatically rotate the user.

## How was this patch tested?

Unit test were updated and run.

## Integration Tests

LDAP proxy search workflow tests were updated to use the configured bind user instead of a user in the remote LDAP.
A test was added to verify that anonymous bind does not work when the bind user is configured.

## UI changes

no ui changes
