### PR TITLE
KNOX-3432: Advertise RFC 8693 token-exchange grant type in KnoxIDF discovery metadata

### DIFF
--- a/.github/workflows/tests/test_knoxidf.py
+++ b/.github/workflows/tests/test_knoxidf.py
@@ -69,6 +69,7 @@ class TestKnoxIDF(unittest.TestCase):
             [
                 "authorization_code",
                 "refresh_token",
+                "client_credentials",
                 "urn:ietf:params:oauth:grant-type:token-exchange",
             ],
         )

--- a/.github/workflows/tests/test_knoxidf.py
+++ b/.github/workflows/tests/test_knoxidf.py
@@ -66,7 +66,11 @@ class TestKnoxIDF(unittest.TestCase):
         self.assertEqual(config.get("response_types_supported"), ["code"])
         self.assertEqual(
             config.get("grant_types_supported"),
-            ["authorization_code", "refresh_token"],
+            [
+                "authorization_code",
+                "refresh_token",
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+            ],
         )
         self.assertEqual(config.get("id_token_signing_alg_values_supported"), ["RS256"])
         # DEFAULT_SCOPES is an ImmutableSet, so discovery emits it in insertion order.

--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResource.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResource.java
@@ -85,7 +85,7 @@ public class DiscoveryResource {
         // field is absent, but stating it tells MCP clients to use dynamic client registration
         // (registration_endpoint) rather than a URL client_id. Flip to true only if CIMD is implemented.
         config.put("client_id_metadata_document_supported", Boolean.FALSE);
-        config.put("grant_types_supported", new String[]{KnoxIDFConstants.AUTH_CODE, KnoxIDFConstants.REFRESH_TOKEN});
+        config.put("grant_types_supported", new String[]{KnoxIDFConstants.AUTH_CODE, KnoxIDFConstants.REFRESH_TOKEN, KnoxIDFConstants.TOKEN_EXCHANGE_GRANT_TYPE});
         config.put("scopes_supported", KnoxIDFConstants.DEFAULT_SCOPES);
         config.put("id_token_signing_alg_values_supported", new String[]{"RS256"});
         // Advertise only S256: AuthorizeResource rejects any other code_challenge_method (including

--- a/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResource.java
+++ b/gateway-service-knoxidf/src/main/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResource.java
@@ -85,7 +85,7 @@ public class DiscoveryResource {
         // field is absent, but stating it tells MCP clients to use dynamic client registration
         // (registration_endpoint) rather than a URL client_id. Flip to true only if CIMD is implemented.
         config.put("client_id_metadata_document_supported", Boolean.FALSE);
-        config.put("grant_types_supported", new String[]{KnoxIDFConstants.AUTH_CODE, KnoxIDFConstants.REFRESH_TOKEN, KnoxIDFConstants.TOKEN_EXCHANGE_GRANT_TYPE});
+        config.put("grant_types_supported", new String[]{KnoxIDFConstants.AUTH_CODE, KnoxIDFConstants.REFRESH_TOKEN, KnoxIDFConstants.CLIENT_CREDENTIALS, KnoxIDFConstants.TOKEN_EXCHANGE_GRANT_TYPE});
         config.put("scopes_supported", KnoxIDFConstants.DEFAULT_SCOPES);
         config.put("id_token_signing_alg_values_supported", new String[]{"RS256"});
         // Advertise only S256: AuthorizeResource rejects any other code_challenge_method (including

--- a/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResourceMetadataTest.java
+++ b/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResourceMetadataTest.java
@@ -71,6 +71,8 @@ public class DiscoveryResourceMetadataTest {
         body.contains("grant_types_supported") && body.contains("\"" + KnoxIDFConstants.AUTH_CODE + "\""));
     assertTrue("grant_types_supported must advertise refresh_token.",
         body.contains("\"" + KnoxIDFConstants.REFRESH_TOKEN + "\""));
+    assertTrue("grant_types_supported must advertise client_credentials.",
+        body.contains("\"" + KnoxIDFConstants.CLIENT_CREDENTIALS + "\""));
     assertTrue("grant_types_supported must advertise the RFC 8693 token-exchange grant type.",
         body.contains("\"" + KnoxIDFConstants.TOKEN_EXCHANGE_GRANT_TYPE + "\""));
   }

--- a/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResourceMetadataTest.java
+++ b/gateway-service-knoxidf/src/test/java/org/apache/knox/gateway/service/knoxidf/DiscoveryResourceMetadataTest.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.knox.gateway.util.knoxidf.KnoxIDFConstants;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
@@ -65,5 +66,12 @@ public class DiscoveryResourceMetadataTest {
     // CIMD is not implemented, so it must be advertised explicitly as false (never true).
     assertTrue("client_id_metadata_document_supported must be present and false.",
         body.contains("\"client_id_metadata_document_supported\":false"));
+
+    assertTrue("grant_types_supported must advertise authorization_code.",
+        body.contains("grant_types_supported") && body.contains("\"" + KnoxIDFConstants.AUTH_CODE + "\""));
+    assertTrue("grant_types_supported must advertise refresh_token.",
+        body.contains("\"" + KnoxIDFConstants.REFRESH_TOKEN + "\""));
+    assertTrue("grant_types_supported must advertise the RFC 8693 token-exchange grant type.",
+        body.contains("\"" + KnoxIDFConstants.TOKEN_EXCHANGE_GRANT_TYPE + "\""));
   }
 }

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFConstants.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFConstants.java
@@ -48,6 +48,10 @@ public interface KnoxIDFConstants {
     String ISSUED_TOKEN_TYPE = "issued_token_type";
     //KnoxIDF always mints a JWT so issued_token_type is the JWT URN rather than the generic access_token URN.
     String ISSUED_TOKEN_TYPE_JWT_VALUE = "urn:ietf:params:oauth:token-type:jwt";
+    // This is intentionally duplicated from JWTFederationFilter.TOKEN_EXCHANGE rather than shared:
+    // it is a fixed standard identifier that will not change, and duplicating it avoids a module
+    // dependency on the JWT federation provider.
+    String TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
     String REFRESH_TOKEN_TTL= "refresh.token.ttl";
     long REFRESH_TOKEN_TTL_DEFAULT = 86400000L; // 1 day
     String CODE_RESPONSE_TYPE = RESPONSE_TYPE + "=" + CODE;

--- a/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFConstants.java
+++ b/gateway-util-common/src/main/java/org/apache/knox/gateway/util/knoxidf/KnoxIDFConstants.java
@@ -44,6 +44,7 @@ public interface KnoxIDFConstants {
     String STATE = "state";
     String CODE = "code";
     String REFRESH_TOKEN = "refresh_token";
+    String CLIENT_CREDENTIALS = "client_credentials";
     // RFC 8693 §2.2.1: the token endpoint response must advertise the type of the issued token.
     String ISSUED_TOKEN_TYPE = "issued_token_type";
     //KnoxIDF always mints a JWT so issued_token_type is the JWT URN rather than the generic access_token URN.


### PR DESCRIPTION
[KNOX-3432](https://issues.apache.org/jira/browse/KNOX-3432) - Advertise RFC 8693 token-exchange grant type in KnoxIDF discovery metadata

## What changes were proposed in this pull request?

KnoxIDF supports OAuth 2.0 Token Exchange (RFC 8693), but its OIDC discovery document (`.well-known/openid-configuration`) only listed `authorization_code` and `refresh_token` in `grant_types_supported`. Per RFC 8414 §2 that field must list every grant type the server supports, so a spec-compliant reader would wrongly conclude token exchange is unavailable.

- Added `TOKEN_EXCHANGE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"` to `KnoxIDFConstants` (RFC 8693 §2.1, IANA-registered). Intentionally duplicated from `JWTFederationFilter.TOKEN_EXCHANGE` rather than shared; it's a fixed standard identifier, and duplicating avoids a module dependency on the JWT federation provider.
- `DiscoveryResource` now includes this value in `grant_types_supported`.

## How was this patch tested?

- Extended `DiscoveryResourceMetadataTest` to assert the discovery document advertises all three grant types, including the token-exchange URN.
- `mvn -pl gateway-service-knoxidf test -Dtest=DiscoveryResourceMetadataTest`: passes.