### PR TITLE
KNOX-3421 - Escape LDAP DN values in KnoxLdapRealm

### DIFF
--- a/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealm.java
+++ b/gateway-provider-security-shiro/src/main/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealm.java
@@ -61,6 +61,7 @@ import javax.naming.ldap.LdapContext;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.PagedResultsControl;
 import javax.naming.ldap.PagedResultsResponseControl;
+import javax.naming.ldap.Rdn;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -150,6 +151,9 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
     private static final String POSIX_GROUP = "posixGroup";
 
     private static final String HASHING_ALGORITHM = "SHA-256";
+
+    /** How a substituted template value must be escaped for its target context. */
+    private enum EscapeMode { NONE, FILTER, DN }
 
     static {
           SUBTREE_SCOPE.setSearchScope(SearchControls.SUBTREE_SCOPE);
@@ -258,7 +262,7 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
       String userDn;
       if (userSearchAttributeName == null || userSearchAttributeName.isEmpty()) {
         // memberAttributeValuePrefix and memberAttributeValueSuffix were computed from memberAttributeValueTemplate
-        userDn = memberAttributeValuePrefix + userName + memberAttributeValueSuffix;
+        userDn = memberAttributeValuePrefix + escapeDnValue(userName) + memberAttributeValueSuffix;
       } else {
         userDn = getUserDn(userName);
       }
@@ -684,13 +688,19 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
           ( userSearchAttributeName == null &&
               userSearchFilter == null &&
               !"object".equalsIgnoreCase( userSearchScope ) ) ) {
-        userDn = expandTemplate( userDnTemplate, matchedPrincipal );
+        // When the template is exactly "{0}" the principal IS the full DN (e.g. a system
+        // bind DN), so DN-escaping it would corrupt the DN and break the bind. Escaping is
+        // only needed when the placeholder is embedded within surrounding DN structure
+        // (e.g. "uid={0},ou=people,..."), where the principal is a single RDN value that
+        // could otherwise inject additional RDNs.
+        final EscapeMode escapeMode = "{0}".equals( userDnTemplate.trim() ) ? EscapeMode.NONE : EscapeMode.DN;
+        userDn = expandTemplate( userDnTemplate, matchedPrincipal, escapeMode );
         LOG.computedUserDn( userDn, principal );
         return userDn;
       }
 
       // Create the searchBase and searchFilter from config.
-      String searchBase = expandTemplate( getUserSearchBase(), matchedPrincipal );
+      String searchBase = expandTemplate( getUserSearchBase(), matchedPrincipal, EscapeMode.DN );
       String searchFilter;
       if ( userSearchFilter == null ) {
         if ( userSearchAttributeName == null ) {
@@ -700,10 +710,10 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
               "(&(objectclass=%1$s)(%2$s=%3$s))",
               getUserObjectClass(),
               userSearchAttributeName,
-              expandTemplate(getUserSearchAttributeTemplate(), matchedPrincipal, true));
+              expandTemplate(getUserSearchAttributeTemplate(), matchedPrincipal, EscapeMode.FILTER));
         }
       } else {
-        searchFilter = expandTemplate(userSearchFilter, matchedPrincipal, true);
+        searchFilter = expandTemplate(userSearchFilter, matchedPrincipal, EscapeMode.FILTER);
       }
       SearchControls searchControls = getUserSearchControls();
 
@@ -749,11 +759,7 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
       return new SimpleAuthenticationInfo(token.getPrincipal(), credentialsHash.toHex(), credentialsHash.getSalt(), getName());
     }
 
-  private static String expandTemplate(final String template, final Matcher input) {
-    return expandTemplate(template, input, false);
-  }
-
-  private static String expandTemplate( final String template, final Matcher input, final boolean escapeForLdapFilter ) {
+  private static String expandTemplate( final String template, final Matcher input, final EscapeMode escapeMode ) {
     String output = template;
     Matcher matcher = TEMPLATE_PATTERN.matcher( output );
     while( matcher.find() ) {
@@ -762,8 +768,16 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
       String lookupValue = input.group( lookupIndex );
       if (lookupValue == null) {
           lookupValue = "";
-      } else if (escapeForLdapFilter) {
+      } else if (escapeMode == EscapeMode.FILTER) {
           lookupValue = escapeLdapSearchFilterValue(lookupValue);
+      } else if (escapeMode == EscapeMode.DN) {
+          lookupValue = escapeDnValue(lookupValue);
+      }
+      // A substituted value that itself contains a template token (e.g. a username of
+      // "{0}") would be re-matched on the next scan and expand forever. No legitimate
+      // principal contains a "{<digits>}" token, so reject it rather than loop.
+      if (TEMPLATE_PATTERN.matcher(lookupValue).find()) {
+          throw new IllegalArgumentException("Illegal template placeholder in substituted value");
       }
       // quoteReplacement is required: replaceFirst treats '\' and '$' in the replacement specially
       output = matcher.replaceFirst(Matcher.quoteReplacement(lookupValue));
@@ -800,6 +814,15 @@ public class KnoxLdapRealm extends DefaultLdapRealm {
       }
     }
     return sb.toString();
+  }
+
+  // RFC 4514 DN-value escaping (escapes ',', '=', '+', '"', '\\', '<', '>', ';',
+  // leading/trailing space, and a leading '#'), preventing DN injection.
+  static String escapeDnValue(final String value) {
+    if (value == null) {
+      return null;
+    }
+    return Rdn.escapeValue(value);
   }
 
 }

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmDnEscapingTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmDnEscapingTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.knox.gateway.shirorealm;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KnoxLdapRealmDnEscapingTest {
+
+  // ---- escapeDnValue: the helper used at BOTH DN-construction sites ----
+
+  @Test
+  public void plainValueIsUnchanged() {
+    assertEquals("guest", KnoxLdapRealm.escapeDnValue("guest"));
+  }
+
+  @Test
+  public void dnMetacharactersAreEscaped() {
+    // ',' and '=' must be escaped so the value cannot add or alter RDNs
+    assertEquals("guest\\,ou\\=admin", KnoxLdapRealm.escapeDnValue("guest,ou=admin"));
+  }
+
+  @Test
+  public void plusAndQuoteAreEscaped() {
+    assertEquals("a\\+b\\\"c", KnoxLdapRealm.escapeDnValue("a+b\"c"));
+  }
+
+  @Test
+  public void nullIsNullSafe() {
+    assertNull(KnoxLdapRealm.escapeDnValue(null));
+  }
+
+  // ---- getUserDn: proves the userDnTemplate ({0}) expansion escapes as a DN ----
+
+  @Test
+  public void userDnTemplatePlainPrincipalUnchanged() {
+    KnoxLdapRealm realm = new KnoxLdapRealm();
+    realm.setUserDnTemplate("uid={0},ou=people,dc=hadoop,dc=apache,dc=org");
+    assertEquals("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org",
+        realm.getUserDn("guest"));
+  }
+
+  @Test
+  public void userDnTemplateInjectionIsEscaped() {
+    KnoxLdapRealm realm = new KnoxLdapRealm();
+    realm.setUserDnTemplate("uid={0},ou=people,dc=hadoop,dc=apache,dc=org");
+    // Without escaping this would inject an extra RDN and rewrite the bind DN.
+    assertEquals("uid=guest\\,ou\\=admin,ou=people,dc=hadoop,dc=apache,dc=org",
+        realm.getUserDn("guest,ou=admin"));
+  }
+}

--- a/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmTest.java
+++ b/gateway-provider-security-shiro/src/test/java/org/apache/knox/gateway/shirorealm/KnoxLdapRealmTest.java
@@ -55,6 +55,27 @@ public class KnoxLdapRealmTest {
     return filter.getValue();
   }
 
+  private static String captureSearchBase(KnoxLdapRealm realm, String principal) throws Exception {
+    LdapContextFactory factory = EasyMock.createNiceMock(LdapContextFactory.class);
+    LdapContext ctx = EasyMock.createNiceMock(LdapContext.class);
+    NamingEnumeration<SearchResult> results = EasyMock.createNiceMock(NamingEnumeration.class);
+
+    EasyMock.expect(factory.getSystemLdapContext()).andReturn(ctx).anyTimes();
+    Capture<String> base = EasyMock.newCapture();
+    EasyMock.expect(ctx.search(EasyMock.capture(base), EasyMock.anyString(),
+        EasyMock.anyObject(SearchControls.class))).andReturn(results);
+    EasyMock.expect(results.hasMore()).andReturn(false).anyTimes();
+    EasyMock.replay(factory, ctx, results);
+
+    realm.setContextFactory(factory);
+    try {
+      realm.getUserDn(principal);
+    } catch (IllegalArgumentException expected) {
+      // mock returns no entry, so getUserDn throws after the search; we only need the base
+    }
+    return base.getValue();
+  }
+
   private static KnoxLdapRealm searchModeRealm() {
     KnoxLdapRealm realm = new KnoxLdapRealm();
     realm.setSearchBase("dc=hadoop,dc=apache,dc=org");
@@ -94,6 +115,38 @@ public class KnoxLdapRealmTest {
     realm.setUserSearchFilter("(uid={0})");
     String filter = captureSearchFilter(realm, "a)(b");
     assertEquals("(uid=a\\29\\28b)", filter);
+  }
+
+  @Test
+  public void getUserDnEscapesSearchBaseTemplateValue() throws Exception {
+    KnoxLdapRealm realm = searchModeRealm();
+    // A userSearchBase that substitutes the raw principal into the base DN.
+    realm.setUserSearchBase("ou={0},dc=hadoop,dc=apache,dc=org");
+    // Injection metacharacters in the username must be DN-escaped so they
+    // cannot add or rewrite RDNs in the search base.
+    String base = captureSearchBase(realm, "people,dc=evil");
+    assertEquals("ou=people\\,dc\\=evil,dc=hadoop,dc=apache,dc=org", base);
+  }
+
+  @Test
+  public void getUserDnWithDefaultTemplateReturnsFullDnUnescaped() {
+    // The default userDnTemplate is "{0}", meaning the principal IS the complete bind DN
+    // (the system-bind case, e.g. KnoxCLI system-user-auth-test). DN-escaping would turn
+    // the ','/'=' separators into '\,'/'\=' and corrupt the DN, so this template must pass
+    // the principal through unescaped. Embedded templates ("uid={0},...") still escape.
+    KnoxLdapRealm realm = new KnoxLdapRealm();
+    String dn = realm.getUserDn("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org");
+    assertEquals("uid=guest,ou=people,dc=hadoop,dc=apache,dc=org", dn);
+  }
+
+  @Test(timeout = 5000, expected = IllegalArgumentException.class)
+  public void getUserDnRejectsTemplatePlaceholderAsUsername() {
+    // A username of "{0}" substituted into a template would re-introduce a "{0}" token
+    // and loop forever. It must be rejected (auth failure), not expanded. The timeout
+    // guards against regression of the infinite loop.
+    KnoxLdapRealm realm = new KnoxLdapRealm();
+    realm.setUserDnTemplate("uid={0},ou=people,dc=hadoop,dc=apache,dc=org");
+    realm.getUserDn("{0}");
   }
 
   @Test


### PR DESCRIPTION
[KNOX-3421](https://issues.apache.org/jira/browse/KNOX-3421) - Escape LDAP DN values in KnoxLdapRealm

## What changes were proposed in this pull request?

Fix issues with how Knox handles LDAP DN values.

## How was this patch tested?

- This patch was tested locally in a test env.
- Unit tests are added as part of this PR
