### PR TITLE
KNOX-3444: Optimize CM discovery memory usage by only caching role configurations that ServiceModelGenerators actually use

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolder.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolder.java
@@ -17,21 +17,30 @@
 package org.apache.knox.gateway.topology.discovery.cm;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 
 public class ServiceModelGeneratorsHolder {
 
   private static final ServiceModelGeneratorsHolder INSTANCE = new ServiceModelGeneratorsHolder();
   private final Map<String, List<ServiceModelGenerator>> serviceModelGenerators = new HashMap<>();
+  private final Set<String> allRoleTypes = new HashSet<>();
 
   private ServiceModelGeneratorsHolder() {
     final ServiceLoader<ServiceModelGenerator> loader = ServiceLoader.load(ServiceModelGenerator.class);
     for (ServiceModelGenerator serviceModelGenerator : loader) {
       List<ServiceModelGenerator> smgList = serviceModelGenerators.computeIfAbsent(serviceModelGenerator.getServiceType(), k -> new ArrayList<>());
       smgList.add(serviceModelGenerator);
+
+      final String roleType = serviceModelGenerator.getRoleType();
+      if (roleType != null) {
+        allRoleTypes.add(roleType);
+      }
     }
   }
 
@@ -41,6 +50,16 @@ public class ServiceModelGeneratorsHolder {
 
   public List<ServiceModelGenerator> getServiceModelGenerators(String serviceType) {
     return serviceModelGenerators.get(serviceType);
+  }
+
+  /**
+   * @return the union of the CM role types that any registered
+   *         {@link ServiceModelGenerator} operates on. Role types outside of this
+   *         set can never produce a service model and therefore do not need to be
+   *         fetched or cached during CM service discovery.
+   */
+  public Set<String> getAllRoleTypes() {
+    return Collections.unmodifiableSet(allRoleTypes);
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorBuilder.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorBuilder.java
@@ -22,6 +22,7 @@ import org.apache.knox.gateway.config.GatewayConfig;
 import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static org.apache.knox.gateway.config.GatewayConfig.CLOUDERA_MANAGER_SERVICE_DISCOVERY_ROLE_FETCH_STRATEGY_BY_ROLE;
 import static org.apache.knox.gateway.config.GatewayConfig.CLOUDERA_MANAGER_SERVICE_DISCOVERY_ROLE_FETCH_STRATEGY_BY_SERVICE;
@@ -78,7 +79,8 @@ public class ServiceRoleCollectorBuilder {
             String fetchStrategy = gatewayConfig.getClouderaManagerServiceDiscoveryRoleFetchStrategy();
             long pageSize = gatewayConfig.getClouderaManagerServiceDiscoveryRoleConfigPageSize();
             Collection<String> excludedRoleTypes = gatewayConfig.getClouderaManagerServiceDiscoveryExcludedRoleTypes();
-            TypeNameFilter roleTypeNameFilter = new TypeNameFilter(excludedRoleTypes);
+            Set<String> requiredRoleTypes = ServiceModelGeneratorsHolder.getInstance().getAllRoleTypes();
+            TypeNameFilter roleTypeNameFilter = new TypeNameFilter(excludedRoleTypes, requiredRoleTypes);
             String clientBasePath = rolesResourceApi.getApiClient().getBasePath();
 
             if (CLOUDERA_MANAGER_SERVICE_DISCOVERY_ROLE_FETCH_STRATEGY_BY_ROLE.equals(fetchStrategy)) {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByService.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByService.java
@@ -25,8 +25,6 @@ import org.apache.knox.gateway.i18n.messages.MessagesFactory;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ServiceRoleCollectorByService implements ServiceRoleCollector {
 
@@ -55,19 +53,16 @@ public class ServiceRoleCollectorByService implements ServiceRoleCollector {
             roleConfigList = rolesResourceApi.readRolesConfig(clusterName, serviceName,
                     BigDecimal.valueOf(limit), BigDecimal.valueOf(offset), VIEW_FULL);
             if (roleConfigList != null && roleConfigList.getItems() != null) {
-                allServiceRoleConfigs.getItems().addAll(roleConfigList.getItems());
+                // filter each page as it arrives so unneeded role configs never accumulate
+                roleConfigList.getItems().stream()
+                        .filter(this::isIncluded)
+                        .forEach(allServiceRoleConfigs.getItems()::add);
             } else {
                 log.receivedNullServiceRoleConfigs(serviceName, clusterName);
             }
             offset += limit;
         } while (configItemSizeMatchesLimit(roleConfigList, limit));
-        return filterIncluded(allServiceRoleConfigs);
-    }
-
-    private ApiRoleConfigList filterIncluded(ApiRoleConfigList roleConfigs) {
-        List<ApiRoleConfig> filteredItems = roleConfigs.getItems().stream()
-                .filter(this::isIncluded).collect(Collectors.toList());
-        return new ApiRoleConfigList().items(filteredItems);
+        return allServiceRoleConfigs;
     }
 
     private boolean configItemSizeMatchesLimit(ApiRoleConfigList roleConfigList, long limit) {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilter.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilter.java
@@ -27,15 +27,10 @@ public class TypeNameFilter {
     private final Set<String> excludedTypeNames;
     private final Set<String> requiredTypeNames;
 
-    public TypeNameFilter(Collection<String> excludedTypeNames) {
-        this(excludedTypeNames, Collections.emptySet());
-    }
-
     /**
      * @param excludedTypeNames a deny-list of type names that are always excluded
-     * @param requiredTypeNames an allow-list of type names; when non-empty, any type
-     *                          not contained in it is excluded. An empty allow-list
-     *                          means no allow-list restriction is applied.
+     * @param requiredTypeNames an allow-list of type names; any type not contained in it
+     *                          is excluded. An empty (or null) allow-list excludes every type.
      */
     public TypeNameFilter(Collection<String> excludedTypeNames, Collection<String> requiredTypeNames) {
         this.excludedTypeNames = mapToLowerCase(excludedTypeNames);
@@ -47,7 +42,7 @@ public class TypeNameFilter {
         if (excludedTypeNames.contains(lower)) {
             return true;
         }
-        return !requiredTypeNames.isEmpty() && !requiredTypeNames.contains(lower);
+        return !requiredTypeNames.contains(lower);
     }
 
     private Set<String> mapToLowerCase(Collection<String> items) {

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilter.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilter.java
@@ -24,14 +24,30 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class TypeNameFilter {
-    private final Collection<String> excludedTypeNames;
+    private final Set<String> excludedTypeNames;
+    private final Set<String> requiredTypeNames;
 
     public TypeNameFilter(Collection<String> excludedTypeNames) {
+        this(excludedTypeNames, Collections.emptySet());
+    }
+
+    /**
+     * @param excludedTypeNames a deny-list of type names that are always excluded
+     * @param requiredTypeNames an allow-list of type names; when non-empty, any type
+     *                          not contained in it is excluded. An empty allow-list
+     *                          means no allow-list restriction is applied.
+     */
+    public TypeNameFilter(Collection<String> excludedTypeNames, Collection<String> requiredTypeNames) {
         this.excludedTypeNames = mapToLowerCase(excludedTypeNames);
+        this.requiredTypeNames = mapToLowerCase(requiredTypeNames);
     }
 
     public boolean isExcluded(String roleType) {
-        return excludedTypeNames.contains(roleType.toLowerCase(Locale.ROOT));
+        final String lower = roleType.toLowerCase(Locale.ROOT);
+        if (excludedTypeNames.contains(lower)) {
+            return true;
+        }
+        return !requiredTypeNames.isEmpty() && !requiredTypeNames.contains(lower);
     }
 
     private Set<String> mapToLowerCase(Collection<String> items) {

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolderTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+
+public class ServiceModelGeneratorsHolderTest {
+
+    @Test
+    public void testGetAllRoleTypesContainsGeneratorRoleTypes() {
+        Set<String> roleTypes = ServiceModelGeneratorsHolder.getInstance().getAllRoleTypes();
+        assertThat("Should contain role types declared by registered generators",
+                roleTypes, hasItems("SOLR_SERVER", "NAMENODE", "ATLAS_SERVER", "HIVESERVER2"));
+    }
+
+    @Test
+    public void testGetAllRoleTypesDoesNotContainUnknownRoleType() {
+        Set<String> roleTypes = ServiceModelGeneratorsHolder.getInstance().getAllRoleTypes();
+        assertThat("Should not contain a role type no generator declares",
+                roleTypes.contains("NO_SUCH_ROLE_TYPE"), is(false));
+        assertThat(roleTypes, not(hasItems("NO_SUCH_ROLE_TYPE")));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetAllRoleTypesIsUnmodifiable() {
+        ServiceModelGeneratorsHolder.getInstance().getAllRoleTypes().add("SOME_ROLE_TYPE");
+    }
+
+}

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByRoleTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByRoleTest.java
@@ -205,6 +205,30 @@ public class ServiceRoleCollectorByRoleTest {
         EasyMock.verify(api);
     }
 
+    @Test
+    public void testRequiredRoleTypeFilterDropsUnneededRoleWithoutReadingItsConfig() throws ApiException {
+        RolesResourceApi api = EasyMock.createNiceMock(RolesResourceApi.class);
+        ApiRoleList serviceRoleList = new ApiRoleList().items(Arrays.asList(hiveServer2Role(), gatewayRole1()));
+        ApiConfigList hiveServer2ConfigList = hiveServer2ConfigList();
+        EasyMock.expect(api.readRoles(eq(clusterName), eq(serviceName), anyString(), eq(DATA_VIEW_FULL))).andReturn(serviceRoleList);
+        // Only the required (HIVESERVER2) role config should be read; GATEWAY must be skipped before readRoleConfig.
+        EasyMock.expect(api.readRoleConfig(eq(clusterName), eq(hiveServer2Role().getName()), eq(serviceName), eq(DATA_VIEW_FULL))).andReturn(hiveServer2ConfigList);
+        EasyMock.replay(api);
+        Set<String> requiredRoleTypes = Collections.singleton("HIVESERVER2");
+        TypeNameFilter roleTypeFilter = new TypeNameFilter(Collections.emptySet(), requiredRoleTypes);
+        ServiceRoleCollector collector = createRoleCollectorWithFilter(api, roleTypeFilter);
+
+        ApiRoleConfigList roleConfigList = collector.getAllServiceRoleConfigurations(clusterName, serviceName);
+
+        List<ApiRoleConfig> items = roleConfigList.getItems();
+        List<ApiRoleConfig> expectedItems = new ArrayList<>();
+        expectedItems.add(toApiRoleConfig(hiveServer2Role(), hiveServer2ConfigList()));
+        assertEquals("Unexpected role config list size.", expectedItems.size(), items.size());
+        assertThat("Config items should match", items, containsInAnyOrder(expectedItems.toArray()));
+        // verify() confirms readRoleConfig was never called for the GATEWAY role.
+        EasyMock.verify(api);
+    }
+
     private static ApiConfigList gatewayConfigList() {
         return new ApiConfigList().addItemsItem(gatewayClientConfigPriorityConfig());
     }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByRoleTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByRoleTest.java
@@ -192,7 +192,8 @@ public class ServiceRoleCollectorByRoleTest {
         EasyMock.expect(api.readRoleConfig(eq(clusterName), eq(hiveServer2Role().getName()), eq(serviceName), eq(DATA_VIEW_FULL))).andReturn(hiveServer2ConfigList);
         EasyMock.replay(api);
         Set<String> excludedRoleTypes = Collections.singleton("GATEWAY");
-        TypeNameFilter roleTypeFilter = new TypeNameFilter(excludedRoleTypes);
+        Set<String> requiredRoleTypes = Collections.singleton("HIVESERVER2");
+        TypeNameFilter roleTypeFilter = new TypeNameFilter(excludedRoleTypes, requiredRoleTypes);
         ServiceRoleCollector collector = createRoleCollectorWithFilter(api, roleTypeFilter);
 
         ApiRoleConfigList roleConfigList = collector.getAllServiceRoleConfigurations(clusterName, serviceName);

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByServiceTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceRoleCollectorByServiceTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -198,7 +200,8 @@ public class ServiceRoleCollectorByServiceTest {
         RolesResourceApi api = createApiWithTwoFullPages();
 
         Set<String> excludedRoleTypes = Collections.singleton("RolE1");
-        TypeNameFilter filter = new TypeNameFilter(excludedRoleTypes);
+        Set<String> requiredRoleTypes = new HashSet<>(Arrays.asList("role1", "role2", "role3", "role4"));
+        TypeNameFilter filter = new TypeNameFilter(excludedRoleTypes, requiredRoleTypes);
         ServiceRoleCollector serviceRoleCollector = createRoleCollectorWithFilter(api, filter);
 
         ApiRoleConfigList result = serviceRoleCollector.getAllServiceRoleConfigurations(clusterName, serviceName);

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilterTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilterTest.java
@@ -29,27 +29,27 @@ import static org.hamcrest.core.Is.is;
 public class TypeNameFilterTest {
 
     @Test
-    public void testExcludedNamesIsNull() {
-        TypeNameFilter filter = new TypeNameFilter(null);
-        assertThat("Should exclude nothing", filter.isExcluded("HIVESERVER2"), is(false));
+    public void testNullExcludeListDoesNotExcludeAllowedType() {
+        TypeNameFilter filter = new TypeNameFilter(null, Collections.singleton("HIVESERVER2"));
+        assertThat("Null exclude list should not exclude an allowed type", filter.isExcluded("HIVESERVER2"), is(false));
     }
 
     @Test
-    public void testExcludedNamesIsEmpty() {
-        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet());
-        assertThat("Should exclude nothing", filter.isExcluded("HIVESERVER2"), is(false));
+    public void testEmptyExcludeListDoesNotExcludeAllowedType() {
+        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), Collections.singleton("HIVESERVER2"));
+        assertThat("Empty exclude list should not exclude an allowed type", filter.isExcluded("HIVESERVER2"), is(false));
     }
 
     @Test
     public void testExcludeWhenExactMatch() {
-        TypeNameFilter filter = new TypeNameFilter(Collections.singleton("HIVESERVER2"));
+        TypeNameFilter filter = new TypeNameFilter(Collections.singleton("HIVESERVER2"), Collections.singleton("HIVESERVER2"));
         assertThat("Should exclude exact match", filter.isExcluded("HIVESERVER2"), is(true));
     }
 
     @Test
     public void testExcludeWhenIgnoreCaseMatch() {
-        TypeNameFilter filter = new TypeNameFilter(Collections.singleton("hiveServer2"));
-        assertThat("Should exclude exact match", filter.isExcluded("HIVESERVER2"), is(true));
+        TypeNameFilter filter = new TypeNameFilter(Collections.singleton("hiveServer2"), Collections.singleton("HIVESERVER2"));
+        assertThat("Should exclude case-insensitive match", filter.isExcluded("HIVESERVER2"), is(true));
     }
 
 
@@ -57,7 +57,7 @@ public class TypeNameFilterTest {
     public void testExcludeMultipleTypesWithExactMatch() {
         Set<String> excludedTypeNames =
                 new HashSet<>(Arrays.asList("GATEWAY", "HIVESERVER2"));
-        TypeNameFilter filter = new TypeNameFilter(excludedTypeNames);
+        TypeNameFilter filter = new TypeNameFilter(excludedTypeNames, Collections.singleton("HIVESERVER2"));
         assertThat("Should exclude exact match", filter.isExcluded("HIVESERVER2"), is(true));
     }
 
@@ -65,8 +65,8 @@ public class TypeNameFilterTest {
     public void testExcludeMultipleTypesWithIgnoreCaseMatch() {
         Set<String> excludedTypeNames =
                 new HashSet<>(Arrays.asList("Gateway", "HiveserVER2"));
-        TypeNameFilter filter = new TypeNameFilter(excludedTypeNames);
-        assertThat("Should exclude exact match", filter.isExcluded("HIVESERVER2"), is(true));
+        TypeNameFilter filter = new TypeNameFilter(excludedTypeNames, Collections.singleton("HIVESERVER2"));
+        assertThat("Should exclude case-insensitive match", filter.isExcluded("HIVESERVER2"), is(true));
     }
 
     @Test
@@ -82,15 +82,15 @@ public class TypeNameFilterTest {
     }
 
     @Test
-    public void testEmptyRequiredTypesAppliesNoAllowListRestriction() {
+    public void testEmptyAllowListExcludesEverything() {
         TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), Collections.emptySet());
-        assertThat("Empty allow-list should not exclude anything", filter.isExcluded("DATANODE"), is(false));
+        assertThat("Empty allow-list should exclude every type", filter.isExcluded("DATANODE"), is(true));
     }
 
     @Test
-    public void testNullRequiredTypesAppliesNoAllowListRestriction() {
+    public void testNullAllowListExcludesEverything() {
         TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), null);
-        assertThat("Null allow-list should not exclude anything", filter.isExcluded("DATANODE"), is(false));
+        assertThat("Null allow-list should exclude every type", filter.isExcluded("DATANODE"), is(true));
     }
 
     @Test

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilterTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/TypeNameFilterTest.java
@@ -69,4 +69,41 @@ public class TypeNameFilterTest {
         assertThat("Should exclude exact match", filter.isExcluded("HIVESERVER2"), is(true));
     }
 
+    @Test
+    public void testRequiredTypeIsNotExcluded() {
+        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), Collections.singleton("HIVESERVER2"));
+        assertThat("Required type should not be excluded", filter.isExcluded("HIVESERVER2"), is(false));
+    }
+
+    @Test
+    public void testNonRequiredTypeIsExcludedWhenAllowListNonEmpty() {
+        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), Collections.singleton("HIVESERVER2"));
+        assertThat("Type absent from a non-empty allow-list should be excluded", filter.isExcluded("DATANODE"), is(true));
+    }
+
+    @Test
+    public void testEmptyRequiredTypesAppliesNoAllowListRestriction() {
+        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), Collections.emptySet());
+        assertThat("Empty allow-list should not exclude anything", filter.isExcluded("DATANODE"), is(false));
+    }
+
+    @Test
+    public void testNullRequiredTypesAppliesNoAllowListRestriction() {
+        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), null);
+        assertThat("Null allow-list should not exclude anything", filter.isExcluded("DATANODE"), is(false));
+    }
+
+    @Test
+    public void testRequiredTypeMatchIsCaseInsensitive() {
+        TypeNameFilter filter = new TypeNameFilter(Collections.emptySet(), Collections.singleton("HiveServer2"));
+        assertThat("Required type match should be case-insensitive", filter.isExcluded("HIVESERVER2"), is(false));
+    }
+
+    @Test
+    public void testExcludedTypeWinsOverAllowList() {
+        TypeNameFilter filter =
+                new TypeNameFilter(Collections.singleton("HIVESERVER2"), Collections.singleton("HIVESERVER2"));
+        assertThat("Deny-list should take precedence over allow-list", filter.isExcluded("HIVESERVER2"), is(true));
+    }
+
 }


### PR DESCRIPTION
[KNOX-3444](https://issues.apache.org/jira/browse/KNOX-3444) - Exclude role types that are not referenced by ServiceModelGenerators

## What changes were proposed in this pull request?

During CM discovery only cache role configurations that ServiceModelGenerators actually use.

## How was this patch tested?

Updated unit tests and did manual test on a cluster.
Verified that the ClusterConfiguration cache persisted after discovery is the same as before the changes were applied and the topologies have the same generated service URLs.

Acquired a heap dump using jmap: 
```bash
jmap -dump:live,format=b,file="/tmp/knox-heap-jmap-${knox_pid}".hprof "${knox_pid}";
```
Used Eclipse Memory Analyzer Tool and Calcite SQL plugin to analyze the heap usage of the ApiRoleConfig objects cached in `ClouderaManagerServiceDiscoveryRepository`

```sql
SELECT toString(r.this['roleType']) roleType, COUNT(r.this) as cnt, 
AVG(retainedSize(r.this)) as avg_retained_size, SUM(retainedSize(r.this)) sum_retained_size
FROM "com.cloudera.api.swagger.model.ApiRoleConfig" r 
GROUP BY toString(r.this['roleType'])
ORDER BY sum_retained_size desc, roleType
```
The unused roles (e.g. NODEMANAGER, REGIONSERVER, GATEWAY, DATANODE, KNOX_GATEWAY, KAFKA_BROKER, OZONE_DATANODE, etc.) are not cached. For each unused role, the memory savings are 60K - 150K by role instance not cached (with an average of roughly 100K).


## Integration Tests

N/A. Integration tests would require a live CM dependency. Setting up a real (or faithfully simulated) Cloudera Manager server with representative services/roles is heavy infrastructure that the project's test suite does not provide, and a mock-based "integration" test would exercise the same code paths the unit tests already cover.