### PR TITLE
Reject authorization codes on OAuth state mismatch

### DIFF
--- a/gateway-openapi-ui/pom.xml
+++ b/gateway-openapi-ui/pom.xml
@@ -97,5 +97,12 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-openapi-ui/src/main/resources/swagger/oauth2-redirect.js
+++ b/gateway-openapi-ui/src/main/resources/swagger/oauth2-redirect.js
@@ -14,4 +14,95 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";function run(){var e,r,t,a=window.opener.swaggerUIRedirectOauth2,o=a.state,n=a.redirectUrl;if((t=(r=/code|token|error/.test(window.location.hash)?window.location.hash.substring(1).replace("?","&"):location.search.substring(1)).split("&")).forEach((function(e,r,t){t[r]='"'+e.replace("=",'":"')+'"'})),e=(r=r?JSON.parse("{"+t.join()+"}",(function(e,r){return""===e?r:decodeURIComponent(r)})):{}).state===o,"accessCode"!==a.auth.schema.get("flow")&&"authorizationCode"!==a.auth.schema.get("flow")&&"authorization_code"!==a.auth.schema.get("flow")||a.auth.code)a.callback({auth:a.auth,token:r,isValid:e,redirectUrl:n});else if(e||a.errCb({authId:a.auth.name,source:"auth",level:"warning",message:"Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"}),r.code)delete a.state,a.auth.code=r.code,a.callback({auth:a.auth,redirectUrl:n});else{let e;r.error&&(e="["+r.error+"]: "+(r.error_description?r.error_description+". ":"no accessCode received from the server. ")+(r.error_uri?"More info: "+r.error_uri:"")),a.errCb({authId:a.auth.name,source:"auth",level:"error",message:e||"[Authorization failed]: no accessCode received from the server"})}window.close()}"loading"!==document.readyState?run():document.addEventListener("DOMContentLoaded",(function(){run()}));
+"use strict";
+
+function getResponseParams() {
+  var queryString;
+
+  if (/code|token|error/.test(window.location.hash)) {
+    queryString = window.location.hash.substring(1).replace("?", "&");
+  } else {
+    queryString = location.search.substring(1);
+  }
+
+  var pairs = queryString.split("&");
+  pairs.forEach(function (value, index, allPairs) {
+    allPairs[index] = '"' + value.replace("=", '":"') + '"';
+  });
+
+  return queryString ? JSON.parse("{" + pairs.join() + "}", function (key, value) {
+    return key === "" ? value : decodeURIComponent(value);
+  }) : {};
+}
+
+function isAuthorizationCodeFlow(oauth2) {
+  var flow = oauth2.auth.schema.get("flow");
+  return flow === "accessCode"
+    || flow === "authorizationCode"
+    || flow === "authorization_code";
+}
+
+function reportAuthorizationCodeError(oauth2, response) {
+  var oauthErrorMsg;
+
+  if (response.error) {
+    oauthErrorMsg = "[" + response.error + "]: "
+      + (response.error_description ? response.error_description + ". " : "no accessCode received from the server. ")
+      + (response.error_uri ? "More info: " + response.error_uri : "");
+  }
+
+  oauth2.errCb({
+    authId: oauth2.auth.name,
+    source: "auth",
+    level: "error",
+    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+  });
+}
+
+function run() {
+  var oauth2 = window.opener.swaggerUIRedirectOauth2;
+  var sentState = oauth2.state;
+  var redirectUrl = oauth2.redirectUrl;
+  var response = getResponseParams();
+  var isValid = response.state === sentState;
+
+  if (!isAuthorizationCodeFlow(oauth2) || oauth2.auth.code) {
+    oauth2.callback({
+      auth: oauth2.auth,
+      token: response,
+      isValid: isValid,
+      redirectUrl: redirectUrl
+    });
+    window.close();
+    return;
+  }
+
+  if (!isValid) {
+    oauth2.errCb({
+      authId: oauth2.auth.name,
+      source: "auth",
+      level: "warning",
+      message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
+    });
+  }
+
+  if (response.code) {
+    if (isValid) {
+      delete oauth2.state;
+      oauth2.auth.code = response.code;
+      oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+    }
+  } else {
+    reportAuthorizationCodeError(oauth2, response);
+  }
+
+  window.close();
+}
+
+if (document.readyState !== "loading") {
+  run();
+} else {
+  document.addEventListener("DOMContentLoaded", function () {
+    run();
+  });
+}

--- a/gateway-openapi-ui/src/test/java/org/apache/knox/gateway/openapi/ui/OAuth2RedirectScriptTest.java
+++ b/gateway-openapi-ui/src/test/java/org/apache/knox/gateway/openapi/ui/OAuth2RedirectScriptTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.openapi.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.junit.Test;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class OAuth2RedirectScriptTest {
+
+  private static final String SCRIPT = loadScript();
+
+  @Test
+  public void rejectsAuthorizationCodeWhenStateDoesNotMatch() throws Exception {
+    ScriptEngine engine = newEngine("?code=foreign-code&state=unexpected-state", "", "expected-state", "authorizationCode");
+
+    run(engine);
+
+    assertNull(engine.get("callbackPayload"));
+    assertEquals(1, numberResult(engine, "errPayloads.length"));
+    assertEquals("warning", stringResult(engine, "errPayloads[0].level"));
+    assertNull(engine.eval("window.opener.swaggerUIRedirectOauth2.auth.code"));
+    assertEquals("expected-state", stringResult(engine, "window.opener.swaggerUIRedirectOauth2.state"));
+    assertEquals(1, numberResult(engine, "closeCount"));
+  }
+
+  @Test
+  public void acceptsAuthorizationCodeWhenStateMatches() throws Exception {
+    ScriptEngine engine = newEngine("?code=expected-code&state=expected-state", "", "expected-state", "authorizationCode");
+
+    run(engine);
+
+    assertNotNull(engine.get("callbackPayload"));
+    assertEquals("expected-code", stringResult(engine, "window.opener.swaggerUIRedirectOauth2.auth.code"));
+    assertEquals(Boolean.FALSE, engine.eval("window.opener.swaggerUIRedirectOauth2.hasOwnProperty('state')"));
+    assertEquals(0, numberResult(engine, "errPayloads.length"));
+    assertEquals(1, numberResult(engine, "closeCount"));
+  }
+
+  @Test
+  public void preservesImplicitFlowCallbackBehavior() throws Exception {
+    ScriptEngine engine = newEngine("", "#access_token=token-value&state=unexpected-state", "expected-state", "implicit");
+
+    run(engine);
+
+    assertNotNull(engine.get("callbackPayload"));
+    assertEquals(Boolean.FALSE, engine.eval("callbackPayload.isValid"));
+    assertEquals("token-value", stringResult(engine, "callbackPayload.token.access_token"));
+    assertEquals(0, numberResult(engine, "errPayloads.length"));
+    assertEquals(1, numberResult(engine, "closeCount"));
+  }
+
+  private static ScriptEngine newEngine(String search, String hash, String state, String flow) throws ScriptException {
+    ScriptEngine engine = new NashornScriptEngineFactory().getScriptEngine();
+    engine.put("searchValue", search);
+    engine.put("hashValue", hash);
+    engine.put("expectedState", state);
+    engine.put("flowValue", flow);
+    engine.eval(
+        "var callbackPayload = null;\n"
+            + "var errPayloads = [];\n"
+            + "var closeCount = 0;\n"
+            + "var document = { readyState: 'loading', addEventListener: function() {} };\n"
+            + "var location = { search: searchValue, hash: hashValue };\n"
+            + "var window = {\n"
+            + "  location: location,\n"
+            + "  opener: {\n"
+            + "    swaggerUIRedirectOauth2: {\n"
+            + "      state: expectedState,\n"
+            + "      redirectUrl: 'https://gateway.example.test/oauth2-redirect.html',\n"
+            + "      auth: {\n"
+            + "        code: null,\n"
+            + "        name: 'oauth2',\n"
+            + "        schema: { get: function(key) { return key === 'flow' ? flowValue : null; } }\n"
+            + "      },\n"
+            + "      errCb: function(payload) { errPayloads.push(payload); },\n"
+            + "      callback: function(payload) { callbackPayload = payload; }\n"
+            + "    }\n"
+            + "  },\n"
+            + "  close: function() { closeCount++; },\n"
+            + "  addEventListener: function() {}\n"
+            + "};\n");
+    engine.eval(SCRIPT);
+    return engine;
+  }
+
+  private static void run(ScriptEngine engine) throws Exception {
+    ((Invocable) engine).invokeFunction("run");
+  }
+
+  private static int numberResult(ScriptEngine engine, String expression) throws ScriptException {
+    return ((Number) engine.eval(expression)).intValue();
+  }
+
+  private static String stringResult(ScriptEngine engine, String expression) throws ScriptException {
+    return (String) engine.eval(expression);
+  }
+
+  private static String loadScript() {
+    try (InputStream input = OAuth2RedirectScriptTest.class.getResourceAsStream("/swagger/oauth2-redirect.js")) {
+      if (input == null) {
+        throw new IllegalStateException("Unable to load swagger/oauth2-redirect.js");
+      }
+
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to read swagger/oauth2-redirect.js", e);
+    }
+  }
+}


### PR DESCRIPTION
Problem

Swagger UI detects a state mismatch in the authorization-code callback but
only logs a warning. It still saves the returned code, deletes the original
state, and starts the token exchange.

This can attach a response from another or older OAuth request to the current
authorization flow, leading to login CSRF or authorization under the wrong
account, tenant, or OAuth configuration.

Fix

Validate the returned state before either authorization-code callback path.
This includes the normal path that stores a new code and the path where the
authorization object already contains a code.

On a mismatch, report an authorization error, close the redirect window, and
return immediately. Do not update the authorization object, delete the saved
state, invoke the callback, or start token exchange.

Valid authorization-code responses continue through the existing callback.
Implicit-flow responses keep their current behavior and still pass the state
validation result to the caller.

Result

After this change, an authorization response cannot cross from one OAuth
request into another. The original request state remains available after a
rejected response, and downstream code never receives or exchanges a code
that failed the state check.

Tests cover all supported authorization-code flow names, matching and
mismatched states, an existing authorization code, and the implicit flow.

Verification

mvn -pl gateway-openapi-ui -am -Dtest=OAuth2RedirectScriptTest -Dsurefire.failIfNoSpecifiedTests=false test
