### PR TITLE
KNOX-3439: Add tests for NoClassNameMultiLineToStringStyle

### DIFF
--- a/gateway-util-common/src/test/java/org/apache/knox/gateway/util/NoClassNameMultiLineToStringStyleTest.java
+++ b/gateway-util-common/src/test/java/org/apache/knox/gateway/util/NoClassNameMultiLineToStringStyleTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.junit.Test;
+
+public class NoClassNameMultiLineToStringStyleTest {
+
+  @Test
+  public void shouldFormatFieldsOnSeparateLines() {
+    final Object object = new Object();
+
+    final String result = new ToStringBuilder(object, new NoClassNameMultiLineToStringStyle())
+        .append("name", "knox")
+        .append("port", 8443)
+        .toString();
+
+    final String expected = "name=knox" + System.lineSeparator()
+        + "port=8443" + System.lineSeparator();
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void shouldNotIncludeClassNameOrIdentityHashCode() {
+    final Object object = new Object();
+
+    final String result = new ToStringBuilder(object, new NoClassNameMultiLineToStringStyle())
+        .append("name", "knox")
+        .toString();
+
+    assertFalse(result.contains(object.getClass().getName()));
+    assertFalse(result.contains(Integer.toHexString(System.identityHashCode(object))));
+  }
+
+  @Test
+  public void shouldNotAddSeparatorBeforeFirstField() {
+    final String result = new ToStringBuilder(new Object(), new NoClassNameMultiLineToStringStyle())
+        .append("name", "knox")
+        .toString();
+
+    assertEquals("name=knox" + System.lineSeparator(), result);
+  }
+
+  @Test
+  public void shouldEndWithLineSeparatorWhenNoFieldsAreAdded() {
+    final String result =
+        new ToStringBuilder(new Object(), new NoClassNameMultiLineToStringStyle()).toString();
+
+    assertEquals(System.lineSeparator(), result);
+  }
+}


### PR DESCRIPTION
What changes were proposed in this pull request?

This change adds dedicated unit test coverage for NoClassNameMultiLineToStringStyle.

The tests verify that:

Fields are formatted on separate lines.
The class name and identity hash code are not included in the generated string.
No field separator is added before the first field.
The generated output ends with the expected line separator, including when no fields are present.

This is a test-only change and does not modify the existing production behavior.

How was this patch tested?

The new unit tests were executed directly using:

`mvn -pl gateway-util-common -Dtest=NoClassNameMultiLineToStringStyleTest test`

Result:

Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

The complete project build was also verified using:

`mvn clean verify`

The build completed successfully.

Additionally, Checkstyle reported no violations for the changes.

Integration Tests

No integration tests were added because this change only adds unit test coverage for the formatting behavior of the NoClassNameMultiLineToStringStyle utility class.

The functionality does not require a running Knox Gateway, external services, Docker-based infrastructure, or end-to-end validation.

Dedicated unit tests have been added to cover the affected behavior.