### PR TITLE
KNOX-3430: Deprecate AccessTokenFederationFilter, also added Unsuppor…

### DIFF
--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/deploy/AccessTokenFederationContributor.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/deploy/AccessTokenFederationContributor.java
@@ -26,9 +26,10 @@ import org.apache.knox.gateway.topology.Service;
 
 import java.util.List;
 
+@Deprecated
 public class AccessTokenFederationContributor extends ProviderDeploymentContributorBase {
 
-  private static final String FILTER_CLASSNAME = "org.apache.knox.gateway.provider.federation.jwt.filter.AccessTokenFederationFilter";
+  //private static final String FILTER_CLASSNAME = "org.apache.knox.gateway.provider.federation.jwt.filter.AccessTokenFederationFilter";
 
   @Override
   public String getRole() {
@@ -46,6 +47,6 @@ public class AccessTokenFederationContributor extends ProviderDeploymentContribu
 
   @Override
   public void contributeFilter( DeploymentContext context, Provider provider, Service service, ResourceDescriptor resource, List<FilterParamDescriptor> params ) {
-    resource.addFilter().name( getName() ).role( getRole() ).impl( FILTER_CLASSNAME ).params( params );
+    throw new UnsupportedOperationException("AccessTokenFederationFilter is deprecated use JWTFederationFilter instead");
   }
 }

--- a/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AccessTokenFederationFilter.java
+++ b/gateway-provider-security-jwt/src/main/java/org/apache/knox/gateway/provider/federation/jwt/filter/AccessTokenFederationFilter.java
@@ -17,161 +17,31 @@
  */
 package org.apache.knox.gateway.provider.federation.jwt.filter;
 
-import org.apache.knox.gateway.i18n.messages.MessagesFactory;
-import org.apache.knox.gateway.provider.federation.jwt.JWTMessages;
-import org.apache.knox.gateway.security.PrimaryPrincipal;
-import org.apache.knox.gateway.services.ServiceType;
-import org.apache.knox.gateway.services.GatewayServices;
-import org.apache.knox.gateway.services.security.token.JWTokenAuthority;
-import org.apache.knox.gateway.services.security.token.TokenServiceException;
-import org.apache.knox.gateway.services.security.token.TokenStateService;
-import org.apache.knox.gateway.services.security.token.TokenUtils;
-import org.apache.knox.gateway.services.security.token.UnknownTokenException;
-import org.apache.knox.gateway.services.security.token.impl.JWTToken;
-import org.apache.knox.gateway.util.Tokens;
-
-import javax.security.auth.Subject;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.security.Principal;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.text.ParseException;
-import java.util.Collections;
-import java.util.Locale;
-import java.util.Set;
 
+@Deprecated
 public class AccessTokenFederationFilter implements Filter {
-  private static JWTMessages log = MessagesFactory.get( JWTMessages.class );
-  private static final String BEARER = "Bearer ";
 
-  private JWTokenAuthority authority;
-
-  private TokenStateService tokenStateService;
-
-  @Override
-  public void init( FilterConfig filterConfig ) throws ServletException {
-    GatewayServices services = (GatewayServices) filterConfig.getServletContext().getAttribute(GatewayServices.GATEWAY_SERVICES_ATTRIBUTE);
-    authority = services.getService(ServiceType.TOKEN_SERVICE);
-
-    if (TokenUtils.isServerManagedTokenStateEnabled(filterConfig)) {
-      tokenStateService = services.getService(ServiceType.TOKEN_STATE_SERVICE);
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        //NO-OP
     }
-  }
 
-  @Override
-  public void destroy() {
-  }
-
-  @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-      throws IOException, ServletException {
-    String header = ((HttpServletRequest) request).getHeader("Authorization");
-    if (header != null && header.startsWith(BEARER)) {
-      // what follows the bearer designator should be the JWT token being used to request or as an access token
-      String wireToken = header.substring(BEARER.length());
-      JWTToken token;
-      try {
-        token = JWTToken.parseToken(wireToken);
-      } catch (ParseException e) {
-        throw new ServletException("ParseException encountered while processing the JWT token: ", e);
-      }
-
-      boolean verified = false;
-      try {
-        verified = authority.verifyToken(token);
-      } catch (TokenServiceException e) {
-        log.unableToVerifyToken(e);
-      }
-
-      final String tokenId = TokenUtils.getTokenId(token);
-      final String displayableTokenId = Tokens.getTokenIDDisplayText(tokenId);
-      final String displayableToken = Tokens.getTokenDisplayText(token.toString());
-      if (verified) {
-        try {
-          if (!isExpired(token)) {
-            if (((HttpServletRequest) request).getRequestURL().indexOf(token.getAudience().toLowerCase(Locale.ROOT)) != -1) {
-              Subject subject = createSubjectFromToken(token);
-              continueWithEstablishedSecurityContext(subject, (HttpServletRequest)request, (HttpServletResponse)response, chain);
-            } else {
-              log.failedToValidateAudience(displayableToken, displayableTokenId);
-              sendUnauthorized(response);
-            }
-          } else {
-            log.tokenHasExpired(displayableToken, displayableTokenId);
-            sendUnauthorized(response);
-          }
-        } catch (UnknownTokenException e) {
-          log.unableToVerifyExpiration(e);
-          sendUnauthorized(response);
-        }
-      } else {
-        log.failedToVerifyTokenSignature(displayableToken, displayableTokenId);
-        sendUnauthorized(response);
-      }
-    } else {
-      log.missingBearerToken();
-      sendUnauthorized(response);
+    @Override
+    public void destroy() {
+        //NO-OP
     }
-  }
 
-  private boolean isExpired(JWTToken token) throws UnknownTokenException {
-    return (tokenStateService != null) ? tokenStateService.isExpired(token)
-                                       : (Long.parseLong(token.getExpires()) <= System.currentTimeMillis());
-  }
-
-  private void sendUnauthorized(ServletResponse response) throws IOException {
-    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
-  }
-
-  private void continueWithEstablishedSecurityContext(Subject subject,
-                                                      final HttpServletRequest request,
-                                                      final HttpServletResponse response,
-                                                      final FilterChain chain) throws IOException, ServletException {
-    try {
-      Subject.doAs(
-        subject,
-        new PrivilegedExceptionAction<Object>() {
-          @Override
-          public Object run() throws Exception {
-            chain.doFilter(request, response);
-            return null;
-          }
-        }
-        );
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException {
+        throw new UnsupportedOperationException("AccessTokenFederationFilter is deprecated use JWTFederationFilter instead");
     }
-    catch (PrivilegedActionException e) {
-      Throwable t = e.getCause();
-      if (t instanceof IOException) {
-        throw (IOException) t;
-      }
-      else if (t instanceof ServletException) {
-        throw (ServletException) t;
-      }
-      else {
-        throw new ServletException(t);
-      }
-    }
-  }
 
-  private Subject createSubjectFromToken(JWTToken token) {
-    final String principal = token.getPrincipal();
-    final Set<Principal> principals = Collections.singleton(new PrimaryPrincipal(principal));
-
-    // The newly constructed Sets check whether this Subject has been set read-only
-    // before permitting subsequent modifications. The newly created Sets also prevent
-    // illegal modifications by ensuring that callers have sufficient permissions.
-    //
-    // To modify the Principals Set, the caller must have AuthPermission("modifyPrincipals").
-    // To modify the public credential Set, the caller must have AuthPermission("modifyPublicCredentials").
-    // To modify the private credential Set, the caller must have AuthPermission("modifyPrivateCredentials").
-    return new javax.security.auth.Subject(true, principals, Collections.emptySet(), Collections.emptySet());
-  }
 }


### PR DESCRIPTION
…tedOperatorException

[KNOX-3430](https://issues.apache.org/jira/browse/KNOX-3430) - Deprecate AccessTokenFederationFilter

## What changes were proposed in this pull request?

Deprecated `AccessTokenFederationFilter` it also throws `UnsupportedOperationException` during deploy time.

## How was this patch tested?

Tried to deploy a topology with the filter