### PR TITLE
KNOX-3435: Reject authorization codes on OAuth state mismatch

### DIFF
--- a/gateway-openapi-ui/pom.xml
+++ b/gateway-openapi-ui/pom.xml
@@ -97,5 +97,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gateway-openapi-ui/src/main/resources/swagger/oauth2-redirect.js
+++ b/gateway-openapi-ui/src/main/resources/swagger/oauth2-redirect.js
@@ -14,4 +14,96 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-"use strict";function run(){var e,r,t,a=window.opener.swaggerUIRedirectOauth2,o=a.state,n=a.redirectUrl;if((t=(r=/code|token|error/.test(window.location.hash)?window.location.hash.substring(1).replace("?","&"):location.search.substring(1)).split("&")).forEach((function(e,r,t){t[r]='"'+e.replace("=",'":"')+'"'})),e=(r=r?JSON.parse("{"+t.join()+"}",(function(e,r){return""===e?r:decodeURIComponent(r)})):{}).state===o,"accessCode"!==a.auth.schema.get("flow")&&"authorizationCode"!==a.auth.schema.get("flow")&&"authorization_code"!==a.auth.schema.get("flow")||a.auth.code)a.callback({auth:a.auth,token:r,isValid:e,redirectUrl:n});else if(e||a.errCb({authId:a.auth.name,source:"auth",level:"warning",message:"Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"}),r.code)delete a.state,a.auth.code=r.code,a.callback({auth:a.auth,redirectUrl:n});else{let e;r.error&&(e="["+r.error+"]: "+(r.error_description?r.error_description+". ":"no accessCode received from the server. ")+(r.error_uri?"More info: "+r.error_uri:"")),a.errCb({authId:a.auth.name,source:"auth",level:"error",message:e||"[Authorization failed]: no accessCode received from the server"})}window.close()}"loading"!==document.readyState?run():document.addEventListener("DOMContentLoaded",(function(){run()}));
+"use strict";
+
+function getResponseParams() {
+  var queryString;
+
+  if (/code|token|error/.test(window.location.hash)) {
+    queryString = window.location.hash.substring(1).replace("?", "&");
+  } else {
+    queryString = location.search.substring(1);
+  }
+
+  var pairs = queryString.split("&");
+  pairs.forEach(function (value, index, allPairs) {
+    allPairs[index] = '"' + value.replace("=", '":"') + '"';
+  });
+
+  return queryString ? JSON.parse("{" + pairs.join() + "}", function (key, value) {
+    return key === "" ? value : decodeURIComponent(value);
+  }) : {};
+}
+
+function isAuthorizationCodeFlow(oauth2) {
+  var flow = oauth2.auth.schema.get("flow");
+  return flow === "accessCode"
+    || flow === "authorizationCode"
+    || flow === "authorization_code";
+}
+
+function reportAuthorizationCodeError(oauth2, response) {
+  var oauthErrorMsg;
+
+  if (response.error) {
+    oauthErrorMsg = "[" + response.error + "]: "
+      + (response.error_description ? response.error_description + ". " : "no accessCode received from the server. ")
+      + (response.error_uri ? "More info: " + response.error_uri : "");
+  }
+
+  oauth2.errCb({
+    authId: oauth2.auth.name,
+    source: "auth",
+    level: "error",
+    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+  });
+}
+
+function run() {
+  var oauth2 = window.opener.swaggerUIRedirectOauth2;
+  var sentState = oauth2.state;
+  var redirectUrl = oauth2.redirectUrl;
+  var response = getResponseParams();
+  var isValid = response.state === sentState;
+  var authorizationCodeFlow = isAuthorizationCodeFlow(oauth2);
+
+  if (authorizationCodeFlow && !isValid) {
+    oauth2.errCb({
+      authId: oauth2.auth.name,
+      source: "auth",
+      level: "error",
+      message: "[Authorization failed]: returned state does not match the original request"
+    });
+    window.close();
+    return;
+  }
+
+  if (!authorizationCodeFlow || oauth2.auth.code) {
+    oauth2.callback({
+      auth: oauth2.auth,
+      token: response,
+      isValid: isValid,
+      redirectUrl: redirectUrl
+    });
+    window.close();
+    return;
+  }
+
+  if (response.code) {
+    delete oauth2.state;
+    oauth2.auth.code = response.code;
+    oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+  } else {
+    reportAuthorizationCodeError(oauth2, response);
+  }
+
+  window.close();
+}
+
+if (document.readyState !== "loading") {
+  run();
+} else {
+  document.addEventListener("DOMContentLoaded", function () {
+    run();
+  });
+}

--- a/gateway-openapi-ui/src/test/java/org/apache/knox/gateway/openapi/ui/OAuth2RedirectScriptTest.java
+++ b/gateway-openapi-ui/src/test/java/org/apache/knox/gateway/openapi/ui/OAuth2RedirectScriptTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.openapi.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+
+import org.junit.Test;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class OAuth2RedirectScriptTest {
+
+  private static final String[] AUTHORIZATION_CODE_FLOWS = {
+      "accessCode", "authorizationCode", "authorization_code"
+  };
+  private static final String SCRIPT = loadScript();
+
+  @Test
+  public void rejectsAuthorizationCodeWhenStateDoesNotMatch() throws Exception {
+    for (String flow : AUTHORIZATION_CODE_FLOWS) {
+      ScriptEngine engine = newEngine("?code=foreign-code&state=unexpected-state", "", "expected-state", flow, null);
+
+      run(engine);
+
+      assertNull(engine.get("callbackPayload"));
+      assertEquals(1, numberResult(engine, "errPayloads.length"));
+      assertEquals("error", stringResult(engine, "errPayloads[0].level"));
+      assertEquals("[Authorization failed]: returned state does not match the original request",
+          stringResult(engine, "errPayloads[0].message"));
+      assertNull(engine.eval("window.opener.swaggerUIRedirectOauth2.auth.code"));
+      assertEquals("expected-state", stringResult(engine, "window.opener.swaggerUIRedirectOauth2.state"));
+      assertEquals(1, numberResult(engine, "closeCount"));
+    }
+  }
+
+  @Test
+  public void acceptsAuthorizationCodeWhenStateMatches() throws Exception {
+    for (String flow : AUTHORIZATION_CODE_FLOWS) {
+      ScriptEngine engine = newEngine("?code=expected-code&state=expected-state", "", "expected-state", flow, null);
+
+      run(engine);
+
+      assertNotNull(engine.get("callbackPayload"));
+      assertEquals("expected-code", stringResult(engine, "window.opener.swaggerUIRedirectOauth2.auth.code"));
+      assertEquals(Boolean.FALSE, engine.eval("window.opener.swaggerUIRedirectOauth2.hasOwnProperty('state')"));
+      assertEquals(0, numberResult(engine, "errPayloads.length"));
+      assertEquals(1, numberResult(engine, "closeCount"));
+    }
+  }
+
+  @Test
+  public void rejectsMismatchedStateWhenAuthorizationCodeAlreadyExists() throws Exception {
+    ScriptEngine engine = newEngine("?code=foreign-code&state=unexpected-state", "", "expected-state",
+        "authorizationCode", "stale-code");
+
+    run(engine);
+
+    assertNull(engine.get("callbackPayload"));
+    assertEquals(1, numberResult(engine, "errPayloads.length"));
+    assertEquals("error", stringResult(engine, "errPayloads[0].level"));
+    assertEquals("stale-code", stringResult(engine, "window.opener.swaggerUIRedirectOauth2.auth.code"));
+    assertEquals("expected-state", stringResult(engine, "window.opener.swaggerUIRedirectOauth2.state"));
+    assertEquals(1, numberResult(engine, "closeCount"));
+  }
+
+  @Test
+  public void preservesImplicitFlowCallbackBehavior() throws Exception {
+    ScriptEngine engine = newEngine("", "#access_token=token-value&state=unexpected-state", "expected-state",
+        "implicit", null);
+
+    run(engine);
+
+    assertNotNull(engine.get("callbackPayload"));
+    assertEquals(Boolean.FALSE, engine.eval("callbackPayload.isValid"));
+    assertEquals("token-value", stringResult(engine, "callbackPayload.token.access_token"));
+    assertEquals(0, numberResult(engine, "errPayloads.length"));
+    assertEquals(1, numberResult(engine, "closeCount"));
+  }
+
+  private static ScriptEngine newEngine(String search, String hash, String state, String flow, String code)
+      throws ScriptException {
+    ScriptEngine engine = new NashornScriptEngineFactory().getScriptEngine();
+    engine.put("searchValue", search);
+    engine.put("hashValue", hash);
+    engine.put("expectedState", state);
+    engine.put("flowValue", flow);
+    engine.put("initialCode", code);
+    engine.eval(
+        "var callbackPayload = null;\n"
+            + "var errPayloads = [];\n"
+            + "var closeCount = 0;\n"
+            + "var document = { readyState: 'loading', addEventListener: function() {} };\n"
+            + "var location = { search: searchValue, hash: hashValue };\n"
+            + "var window = {\n"
+            + "  location: location,\n"
+            + "  opener: {\n"
+            + "    swaggerUIRedirectOauth2: {\n"
+            + "      state: expectedState,\n"
+            + "      redirectUrl: 'https://gateway.example.test/oauth2-redirect.html',\n"
+            + "      auth: {\n"
+            + "        code: initialCode,\n"
+            + "        name: 'oauth2',\n"
+            + "        schema: { get: function(key) { return key === 'flow' ? flowValue : null; } }\n"
+            + "      },\n"
+            + "      errCb: function(payload) { errPayloads.push(payload); },\n"
+            + "      callback: function(payload) { callbackPayload = payload; }\n"
+            + "    }\n"
+            + "  },\n"
+            + "  close: function() { closeCount++; },\n"
+            + "  addEventListener: function() {}\n"
+            + "};\n");
+    engine.eval(SCRIPT);
+    return engine;
+  }
+
+  private static void run(ScriptEngine engine) throws Exception {
+    ((Invocable) engine).invokeFunction("run");
+  }
+
+  private static int numberResult(ScriptEngine engine, String expression) throws ScriptException {
+    return ((Number) engine.eval(expression)).intValue();
+  }
+
+  private static String stringResult(ScriptEngine engine, String expression) throws ScriptException {
+    return (String) engine.eval(expression);
+  }
+
+  private static String loadScript() {
+    try (InputStream input = OAuth2RedirectScriptTest.class.getResourceAsStream("/swagger/oauth2-redirect.js")) {
+      if (input == null) {
+        throw new IllegalStateException("Unable to load swagger/oauth2-redirect.js");
+      }
+
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to read swagger/oauth2-redirect.js", e);
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <metrics.version>4.2.38</metrics.version>
         <mina.version>2.2.8</mina.version>
+        <nashorn.version>15.4</nashorn.version>
         <netty.version>4.1.137.Final</netty.version>
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
         <nodejs.version>v22.20.0</nodejs.version>
@@ -2594,6 +2595,21 @@
                 <artifactId>asm-commons</artifactId>
                 <version>${asm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-analysis</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-tree</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm-util</artifactId>
+                <version>${asm.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.taglibs</groupId>
@@ -3085,6 +3101,13 @@
                         <artifactId>objenesis</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.openjdk.nashorn</groupId>
+                <artifactId>nashorn-core</artifactId>
+                <version>${nashorn.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
[KNOX-3435](https://issues.apache.org/jira/browse/KNOX-3435) - Reject authorization codes on OAuth state mismatch

## What changes were proposed in this pull request?

The Swagger OAuth redirect callback currently detects a state mismatch in an authorization-code response but continues processing the returned code.

This change validates the returned state before either authorization-code callback path runs. For the `accessCode`, `authorizationCode`, and `authorization_code` flow names, a mismatch now reports an authorization error, closes the redirect window, and returns without changing the authorization object, deleting the saved state, invoking the callback, or starting token exchange.

Matching authorization-code responses retain the existing behavior. The implicit flow is unchanged and continues to receive the state-validation result in its callback payload.

## How was this patch tested?

Added `gateway-openapi-ui/src/test/java/org/apache/knox/gateway/openapi/ui/OAuth2RedirectScriptTest.java` with coverage for:

- mismatched state for all three supported authorization-code flow names;
- matching state and successful code handling;
- mismatched state when the authorization object already contains a code; and
- unchanged implicit-flow callback behavior.

The focused reactor test passed with Maven 3.9.11 and Temurin 17 on the rebased commit:

```bash
mvn -pl gateway-openapi-ui -am -Dtest=OAuth2RedirectScriptTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Before the rebase, the current public PR head passed the `CI - Java 17`, Docker Compose `build-and-test`, and `Test Results` GitHub checks. These checks must rerun after the updated commit is pushed.

## Integration Tests

No new Docker Compose scenario was added. The change is isolated to the standalone browser redirect helper and is covered directly by `OAuth2RedirectScriptTest`. The existing Docker Compose test workflow passed on the pre-rebase PR head and must rerun after the updated commit is pushed.

### Opt-in test suites (PR labels)

No opt-in suite is required for this change. Neither `test-federation` nor `skip-tests` should be added.

Please review [Knox Contributing Process](https://cwiki.apache.org/confluence/display/KNOX/Contribution+Process#ContributionProcess-GithubWorkflow) before opening a pull request.
