### PR TITLE
KNOX-3427: Bump Netty to 1.137.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <metrics.version>4.2.38</metrics.version>
         <mina.version>2.2.8</mina.version>
-        <netty.version>4.1.135.Final</netty.version>
+        <netty.version>4.1.137.Final</netty.version>
         <nimbus-jose-jwt.version>10.9.1</nimbus-jose-jwt.version>
         <nodejs.version>v22.20.0</nodejs.version>
         <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>


### PR DESCRIPTION
[KNOX-3427](https://issues.apache.org/jira/browse/KNOX-3427) - Bump Netty to 1.137.Final

## What changes were proposed in this pull request?
Bumped Netty version to 1.137.Final

## How was this patch tested?
Built and deployed locally.
Relying on unit tests and Docker-based integration tests.

## Integration Tests
N/A

## UI changes
N/A