### PR TITLE
KNOX-3447: Harden ServiceDefinitonUnmarshaller

### DIFF
--- a/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/ServiceDefinitionUnmarshaller.java
+++ b/gateway-service-admin/src/main/java/org/apache/knox/gateway/service/admin/ServiceDefinitionUnmarshaller.java
@@ -28,6 +28,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.transform.stream.StreamSource;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
@@ -49,8 +53,13 @@ public class ServiceDefinitionUnmarshaller implements MessageBodyReader<ServiceD
   public ServiceDefinitionPair readFrom(Class<ServiceDefinitionPair> instance, Type genericType, Annotation[] annotations, MediaType mediaType,
       MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
     try {
-      return (ServiceDefinitionPair) getUnmarshaller().unmarshal(entityStream);
-    } catch (JAXBException e) {
+      XMLInputFactory xif = XMLInputFactory.newFactory();
+      xif.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+      xif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+      xif.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+      XMLStreamReader xsr = xif.createXMLStreamReader(new StreamSource(entityStream));
+      return (ServiceDefinitionPair) getUnmarshaller().unmarshal(xsr);
+    } catch (XMLStreamException | JAXBException e) {
       throw new IOException(e);
     }
   }

--- a/gateway-service-admin/src/test/java/org/apache/knox/gateway/service/admin/ServiceDefinitionUnmarshallerTest.java
+++ b/gateway-service-admin/src/test/java/org/apache/knox/gateway/service/admin/ServiceDefinitionUnmarshallerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.knox.gateway.service.admin;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.knox.gateway.service.definition.ServiceDefinitionPair;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class ServiceDefinitionUnmarshallerTest {
+
+  private static InputStream stream(String xml) {
+    return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testExternalEntityIsNotResolved() throws Exception {
+    final File secret = File.createTempFile("xxe-secret", ".txt");
+    try {
+      Files.write(secret.toPath(), "TOP-SECRET".getBytes(StandardCharsets.UTF_8));
+
+      final String malicious = "<?xml version=\"1.0\"?>"
+          + "<!DOCTYPE serviceDefinition [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>"
+          + "<serviceDefinition><service name=\"test\" role=\"test\" version=\"1.0.0\">"
+          + "<testURLs><testURL>&xxe;</testURL></testURLs></service></serviceDefinition>";
+
+      try {
+        final ServiceDefinitionPair pair = new ServiceDefinitionUnmarshaller().readFrom(
+            ServiceDefinitionPair.class, null, null, MediaType.APPLICATION_XML_TYPE, null, stream(malicious));
+        if (pair != null && pair.getService() != null) {
+          assertFalse("External entity was resolved - XXE!",
+              String.valueOf(pair.getService().getTestURLs()).contains("TOP-SECRET"));
+        }
+      } catch (IOException rejected) {
+        // no-op
+      }
+    } finally {
+      Files.deleteIfExists(secret.toPath());
+    }
+  }
+
+  @Test
+  public void testEntityExpansionIsNotResolved() throws Exception {
+    final String malicious = "<?xml version=\"1.0\"?>"
+        + "<!DOCTYPE serviceDefinition [ "
+        + "<!ENTITY a0 \"EXPANDED-PAYLOAD\">"
+        + "<!ENTITY a1 \"&a0;&a0;\">"
+        + "<!ENTITY a2 \"&a1;&a1;\">"
+        + "<!ENTITY a3 \"&a2;&a2;\"> ]>"
+        + "<serviceDefinition><service name=\"test\" role=\"test\" version=\"1.0.0\">"
+        + "<testURLs><testURL>&a3;</testURL></testURLs></service></serviceDefinition>";
+
+    try {
+      final ServiceDefinitionPair pair = new ServiceDefinitionUnmarshaller().readFrom(
+          ServiceDefinitionPair.class, null, null, MediaType.APPLICATION_XML_TYPE, null, stream(malicious));
+      if (pair != null && pair.getService() != null) {
+        assertFalse("Internal entity was expanded - entity expansion!",
+            String.valueOf(pair.getService().getTestURLs()).contains("EXPANDED-PAYLOAD"));
+      }
+    } catch (IOException rejected) {
+      // no-op
+    }
+  }
+
+  @Test
+  public void testValidServiceDefinitionParses() throws Exception {
+    final String xml = "<?xml version=\"1.0\"?>"
+        + "<serviceDefinition><service name=\"test\" role=\"test\" version=\"1.0.0\"/></serviceDefinition>";
+
+    final ServiceDefinitionPair pair = new ServiceDefinitionUnmarshaller().readFrom(
+        ServiceDefinitionPair.class, null, null, MediaType.APPLICATION_XML_TYPE, null, stream(xml));
+
+    assertNotNull(pair);
+    assertNotNull(pair.getService());
+  }
+}

--- a/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
+++ b/gateway-test/src/test/java/org/apache/knox/gateway/GatewayAdminTopologyFuncTest.java
@@ -952,6 +952,62 @@ public class GatewayAdminTopologyFuncTest {
   }
 
   @Test( timeout = TestUtils.LONG_TIMEOUT )
+  public void testPutServiceDefinitionWithEntityInjection() throws Exception {
+    LOG_ENTER();
+
+    final String username = "admin";
+    final String password = "admin-password";
+
+    final String name = "xxetest";
+    final String role = "XXETEST";
+    final String version = "1.0.0";
+
+    final String canary = "XXE-LEAK-CANARY-" + UUID.randomUUID();
+    final File secret = File.createTempFile("knox-xxe-secret", ".txt");
+    Files.write(secret.toPath(), canary.getBytes(StandardCharsets.UTF_8));
+
+    final String XML_WITH_INJECTION =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+        "<!DOCTYPE foo [<!ENTITY xxeinj SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n" +
+        "<serviceDefinition>\n" +
+        "    <service name=\"" + name + "\" role=\"" + role + "\" version=\"" + version + "\">\n" +
+        "        <routes>\n" +
+        "            <route path=\"/xxetest/?**\"/>\n" +
+        "        </routes>\n" +
+        "        <testURLs>\n" +
+        "            <testURL>&xxeinj;</testURL>\n" +
+        "        </testURLs>\n" +
+        "    </service>\n" +
+        "</serviceDefinition>";
+
+    final String putUrl = clusterUrl + "/api/v1/servicedefinitions";
+    final String getUrl = clusterUrl + "/api/v1/servicedefinitions/" + name + "/" + role + "/" + version;
+
+    try {
+      given().auth().preemptive().basic(username, password)
+             .contentType(MediaType.APPLICATION_XML)
+             .body(XML_WITH_INJECTION)
+             .then()
+             .statusCode(HttpStatus.SC_CREATED)
+             .when().put(putUrl);
+
+      String getResponse = given().auth().preemptive().basic(username, password)
+             .header("Accept", MediaType.APPLICATION_XML)
+             .then()
+             .statusCode(HttpStatus.SC_OK)
+             .when().get(getUrl).getBody().asString();
+
+      assertThat(getResponse, not(containsString(canary)));
+    } finally {
+      given().auth().preemptive().basic(username, password)
+             .when().delete(getUrl);
+      Files.deleteIfExists(secret.toPath());
+    }
+
+    LOG_EXIT();
+  }
+
+  @Test( timeout = TestUtils.LONG_TIMEOUT )
   public void testXForwardedHeaders() {
     LOG_ENTER();
 


### PR DESCRIPTION
[KNOX-3447](https://issues.apache.org/jira/browse/KNOX-3447) - Harden ServiceDefinitionUnmarshaller

## What changes were proposed in this pull request?

- This change is copying the [KNOX-1308](https://issues.apache.org/jira/browse/KNOX-1308) TopologyMarshaller solution into ServiceDefinitonUnmarshaller to prevent XXE injections.

## How was this patch tested?

Unit tests
