### PR TITLE
KNOX-3428: Bump Spring to 6.2.19 and add HashiCorp Vault alias service integration tests

### DIFF
--- a/.github/workflows/compose/docker-compose.hashicorp-vault.yml
+++ b/.github/workflows/compose/docker-compose.hashicorp-vault.yml
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with this
+# work for additional information regarding copyright ownership. The ASF
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# HashiCorp Vault alias-service compose OVERRIDE.
+#
+# Layers a dev-mode HashiCorp Vault onto the base stack and reconfigures Knox to
+# use it as its remote alias service (RemoteAliasService -> hashicorp.vault). It
+# runs ONLY the Vault alias suite (test_knox_hashicorp_vault_alias.py), which the
+# base docker-compose ignores. The Vault dev image is small and boots in seconds,
+# so unlike the Keycloak federation override this runs on every PR.
+#
+# The override:
+#   - adds a `vault` service (dev mode, KV v2 at "secret", root token "myroot"),
+#   - mounts the Vault-flavoured gateway-site.xml over the baked one,
+#   - mounts an `admin` topology exposing the KNOX admin (alias) REST API,
+#   - points the `tests` service at the Vault suite and gives it VAULT_ADDR /
+#     VAULT_TOKEN so it can confirm secrets landed in Vault directly.
+#
+# Run it locally (from repo root):
+#
+#   docker compose \
+#     -f .github/workflows/compose/docker-compose.yml \
+#     -f .github/workflows/compose/docker-compose.hashicorp-vault.yml \
+#     up -d knox vault
+#   docker compose \
+#     -f .github/workflows/compose/docker-compose.yml \
+#     -f .github/workflows/compose/docker-compose.hashicorp-vault.yml \
+#     run --rm tests bash -c "pip install -r requirements.txt \
+#       && pytest test_knox_hashicorp_vault_alias.py"
+#   docker compose \
+#     -f .github/workflows/compose/docker-compose.yml \
+#     -f .github/workflows/compose/docker-compose.hashicorp-vault.yml down --volumes
+services:
+  vault:
+    image: hashicorp/vault:1.17
+    # Vault mlock()s its memory to keep secrets out of swap; IPC_LOCK allows that.
+    cap_add:
+      - IPC_LOCK
+    environment:
+      # Dev mode: an in-memory, auto-unsealed server with a KV v2 engine mounted
+      # at "secret". Root token and listen address are dev-only fixtures.
+      - VAULT_DEV_ROOT_TOKEN_ID=myroot
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      # Used by the `vault status` healthcheck (the CLI talks to the local API).
+      - VAULT_ADDR=http://127.0.0.1:8200
+    command: server -dev
+    healthcheck:
+      # `vault status` exits 0 only once the server is initialized and unsealed,
+      # which in dev mode is immediately after it binds. Gate `knox` on this so
+      # the gateway's alias-service init can reach Vault straight away.
+      test: ["CMD", "vault", "status"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
+
+  knox:
+    volumes:
+      # Swap in the Vault-backed alias-service configuration and add the admin
+      # topology that serves the alias REST API. Both layer on top of the base
+      # knox mounts (topologies dir, logs, k3s kubeconfig).
+      - ./hashicorp-vault/gateway-site.xml:/knox-runtime/conf/gateway-site.xml:ro
+      - ./hashicorp-vault/admin.xml:/knox-runtime/conf/topologies/admin.xml:ro
+    depends_on:
+      # Vault must be up before gateway.sh runs: RemoteAliasService connects to it
+      # at init (and the bootstrap knoxcli alias writes go through it too).
+      vault:
+        condition: service_healthy
+
+  tests:
+    environment:
+      - KNOX_GATEWAY_URL=https://knox:8443/
+      - VAULT_ADDR=http://vault:8200
+      - VAULT_TOKEN=myroot
+    command: >
+      bash -c "pip install -r requirements.txt
+      && echo 'Waiting for knox...'
+      && sleep 30
+      && pytest test_knox_hashicorp_vault_alias.py --junitxml=test-results-hashicorp-vault.xml"
+    depends_on:
+      knox:
+        condition: service_started
+      vault:
+        condition: service_healthy

--- a/.github/workflows/compose/docker-compose.yml
+++ b/.github/workflows/compose/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       && pylint *.py
       && echo 'Waiting for knox...'
       && sleep 30
-      && pytest --ignore=test_single_eku_mtls.py --ignore=test_single_eku_no_mtls.py --ignore=test_knoxidf_federation.py --junitxml=test-results.xml"
+      && pytest --ignore=test_single_eku_mtls.py --ignore=test_single_eku_no_mtls.py --ignore=test_knoxidf_federation.py --ignore=test_knox_hashicorp_vault_alias.py --junitxml=test-results.xml"
     depends_on:
       - knox
 

--- a/.github/workflows/compose/hashicorp-vault/admin.xml
+++ b/.github/workflows/compose/hashicorp-vault/admin.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!--
+  Admin topology used by test_knox_hashicorp_vault_alias.py. It exposes the KNOX
+  admin service (which serves the alias management REST API at
+  /gateway/admin/api/v1/aliases/...). Alias writes go through the gateway's alias
+  service, which in the HashiCorp Vault compose override is RemoteAliasService
+  backed by Vault - so a PUT here lands the secret in Vault.
+
+  Authentication reuses the same embedded Knox LDAP (LDAPS on localhost:33390,
+  base dc=proxy,dc=org) that the other LDAP-backed topologies use; gateway.sh
+  provisions and trusts its dev certificate. Authorization is a simple user ACL:
+  only "admin" (a member of the demo "admin" group) may call the admin API. The
+  ACL's first field is the user list, so no group resolution is required.
+-->
+<topology>
+
+    <gateway>
+
+        <provider>
+            <role>authentication</role>
+            <name>ShiroProvider</name>
+            <enabled>true</enabled>
+            <param>
+                <name>sessionTimeout</name>
+                <value>30</value>
+            </param>
+            <param>
+                <name>main.ldapRealm</name>
+                <value>org.apache.knox.gateway.shirorealm.KnoxLdapRealm</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.userDnTemplate</name>
+                <value>uid={0},ou=people,dc=proxy,dc=org</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.url</name>
+                <value>ldaps://localhost:33390</value>
+            </param>
+            <param>
+                <name>main.ldapRealm.contextFactory.authenticationMechanism</name>
+                <value>simple</value>
+            </param>
+            <param>
+                <name>urls./**</name>
+                <value>authcBasic</value>
+            </param>
+        </provider>
+
+        <provider>
+            <role>authorization</role>
+            <name>AclsAuthz</name>
+            <enabled>true</enabled>
+            <param>
+                <name>knox.acl</name>
+                <value>admin;*;*</value>
+            </param>
+        </provider>
+
+        <provider>
+            <role>identity-assertion</role>
+            <name>Default</name>
+            <enabled>true</enabled>
+        </provider>
+
+    </gateway>
+
+    <service>
+        <role>KNOX</role>
+    </service>
+
+</topology>

--- a/.github/workflows/compose/hashicorp-vault/gateway-site.xml
+++ b/.github/workflows/compose/hashicorp-vault/gateway-site.xml
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<configuration>
+
+    <!--
+      HashiCorp Vault remote alias service (added on top of the baked
+      .github/workflows/build/gateway-site.xml). This file is mounted over the
+      baked one by docker-compose.hashicorp-vault.yml.
+
+      The alias service implementation is switched to RemoteAliasService, the
+      wrapper that layers a remote backend (here: HashiCorp Vault) on top of the
+      local keystore. On write it stores into BOTH the local keystore and Vault;
+      on read it prefers the remote backend and falls back to local. That
+      fallback is what lets the gateway keep resolving its keystore/identity
+      passwords (which are NOT in Vault) from the local master secret while the
+      admin alias API round-trips real aliases through Vault.
+
+      Vault is reachable at http://vault:8200 (the dev-mode container defined in
+      the compose override). Dev mode mounts a KV v2 secrets engine at "secret"
+      and accepts the root token "myroot"; both are dev-only fixtures, not
+      secrets. Aliases land under secret/data/knox/<cluster>/<alias>.
+    -->
+    <property>
+        <name>gateway.service.alias.impl</name>
+        <value>org.apache.knox.gateway.services.security.impl.RemoteAliasService</value>
+    </property>
+    <property>
+        <name>gateway.remote.alias.service.enabled</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.remote.alias.service.config.type</name>
+        <value>hashicorp.vault</value>
+    </property>
+    <property>
+        <name>gateway.remote.alias.service.config.hashicorp.vault.address</name>
+        <value>http://vault:8200</value>
+    </property>
+    <property>
+        <name>gateway.remote.alias.service.config.hashicorp.vault.secrets.engine</name>
+        <value>secret</value>
+    </property>
+    <property>
+        <name>gateway.remote.alias.service.config.hashicorp.vault.path.prefix</name>
+        <value>knox</value>
+    </property>
+    <property>
+        <name>gateway.remote.alias.service.config.hashicorp.vault.authentication.type</name>
+        <value>token</value>
+    </property>
+    <!-- Dev-only root token; matches VAULT_DEV_ROOT_TOKEN_ID in the compose override. -->
+    <property>
+        <name>gateway.remote.alias.service.config.hashicorp.vault.authentication.token</name>
+        <value>myroot</value>
+    </property>
+
+    <!--
+      Use the in-memory DefaultTokenStateService instead of the baked default
+      (DerbyDBTokenStateService). The Derby service reads its DB-credential alias
+      (gateway_database_user) from the alias service at init; with the alias
+      service pointed at Vault, that becomes a hard, fatal dependency on Vault
+      being reachable during gateway startup. DefaultTokenStateService reads no
+      aliases at init, so the gateway boots independently of Vault and this suite
+      stays focused on the alias round-trip (token state is not under test here).
+    -->
+    <property>
+        <name>gateway.service.tokenstate.impl</name>
+        <value>org.apache.knox.gateway.services.token.impl.DefaultTokenStateService</value>
+    </property>
+
+    <property>
+        <name>gateway.port</name>
+        <value>8443</value>
+        <description>The HTTP port for the Gateway.</description>
+    </property>
+
+    <property>
+        <name>gateway.path</name>
+        <value>gateway</value>
+        <description>The default context path for the gateway.</description>
+    </property>
+
+    <property>
+        <name>gateway.gateway.conf.dir</name>
+        <value>deployments</value>
+        <description>The directory within GATEWAY_HOME that contains gateway topology files and deployments.</description>
+    </property>
+
+    <!-- @since 0.10 Websocket configs -->
+    <property>
+        <name>gateway.websocket.feature.enabled</name>
+        <value>true</value>
+        <description>Enable/Disable websocket feature.</description>
+    </property>
+
+    <property>
+        <name>gateway.scope.cookies.feature.enabled</name>
+        <value>false</value>
+        <description>Enable/Disable cookie scoping feature.</description>
+    </property>
+
+    <!-- @since 2.0.0 WebShell configs -->
+    <!-- must have websocket enabled to use webshell -->
+    <property>
+        <name>gateway.webshell.feature.enabled</name>
+        <value>true</value>
+        <description>Enable/Disable webshell feature.</description>
+    </property>
+    <property>
+        <name>gateway.webshell.max.concurrent.sessions</name>
+        <value>20</value>
+        <description>Maximum number of total concurrent webshell sessions</description>
+    </property>
+    <property>
+        <name>gateway.webshell.read.buffer.size</name>
+        <value>1024</value>
+        <description>Web Shell buffer size for reading</description>
+    </property>
+
+    <!-- @since 2.0.0 websocket JWT validation configs -->
+    <property>
+        <name>gateway.websocket.JWT.validation.feature.enabled</name>
+        <value>true</value>
+        <description>Enable/Disable websocket JWT validation at websocket layer.</description>
+    </property>
+
+    <!-- @since 1.5.0 homepage logout -->
+    <property>
+        <name>knox.homepage.logout.enabled</name>
+        <value>true</value>
+        <description>Enable/disable logout from the Knox Homepage.</description>
+    </property>
+
+    <!-- @since 1.6.0 token management related properties -->
+    <property>
+        <name>gateway.knox.token.eviction.grace.period</name>
+        <value>0</value>
+        <description>A duration (in seconds) beyond a token’s expiration to wait before evicting its state. This configuration only applies when server-managed token state is enabled either in gateway-site or at the topology level.</description>
+    </property>
+
+    <!-- Knox Admin related config -->
+    <property>
+        <name>gateway.knox.admin.groups</name>
+        <value>admin</value>
+    </property>
+
+    <!-- DEMO LDAP config for Hadoop Group Provider -->
+    <property>
+        <name>gateway.group.config.hadoop.security.group.mapping</name>
+        <value>org.apache.hadoop.security.LdapGroupsMapping</value>
+    </property>
+    <property>
+        <name>gateway.group.config.use.ldap.service</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.dispatch.whitelist.services</name>
+        <value>DATANODE,HBASEUI,HDFSUI,JOBHISTORYUI,NODEUI,YARNUI,knoxauth</value>
+        <description>The comma-delimited list of service roles for which the gateway.dispatch.whitelist should be applied.</description>
+    </property>
+    <property>
+        <name>gateway.dispatch.whitelist</name>
+        <value>^https?:\/\/(www\.local\.com|localhost|127\.0\.0\.1|0:0:0:0:0:0:0:1|::1):[0-9].*$</value>
+        <description>The whitelist to be applied for dispatches associated with the service roles specified by gateway.dispatch.whitelist.services.
+        If the value is DEFAULT, a domain-based whitelist will be derived from the Knox host.</description>
+    </property>
+    <property>
+        <name>gateway.xforwarded.header.context.append.servicename</name>
+        <value>LIVYSERVER</value>
+        <description>Add service name to x-forward-context header for the list of services defined above.</description>
+    </property>
+    <property>
+        <name>gateway.strict.transport.enabled</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.strict.transport.option</name>
+        <value>max-age=300; includeSubDomains</value>
+    </property>
+
+    <!-- KnoxLDAP Service Configuration -->
+    <property>
+        <name>gateway.ldap.enabled</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.ldap.port</name>
+        <value>33390</value>
+    </property>
+    <property>
+        <name>gateway.ldap.base.dn</name>
+        <value>dc=proxy,dc=org</value>
+    </property>
+    <property>
+        <name>gateway.ldap.bind.user</name>
+        <value>uid=bind,ou=people,dc=proxy,dc=org</value>
+    </property>
+    <property>
+        <name>gateway.ldap.max.size.limit</name>
+        <value>1000</value>
+    </property>
+    <property>
+        <name>gateway.ldap.max.time.limit</name>
+        <value>60000</value>
+    </property>
+    <property>
+        <name>gateway.ldap.recursive.group.resolution</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.names</name>
+        <value>demoldap</value>
+    </property>
+    <!-- Expose the embedded Knox LDAP service over LDAPS using the dev keystore that
+         gateway.sh provisions; its password is resolved from the credential store. -->
+    <property>
+        <name>gateway.ldap.ssl.enabled</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.ldap.ssl.keystore.path</name>
+        <value>/knox-runtime/conf/ldaps-keystore.p12</value>
+    </property>
+    <property>
+        <name>gateway.ldap.ssl.keystore.password.alias</name>
+        <value>gateway_ldap_ssl_keystore_password</value>
+    </property>
+
+    <!-- LDAP Backend specific configuration (proxying to demo ldap) -->
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.interceptorType</name>
+        <value>backend</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.backendType</name>
+        <value>ldap</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.url</name>
+        <value>ldaps://ldap:33389</value>
+    </property>
+    <!-- The demo LDAP presents a self-signed dev certificate; trust it rather than
+         wiring a truststore for this dev/CI fixture. -->
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.trustAllCertificates</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.remoteBaseDn</name>
+        <value>dc=hadoop,dc=apache,dc=org</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.systemUsername</name>
+        <value>uid=guest,ou=people,dc=hadoop,dc=apache,dc=org</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.systemPassword</name>
+        <value>guest-password</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.userSearchBase</name>
+        <value>ou=people,dc=hadoop,dc=apache,dc=org</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.groupSearchBase</name>
+        <value>ou=groups,dc=hadoop,dc=apache,dc=org</value>
+    </property>
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.groupMemberAttribute</name>
+        <value>member</value>
+    </property>
+    <!-- Set an unnaturally low page size to ensure that paging is used in tests -->
+    <property>
+        <name>gateway.ldap.interceptor.demoldap.pageSize</name>
+        <value>3</value>
+    </property>
+
+</configuration>

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,59 @@ jobs:
           echo '===== gateway.log ====='
           cat ./.github/workflows/compose/logs/gateway.log || true
 
+      # HashiCorp Vault alias-service E2E. Unlike the Keycloak federation run,
+      # this is NOT label-gated: the Vault dev image is small and boots in
+      # seconds, so it runs on every PR to guard the spring-vault integration
+      # (e.g. after a Spring / Spring Vault bump). It stands up a dev-mode Vault
+      # and recreates 'knox' with the Vault-backed RemoteAliasService, then
+      # round-trips an alias through the admin API and confirms it in Vault. It
+      # runs here, before the single-EKU steps, so 'knox' is still in its base
+      # config when the override recreates it.
+      - name: Start Vault + Knox for HashiCorp Vault alias service
+        run: |
+          docker compose \
+            -f ./.github/workflows/compose/docker-compose.yml \
+            -f ./.github/workflows/compose/docker-compose.hashicorp-vault.yml \
+            up -d knox vault
+
+      - name: Wait for Vault stack to stabilize
+        run: sleep 30  # Adjust as needed for services startup time
+
+      - name: Run HashiCorp Vault Alias Tests
+        id: hashicorp_vault_tests
+        run: |
+          # Emit a distinct JUnit file so it reports as its own test suite.
+          docker compose \
+            -f ./.github/workflows/compose/docker-compose.yml \
+            -f ./.github/workflows/compose/docker-compose.hashicorp-vault.yml \
+            run --rm tests bash -c "pip install -r requirements.txt \
+            && pytest test_knox_hashicorp_vault_alias.py --junitxml=test-results-hashicorp-vault.xml"
+
+      # Evidence gathering: an alias-API failure could be a gateway that never
+      # reached Vault (bad address/token/engine) or a Vault that never came up.
+      # Dump container status plus the knox and vault logs so the two can be told
+      # apart.
+      - name: Dump HashiCorp Vault diagnostics on failure
+        if: failure() && steps.hashicorp_vault_tests.outcome == 'failure'
+        run: |
+          echo '===== docker compose ps -a ====='
+          docker compose \
+            -f ./.github/workflows/compose/docker-compose.yml \
+            -f ./.github/workflows/compose/docker-compose.hashicorp-vault.yml \
+            ps -a || true
+          echo '===== knox container logs ====='
+          docker compose \
+            -f ./.github/workflows/compose/docker-compose.yml \
+            -f ./.github/workflows/compose/docker-compose.hashicorp-vault.yml \
+            logs --no-color knox || true
+          echo '===== vault container logs ====='
+          docker compose \
+            -f ./.github/workflows/compose/docker-compose.yml \
+            -f ./.github/workflows/compose/docker-compose.hashicorp-vault.yml \
+            logs --no-color vault || true
+          echo '===== gateway.log ====='
+          cat ./.github/workflows/compose/logs/gateway.log || true
+
       # Single-EKU mTLS runs as its own pass. Its override turns on
       # gateway.client.auth.needed=true, which would break the default
       # (no-client-cert) tests above, so the gateway is recreated with the
@@ -226,6 +279,7 @@ jobs:
             .github/workflows/tests/test-results-single-eku.xml
             .github/workflows/tests/test-results-single-eku-no-mtls.xml
             .github/workflows/tests/test-results-federation.xml
+            .github/workflows/tests/test-results-hashicorp-vault.xml
 
       - name: Archive Knox Logs
         if: always()

--- a/.github/workflows/tests/test_knox_hashicorp_vault_alias.py
+++ b/.github/workflows/tests/test_knox_hashicorp_vault_alias.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end test of Knox's HashiCorp Vault remote alias service.
+
+This is opt-in and NOT part of the default test run (the base docker-compose
+ignores it). It runs only under docker-compose.hashicorp-vault.yml, which stands
+up a dev-mode HashiCorp Vault and reconfigures Knox to use RemoteAliasService
+backed by that Vault. See that override file for how to run it.
+
+What it proves (relevant to Spring / Spring Vault upgrades): the running gateway
+can still talk to Vault through spring-vault. The flow is:
+  1. write an alias via the Knox admin alias REST API (as user "admin"),
+  2. read it back through the admin API listing,
+  3. confirm the secret actually landed in Vault by querying Vault's HTTP API
+     directly at secret/data/knox/<cluster>/<alias>,
+  4. delete the alias via the admin API and confirm it drops out of the listing.
+"""
+
+import os
+import unittest
+import uuid
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from common_utils import (
+    KNOX_REQUEST_TIMEOUT,
+    gateway_base_url,
+    knox_delete,
+    knox_get,
+    knox_post,
+)
+
+# Demo LDAP user that belongs to the "admin" group; the admin topology's ACL
+# (admin;*;*) authorizes this user for the alias API.
+ADMIN_USER = "admin"
+ADMIN_PASSWORD = "admin-password"
+
+# Must match the HashiCorp Vault settings in hashicorp-vault/gateway-site.xml.
+VAULT_SECRETS_ENGINE = "secret"
+VAULT_PATH_PREFIX = "knox"
+
+# Injected by docker-compose.hashicorp-vault.yml for the direct-to-Vault check.
+VAULT_ADDR = os.environ.get("VAULT_ADDR", "http://localhost:8200")
+VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "myroot")
+
+
+class TestKnoxHashicorpVaultAlias(unittest.TestCase):
+    """Round-trip aliases through the Knox admin API and verify them in Vault."""
+
+    def setUp(self):
+        self.admin_auth = HTTPBasicAuth(ADMIN_USER, ADMIN_PASSWORD)
+        self.aliases_base = gateway_base_url() + "gateway/admin/api/v1/aliases"
+        # Unique, lowercase names per test run (Knox lowercases alias names, and
+        # Vault paths are case-sensitive), so reruns never collide.
+        suffix = uuid.uuid4().hex[:12]
+        self.cluster = "vault-it-" + suffix
+        self.alias = "test-alias-" + suffix
+        self.secret_value = "s3cret-" + suffix
+
+    def tearDown(self):
+        # Best-effort cleanup so a failed assertion mid-test does not leak state.
+        try:
+            knox_delete(self._alias_url(), auth=self.admin_auth)
+        except requests.RequestException:
+            pass
+
+    def _alias_url(self):
+        return f"{self.aliases_base}/{self.cluster}/{self.alias}"
+
+    def _list_aliases(self):
+        response = knox_get(f"{self.aliases_base}/{self.cluster}", auth=self.admin_auth)
+        self.assertEqual(response.status_code, 200)
+        return response.json().get("aliases", [])
+
+    def _read_from_vault(self):
+        # KV v2 read: the secrets engine "secret" exposes reads under
+        # secret/data/<logical-path>. Knox stores the value under the "data" key.
+        url = (
+            f"{VAULT_ADDR}/v1/{VAULT_SECRETS_ENGINE}/data/"
+            f"{VAULT_PATH_PREFIX}/{self.cluster}/{self.alias}"
+        )
+        return requests.get(
+            url,
+            headers={"X-Vault-Token": VAULT_TOKEN},
+            timeout=KNOX_REQUEST_TIMEOUT,
+        )
+
+    def test_alias_write_is_stored_in_vault(self):
+        """A PUT/POST via the admin API stores the secret in HashiCorp Vault."""
+        create = knox_post(
+            self._alias_url(),
+            auth=self.admin_auth,
+            data={"value": self.secret_value},
+        )
+        self.assertEqual(create.status_code, 201)
+
+        # Readable through Knox's own alias listing (which itself reads Vault).
+        self.assertIn(self.alias, self._list_aliases())
+
+        # And present in Vault directly, proving the write reached the backend.
+        vault_response = self._read_from_vault()
+        self.assertEqual(vault_response.status_code, 200)
+        stored = vault_response.json()["data"]["data"]
+        self.assertEqual(stored.get("data"), self.secret_value)
+
+    def test_alias_delete_removes_from_listing(self):
+        """Deleting an alias via the admin API removes it from the listing."""
+        create = knox_post(
+            self._alias_url(),
+            auth=self.admin_auth,
+            data={"value": self.secret_value},
+        )
+        self.assertEqual(create.status_code, 201)
+        self.assertIn(self.alias, self._list_aliases())
+
+        delete = knox_delete(self._alias_url(), auth=self.admin_auth)
+        self.assertEqual(delete.status_code, 200)
+
+        self.assertNotIn(self.alias, self._list_aliases())
+
+    def test_admin_alias_api_requires_authentication(self):
+        """The alias API is protected: an unauthenticated request is rejected."""
+        response = knox_get(f"{self.aliases_base}/{self.cluster}")
+        self.assertEqual(response.status_code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <slf4j.version>2.0.13</slf4j.version>
         <spotbugs.version>4.9.3</spotbugs.version>
         <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
-        <spring.version>6.2.11</spring.version>
+        <spring.version>6.2.19</spring.version>
         <spring-vault.version>3.2.0</spring-vault.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <stax2-api.version>4.2.1</stax2-api.version>


### PR DESCRIPTION
[KNOX-3428](https://issues.apache.org/jira/browse/KNOX-3428) - Bump Spring to 6.2.19 and add HashiCorp Vault alias-service integration tests

## What changes were proposed in this pull request?

- Bumped spring.version to 6.2.19 (from 6.2.11) in pom.xml.
- Added a Docker-based integration suite exercising Knox's HashiCorp Vault remote alias service end-to-end, as a safety net for the Spring / Spring Vault bump. Under .github/workflows:
  - `tests/test_knox_hashicorp_vault_alias.py`: round-trips an alias through the admin alias REST API and verifies the secret directly in Vault, plus delete-removal and an unauthenticated-401 check.
  - `compose/docker-compose.hashicorp-vault.yml` + `compose/hashicorp-vault/{gateway-site,admin}.xml`:  dev-mode Vault (hashicorp/vault:1.17) and Knox on a Vault-backed RemoteAliasService. gateway-site.xml also sets `gateway.service.tokenstate.impl=DefaultTokenStateService` to avoid an init-time alias read that would make Vault a fatal startup dependency.
  - `compose/docker-compose.yml + tests.yml`: base run ignores the suite; CI runs it and uploads test-results-hashicorp-vault.xml.

## How was this patch tested?

Ran the suite locally via Docker Compose (`up -d knox vault` → `run --rm tests pytest -v test_knox_hashicorp_vault_alias.py`): 3 passed. `test_alias_write_is_stored_in_vault` reads the secret straight from Vault's HTTP API and asserts the exact value, confirming the write reached Vault (not just the local keystore fallback). 

`pylint *.py` rated 10.00/10.

## Integration Tests

Added `test_knox_hashicorp_vault_alias.py`. The Vault dev image boots in seconds, so it runs on every PR (not label-gated).