### PR TITLE
KNOX-3431: UserSearchInterceptor throws exceptions on failed search

### DIFF
--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/LdapMessages.java
@@ -118,8 +118,8 @@ public interface LdapMessages {
     void ldapPagedSearchCompleted(String baseDn, String filter, int numResults);
 
     @Message(level = MessageLevel.ERROR,
-            text = "LDAP Search failed: {0} | {1}, {2}")
-    void ldapSearchFailed(String baseDn, String filter, @StackTrace(level = MessageLevel.DEBUG) Exception e);
+            text = "LDAP Search to backend {0} failed: {1} | {2}, {3}")
+    void ldapSearchFailed(String name, String baseDn, String filter, @StackTrace(level = MessageLevel.DEBUG) Exception e);
 
     @Message(level = MessageLevel.DEBUG,
             text = "LDAP Bind: {0}")
@@ -153,11 +153,11 @@ public interface LdapMessages {
             text = "Failed to copy attribute: {0}")
     void ldapAttributeCopyError(@StackTrace(level = MessageLevel.TRACE) Exception e);
 
-    @Message(level = MessageLevel.DEBUG, text = "LDAP authentication succeeded for user: {0}")
-    void ldapAuthSucceeded(String user);
+    @Message(level = MessageLevel.DEBUG, text = "LDAP authentication to backend {0} succeeded for user: {1}")
+    void ldapAuthSucceeded(String name, String user);
 
-    @Message(level = MessageLevel.WARN, text = "LDAP authentication failed for user: {0}")
-    void ldapAuthFailed(String user, @StackTrace(level = MessageLevel.INFO) Throwable cause);
+    @Message(level = MessageLevel.WARN, text = "LDAP authentication to backend {0} failed for user: {1}, {2}")
+    void ldapAuthFailed(String name, String user, @StackTrace(level = MessageLevel.DEBUG) Throwable cause);
 
     @Message(level = MessageLevel.INFO,
             text = "Reloading LDAP configuration")

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/backend/LdapProxyBackend.java
@@ -477,10 +477,10 @@ public class LdapProxyBackend implements LdapBackend {
         authConfig.setCredentials(password);
         try (LdapConnection connection =  new LdapNetworkConnection(authConfig)){
             connection.bind();
-            LOG.ldapAuthSucceeded(userDnText);
+            LOG.ldapAuthSucceeded(getName(), userDnText);
             return true;
         } catch (Exception e) {
-            LOG.ldapAuthFailed(userDnText, e);
+            LOG.ldapAuthFailed(getName(), userDnText, e);
             return false;
         }
     }

--- a/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
+++ b/gateway-server/src/main/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptor.java
@@ -18,9 +18,12 @@
 package org.apache.knox.gateway.services.ldap.interceptor;
 
 import org.apache.directory.api.ldap.model.constants.AuthenticationLevel;
+import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.cursor.ListCursor;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapOperationException;
+import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
 import org.apache.directory.server.core.api.CoreSession;
 import org.apache.directory.server.core.api.LdapPrincipal;
 import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
@@ -35,6 +38,7 @@ import org.apache.knox.gateway.services.ldap.LdapUtils;
 import org.apache.knox.gateway.services.ldap.backend.BackendFactory;
 import org.apache.knox.gateway.services.ldap.backend.LdapBackend;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +75,7 @@ public class UserSearchInterceptor extends BaseInterceptor {
                     entry = backend.getUser(username, schemaManager);
                 } catch (Exception e) {
                     LOG.ldapLookupFailed(ctx.getDn().toString(),e);
+                    throw new LdapOperationException(ResultCodeEnum.OTHER, "Lookup request to backend " + getName() + " failed.", e);
                 }
             }
         }
@@ -92,8 +97,10 @@ public class UserSearchInterceptor extends BaseInterceptor {
             while (originalResults.next()) {
                 entries.add(originalResults.get());
             }
-        } catch (Exception e) {
-            // If we get an error or no results, try the backends
+        }  catch (CursorException e ) {
+            throw new LdapException(e.getMessage(), e);
+        } catch (IOException e) {
+            // swallow error closing cursor
         }
 
         // Only forward to the backend when the search base is under the backend's namespace.
@@ -102,7 +109,8 @@ public class UserSearchInterceptor extends BaseInterceptor {
             try {
                 entries.addAll(backend.search(baseDn, ctx.getScope(), filter, schemaManager));
             } catch (Exception e) {
-                LOG.ldapSearchFailed(baseDn, filter, e);
+                LOG.ldapSearchFailed(getName(), baseDn, filter, e);
+                throw new LdapOperationException(ResultCodeEnum.OTHER, "Search request to backend " + getName() + " failed.", e);
             }
         }
 

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableLookupTestInterceptor.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/ConfigurableLookupTestInterceptor.java
@@ -17,47 +17,36 @@
  */
 package org.apache.knox.gateway.services.ldap.interceptor;
 
-import org.apache.directory.api.ldap.model.cursor.ListCursor;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
-import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
-import org.apache.directory.server.core.api.filtering.EntryFilteringCursorImpl;
 import org.apache.directory.server.core.api.interceptor.BaseInterceptor;
-import org.apache.directory.server.core.api.interceptor.context.SearchOperationContext;
-
-import java.util.List;
+import org.apache.directory.server.core.api.interceptor.context.LookupOperationContext;
 
 /**
  * Interceptor for testing. This interceptor will return a Cursor of a List
  * of configured Entries.
  */
-public class ConfigurableSearchTestInterceptor extends BaseInterceptor {
-    private List<Entry> entries;
+public class ConfigurableLookupTestInterceptor extends BaseInterceptor {
+    private Entry entry;
     private LdapException ldapException;
-    private EntryFilteringCursor cursor;
 
-    ConfigurableSearchTestInterceptor(String name) {
+    ConfigurableLookupTestInterceptor(String name) {
         super(name);
     }
 
-    public void setEntries(List<Entry> entries) {
-        this.entries = entries;
+    public void setEntry(Entry entry) {
+        this.entry = entry;
     }
 
     public void setLdapException(LdapException ldapException) {
         this.ldapException = ldapException;
     }
 
-    public EntryFilteringCursor getCursor() {
-        return cursor;
-    }
-
     @Override
-    public EntryFilteringCursor search(SearchOperationContext searchContext) throws LdapException {
+    public Entry lookup(LookupOperationContext lookupOperationContext) throws LdapException {
         if (ldapException != null) {
             throw ldapException;
         }
-        cursor = new EntryFilteringCursorImpl(new ListCursor<>(entries), searchContext, schemaManager);
-        return cursor;
+        return entry;
     }
 }

--- a/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorTest.java
+++ b/gateway-server/src/test/java/org/apache/knox/gateway/services/ldap/interceptor/UserSearchInterceptorTest.java
@@ -17,11 +17,20 @@
  */
 package org.apache.knox.gateway.services.ldap.interceptor;
 
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapOperationException;
+import org.apache.directory.api.ldap.model.filter.FilterParser;
+import org.apache.directory.api.ldap.model.message.ResultCodeEnum;
+import org.apache.directory.api.ldap.model.message.SearchScope;
 import org.apache.directory.api.ldap.model.name.Dn;
 import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
 import org.apache.directory.server.core.api.interceptor.context.BindOperationContext;
+import org.apache.directory.server.core.api.interceptor.context.LookupOperationContext;
+import org.apache.directory.server.core.api.interceptor.context.SearchOperationContext;
 import org.apache.knox.gateway.security.ldap.SimpleDirectoryService;
 import org.apache.knox.gateway.services.ldap.SchemaManagerFactory;
 import org.apache.knox.gateway.services.ldap.backend.LdapBackend;
@@ -30,13 +39,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class UserSearchInterceptorTest {
     private static final String TEST_INTERCEPTOR = "TEST";
@@ -48,6 +66,8 @@ public class UserSearchInterceptorTest {
     private DirectoryService directoryService;
     private SchemaManager schemaManager;
     private ConfigurableBindTestInterceptor nextBindInterceptor;
+    private ConfigurableLookupTestInterceptor nextLookupInterceptor;
+    private ConfigurableSearchTestInterceptor nextSearchInterceptor;
 
     @Before
     public void setUp() throws Exception {
@@ -158,5 +178,265 @@ public class UserSearchInterceptorTest {
         ctx.setCredentials(bindPassword.getBytes(StandardCharsets.UTF_8));
 
         interceptor.bind(ctx);
+    }
+
+    private LookupOperationContext setupLookupContext() throws Exception {
+        nextLookupInterceptor = new ConfigurableLookupTestInterceptor(NEXT_INTERCEPTOR);
+        nextLookupInterceptor.init(directoryService);
+        directoryService.addLast(nextLookupInterceptor);
+
+        LookupOperationContext lookupCtx = new LookupOperationContext(directoryService.getSession());
+        lookupCtx.setInterceptors(List.of(NEXT_INTERCEPTOR));
+        return lookupCtx;
+    }
+
+    @Test
+    public void testLookup() throws Exception {
+        Dn lookupDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        Entry entry = new DefaultEntry(lookupDn);
+        expect(mockLdapBackend.getUser("admin", schemaManager)).andReturn(entry);
+        replay(mockLdapBackend);
+        LookupOperationContext ctx = setupLookupContext();
+        ctx.setDn(lookupDn);
+
+        Entry result = interceptor.lookup(ctx);
+
+        verify(mockLdapBackend);
+        assertEquals(entry, result);
+    }
+
+    @Test
+    public void testLookupNotFound() throws Exception {
+        Dn lookupDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        expect(mockLdapBackend.getUser("admin", schemaManager)).andReturn(null);
+        replay(mockLdapBackend);
+        LookupOperationContext ctx = setupLookupContext();
+        ctx.setDn(lookupDn);
+
+        Entry result = interceptor.lookup(ctx);
+
+        verify(mockLdapBackend);
+        assertNull(result);
+    }
+
+    @Test
+    public void testLookupNextInterceptorFound() throws Exception {
+        Dn lookupDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        Entry entry = new DefaultEntry(lookupDn);
+        expect(mockLdapBackend.getUser(anyString(), anyObject()))
+                .andThrow(new AssertionError("getUser should not be called if entry returned by next interceptor"))
+                .anyTimes();
+        replay(mockLdapBackend);
+        LookupOperationContext ctx = setupLookupContext();
+        ctx.setDn(lookupDn);
+        nextLookupInterceptor.setEntry(entry);
+
+        Entry result = interceptor.lookup(ctx);
+
+        verify(mockLdapBackend);
+        assertEquals(entry, result);
+    }
+
+    @Test
+    public void testLookupNextInterceptorThrows() throws Exception {
+        Dn lookupDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        expect(mockLdapBackend.getUser(anyString(), anyObject()))
+                .andThrow(new AssertionError("getUser should not be called if entry returned by next interceptor"))
+                .anyTimes();
+        replay(mockLdapBackend);
+        LookupOperationContext ctx = setupLookupContext();
+        ctx.setDn(lookupDn);
+        LdapException expectedException = new LdapException("lookup failed");
+        nextLookupInterceptor.setLdapException(expectedException);
+
+        LdapException resultException = assertThrows(LdapException.class,() -> interceptor.lookup(ctx));
+
+        verify(mockLdapBackend);
+        assertEquals(expectedException, resultException);
+    }
+
+    @Test
+    public void testLookupBackendThrows() throws Exception {
+        Dn lookupDn = new Dn(schemaManager, "uid=admin,ou=people,dc=proxy,dc=com");
+        LdapException expectedException = new LdapException("lookup failed");
+        expect(mockLdapBackend.getUser(anyString(), anyObject())).andThrow(expectedException);
+        replay(mockLdapBackend);
+        LookupOperationContext ctx = setupLookupContext();
+        ctx.setDn(lookupDn);
+
+        LdapOperationException resultException = assertThrows(LdapOperationException.class,() -> interceptor.lookup(ctx));
+
+        verify(mockLdapBackend);
+        assertEquals(ResultCodeEnum.OTHER, resultException.getResultCode());
+        assertEquals("Lookup request to backend TEST failed.", resultException.getMessage());
+        assertEquals(expectedException, resultException.getCause());
+    }
+
+    private SearchOperationContext setupSearchContext() throws Exception {
+        nextSearchInterceptor = new ConfigurableSearchTestInterceptor(NEXT_INTERCEPTOR);
+        nextSearchInterceptor.init(directoryService);
+        directoryService.addLast(nextSearchInterceptor);
+
+        SearchOperationContext searchCtx = new SearchOperationContext(directoryService.getSession());
+        searchCtx.setInterceptors(List.of(NEXT_INTERCEPTOR));
+        return searchCtx;
+    }
+
+    @Test
+    public void testSearch() throws Exception {
+        Dn baseDn = new Dn(schemaManager, "ou=people,dc=proxy,dc=com");
+        String filter = "(objectClass=*)";
+
+        Set<String> expectedDns = new HashSet<>();
+        List<Entry> nextEntries = createEntryList(baseDn, 5);
+        for (Entry entry : nextEntries) {
+            expectedDns.add(entry.getDn().toString());
+        }
+        List<Entry> backendEntries = createEntryList(baseDn, 5);
+        for (Entry entry : backendEntries) {
+            expectedDns.add(entry.getDn().toString());
+        }
+
+        expect(mockLdapBackend.isSupportedSearchBase(baseDn.toString())).andReturn(true);
+        expect(mockLdapBackend.search(baseDn.toString(), SearchScope.SUBTREE, filter, schemaManager)).andReturn(backendEntries);
+        replay(mockLdapBackend);
+        SearchOperationContext ctx = setupSearchContext();
+        ctx.setDn(baseDn);
+        ctx.setScope(SearchScope.SUBTREE);
+        ctx.setFilter(FilterParser.parse(filter));
+        nextSearchInterceptor.setEntries(nextEntries);
+
+        Set<String> resultDns = new HashSet<>();
+        try (EntryFilteringCursor result = interceptor.search(ctx)) {
+            for (Entry entry : result) {
+                resultDns.add(entry.getDn().toString());
+            }
+
+        }
+        verify(mockLdapBackend);
+        assertEquals(expectedDns, resultDns);
+        EntryFilteringCursor nextInterceptorCursor = nextSearchInterceptor.getCursor();
+        assertTrue("Next cursor must be closed", nextInterceptorCursor.isClosed());
+    }
+
+    @Test
+    public void testSearchBaseDnDoesntMatchBackend() throws Exception {
+        Dn baseDn = new Dn(schemaManager, "ou=people,dc=proxy,dc=com");
+        String filter = "(objectClass=*)";
+
+        Set<String> expectedDns = new HashSet<>();
+        List<Entry> nextEntries = createEntryList(baseDn, 5);
+        for (Entry entry : nextEntries) {
+            expectedDns.add(entry.getDn().toString());
+        }
+
+        expect(mockLdapBackend.isSupportedSearchBase(baseDn.toString())).andReturn(false);
+        expect(mockLdapBackend.search(anyString(), anyObject(SearchScope.class), anyString(), anyObject(SchemaManager.class)))
+                .andThrow(new AssertionError("search should not be called if base dn does not match backend"))
+                .anyTimes();
+        replay(mockLdapBackend);
+        SearchOperationContext ctx = setupSearchContext();
+        ctx.setDn(baseDn);
+        ctx.setScope(SearchScope.SUBTREE);
+        ctx.setFilter(FilterParser.parse(filter));
+        nextSearchInterceptor.setEntries(nextEntries);
+
+        Set<String> resultDns = new HashSet<>();
+        try (EntryFilteringCursor result = interceptor.search(ctx)) {
+            for (Entry entry : result) {
+                resultDns.add(entry.getDn().toString());
+            }
+
+        }
+        verify(mockLdapBackend);
+        assertEquals(expectedDns, resultDns);
+        EntryFilteringCursor nextInterceptorCursor = nextSearchInterceptor.getCursor();
+        assertTrue("Next cursor must be closed", nextInterceptorCursor.isClosed());
+    }
+
+    @Test
+    public void testSearchNoNextEntries() throws Exception {
+        Dn baseDn = new Dn(schemaManager, "ou=people,dc=proxy,dc=com");
+        String filter = "(objectClass=*)";
+
+        Set<String> expectedDns = new HashSet<>();
+        List<Entry> backendEntries = createEntryList(baseDn, 5);
+        for (Entry entry : backendEntries) {
+            expectedDns.add(entry.getDn().toString());
+        }
+
+        expect(mockLdapBackend.isSupportedSearchBase(baseDn.toString())).andReturn(true);
+        expect(mockLdapBackend.search(baseDn.toString(), SearchScope.SUBTREE, filter, schemaManager)).andReturn(backendEntries);
+        replay(mockLdapBackend);
+        SearchOperationContext ctx = setupSearchContext();
+        ctx.setDn(baseDn);
+        ctx.setScope(SearchScope.SUBTREE);
+        ctx.setFilter(FilterParser.parse(filter));
+        nextSearchInterceptor.setEntries(List.of());
+
+        Set<String> resultDns = new HashSet<>();
+        try (EntryFilteringCursor result = interceptor.search(ctx)) {
+            for (Entry entry : result) {
+                resultDns.add(entry.getDn().toString());
+            }
+
+        }
+        verify(mockLdapBackend);
+        assertEquals(expectedDns, resultDns);
+        EntryFilteringCursor nextInterceptorCursor = nextSearchInterceptor.getCursor();
+        assertTrue("Next cursor must be closed", nextInterceptorCursor.isClosed());
+    }
+
+    @Test
+    public void testSearchNextInterceptorThrows() throws Exception {
+        Dn baseDn = new Dn(schemaManager, "ou=people,dc=proxy,dc=com");
+        String filter = "(objectClass=*)";
+
+        LdapException expectedException = new LdapException("Expected exception");
+        SearchOperationContext ctx = setupSearchContext();
+        ctx.setDn(baseDn);
+        ctx.setScope(SearchScope.SUBTREE);
+        ctx.setFilter(FilterParser.parse(filter));
+        nextSearchInterceptor.setLdapException(expectedException);
+
+        LdapException resultException = assertThrows(LdapException.class, () -> interceptor.search(ctx));
+        assertEquals(expectedException, resultException);
+    }
+
+    @Test
+    public void testSearchBackendThrows() throws Exception {
+        Dn baseDn = new Dn(schemaManager, "ou=people,dc=proxy,dc=com");
+        String filter = "(objectClass=*)";
+
+        List<Entry> nextEntries = createEntryList(baseDn, 5);
+        LdapException expectedException = new LdapException("Expected exception");
+        expect(mockLdapBackend.isSupportedSearchBase(baseDn.toString())).andReturn(true);
+        expect(mockLdapBackend.search(baseDn.toString(), SearchScope.SUBTREE, filter, schemaManager)).andThrow(expectedException);
+        replay(mockLdapBackend);
+        SearchOperationContext ctx = setupSearchContext();
+        ctx.setDn(baseDn);
+        ctx.setScope(SearchScope.SUBTREE);
+        ctx.setFilter(FilterParser.parse(filter));
+        nextSearchInterceptor.setEntries(nextEntries);
+
+        LdapOperationException resultException = assertThrows(LdapOperationException.class, () -> interceptor.search(ctx));
+        assertEquals(ResultCodeEnum.OTHER, resultException.getResultCode());
+        assertEquals("Search request to backend TEST failed.", resultException.getMessage());
+        assertEquals(expectedException, resultException.getCause());
+        EntryFilteringCursor nextInterceptorCursor = nextSearchInterceptor.getCursor();
+        assertTrue("Next cursor must be closed", nextInterceptorCursor.isClosed());
+    }
+
+    private List<Entry> createEntryList(Dn baseDn, int numEntries) throws Exception {
+        List<Entry> entries = new ArrayList<>();
+        for (int i = 0; i < numEntries; i++) {
+            entries.add(createEntry(baseDn));
+        }
+        return entries;
+    }
+
+    private Entry createEntry(Dn baseDn) throws Exception {
+        Dn userDn = baseDn.add("uid=" + UUID.randomUUID().toString());
+        return new DefaultEntry(userDn);
     }
 }


### PR DESCRIPTION
[KNOX-3431](https://issues.apache.org/jira/browse/KNOX-3431) - UserSearchInterceptor throws exceptions on failed search

## What changes were proposed in this pull request?

Improve the behavior such that the UserSearchInterceptor will throw exceptions when a search request fails rather than swallowing the exception. Swallowing exceptions make it difficult to tell if there is a problem communicating with the remote LDAP backend.

## How was this patch tested?

Added unit tests.

## Integration Tests

Ran existing workflow tests.

## UI changes

no UI changes