### PR TITLE
KNOX-3433: set issued_token_type in KnoxIDF token responses (RFC 8693 §2.2.1)

### DIFF
--- a/.github/workflows/tests/test_knoxidf.py
+++ b/.github/workflows/tests/test_knoxidf.py
@@ -99,6 +99,7 @@ class TestKnoxIDF(unittest.TestCase):
         tokens = response.json()
         self.assertIn("access_token", tokens)
         self.assertEqual(tokens["token_type"], "Bearer")
+        self.assertEqual(tokens["issued_token_type"], "urn:ietf:params:oauth:token-type:jwt")
 
     def test_authorization_code_flow(self):
         """
@@ -136,6 +137,7 @@ class TestKnoxIDF(unittest.TestCase):
         self.assertIn("access_token", tokens)
         self.assertIn("id_token", tokens)
         self.assertIn("refresh_token", tokens)
+        self.assertEqual(tokens["issued_token_type"], "urn:ietf:params:oauth:token-type:jwt")
 
         refresh_token = tokens["refresh_token"]
         print(f"Refresh token: {refresh_token}")
@@ -154,6 +156,7 @@ class TestKnoxIDF(unittest.TestCase):
         new_tokens = response.json()
         self.assertIn("access_token", new_tokens)
         self.assertIn("refresh_token", new_tokens)
+        self.assertEqual(new_tokens["issued_token_type"], "urn:ietf:params:oauth:token-type:jwt")
 
         # Verify rotation: new refresh token should be different
         self.assertNotEqual(refresh_token, new_tokens["refresh_token"])

--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/TokenResource.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/TokenResource.java
@@ -71,6 +71,8 @@ import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.CODE_CHALLEN
 import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.CODE_CHALLENGE_METHOD;
 import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.CODE_VERIFIER;
 import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.FEDERATED_IDENTITY_ID;
+import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.ISSUED_TOKEN_TYPE;
+import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.ISSUED_TOKEN_TYPE_JWT_VALUE;
 import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.OFFLINE_ACCESS_SCOPE;
 import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.PKCE_METHOD_S256;
 import static org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants.REDIRECT_URI;
@@ -210,6 +212,11 @@ public class TokenResource extends PasscodeTokenResourceBase {
     @Override
     protected ResponseMap buildResponseMap(JWT token, long expires) throws TokenServiceException {
         final ResponseMap responseMap = super.buildResponseMap(token, expires);
+
+        // RFC 8693 §2.2.1 requires the response to state the type of the issued token. Every KnoxIDF
+        // grant (authorization_code, refresh_token and the client_credentials/other grants routed to
+        // super.doPost()) funnels through here and mints a JWT, so advertise the JWT URN unconditionally.
+        responseMap.map.put(ISSUED_TOKEN_TYPE, ISSUED_TOKEN_TYPE_JWT_VALUE);
 
         // id_token + refresh-token rotation apply to the user-centric grants (authorization_code and
         // refresh_token). client_credentials and other grants routed to super.doPost() must not get an

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFConstants.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFConstants.java
@@ -44,6 +44,10 @@ public interface KnoxIDFConstants {
     String STATE = "state";
     String CODE = "code";
     String REFRESH_TOKEN = "refresh_token";
+    // RFC 8693 §2.2.1: the token endpoint response must advertise the type of the issued token.
+    String ISSUED_TOKEN_TYPE = "issued_token_type";
+    //KnoxIDF always mints a JWT so issued_token_type is the JWT URN rather than the generic access_token URN.
+    String ISSUED_TOKEN_TYPE_JWT_VALUE = "urn:ietf:params:oauth:token-type:jwt";
     String REFRESH_TOKEN_TTL= "refresh.token.ttl";
     long REFRESH_TOKEN_TTL_DEFAULT = 86400000L; // 1 day
     String CODE_RESPONSE_TYPE = RESPONSE_TYPE + "=" + CODE;


### PR DESCRIPTION
[KNOX-3433](https://issues.apache.org/jira/browse/KNOX-3433) - Set issued_token_type in KnoxIDF token responses

## What changes were proposed in this pull request?

RFC 8693 §2.2.1 requires the token response to include `issued_token_type`; KnoxIDF didn't set it.

KnoxIDF always mints a JWT, so `TokenResource.buildResponseMap` now sets `issued_token_type = urn:ietf:params:oauth:token-type:jwt` on all grants (authorization_code, refresh_token, client_credentials).


## How was this patch tested?

Docker Compose integration suite: all 77 tests pass, including `test_knoxidf`:
```
  tests-1  | platform linux -- Python 3.10.20, pytest-9.0.3, pluggy-1.6.0
  tests-1  | rootdir: /tests
  tests-1  | collected 77 items
  tests-1  |
  tests-1  | test_health.py .....                                                     [  6%]
  tests-1  | test_k8s_serviceaccount_validation.py ......                             [ 14%]
  tests-1  | test_knox_admin_path_traversal.py ...                                    [ 18%]
  tests-1  | test_knox_auth_service_and_ldap.py ...                                   [ 22%]
  tests-1  | test_knox_configs.py .                                                   [ 23%]
  tests-1  | test_knox_ldap_cache.py ...                                              [ 27%]
  tests-1  | test_knox_ldap_injection.py .......                                      [ 36%]
  tests-1  | test_knox_ldap_proxy_search.py .........                                 [ 48%]
  tests-1  | test_knoxauth_preauth_and_paths.py ......                                [ 55%]
  tests-1  | test_knoxidf.py ......                                                   [ 63%]
  tests-1  | test_knoxsso_redirect.py .                                               [ 64%]
  tests-1  | test_knoxtoken_jwt.py ....................                               [ 90%]
  tests-1  | test_remote_auth.py ...                                                  [ 94%]
  tests-1  | test_remoteauth_extauthz_additional_path.py ....                         [100%]
  tests-1  |
  tests-1  | =============================== warnings summary ===============================
  tests-1  | ../usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50
  tests-1  |   /usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50: DeprecationWarning: tagMap is deprecated. Please use TAG_MAP instead.
  tests-1  |     from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
  tests-1  |
  tests-1  | ../usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50
  tests-1  |   /usr/local/lib/python3.10/site-packages/ldap3/utils/asn1.py:50: DeprecationWarning: typeMap is deprecated. Please use TYPE_MAP instead.
  tests-1  |     from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
  tests-1  |
  tests-1  | test_health.py: 5 warnings
  tests-1  | test_k8s_serviceaccount_validation.py: 6 warnings
  tests-1  | test_knox_admin_path_traversal.py: 3 warnings
  tests-1  | test_knox_auth_service_and_ldap.py: 3 warnings
  tests-1  | test_knox_configs.py: 1 warning
  tests-1  | test_knox_ldap_cache.py: 3 warnings
  tests-1  | test_knox_ldap_injection.py: 7 warnings
  tests-1  | test_knoxauth_preauth_and_paths.py: 6 warnings
  tests-1  | test_knoxidf.py: 6 warnings
  tests-1  | test_knoxsso_redirect.py: 1 warning
  tests-1  | test_knoxtoken_jwt.py: 20 warnings
  tests-1  | test_remote_auth.py: 3 warnings
  tests-1  | test_remoteauth_extauthz_additional_path.py: 4 warnings
  tests-1  |   /usr/local/lib/python3.10/site-packages/urllib3/connectionpool.py:1110: InsecureRequestWarning is being made to host 'knox'. Adding certificate verification is strongly advised. See:https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  tests-1  |     warnings.warn(
  tests-1  |
  tests-1  | -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
  tests-1  | ----------------- generated xml file: /tests/test-results.xml ------------------
  tests-1  | ======================= 77 passed, 70 warnings in 7.68s ========================
```

## Integration Tests

`test_knoxidf.py` now asserts the JWT URN in the client_credentials, authorization_code, and refresh_token responses.