### PR TITLE
KNOX-3425: LDAP Proxy disallows anonymous binds to remote backends

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -19,6 +19,7 @@ package org.apache.knox.gateway.services.ldap.backend;
 
 import static java.util.Locale.ROOT;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.cursor.EntryCursor;
 import org.apache.directory.api.ldap.model.cursor.SearchCursor;
@@ -454,6 +455,11 @@ public class LdapProxyBackend implements LdapBackend {
     @Override
     public boolean authenticate(Dn userDn, String password) {
         final String userDnText = userDn.toString(); //at this point we are sure it's not NULL
+
+        // Don't allow anonymous or unauthenticated bind
+        if (StringUtils.isBlank(userDnText) || StringUtils.isBlank(password)) {
+            return false;
+        }
 
         // if userDN is using proxy base DN then convert to remote base dn
         final String remoteUserDnText = remoteSchemaConverter.convertProxyDnToRemoteDn(userDnText);

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -112,12 +112,12 @@ public class UserSearchInterceptor extends BaseInterceptor {
 
     @Override
     public void bind(BindOperationContext ctx) throws LdapException {
-        LOG.ldapBind(ctx.getDn() != null ? ctx.getDn().toString() : "anonymous");
+        LOG.ldapBind(ctx.getDn() != null && !ctx.getDn().isEmpty() ? ctx.getDn().toString() : "anonymous");
 
         // Try backend first for non-system users
-        if (ctx.getDn() != null && !ctx.getDn().toString().endsWith("ou=system")) {
+        if (ctx.getDn() != null && !ctx.getDn().isEmpty() && !ctx.getDn().toString().endsWith("ou=system")) {
             byte[] credentials = ctx.getCredentials();
-            if (credentials != null) {
+            if (credentials != null && credentials.length > 0) {
                 String password = new String(credentials, java.nio.charset.StandardCharsets.UTF_8);
                 if (backend.authenticate(ctx.getDn(), password)) {
                     // Create session for the authenticated user and set it in context
@@ -130,11 +130,7 @@ public class UserSearchInterceptor extends BaseInterceptor {
             }
         }
 
-        try {
-            next(ctx);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        next(ctx);
     }
 }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackendTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
+import org.apache.directory.api.ldap.model.message.BindRequest;
 import org.apache.directory.api.ldap.model.message.SearchRequest;
 import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.api.ldap.model.name.Dn;
@@ -50,6 +51,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -71,6 +73,7 @@ public class LdapProxyBackendTest {
     private static LdapServer ldapServer;
     private static SchemaManager schemaManager;
     private static CapturingSearchRequestHandler capturingSearchRequestHandler;
+    private static CapturingBindRequestHandler capturingBindRequestHandler;
 
     private LdapProxyBackend ldapProxyBackend;
 
@@ -131,6 +134,11 @@ public class LdapProxyBackendTest {
                 ldapServer.getSearchResultReferenceHandler(),
                 ldapServer.getSearchResultDoneHandler());
 
+        capturingBindRequestHandler = new CapturingBindRequestHandler(ldapServer.getBindRequestHandler());
+        ldapServer.setBindHandlers(
+                capturingBindRequestHandler,
+                ldapServer.getBindResponseHandler());
+
         // Setup common backend config values for tests
         ldapBackendConfig = Map.of(
                 "baseDn", "dc=hadoop,dc=apache,dc=org",
@@ -161,6 +169,7 @@ public class LdapProxyBackendTest {
     @After
     public void tearDown() throws Exception {
         capturingSearchRequestHandler.reset();
+        capturingBindRequestHandler.reset();
         if (ldapProxyBackend != null) {
             ldapProxyBackend.close();
         }
@@ -738,6 +747,10 @@ public class LdapProxyBackendTest {
         ldapProxyBackend = new LdapProxyBackend("testbackend", ldapBackendConfig);
         Dn dn = new Dn("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org");
         assertTrue(ldapProxyBackend.authenticate(dn, "guest-password"));
+        assertEquals(1, capturingBindRequestHandler.getRequests().size());
+        BindRequest bindRequest = capturingBindRequestHandler.getRequests().get(0);
+        assertEquals("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org", bindRequest.getDn().getName());
+        assertEquals("guest-password", new String(bindRequest.getCredentials(), StandardCharsets.UTF_8));
     }
 
     @Test
@@ -745,13 +758,33 @@ public class LdapProxyBackendTest {
         ldapProxyBackend = new LdapProxyBackend("testbackend", ldapBackendConfig);
         Dn dn = new Dn("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org");
         assertFalse(ldapProxyBackend.authenticate(dn, "bad-password"));
+        assertEquals(1, capturingBindRequestHandler.getRequests().size());
+    }
+
+    @Test
+    public void testAuthenticateNoPassword() throws Exception {
+        ldapProxyBackend = new LdapProxyBackend("testbackend", ldapBackendConfig);
+        Dn dn = new Dn("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org");
+        assertFalse(ldapProxyBackend.authenticate(dn, ""));
+        // No bind request should be sent to server if no password is provided
+        assertEquals(0, capturingBindRequestHandler.getRequests().size());
+    }
+
+    @Test
+    public void testAuthenticateBadUser() throws Exception {
+        ldapProxyBackend = new LdapProxyBackend("testbackend", ldapBackendConfig);
+        Dn dn = new Dn("uid=nobody,ou=people,dc=hadoop,dc=apache,dc=org");
+        assertFalse(ldapProxyBackend.authenticate(dn, "guest-password"));
+        assertEquals(1, capturingBindRequestHandler.getRequests().size());
     }
 
     @Test
     public void testAuthenticateNoUser() throws Exception {
         ldapProxyBackend = new LdapProxyBackend("testbackend", ldapBackendConfig);
-        Dn dn = new Dn("uid=nobody,ou=people,dc=hadoop,dc=apache,dc=org");
+        Dn dn = new Dn("");
         assertFalse(ldapProxyBackend.authenticate(dn, "guest-password"));
+        // No bind request should be sent to server if no user is provided
+        assertEquals(0, capturingBindRequestHandler.getRequests().size());
     }
 
     @Test
@@ -939,6 +972,29 @@ public class LdapProxyBackendTest {
 
         @Override
         public void handle(LdapSession session, SearchRequest message) throws Exception {
+            requests.add(message);
+            delegate.handle(session, message);
+        }
+    }
+
+    private static class CapturingBindRequestHandler extends LdapRequestHandler<BindRequest> {
+        private final LdapRequestHandler<BindRequest> delegate;
+        private final List<BindRequest> requests = Collections.synchronizedList(new ArrayList<>());
+
+        CapturingBindRequestHandler(LdapRequestHandler<BindRequest> delegate) {
+            this.delegate = delegate;
+        }
+
+        public void reset() {
+            requests.clear();
+        }
+
+        public List<BindRequest> getRequests() {
+            return List.copyOf(requests);
+        }
+
+        @Override
+        public void handle(LdapSession session, BindRequest message) throws Exception {
             requests.add(message);
             delegate.handle(session, message);
         }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableBindTestInterceptor.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableBindTestInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.ldap.interceptor;
+
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.server.core.api.interceptor.BaseInterceptor;
+import org.apache.directory.server.core.api.interceptor.context.BindOperationContext;
+
+/**
+ * Interceptor for testing. This interceptor will return or throw a configured Exception on bind.
+ */
+public class ConfigurableBindTestInterceptor extends BaseInterceptor {
+    LdapException bindException;
+    int bindCount;
+
+    ConfigurableBindTestInterceptor(String name) {
+        super(name);
+    }
+
+    public void setBindException(LdapException bindException) {
+        this.bindException = bindException;
+    }
+
+    public int getBindCount() {
+        return bindCount;
+    }
+
+    @Override
+    public void bind(BindOperationContext searchContext) throws LdapException {
+        bindCount++;
+        if (bindException != null) {
+            throw bindException;
+        }
+    }
+}

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableSearchTestInterceptor.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableSearchTestInterceptor.java
@@ -31,11 +31,11 @@ import java.util.List;
  * Interceptor for testing. This interceptor will return a Cursor of a List
  * of configured Entries.
  */
-public class ConfigurableEntriesTestInterceptor extends BaseInterceptor {
+public class ConfigurableSearchTestInterceptor extends BaseInterceptor {
     private List<Entry> entries;
     private EntryFilteringCursor cursor;
 
-    ConfigurableEntriesTestInterceptor(String name) {
+    ConfigurableSearchTestInterceptor(String name) {
         super(name);
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/DisabledUserInterceptorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/DisabledUserInterceptorTest.java
@@ -43,7 +43,7 @@ public class DisabledUserInterceptorTest {
 
     private DirectoryService directoryService;
     private SchemaManager schemaManager;
-    private ConfigurableEntriesTestInterceptor nextInterceptor;
+    private ConfigurableSearchTestInterceptor nextInterceptor;
     private SearchOperationContext ctx;
 
     @Before
@@ -64,12 +64,12 @@ public class DisabledUserInterceptorTest {
         interceptor.init(directoryService);
         directoryService.addLast(interceptor);
 
-        nextInterceptor = new ConfigurableEntriesTestInterceptor(NEXT_INTERCEPTOR);
+        nextInterceptor = new ConfigurableSearchTestInterceptor(NEXT_INTERCEPTOR);
         nextInterceptor.init(directoryService);
         directoryService.addLast(nextInterceptor);
 
         ctx = new SearchOperationContext(directoryService.getSession());
-        ctx.setInterceptors(List.of(TEST_INTERCEPTOR, NEXT_INTERCEPTOR));
+        ctx.setInterceptors(List.of(NEXT_INTERCEPTOR));
     }
 
     @Test

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/DuplicateUserFilteringInterceptorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/DuplicateUserFilteringInterceptorTest.java
@@ -47,7 +47,7 @@ public class DuplicateUserFilteringInterceptorTest {
 
     private DirectoryService directoryService;
     private SchemaManager schemaManager;
-    private ConfigurableEntriesTestInterceptor nextInterceptor;
+    private ConfigurableSearchTestInterceptor nextInterceptor;
     private SearchOperationContext ctx;
 
     @Before
@@ -61,12 +61,12 @@ public class DuplicateUserFilteringInterceptorTest {
         interceptor.init(directoryService);
         directoryService.addLast(interceptor);
 
-        nextInterceptor = new ConfigurableEntriesTestInterceptor(NEXT_INTERCEPTOR);
+        nextInterceptor = new ConfigurableSearchTestInterceptor(NEXT_INTERCEPTOR);
         nextInterceptor.init(directoryService);
         directoryService.addLast(nextInterceptor);
 
         ctx = new SearchOperationContext(directoryService.getSession());
-        ctx.setInterceptors(List.of(TEST_INTERCEPTOR, NEXT_INTERCEPTOR));
+        ctx.setInterceptors(List.of(NEXT_INTERCEPTOR));
 
     }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/LDAPRolesLookupInterceptorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/LDAPRolesLookupInterceptorTest.java
@@ -142,14 +142,14 @@ public class LDAPRolesLookupInterceptorTest {
         interceptor.init(directoryService);
         directoryService.addLast(interceptor);
 
-        ConfigurableEntriesTestInterceptor nextInterceptor =
-                new ConfigurableEntriesTestInterceptor("NEXT");
+        ConfigurableSearchTestInterceptor nextInterceptor =
+                new ConfigurableSearchTestInterceptor("NEXT");
         nextInterceptor.init(directoryService);
         directoryService.addLast(nextInterceptor);
 
         SearchOperationContext ctx =
                 new SearchOperationContext(directoryService.getSession());
-        ctx.setInterceptors(List.of(interceptor.getName(), "NEXT"));
+        ctx.setInterceptors(List.of("NEXT"));
 
         RolesLookupBypassControl control =
                 new RolesLookupBypassControlImpl();
@@ -188,7 +188,7 @@ public class LDAPRolesLookupInterceptorTest {
 
     private record TestContext(
             LDAPRolesLookupInterceptor interceptor,
-            ConfigurableEntriesTestInterceptor nextInterceptor,
+            ConfigurableSearchTestInterceptor nextInterceptor,
             SearchOperationContext ctx) {
     }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.services.ldap.interceptor;
+
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.interceptor.context.BindOperationContext;
+import org.apache.knox.gateway.security.ldap.SimpleDirectoryService;
+import org.apache.knox.gateway.services.ldap.SchemaManagerFactory;
+import org.apache.knox.gateway.services.ldap.backend.LdapBackend;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+
+public class UserSearchInterceptorTest {
+    private static final String TEST_INTERCEPTOR = "TEST";
+    private static final String NEXT_INTERCEPTOR = "NEXT";
+
+    private UserSearchInterceptor interceptor;
+    private LdapBackend mockLdapBackend;
+
+    private DirectoryService directoryService;
+    private SchemaManager schemaManager;
+    private ConfigurableBindTestInterceptor nextBindInterceptor;
+
+    @Before
+    public void setUp() throws Exception {
+        mockLdapBackend = mock(LdapBackend.class);
+
+        directoryService = new SimpleDirectoryService();
+        directoryService.setShutdownHookEnabled(false);
+        schemaManager = SchemaManagerFactory.createSchemaManager();
+        directoryService.setSchemaManager(schemaManager);
+
+        interceptor = new UserSearchInterceptor(TEST_INTERCEPTOR, mockLdapBackend);
+        interceptor.init(directoryService);
+        directoryService.addLast(interceptor);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        directoryService.shutdown();
+    }
+
+    private BindOperationContext setupBindContext() throws Exception {
+        nextBindInterceptor = new ConfigurableBindTestInterceptor(NEXT_INTERCEPTOR);
+        nextBindInterceptor.init(directoryService);
+        directoryService.addLast(nextBindInterceptor);
+
+        BindOperationContext bindCtx = new BindOperationContext(directoryService.getSession());
+        bindCtx.setInterceptors(List.of(NEXT_INTERCEPTOR));
+        return bindCtx;
+    }
+
+    @Test
+    public void testBind() throws Exception {
+        Dn bindDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        String bindPassword = "password";
+        expect(mockLdapBackend.authenticate(bindDn, bindPassword)).andReturn(true);
+        replay(mockLdapBackend);
+        BindOperationContext ctx = setupBindContext();
+        ctx.setDn(bindDn);
+        ctx.setCredentials(bindPassword.getBytes(StandardCharsets.UTF_8));
+
+        interceptor.bind(ctx);
+
+        verify(mockLdapBackend);
+        assertEquals(0, nextBindInterceptor.getBindCount());
+    }
+
+    @Test
+    public void testBindFallsBackOnSystem() throws Exception {
+        Dn bindDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        String bindPassword = "password";
+        expect(mockLdapBackend.authenticate(bindDn, bindPassword)).andReturn(false);
+        replay(mockLdapBackend);
+        BindOperationContext ctx = setupBindContext();
+        ctx.setDn(bindDn);
+        ctx.setCredentials(bindPassword.getBytes(StandardCharsets.UTF_8));
+
+        interceptor.bind(ctx);
+
+        verify(mockLdapBackend);
+        assertEquals(1, nextBindInterceptor.getBindCount());
+    }
+
+    @Test
+    public void testBindAnonymous() throws Exception {
+        // nothing to replay because interceptor should not call ldap backend for anonymous users
+        replay(mockLdapBackend);
+        BindOperationContext ctx = setupBindContext();
+
+        interceptor.bind(ctx);
+
+        verify(mockLdapBackend);
+        assertEquals(1, nextBindInterceptor.getBindCount());
+    }
+
+    @Test(expected = LdapException.class)
+    public void testBindAnonymousNotAllowed() throws Exception {
+        BindOperationContext ctx = setupBindContext();
+        LdapException bindException = new LdapException("Anonymous bind not allowed");
+        nextBindInterceptor.setBindException(bindException);
+
+        interceptor.bind(ctx);
+    }
+
+    @Test
+    public void testBindSystemUser() throws Exception {
+        Dn bindDn = new Dn(schemaManager, "uid=admin,ou=system");
+        String bindPassword = "password";
+        // nothing to replay because interceptor should not call ldap backend for system users
+        replay(mockLdapBackend);
+        BindOperationContext ctx = setupBindContext();
+        ctx.setDn(bindDn);
+        ctx.setCredentials(bindPassword.getBytes(StandardCharsets.UTF_8));
+
+        interceptor.bind(ctx);
+
+        verify(mockLdapBackend);
+        assertEquals(1, nextBindInterceptor.getBindCount());
+    }
+
+    @Test(expected = LdapException.class)
+    public void testBindSystemUserNotAllowed() throws Exception {
+        Dn bindDn = new Dn("uid=admin,ou=system");
+        String bindPassword = "password";
+        BindOperationContext ctx = setupBindContext();
+        LdapException bindException = new LdapException("bind failed");
+        nextBindInterceptor.setBindException(bindException);
+        ctx.setDn(bindDn);
+        ctx.setCredentials(bindPassword.getBytes(StandardCharsets.UTF_8));
+
+        interceptor.bind(ctx);
+    }
+}


### PR DESCRIPTION
[KNOX-3425](https://issues.apache.org/jira/browse/KNOX-3425) - LDAP Proxy disallows anonymous binds to remote backends

## What changes were proposed in this pull request?

The LdapProxyBackend.authenticate method will now return false if either the given DN or password is empty to prevent unauthorized and anonymous binds.

The UserSearchInterceptor is also updated to not call the backend if the DN or password is empty.

Cherry-picks #1358 to v3.0.0

## How was this patch tested?

Unit tests added.
Manual tests performed using ldapsearch to attempt anonymous bind that previously succeeded
```
ldapsearch -v -x -H ldap://localhost:3890 -b 'ou=people,DC=proxy,DC=com' '(uid=guest*)' '*'
```

## Integration Tests

integration tests were run locally

## UI changes

no UI changes