### PR TITLE
KNOX-2900: KNOX-2899 followup - reenable service based discovery filter

### DIFF
--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerCluster.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerCluster.java
@@ -38,6 +38,11 @@ public class ClouderaManagerCluster implements ServiceDiscovery.Cluster {
 
   private Map<String, List<ServiceModel>> serviceModels = new HashMap<>();
 
+  // The CM service types this (possibly filtered) discovery was responsible for. Used by the configuration monitor
+  // to scope-replace the persisted baseline: only these types are refreshed/removed, other descriptors' services are
+  // preserved. A null value means an unfiltered discovery (replace the whole cluster baseline).
+  private Set<String> inScopeServiceTypes;
+
   ClouderaManagerCluster(String clusterName) {
     this.name = clusterName;
   }
@@ -102,6 +107,14 @@ public class ClouderaManagerCluster implements ServiceDiscovery.Cluster {
 
   public Map<String, List<ServiceModel>> getServiceModels() {
     return serviceModels;
+  }
+
+  void setInScopeServiceTypes(Set<String> inScopeServiceTypes) {
+    this.inScopeServiceTypes = inScopeServiceTypes;
+  }
+
+  public Set<String> getInScopeServiceTypes() {
+    return inScopeServiceTypes;
   }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -279,19 +279,25 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
 
     ClouderaManagerCluster cluster = new ClouderaManagerCluster(clusterName);
     cluster.addServiceModels(serviceModels);
+    // Record the CM service types this discovery was responsible for, so the configuration monitor can scope-replace
+    // the persisted baseline instead of overwriting it. An empty includedServices means "discover everything", which
+    // maps to a null scope (full replace).
+    cluster.setInScopeServiceTypes(
+        (includedServices == null || includedServices.isEmpty())
+            ? null
+            : ServiceModelGeneratorsHolder.getInstance().getServiceTypesForServices(includedServices));
     log.discoveredCluster(clusterName);
     return cluster;
   }
 
-  @SuppressWarnings("PMD.UnusedFormalParameter")
   private Set<ServiceModel> discoverService(DiscoveryApiClient client, String clusterName, Collection<String> includedServices,
                                             ApiService service, ServicesResourceApi servicesResourceApi,
                                             ServiceRoleCollector roleCollector, ApiServiceConfig coreSettingsConfig) throws ApiException {
-    //final List<ServiceModelGenerator> modelGenerators = ServiceModelGeneratorsHolder.getInstance().getServiceModelGenerators(service.getType());
-    //if (shouldSkipServiceDiscovery(modelGenerators, includedServices)) {
-      //log.skipServiceDiscovery(service.getName(), service.getType());
-      //continue;
-    //}
+    final List<ServiceModelGenerator> modelGenerators = ServiceModelGeneratorsHolder.getInstance().getServiceModelGenerators(service.getType());
+    if (shouldSkipServiceDiscovery(modelGenerators, includedServices)) {
+      log.skipServiceDiscovery(service.getName(), service.getType());
+      return Collections.emptySet();
+    }
     log.discoveringService(service.getName(), service.getType());
     ApiServiceConfig serviceConfig = null;
     /* no reason to check service config for CM or CORE_SETTINGS services */
@@ -319,7 +325,6 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
     return null;
   }
 
-  @SuppressWarnings("PMD.UnusedPrivateMethod")
   private boolean shouldSkipServiceDiscovery(List<ServiceModelGenerator> modelGenerators, Collection<String> includedServices) {
     if (includedServices == null || includedServices.isEmpty()) {
       // per the contract of org.apache.knox.gateway.topology.discovery.ServiceDiscovery.discover(GatewayConfig, ServiceDiscoveryConfig, String, Collection<String>):

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscovery.java
@@ -19,8 +19,6 @@ package org.apache.knox.gateway.topology.discovery.cm;
 import com.cloudera.api.swagger.RolesResourceApi;
 import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.client.ApiException;
-import com.cloudera.api.swagger.model.ApiConfigList;
-import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiRoleConfig;
 import com.cloudera.api.swagger.model.ApiRoleConfigList;
 import com.cloudera.api.swagger.model.ApiService;
@@ -39,7 +37,6 @@ import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ClusterConfigurationMonitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
-import org.apache.knox.gateway.topology.discovery.cm.model.opensearch.OpenSearchApiMasterServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.monitor.ClouderaManagerClusterConfigurationMonitor;
 
 import java.net.SocketException;
@@ -83,8 +80,6 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
   .addItemsItem(new ApiRoleConfig().name(CM_ROLE_TYPE).roleType(CM_ROLE_TYPE));
 
   public static final String CORE_SETTINGS_TYPE = "CORE_SETTINGS";
-
-  private ServiceModelGeneratorsHolder serviceModelGeneratorsHolder = ServiceModelGeneratorsHolder.getInstance();
 
   private boolean debug;
 
@@ -292,8 +287,7 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
   private Set<ServiceModel> discoverService(DiscoveryApiClient client, String clusterName, Collection<String> includedServices,
                                             ApiService service, ServicesResourceApi servicesResourceApi,
                                             ServiceRoleCollector roleCollector, ApiServiceConfig coreSettingsConfig) throws ApiException {
-    Set<ServiceModel> serviceModels = new HashSet<>();
-    final List<ServiceModelGenerator> modelGenerators = serviceModelGeneratorsHolder.getServiceModelGenerators(service.getType());
+    //final List<ServiceModelGenerator> modelGenerators = ServiceModelGeneratorsHolder.getInstance().getServiceModelGenerators(service.getType());
     //if (shouldSkipServiceDiscovery(modelGenerators, includedServices)) {
       //log.skipServiceDiscovery(service.getName(), service.getType());
       //continue;
@@ -305,64 +299,15 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
       serviceConfig = getServiceConfig(client.getConfig(), servicesResourceApi, service);
     }
     ApiRoleConfigList roleConfigList = getAllServiceRoleConfigurations(client.getConfig(), roleCollector, clusterName, service);
+    Set<ServiceModel> serviceModels = ServiceModelFactory.generateServiceModels(client, service, serviceConfig, roleConfigList, coreSettingsConfig);
     if (roleConfigList != null && roleConfigList.getItems() != null) {
-      List<ApiRole> allApiRoles = new ArrayList<>();
-      for (ApiRoleConfig roleConfig : roleConfigList.getItems()) {
-        ApiRole role = new ApiRole()
-            .name(roleConfig.getName())
-            .type(roleConfig.getRoleType())
-            .hostRef(roleConfig.getHostRef());
-        allApiRoles.add(role);
-
-        ApiConfigList roleConfigs = roleConfig.getConfig();
-        ServiceRoleDetails serviceRoleDetails = new ServiceRoleDetails(service, serviceConfig, role, roleConfigs);
-        log.discoveringServiceRole(role.getName(), role.getType());
-
-        Set<ServiceModel> modelsForRole = generateServiceModels(client, serviceRoleDetails, coreSettingsConfig, modelGenerators, roleConfigList);
-
-        log.discoveredServiceRole(role.getName(), role.getType());
-
-        serviceModels.addAll(modelsForRole);
-      }
-      String allServiceRoles = allApiRoles.stream().map(r -> r.getName() + " (" + r.getType() + ")").collect(Collectors.joining(", "));
+      String allServiceRoles = roleConfigList.getItems().stream()
+          .map(rc -> rc.getName() + " (" + rc.getRoleType() + ")").collect(Collectors.joining(", "));
       log.processedServiceRoles(service.getName(), allServiceRoles);
     }
 
     log.discoveredService(service.getName(), service.getType());
     return serviceModels;
-  }
-
-  private Set<ServiceModel> generateServiceModels(DiscoveryApiClient client, ServiceRoleDetails serviceRoleDetails,
-                                                  ApiServiceConfig coreSettingsConfig, List<ServiceModelGenerator> modelGenerators,
-                                                  ApiRoleConfigList roleConfigList) throws ApiException {
-    Set<ServiceModel> serviceModels = new HashSet<>();
-
-    if (modelGenerators != null) {
-      for (ServiceModelGenerator serviceModelGenerator : modelGenerators) {
-        if (OpenSearchApiMasterServiceModelGenerator.shouldSkipGeneratorWhenOpenSearchMaster(serviceModelGenerator, roleConfigList)) {
-          continue;
-        }
-
-        ServiceModel serviceModel = generateServiceModel(client, serviceRoleDetails, coreSettingsConfig, serviceModelGenerator);
-        if (serviceModel != null) {
-          serviceModels.add(serviceModel);
-        }
-      }
-    }
-
-    return serviceModels;
-  }
-
-  private static ServiceModel generateServiceModel(DiscoveryApiClient client, ServiceRoleDetails sd,
-                                                   ApiServiceConfig coreSettingsConfig, ServiceModelGenerator serviceModelGenerator) throws ApiException {
-    serviceModelGenerator.setApiClient(client);
-    ServiceModelGeneratorHandleResponse response = serviceModelGenerator.handles(sd.getService(), sd.getServiceConfig(), sd.getRole(), sd.getRoleConfig());
-    if (response.handled()) {
-      return serviceModelGenerator.generateService(sd.getService(), sd.getServiceConfig(), sd.getRole(), sd.getRoleConfig(), coreSettingsConfig);
-    } else if (!response.getConfigurationIssues().isEmpty()) {
-      log.serviceRoleHasConfigurationIssues(sd.getRole().getName(), String.join(";", response.getConfigurationIssues()));
-    }
-    return null;
   }
 
   private ApiServiceConfig coreSettingsConfig(DiscoveryApiClient client, ServicesResourceApi servicesResourceApi, List<ApiService> serviceList) throws ApiException {
@@ -483,35 +428,5 @@ public class ClouderaManagerServiceDiscovery implements ServiceDiscovery, Cluste
   public void onConfigurationChange(String source, String clusterName) {
     log.clearServiceDiscoveryRepository();
     repository.clear();
-  }
-
-  private static class ServiceRoleDetails {
-    private final ApiService service;
-    private final ApiServiceConfig serviceConfig;
-    private final ApiRole role;
-    private final ApiConfigList roleConfig;
-
-    ServiceRoleDetails(ApiService service, ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig) {
-      this.service = service;
-      this.serviceConfig = serviceConfig;
-      this.role = role;
-      this.roleConfig = roleConfig;
-    }
-
-    public ApiService getService() {
-      return service;
-    }
-
-    public ApiServiceConfig getServiceConfig() {
-      return serviceConfig;
-    }
-
-    public ApiRole getRole() {
-      return role;
-    }
-
-    public ApiConfigList getRoleConfig() {
-      return roleConfig;
-    }
   }
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -276,6 +276,16 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   @Message(level = MessageLevel.INFO, text = "Role type {0} has been removed.")
   void roleTypeRemoved(String roleType);
 
+  @Message(level = MessageLevel.ERROR,
+           text = "Could not read descriptor {0}; skipping it when determining referenced services for {1}/{2}: {3}")
+  void errorDeterminingReferencedServiceTypes(String descriptor, String source, String clusterName,
+                                              @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
+  @Message(level = MessageLevel.ERROR,
+           text = "Could not read descriptor {0}; keeping cluster {1}/{2} monitored this cycle: {3}")
+  void errorCheckingClusterReferences(String descriptor, String source, String clusterName,
+                                      @StackTrace(level = MessageLevel.DEBUG) Exception e);
+
   @Message(level = MessageLevel.WARN, text = "Failed to create persistence directory {0}")
   void failedToCreatePersistenceDirectory(String path);
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -265,6 +265,10 @@ public interface ClouderaManagerServiceDiscoveryMessages {
            text = "The {0} service configuration has changed, such that it has been enabled for proxying.")
   void serviceEnabled(String serviceName);
 
+  @Message(level = MessageLevel.INFO,
+           text = "The {0} service configuration has changed, such that it can no longer be proxied.")
+  void serviceDisabled(String serviceName);
+
   @Message(level = MessageLevel.DEBUG,
            text = "The {0} ({1}) service was and remains in an invalid configuration state; skipping discovery.")
   void skippingConfigChangeForInvalidService(String serviceName, String serviceType);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -238,8 +238,8 @@ public interface ClouderaManagerServiceDiscoveryMessages {
   void activationEventRelevance(String eventId, boolean relevance, String command, String status, String serviceType, boolean serviceModelGeneratorExists,
                                 boolean rollingOrStalenessRestart);
 
-  @Message(level = MessageLevel.DEBUG, text = "Scale event relevance: {0} = {1} ({2} / {3} / {4})")
-  void scaleEventRelevance(String eventId, String relevance, String eventCode, String serviceType, boolean serviceModelGeneratorExists);
+  @Message(level = MessageLevel.DEBUG, text = "Scale event relevance: {0} = {1} ({2} / {3} / {4} / {5})")
+  void scaleEventRelevance(String eventId, String relevance, String eventCode, String serviceType, String roleType, boolean serviceModelGeneratorExists);
 
   @Message(level = MessageLevel.DEBUG, text = "Activation event - {0} - has already been processed, skipping ...")
   void activationEventAlreadyProcessed(String eventId);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryMessages.java
@@ -265,6 +265,10 @@ public interface ClouderaManagerServiceDiscoveryMessages {
            text = "The {0} service configuration has changed, such that it has been enabled for proxying.")
   void serviceEnabled(String serviceName);
 
+  @Message(level = MessageLevel.DEBUG,
+           text = "The {0} ({1}) service was and remains in an invalid configuration state; skipping discovery.")
+  void skippingConfigChangeForInvalidService(String serviceName, String serviceType);
+
   @Message(level = MessageLevel.INFO, text = "Role type {0} has been removed.")
   void roleTypeRemoved(String roleType);
 

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelFactory.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleConfig;
+import com.cloudera.api.swagger.model.ApiRoleConfigList;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+import org.apache.knox.gateway.i18n.messages.MessagesFactory;
+import org.apache.knox.gateway.topology.discovery.cm.model.opensearch.OpenSearchApiMasterServiceModelGenerator;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Runs the registered {@link ServiceModelGenerator}s against a single Cloudera Manager service and returns the
+ * resulting {@link ServiceModel}s.
+ * <p>
+ * Shared by {@link ClouderaManagerServiceDiscovery} (during cluster discovery) and by the configuration monitor
+ * (to compute the current, model-based configuration of a service). Keeping a single implementation ensures the
+ * monitor sees exactly what discovery would produce: a service whose configuration is invalid yields no model here,
+ * just as it would be absent from the discovered/persisted cluster configuration.
+ */
+public final class ServiceModelFactory {
+
+  private static final ClouderaManagerServiceDiscoveryMessages log =
+      MessagesFactory.get(ClouderaManagerServiceDiscoveryMessages.class);
+
+  private static final ServiceModelGeneratorsHolder serviceModelGeneratorsHolder = ServiceModelGeneratorsHolder.getInstance();
+
+  private ServiceModelFactory() {
+  }
+
+  /**
+   * Generate the service models for the given service by running every {@link ServiceModelGenerator} registered for
+   * the service's type against each of the service's roles.
+   *
+   * @param client             the discovery API client
+   * @param service            the CM service
+   * @param serviceConfig      the service-level configuration (may be null for services without config, e.g. CM)
+   * @param roleConfigList     the role configurations of the service
+   * @param coreSettingsConfig the CORE_SETTINGS service configuration (may be null)
+   * @return the generated service models; empty if no generator handles the service (e.g. invalid configuration)
+   */
+  public static Set<ServiceModel> generateServiceModels(DiscoveryApiClient client, ApiService service,
+      ApiServiceConfig serviceConfig, ApiRoleConfigList roleConfigList, ApiServiceConfig coreSettingsConfig) throws ApiException {
+    Set<ServiceModel> serviceModels = new HashSet<>();
+    final List<ServiceModelGenerator> modelGenerators = serviceModelGeneratorsHolder.getServiceModelGenerators(service.getType());
+    if (roleConfigList != null && roleConfigList.getItems() != null) {
+      for (ApiRoleConfig roleConfig : roleConfigList.getItems()) {
+        ApiRole role = new ApiRole()
+            .name(roleConfig.getName())
+            .type(roleConfig.getRoleType())
+            .hostRef(roleConfig.getHostRef());
+        ApiConfigList roleConfigs = roleConfig.getConfig();
+        log.discoveringServiceRole(role.getName(), role.getType());
+        serviceModels.addAll(
+            generateServiceModelsForRole(client, service, serviceConfig, role, roleConfigs, coreSettingsConfig, modelGenerators, roleConfigList));
+        log.discoveredServiceRole(role.getName(), role.getType());
+      }
+    }
+    return serviceModels;
+  }
+
+  private static Set<ServiceModel> generateServiceModelsForRole(DiscoveryApiClient client, ApiService service,
+      ApiServiceConfig serviceConfig, ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig,
+      List<ServiceModelGenerator> modelGenerators, ApiRoleConfigList roleConfigList) throws ApiException {
+    Set<ServiceModel> serviceModels = new HashSet<>();
+    if (modelGenerators != null) {
+      for (ServiceModelGenerator serviceModelGenerator : modelGenerators) {
+        if (OpenSearchApiMasterServiceModelGenerator.shouldSkipGeneratorWhenOpenSearchMaster(serviceModelGenerator, roleConfigList)) {
+          continue;
+        }
+
+        ServiceModel serviceModel = generateServiceModel(client, service, serviceConfig, role, roleConfig, coreSettingsConfig, serviceModelGenerator);
+        if (serviceModel != null) {
+          serviceModels.add(serviceModel);
+        }
+      }
+    }
+    return serviceModels;
+  }
+
+  private static ServiceModel generateServiceModel(DiscoveryApiClient client, ApiService service, ApiServiceConfig serviceConfig,
+      ApiRole role, ApiConfigList roleConfig, ApiServiceConfig coreSettingsConfig, ServiceModelGenerator serviceModelGenerator) throws ApiException {
+    serviceModelGenerator.setApiClient(client);
+    ServiceModelGeneratorHandleResponse response = serviceModelGenerator.handles(service, serviceConfig, role, roleConfig);
+    if (response.handled()) {
+      return serviceModelGenerator.generateService(service, serviceConfig, role, roleConfig, coreSettingsConfig);
+    } else if (!response.getConfigurationIssues().isEmpty()) {
+      log.serviceRoleHasConfigurationIssues(role.getName(), String.join(";", response.getConfigurationIssues()));
+    }
+    return null;
+  }
+}

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolder.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolder.java
@@ -17,6 +17,7 @@
 package org.apache.knox.gateway.topology.discovery.cm;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,39 +28,65 @@ import java.util.Set;
 
 public class ServiceModelGeneratorsHolder {
 
-  private static final ServiceModelGeneratorsHolder INSTANCE = new ServiceModelGeneratorsHolder();
-  private final Map<String, List<ServiceModelGenerator>> serviceModelGenerators = new HashMap<>();
-  private final Set<String> allRoleTypes = new HashSet<>();
+    private static final ServiceModelGeneratorsHolder INSTANCE = new ServiceModelGeneratorsHolder();
+    private final Map<String, List<ServiceModelGenerator>> serviceModelGenerators = new HashMap<>();
+    private final Set<String> allRoleTypes = new HashSet<>();
+    private final Map<String, Set<String>> serviceTypesByService = new HashMap<>();
 
-  private ServiceModelGeneratorsHolder() {
-    final ServiceLoader<ServiceModelGenerator> loader = ServiceLoader.load(ServiceModelGenerator.class);
-    for (ServiceModelGenerator serviceModelGenerator : loader) {
-      List<ServiceModelGenerator> smgList = serviceModelGenerators.computeIfAbsent(serviceModelGenerator.getServiceType(), k -> new ArrayList<>());
-      smgList.add(serviceModelGenerator);
+    private ServiceModelGeneratorsHolder() {
+        final ServiceLoader<ServiceModelGenerator> loader = ServiceLoader.load(ServiceModelGenerator.class);
+        for (ServiceModelGenerator serviceModelGenerator : loader) {
+            List<ServiceModelGenerator> smgList = serviceModelGenerators.computeIfAbsent(serviceModelGenerator.getServiceType(), k -> new ArrayList<>());
+            smgList.add(serviceModelGenerator);
 
-      final String roleType = serviceModelGenerator.getRoleType();
-      if (roleType != null) {
-        allRoleTypes.add(roleType);
-      }
+            final String roleType = serviceModelGenerator.getRoleType();
+            if (roleType != null) {
+                allRoleTypes.add(roleType);
+            }
+
+            serviceTypesByService.computeIfAbsent(serviceModelGenerator.getService(), k -> new HashSet<>())
+            .add(serviceModelGenerator.getServiceType());
+        }
     }
-  }
 
-  public static ServiceModelGeneratorsHolder getInstance() {
-    return INSTANCE;
-  }
+    public static ServiceModelGeneratorsHolder getInstance() {
+        return INSTANCE;
+    }
 
-  public List<ServiceModelGenerator> getServiceModelGenerators(String serviceType) {
-    return serviceModelGenerators.get(serviceType);
-  }
+    public List<ServiceModelGenerator> getServiceModelGenerators(String serviceType) {
+        return serviceModelGenerators.get(serviceType);
+    }
 
-  /**
-   * @return the union of the CM role types that any registered
-   *         {@link ServiceModelGenerator} operates on. Role types outside of this
-   *         set can never produce a service model and therefore do not need to be
-   *         fetched or cached during CM service discovery.
-   */
-  public Set<String> getAllRoleTypes() {
-    return Collections.unmodifiableSet(allRoleTypes);
-  }
+    /**
+     * @return the union of the CM role types that any registered
+     *         {@link ServiceModelGenerator} operates on. Role types outside of this
+     *         set can never produce a service model and therefore do not need to be
+     *         fetched or cached during CM service discovery.
+     */
+    public Set<String> getAllRoleTypes() {
+        return Collections.unmodifiableSet(allRoleTypes);
+    }
+
+    /**
+     * Map a collection of Knox service names (as declared in a topology descriptor) to the set of CM service types
+     * that any registered {@link ServiceModelGenerator} produces them from. This is the "scope" of a filtered
+     * discovery: the CM service types a descriptor is responsible for, independent of whether those services
+     * currently exist in Cloudera Manager.
+     *
+     * @param knoxServiceNames the Knox service names referenced by a descriptor
+     * @return the CM service types those Knox services are discovered from
+     */
+    public Set<String> getServiceTypesForServices(Collection<String> knoxServiceNames) {
+        final Set<String> serviceTypes = new HashSet<>();
+        if (knoxServiceNames != null) {
+            for (String knoxServiceName : knoxServiceNames) {
+                final Set<String> types = serviceTypesByService.get(knoxServiceName);
+                if (types != null) {
+                    serviceTypes.addAll(types);
+                }
+            }
+        }
+        return serviceTypes;
+    }
 
 }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
@@ -153,11 +153,11 @@ public class ClouderaManagerClusterConfigurationMonitor implements ClusterConfig
     serviceModels.values().forEach(allModels::addAll);
     Map<String, ServiceConfigurationModel> scpMap = ServiceConfigurationModel.fromServiceModels(allModels);
 
-    // Persist the service configurations
-    serviceConfigStore.store(address, clusterName, scpMap);
-
-    // Add the service configurations to the cache
-    configCache.addServiceConfiguration(address, clusterName, scpMap);
+    // Scope-replace the freshly discovered services into the cluster baseline (preserving services discovered for
+    // other descriptors of the same cluster), then persist the merged result so the cache and the .ver stay in sync.
+    Map<String, ServiceConfigurationModel> merged =
+        configCache.mergeServiceConfiguration(address, clusterName, scpMap, cluster.getInScopeServiceTypes());
+    serviceConfigStore.store(address, clusterName, merged);
   }
 
   /**

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClouderaManagerClusterConfigurationMonitor.java
@@ -29,7 +29,6 @@ import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -150,26 +149,9 @@ public class ClouderaManagerClusterConfigurationMonitor implements ClusterConfig
     Map<String, List<ServiceModel>> serviceModels = cluster.getServiceModels();
 
     // Process the service models
-    Map<String, ServiceConfigurationModel> scpMap = new HashMap<>();
-    for (String service : serviceModels.keySet()) {
-      for (ServiceModel model : serviceModels.get(service)) {
-        ServiceConfigurationModel scp =
-            scpMap.computeIfAbsent(model.getServiceType(), p -> new ServiceConfigurationModel());
-
-        Map<String, String> serviceProps = model.getServiceProperties();
-        for (Map.Entry<String, String> entry : serviceProps.entrySet()) {
-          scp.addServiceProperty(entry.getKey(), entry.getValue());
-        }
-
-        Map<String, Map<String, String>> roleProps = model.getRoleProperties();
-        for (String roleName : roleProps.keySet()) {
-          Map<String, String> rp = roleProps.get(roleName);
-          for (Map.Entry<String, String> entry : rp.entrySet()) {
-            scp.addRoleProperty(roleName, entry.getKey(), entry.getValue());
-          }
-        }
-      }
-    }
+    final List<ServiceModel> allModels = new ArrayList<>();
+    serviceModels.values().forEach(allModels::addAll);
+    Map<String, ServiceConfigurationModel> scpMap = ServiceConfigurationModel.fromServiceModels(allModels);
 
     // Persist the service configurations
     serviceConfigStore.store(address, clusterName, scpMap);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClusterConfigurationCache.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClusterConfigurationCache.java
@@ -19,9 +19,11 @@ package org.apache.knox.gateway.topology.discovery.cm.monitor;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -55,6 +57,47 @@ class ClusterConfigurationCache {
     serviceConfigurationsLock.writeLock().lock();
     try {
       clusterServiceConfigurations.computeIfAbsent(address, k -> new HashMap<>()).put(cluster, configs);
+    } finally {
+      serviceConfigurationsLock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Merge the results of a (possibly filtered) discovery into the cluster's service configuration baseline and return
+   * a snapshot of the merged result.
+   * <p>
+   * When {@code inScopeServiceTypes} is null the discovery was unfiltered, so the whole cluster baseline is replaced
+   * (previous behavior). Otherwise only the in-scope service types are replaced: they are cleared first (so a service
+   * that is in scope but produced no model - because it became invalid or was removed - is dropped from the baseline)
+   * and then the freshly discovered configs are added back. Service types outside the scope (belonging to other
+   * descriptors of the same cluster) are preserved.
+   *
+   * @param address             the CM address
+   * @param cluster             the cluster name
+   * @param configs             the freshly discovered service configurations (keyed by service type)
+   * @param inScopeServiceTypes the service types this discovery was responsible for, or null for a full discovery
+   * @return a snapshot copy of the merged per-cluster baseline
+   */
+  Map<String, ServiceConfigurationModel> mergeServiceConfiguration(final String address,
+                                                                   final String cluster,
+                                                                   final Map<String, ServiceConfigurationModel> configs,
+                                                                   final Set<String> inScopeServiceTypes) {
+    serviceConfigurationsLock.writeLock().lock();
+    try {
+      final Map<String, Map<String, ServiceConfigurationModel>> clusterMap =
+          clusterServiceConfigurations.computeIfAbsent(address, k -> new HashMap<>());
+
+      final Map<String, ServiceConfigurationModel> merged;
+      if (inScopeServiceTypes == null) {
+        merged = new HashMap<>(configs);
+      } else {
+        merged = new HashMap<>(clusterMap.getOrDefault(cluster, Collections.emptyMap()));
+        merged.keySet().removeAll(inScopeServiceTypes);
+        merged.putAll(configs);
+      }
+
+      clusterMap.put(cluster, merged);
+      return new HashMap<>(merged);
     } finally {
       serviceConfigurationsLock.writeLock().unlock();
     }

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -59,7 +59,6 @@ import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorFactory;
 
 import java.io.File;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.security.KeyStore;
 import java.time.Instant;
@@ -427,6 +426,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
     if (source != null && clusterName != null) {
       TopologyService ts = getTopologyService();
       if (ts != null) {
+        boolean referencesIncomplete = false;
         for (File f : ts.getDescriptors()) {
           try {
             SimpleDescriptor sd = SimpleDescriptorFactory.parse(f.toPath().toAbsolutePath().toString());
@@ -434,9 +434,18 @@ public class PollingConfigurationAnalyzer implements Runnable {
               remainingClusterRefs = true;
               break;
             }
-          } catch (IOException e) {
-            // Ignore these errors
+          } catch (Exception e) {
+            // A descriptor we cannot read/parse might reference this cluster. Concluding "no references" on
+            // incomplete information would tear down a still-referenced cluster's cache, so remember the gap and
+            // assume a reference remains below.
+            log.errorCheckingClusterReferences(f.getName(), source, clusterName, e);
+            referencesIncomplete = true;
           }
+        }
+        if (!remainingClusterRefs && referencesIncomplete) {
+          // Could not rule out a reference from an unreadable/unparseable descriptor; assume a reference remains and
+          // keep monitoring rather than evict the cache (mirroring the unavailable-TopologyService case below).
+          remainingClusterRefs = true;
         }
       } else {
         remainingClusterRefs = true; // If the TopologyService is unavailable, assume references remain
@@ -580,8 +589,15 @@ public class PollingConfigurationAnalyzer implements Runnable {
    * Determine the CM service types referenced by the deployed descriptors targeting the given discovery source and
    * cluster, by mapping each descriptor's declared Knox service names to CM service types via the registered service
    * model generators.
+   * <p>
+   * The set is built only from descriptors that could be read and parsed. An unreadable/unparseable descriptor is
+   * logged and skipped: a re-discovery can only ever refresh a descriptor that is parseable (an unparseable one cannot
+   * be regenerated until it is fixed, which itself triggers a fresh discovery), so filtering relevance on the services
+   * of the parseable descriptors never drops an actionable re-discovery. This intentionally differs from
+   * {@link #clusterReferencesExist(String, String)}, which must instead assume references remain so an unreadable
+   * descriptor never causes the monitored baseline to be discarded.
    *
-   * @return the referenced CM service types, or null if the TopologyService is unavailable (references undeterminable)
+   * @return the referenced CM service types (possibly empty), or null if the TopologyService is unavailable
    */
   private Set<String> getReferencedServiceTypes(final String source, final String clusterName) {
     final TopologyService ts = getTopologyService();
@@ -598,8 +614,11 @@ public class PollingConfigurationAnalyzer implements Runnable {
             referencedServices.add(service.getName());
           }
         }
-      } catch (IOException e) {
-        // Ignore these errors
+      } catch (Exception e) {
+        // A descriptor we cannot read/parse is skipped: it cannot be re-generated until it is fixed, so it cannot be
+        // the target of a useful re-discovery now. Log the offending file and keep filtering on the descriptors we
+        // could read.
+        log.errorDeterminingReferencedServiceTypes(f.getName(), source, clusterName, e);
       }
     }
     return serviceModelGeneratorsHolder.getServiceTypesForServices(referencedServices);

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -21,16 +21,14 @@ import com.cloudera.api.swagger.RolesResourceApi;
 import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
-import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiEvent;
 import com.cloudera.api.swagger.model.ApiEventAttribute;
 import com.cloudera.api.swagger.model.ApiEventCategory;
 import com.cloudera.api.swagger.model.ApiEventQueryResult;
-import com.cloudera.api.swagger.model.ApiHostRef;
-import com.cloudera.api.swagger.model.ApiRole;
-import com.cloudera.api.swagger.model.ApiRoleConfig;
 import com.cloudera.api.swagger.model.ApiRoleConfigList;
+import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
+import com.cloudera.api.swagger.model.ApiServiceList;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
@@ -48,8 +46,11 @@ import org.apache.knox.gateway.services.topology.impl.GatewayStatusService;
 import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.ApiClientFactory;
+import org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscovery;
 import org.apache.knox.gateway.topology.discovery.cm.ClouderaManagerServiceDiscoveryMessages;
 import org.apache.knox.gateway.topology.discovery.cm.DiscoveryApiClient;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModelFactory;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGeneratorsHolder;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceRoleCollector;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceRoleCollectorBuilder;
@@ -66,7 +67,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -340,11 +340,13 @@ public class PollingConfigurationAnalyzer implements Runnable {
         // Get the previously-recorded configuration
         ServiceConfigurationModel serviceConfig = serviceConfigurations.get(re.getServiceType());
 
-        if (serviceConfig != null) {
-          // Get the current config for the started service, and compare with the previously-recorded config
-          ServiceConfigurationModel currentConfig =
-                          getCurrentServiceConfiguration(address, clusterName, re.getService());
+        // Get the current (model-derived) config for the started service. This is null when the service produces no
+        // model (e.g. invalid configuration), just as such a service is absent from the recorded baseline.
+        ServiceConfigurationModel currentConfig =
+                        getCurrentServiceConfiguration(address, clusterName, re.getService(), re.getServiceType());
 
+        if (serviceConfig != null) {
+          // The service had a prior (valid) config. Compare with the current config to detect changes.
           if (currentConfig != null) {
             log.analyzingCurrentServiceConfiguration(re.getService());
             try {
@@ -353,12 +355,16 @@ public class PollingConfigurationAnalyzer implements Runnable {
               log.errorAnalyzingCurrentServiceConfiguration(re.getService(), e);
             }
           }
-        } else {
-          // A new service (no prior config) represent a config change, since a descriptor may have referenced
-          // the "new" service, but discovery had previously not succeeded because the service had not been
-          // configured (appropriately) at that time.
+        } else if (currentConfig != null) {
+          // No prior config, but the service now produces a model: it is a new/now-valid service. A descriptor may
+          // have referenced it while discovery previously did not succeed because it had not been configured
+          // (appropriately) at that time, so re-discover.
           log.serviceEnabled(re.getService());
           configHasChanged = true;
+        } else {
+          // No prior config and still no model: the service was and remains in an invalid configuration state.
+          // Re-discovery would again produce no model, so do not trigger it.
+          log.skippingConfigChangeForInvalidService(re.getService(), re.getServiceType());
         }
 
         handledServiceTypes.add(serviceType);
@@ -609,28 +615,34 @@ public class PollingConfigurationAnalyzer implements Runnable {
   }
 
   /**
-   * Get the current configuration for the specified service.
+   * Get the current configuration for the specified service, built by running the service model generators exactly
+   * as cluster discovery does and transforming the resulting models the same way the persisted baseline is built.
+   * <p>
+   * Because the baseline is model-derived, computing the current snapshot the same way keeps the two comparable, and
+   * a service whose configuration is invalid (no generator produces a model) yields {@code null} here - mirroring its
+   * absence from the baseline, so a service that was and remains invalid is not misread as a change.
    *
    * @param address     The address of the ClouderaManager instance.
    * @param clusterName The name of the cluster.
    * @param service     The name of the service.
+   * @param serviceType The type of the service.
    *
-   * @return A ServiceConfigurationModel object with the configuration properties associated with the specified
-   * service.
+   * @return A ServiceConfigurationModel with the model-derived configuration of the service, or {@code null} if the
+   * service produces no model (e.g. invalid configuration).
    */
   protected ServiceConfigurationModel getCurrentServiceConfiguration(final String address,
                                                                      final String clusterName,
-                                                                     final String service) {
+                                                                     final String service,
+                                                                     final String serviceType) {
     ServiceConfigurationModel currentConfig = null;
 
     log.gettingCurrentClusterConfiguration(service, clusterName, address);
 
-    ApiClient apiClient = getApiClient(configCache.getDiscoveryConfig(address, clusterName));
+    DiscoveryApiClient apiClient = getApiClient(configCache.getDiscoveryConfig(address, clusterName));
     ServicesResourceApi api = new ServicesResourceApi(apiClient);
     try {
       ApiServiceConfig svcConfig = api.readServiceConfig(clusterName, service, "full");
 
-      Map<ApiRole, ApiConfigList> roleConfigs = new HashMap<>();
       RolesResourceApi rolesResourceApi = new RolesResourceApi(apiClient);
       ServiceRoleCollector roleCollector = ServiceRoleCollectorBuilder.newBuilder()
               .gatewayConfig(gatewayConfig)
@@ -639,20 +651,31 @@ public class PollingConfigurationAnalyzer implements Runnable {
 
       ApiRoleConfigList roleConfigList = roleCollector.getAllServiceRoleConfigurations(clusterName, service);
 
-      for (ApiRoleConfig roleConfig : roleConfigList.getItems()) {
-        ApiConfigList configList = roleConfig.getConfig();
-
-        String roleName = roleConfig.getName();
-        String roleType = roleConfig.getRoleType();
-        ApiHostRef hostRef = roleConfig.getHostRef();
-        ApiRole role = new ApiRole().name(roleName).type(roleType).hostRef(hostRef);
-        roleConfigs.put(role, configList);
-      }
-      currentConfig = new ServiceConfigurationModel(svcConfig, roleConfigs);
+      final ApiService apiService = new ApiService().name(service).type(serviceType);
+      final ApiServiceConfig coreSettingsConfig = getCoreSettingsConfig(api, clusterName);
+      final Set<ServiceModel> serviceModels =
+              ServiceModelFactory.generateServiceModels(apiClient, apiService, svcConfig, roleConfigList, coreSettingsConfig);
+      currentConfig = ServiceConfigurationModel.fromServiceModels(serviceModels).get(serviceType);
     } catch (ApiException e) {
       log.clouderaManagerConfigurationAPIError(e);
     }
     return currentConfig;
+  }
+
+  /**
+   * Look up the CORE_SETTINGS service configuration for the cluster, needed to run generators faithfully (some HDFS
+   * models read settings from CORE_SETTINGS). Returns {@code null} if the cluster has no CORE_SETTINGS service.
+   */
+  private ApiServiceConfig getCoreSettingsConfig(final ServicesResourceApi api, final String clusterName) throws ApiException {
+    final ApiServiceList serviceList = api.readServices(clusterName, "summary");
+    if (serviceList != null && serviceList.getItems() != null) {
+      for (ApiService service : serviceList.getItems()) {
+        if (ClouderaManagerServiceDiscovery.CORE_SETTINGS_TYPE.equals(service.getType())) {
+          return api.readServiceConfig(clusterName, service.getName(), "full");
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -532,7 +532,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
     final boolean clusterRollingOrStalenessRestart = CM_SERVICE.equals(service) && CM_SERVICE_TYPE.equals(serviceType)
             && (ROLLING_RESTART_COMMAND.equals(command) || RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND.equals(command));
     final boolean relevant = (clusterRollingOrStalenessRestart && SUCCEEDED_STATUS.equals(status))
-            || (START_COMMANDS.contains(command) && SUCCEEDED_STATUS.equals(status) && serviceModelGeneratorExists);
+            || (START_COMMANDS.contains(command) && SUCCEEDED_STATUS.equals(status) && serviceModelGeneratorExists && !isExcludedServiceType(serviceType));
     log.activationEventRelevance(event.getId(), relevant, command, status, serviceType, serviceModelGeneratorExists, clusterRollingOrStalenessRestart);
     return relevant;
   }
@@ -542,10 +542,31 @@ public class PollingConfigurationAnalyzer implements Runnable {
     final String serviceType = getAttribute(attributeMap, RelevantEvent.ATTR_SERVICE_TYPE);
     final String eventCode = getAttribute(attributeMap, RelevantEvent.ATTR_EVENT_CODE);
     final boolean serviceModelGeneratorExists = serviceModelGeneratorsHolder.getServiceModelGenerators(serviceType) != null;
-    final boolean relevant = serviceModelGeneratorExists &&
+    final boolean relevant = serviceModelGeneratorExists && !isExcludedServiceType(serviceType) &&
             (CREATED_EVENT_CODES.contains(eventCode) || DELETED_EVENT_CODES.contains(eventCode));
     log.scaleEventRelevance(event.getId(), String.valueOf(relevant), eventCode, serviceType, relevant);
     return relevant;
+  }
+
+  /**
+   * Determine whether the given CM service type is configured to be excluded from CM service discovery via
+   * {@code gateway.cloudera.manager.service.discovery.excluded.service.types}. Excluded service types are never
+   * discovered (see ClouderaManagerServiceDiscovery#getClusterServices), so their configuration is never present in
+   * the monitored baseline. Treating their start/scale events as relevant would otherwise cause the analyzer to see a
+   * missing baseline and trigger an unnecessary re-discovery on every restart of such a service.
+   *
+   * @param serviceType the CM service type from an audit event
+   * @return true if the service type is excluded from discovery; false otherwise
+   */
+  private boolean isExcludedServiceType(final String serviceType) {
+    if (serviceType == null) {
+      return false;
+    }
+    final Collection<String> excludedServiceTypes = gatewayConfig.getClouderaManagerServiceDiscoveryExcludedServiceTypes();
+    if (excludedServiceTypes == null || excludedServiceTypes.isEmpty()) {
+      return false;
+    }
+    return excludedServiceTypes.stream().anyMatch(serviceType::equalsIgnoreCase);
   }
 
   @SuppressWarnings("unchecked")

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -54,6 +54,7 @@ import org.apache.knox.gateway.topology.discovery.cm.ServiceModelFactory;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceModelGeneratorsHolder;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceRoleCollector;
 import org.apache.knox.gateway.topology.discovery.cm.ServiceRoleCollectorBuilder;
+import org.apache.knox.gateway.topology.discovery.cm.TypeNameFilter;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptor;
 import org.apache.knox.gateway.topology.simple.SimpleDescriptorFactory;
 
@@ -156,6 +157,10 @@ public class PollingConfigurationAnalyzer implements Runnable {
   private long eventQueryDefaultTimestampOffset = DEFAULT_EVENT_QUERY_DEFAULT_TIMESTAMP_OFFSET;
 
   private ServiceModelGeneratorsHolder serviceModelGeneratorsHolder = ServiceModelGeneratorsHolder.getInstance();
+
+  // Filters CM role types the same way discovery does: the configured excluded-role-types deny-list combined with the
+  // allow-list of role types some ServiceModelGenerator actually uses. Lazily built so it picks up gatewayConfig.
+  private TypeNameFilter roleTypeFilter;
 
   private boolean isActive;
 
@@ -552,12 +557,14 @@ public class PollingConfigurationAnalyzer implements Runnable {
   private boolean isScaleEvent(ApiEvent event, Set<String> referencedServiceTypes) {
     final Map<String, Object> attributeMap = getAttributeMap(event.getAttributes());
     final String serviceType = getAttribute(attributeMap, RelevantEvent.ATTR_SERVICE_TYPE);
+    final String roleType = getAttribute(attributeMap, RelevantEvent.ATTR_ROLE);
     final String eventCode = getAttribute(attributeMap, RelevantEvent.ATTR_EVENT_CODE);
     final boolean serviceModelGeneratorExists = serviceModelGeneratorsHolder.getServiceModelGenerators(serviceType) != null;
     final boolean relevant = serviceModelGeneratorExists && !isExcludedServiceType(serviceType)
             && isReferencedServiceType(serviceType, referencedServiceTypes)
+            && !isExcludedRoleType(roleType)
             && (CREATED_EVENT_CODES.contains(eventCode) || DELETED_EVENT_CODES.contains(eventCode));
-    log.scaleEventRelevance(event.getId(), String.valueOf(relevant), eventCode, serviceType, relevant);
+    log.scaleEventRelevance(event.getId(), String.valueOf(relevant), eventCode, serviceType, roleType, serviceModelGeneratorExists);
     return relevant;
   }
 
@@ -617,6 +624,31 @@ public class PollingConfigurationAnalyzer implements Runnable {
       return false;
     }
     return excludedServiceTypes.stream().anyMatch(serviceType::equalsIgnoreCase);
+  }
+
+  /**
+   * Determine whether the given CM role type would be excluded from CM service discovery, using the exact same filter
+   * discovery applies when collecting role configurations (see ServiceRoleCollectorBuilder): the configured
+   * {@code gateway.cloudera.manager.service.discovery.excluded.role.types} deny-list combined with the allow-list of
+   * role types some ServiceModelGenerator actually uses ({@link ServiceModelGeneratorsHolder#getAllRoleTypes()}).
+   * Role types discovery never collects can never produce a service model, so a scale (role added/removed) event for
+   * such a role type must not be treated as relevant - it would otherwise trigger an unnecessary re-discovery that
+   * would recompute an identical model.
+   * <p>
+   * Fails open on a missing/empty role type: the event is kept relevant rather than dropped on missing information.
+   *
+   * @param roleType the CM role type from an audit event
+   * @return true if the role type is excluded from discovery; false otherwise (including when it is null/empty)
+   */
+  private boolean isExcludedRoleType(final String roleType) {
+    if (roleType == null || roleType.isEmpty()) {
+      return false;
+    }
+    if (roleTypeFilter == null) {
+      roleTypeFilter = new TypeNameFilter(gatewayConfig.getClouderaManagerServiceDiscoveryExcludedRoleTypes(),
+              serviceModelGeneratorsHolder.getAllRoleTypes());
+    }
+    return roleTypeFilter.isExcluded(roleType);
   }
 
   @SuppressWarnings("unchecked")

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzer.java
@@ -345,26 +345,26 @@ public class PollingConfigurationAnalyzer implements Runnable {
         ServiceConfigurationModel currentConfig =
                         getCurrentServiceConfiguration(address, clusterName, re.getService(), re.getServiceType());
 
-        if (serviceConfig != null) {
-          // The service had a prior (valid) config. Compare with the current config to detect changes.
-          if (currentConfig != null) {
-            log.analyzingCurrentServiceConfiguration(re.getService());
-            try {
-              configHasChanged = hasConfigurationChanged(serviceConfig, currentConfig);
-            } catch (Exception e) {
-              log.errorAnalyzingCurrentServiceConfiguration(re.getService(), e);
-            }
+        if (serviceConfig == null && currentConfig == null) {
+          // Was and remains in an invalid configuration state (no model either time): nothing to proxy, no change.
+          log.skippingConfigChangeForInvalidService(re.getService(), re.getServiceType());
+        } else if (serviceConfig != null && currentConfig != null) {
+          // Valid before and now: compare the recorded and current configs to detect a change.
+          log.analyzingCurrentServiceConfiguration(re.getService());
+          try {
+            configHasChanged = hasConfigurationChanged(serviceConfig, currentConfig);
+          } catch (Exception e) {
+            log.errorAnalyzingCurrentServiceConfiguration(re.getService(), e);
           }
         } else if (currentConfig != null) {
-          // No prior config, but the service now produces a model: it is a new/now-valid service. A descriptor may
-          // have referenced it while discovery previously did not succeed because it had not been configured
-          // (appropriately) at that time, so re-discover.
+          // No prior config, but the service now produces a model: new / became valid -> re-discover.
           log.serviceEnabled(re.getService());
           configHasChanged = true;
         } else {
-          // No prior config and still no model: the service was and remains in an invalid configuration state.
-          // Re-discovery would again produce no model, so do not trigger it.
-          log.skippingConfigChangeForInvalidService(re.getService(), re.getServiceType());
+          // Had a prior config but produces no model now: became invalid / was removed -> re-discover so the
+          // service is dropped from the affected topologies (and the scoped-replace merge clears its baseline).
+          log.serviceDisabled(re.getService());
+          configHasChanged = true;
         }
 
         handledServiceTypes.add(serviceType);
@@ -518,8 +518,13 @@ public class PollingConfigurationAnalyzer implements Runnable {
     if (events.isEmpty()) {
       log.noActivationEventFound();
     } else {
+      // The CM service types referenced by the deployed descriptors for this cluster. Events for services no
+      // descriptor references are irrelevant: with per-descriptor discovery filtering they are never discovered, so
+      // they must not be treated as "new services" and trigger churn. A null value means references cannot be
+      // determined (no TopologyService), in which case no reference filtering is applied.
+      final Set<String> referencedServiceTypes = getReferencedServiceTypes(address, clusterName);
       for (ApiEvent event : events) {
-        if (isStartEvent(event) || isScaleEvent(event)) {
+        if (isStartEvent(event, referencedServiceTypes) || isScaleEvent(event, referencedServiceTypes)) {
           relevantEvents.add(new RelevantEvent(event));
         }
       }
@@ -528,7 +533,7 @@ public class PollingConfigurationAnalyzer implements Runnable {
     return relevantEvents;
   }
 
-  private boolean isStartEvent(ApiEvent event) {
+  private boolean isStartEvent(ApiEvent event, Set<String> referencedServiceTypes) {
     final Map<String, Object> attributeMap = getAttributeMap(event.getAttributes());
     final String command = getAttribute(attributeMap, COMMAND);
     final String status = getAttribute(attributeMap, COMMAND_STATUS);
@@ -538,20 +543,59 @@ public class PollingConfigurationAnalyzer implements Runnable {
     final boolean clusterRollingOrStalenessRestart = CM_SERVICE.equals(service) && CM_SERVICE_TYPE.equals(serviceType)
             && (ROLLING_RESTART_COMMAND.equals(command) || RESTART_WAITING_FOR_STALENESS_SUCCESS_COMMAND.equals(command));
     final boolean relevant = (clusterRollingOrStalenessRestart && SUCCEEDED_STATUS.equals(status))
-            || (START_COMMANDS.contains(command) && SUCCEEDED_STATUS.equals(status) && serviceModelGeneratorExists && !isExcludedServiceType(serviceType));
+            || (START_COMMANDS.contains(command) && SUCCEEDED_STATUS.equals(status) && serviceModelGeneratorExists
+                && !isExcludedServiceType(serviceType) && isReferencedServiceType(serviceType, referencedServiceTypes));
     log.activationEventRelevance(event.getId(), relevant, command, status, serviceType, serviceModelGeneratorExists, clusterRollingOrStalenessRestart);
     return relevant;
   }
 
-  private boolean isScaleEvent(ApiEvent event) {
+  private boolean isScaleEvent(ApiEvent event, Set<String> referencedServiceTypes) {
     final Map<String, Object> attributeMap = getAttributeMap(event.getAttributes());
     final String serviceType = getAttribute(attributeMap, RelevantEvent.ATTR_SERVICE_TYPE);
     final String eventCode = getAttribute(attributeMap, RelevantEvent.ATTR_EVENT_CODE);
     final boolean serviceModelGeneratorExists = serviceModelGeneratorsHolder.getServiceModelGenerators(serviceType) != null;
-    final boolean relevant = serviceModelGeneratorExists && !isExcludedServiceType(serviceType) &&
-            (CREATED_EVENT_CODES.contains(eventCode) || DELETED_EVENT_CODES.contains(eventCode));
+    final boolean relevant = serviceModelGeneratorExists && !isExcludedServiceType(serviceType)
+            && isReferencedServiceType(serviceType, referencedServiceTypes)
+            && (CREATED_EVENT_CODES.contains(eventCode) || DELETED_EVENT_CODES.contains(eventCode));
     log.scaleEventRelevance(event.getId(), String.valueOf(relevant), eventCode, serviceType, relevant);
     return relevant;
+  }
+
+  /**
+   * @return true if the given CM service type is referenced by a deployed descriptor for the cluster, or if
+   * references could not be determined ({@code referencedServiceTypes} is null, so no filtering is applied).
+   */
+  private boolean isReferencedServiceType(final String serviceType, final Set<String> referencedServiceTypes) {
+    return referencedServiceTypes == null || referencedServiceTypes.contains(serviceType);
+  }
+
+  /**
+   * Determine the CM service types referenced by the deployed descriptors targeting the given discovery source and
+   * cluster, by mapping each descriptor's declared Knox service names to CM service types via the registered service
+   * model generators.
+   *
+   * @return the referenced CM service types, or null if the TopologyService is unavailable (references undeterminable)
+   */
+  private Set<String> getReferencedServiceTypes(final String source, final String clusterName) {
+    final TopologyService ts = getTopologyService();
+    if (ts == null) {
+      return null;
+    }
+
+    final Set<String> referencedServices = new HashSet<>();
+    for (File f : ts.getDescriptors()) {
+      try {
+        SimpleDescriptor sd = SimpleDescriptorFactory.parse(f.toPath().toAbsolutePath().toString());
+        if (source.equals(sd.getDiscoveryAddress()) && clusterName.equals(sd.getCluster())) {
+          for (SimpleDescriptor.Service service : sd.getServices()) {
+            referencedServices.add(service.getName());
+          }
+        }
+      } catch (IOException e) {
+        // Ignore these errors
+      }
+    }
+    return serviceModelGeneratorsHolder.getServiceTypesForServices(referencedServices);
   }
 
   /**

--- a/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ServiceConfigurationModel.java
+++ b/gateway-discovery-cm/src/main/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ServiceConfigurationModel.java
@@ -20,7 +20,10 @@ import com.cloudera.api.swagger.model.ApiConfig;
 import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +39,38 @@ final class ServiceConfigurationModel {
   private Map<String, Map<String, String>> roleProps = new ConcurrentHashMap<>();
 
   ServiceConfigurationModel() {
+  }
+
+  /**
+   * Transform the given discovered {@link ServiceModel}s into a map of service type to its
+   * {@link ServiceConfigurationModel}, preserving exactly the service and role properties that the model generators
+   * extracted. This is the representation the configuration monitor compares against, so building both the persisted
+   * baseline and the current snapshot through this method keeps them comparable.
+   *
+   * @param models the service models produced by the model generators
+   * @return a map keyed by service type; empty if there are no models
+   */
+  static Map<String, ServiceConfigurationModel> fromServiceModels(final Collection<ServiceModel> models) {
+    final Map<String, ServiceConfigurationModel> result = new HashMap<>();
+    if (models != null) {
+      for (ServiceModel model : models) {
+        final ServiceConfigurationModel scp =
+            result.computeIfAbsent(model.getServiceType(), p -> new ServiceConfigurationModel());
+
+        for (Map.Entry<String, String> entry : model.getServiceProperties().entrySet()) {
+          scp.addServiceProperty(entry.getKey(), entry.getValue());
+        }
+
+        final Map<String, Map<String, String>> roleProperties = model.getRoleProperties();
+        for (String roleName : roleProperties.keySet()) {
+          final Map<String, String> rp = roleProperties.get(roleName);
+          for (Map.Entry<String, String> entry : rp.entrySet()) {
+            scp.addRoleProperty(roleName, entry.getKey(), entry.getValue());
+          }
+        }
+      }
+    }
+    return result;
   }
 
   ServiceConfigurationModel(final ApiServiceConfig            serviceConfig,

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ClouderaManagerServiceDiscoveryTest.java
@@ -1547,6 +1547,72 @@ public class ClouderaManagerServiceDiscoveryTest {
     return cluster;
   }
 
+  @Test
+  public void testServiceDiscoveryFiltersServicesNotReferencedByDescriptor() {
+    final Map<String, String> serviceProps = Collections.singletonMap("solr_use_ssl", "false");
+    final Map<String, String> roleProps = new HashMap<>();
+    roleProps.put("solr_http_port", "8983");
+    roleProps.put("solr_https_port", "8985");
+
+    // Included services do NOT reference SOLR -> the SOLR service is skipped (no models discovered).
+    ClouderaManagerCluster skipped = discoverSolr(serviceProps, roleProps, Collections.singleton("RANGER"));
+    assertTrue("A service not referenced by the descriptor must be skipped", skipped.getServiceModels().isEmpty());
+    assertEquals("Discovery scope should reflect the descriptor's referenced service types",
+        ServiceModelGeneratorsHolder.getInstance().getServiceTypesForServices(Collections.singleton("RANGER")),
+        skipped.getInScopeServiceTypes());
+
+    // Included services reference SOLR -> the SOLR service is discovered.
+    ClouderaManagerCluster included = discoverSolr(serviceProps, roleProps, Collections.singleton(SolrServiceModelGenerator.SERVICE));
+    assertFalse("A referenced service must be discovered", included.getServiceModels().isEmpty());
+  }
+
+  private ClouderaManagerCluster discoverSolr(Map<String, String> serviceProps, Map<String, String> roleProps, Set<String> includedServices) {
+    final String clusterName = "cluster-1";
+    final String hostName = "solr-host";
+    final String serviceName = "SOLR-1";
+    final String roleName = "SOLR-SERVER-1";
+
+    GatewayConfig gwConf = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gwConf.getClouderaManagerClientSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
+    EasyMock.expect(gwConf.getClouderaManagerClientSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryApiVersion()).andReturn(null).anyTimes();
+    EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryRoleFetchStrategy())
+        .andReturn(GatewayConfig.CLOUDERA_MANAGER_SERVICE_DISCOVERY_ROLE_FETCH_STRATEGY_BY_ROLE).anyTimes();
+    EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryExcludedServiceTypes()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(gwConf.getClouderaManagerServiceDiscoveryExcludedRoleTypes()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.replay(gwConf);
+
+    ServiceDiscoveryConfig sdConfig = createMockDiscoveryConfig(clusterName);
+    TestDiscoveryApiClient mockClient = new TestDiscoveryApiClient(gwConf, sdConfig, null);
+
+    ApiServiceList serviceList = EasyMock.createNiceMock(ApiServiceList.class);
+    EasyMock.expect(serviceList.getItems())
+        .andReturn(Collections.singletonList(createMockApiService(serviceName, SolrServiceModelGenerator.SERVICE_TYPE, clusterName))).anyTimes();
+    EasyMock.replay(serviceList);
+    mockClient.addResponse(ApiServiceList.class, new TestApiServiceListResponse(serviceList));
+
+    ApiServiceConfig serviceConfig = createMockApiServiceConfig(serviceProps);
+    mockClient.addResponse(ApiServiceConfig.class, new TestApiServiceConfigResponse(serviceConfig));
+
+    ApiConfigList apiConfigList = createMockApiConfigList(roleProps);
+    mockClient.addResponse(ApiConfigList.class, new TestApiConfigListResponse(apiConfigList));
+
+    ApiRole role = createMockApiRole(roleName, SolrServiceModelGenerator.ROLE_TYPE, hostName);
+    ApiRoleList roleList = EasyMock.createNiceMock(ApiRoleList.class);
+    EasyMock.expect(roleList.getItems()).andReturn(Collections.singletonList(role)).anyTimes();
+    EasyMock.replay(roleList);
+    ApiRoleConfig roleConfig = createMockApiRoleConfig(roleName, SolrServiceModelGenerator.ROLE_TYPE, hostName, apiConfigList);
+    ApiRoleConfigList roleConfigList = EasyMock.createNiceMock(ApiRoleConfigList.class);
+    EasyMock.expect(roleConfigList.getItems()).andReturn(Collections.singletonList(roleConfig)).anyTimes();
+    EasyMock.replay(roleConfigList);
+    mockClient.addResponse(ApiRoleList.class, new TestApiRoleListResponse(roleList));
+    mockClient.addResponse(ApiRoleConfigList.class, new TestApiRoleConfigListResponse(roleConfigList));
+
+    ClouderaManagerServiceDiscovery cmsd = new ClouderaManagerServiceDiscovery(true, gwConf);
+    cmsd.onConfigurationChange(null, null); // clear the repository
+    return (ClouderaManagerCluster) cmsd.discover(gwConf, sdConfig, clusterName, includedServices, mockClient);
+  }
+
   private int getExpectedExecuteCount(String roleFetchStrategy, boolean testRetry) {
     // With testRetry, retryAttempts is configured to be 1,
     // the first call for readServices() fails in TestFaultyDiscoveryApiClient

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelFactoryTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelFactoryTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiHostRef;
+import com.cloudera.api.swagger.model.ApiRoleConfig;
+import com.cloudera.api.swagger.model.ApiRoleConfigList;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceConfig;
+import org.apache.knox.gateway.topology.discovery.cm.model.hive.HiveOnTezServiceModelGenerator;
+import org.apache.knox.gateway.topology.discovery.cm.model.solr.SolrServiceModelGenerator;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ServiceModelFactoryTest extends AbstractCMDiscoveryTest {
+
+  @Test
+  public void testValidServiceProducesModel() throws ApiException {
+    ApiService service = createApiServiceMock(SolrServiceModelGenerator.SERVICE_TYPE);
+
+    Map<String, String> serviceProps = new HashMap<>();
+    serviceProps.put("solr_use_ssl", "true");
+    ApiServiceConfig serviceConfig = createApiServiceConfigMock(serviceProps);
+
+    Map<String, String> roleProps = new HashMap<>();
+    roleProps.put("solr_http_port", "8983");
+    roleProps.put("solr_https_port", "8985");
+    ApiRoleConfigList roleConfigList = roleConfigList(SolrServiceModelGenerator.ROLE_TYPE, roleProps);
+
+    Set<ServiceModel> models = ServiceModelFactory.generateServiceModels(null, service, serviceConfig, roleConfigList, null);
+
+    assertEquals("Expected exactly one Solr model", 1, models.size());
+    assertEquals(SolrServiceModelGenerator.SERVICE_TYPE, models.iterator().next().getServiceType());
+  }
+
+  @Test
+  public void testInvalidRoleTypeProducesNoModel() throws ApiException {
+    // The Solr generator only handles SOLR_SERVER roles; an unexpected role type yields no model (invalid config).
+    ApiService service = createApiServiceMock(SolrServiceModelGenerator.SERVICE_TYPE);
+    ApiRoleConfigList roleConfigList = roleConfigList("SOME_OTHER_ROLE", Collections.emptyMap());
+
+    Set<ServiceModel> models = ServiceModelFactory.generateServiceModels(null, service, createApiServiceConfigMock(Collections.emptyMap()), roleConfigList, null);
+
+    assertTrue("A role type no generator handles should produce no model", models.isEmpty());
+  }
+
+  @Test
+  public void testInvalidTransportModeProducesNoModel() throws ApiException {
+    // The Hive-on-Tez generator recognizes HIVE_ON_TEZ/HIVESERVER2 but rejects the config when the HS2 transport
+    // mode is neither "http" nor "all". Cloudera Manager's default is "binary" (see the hive_server2_transport_mode
+    // role config), which is invalid for Knox discovery. This exercises the "handled=false with configuration issues"
+    // branch, distinct from an unhandled (wrong) role type: a valid service type whose configuration is invalid must
+    // yield no model.
+    ApiService service = createApiServiceMock(HiveOnTezServiceModelGenerator.SERVICE_TYPE);
+
+    // Role config assembled from a real HIVE_ON_TEZ readRolesConfig response; the generator reads the transport mode
+    // and thrift HTTP port directly from these role config keys.
+    Map<String, String> roleProps = new HashMap<>();
+    roleProps.put("hive_server2_transport_mode", "binary");
+    roleProps.put("hive_server2_thrift_http_port", "10001");
+    ApiRoleConfigList roleConfigList = roleConfigList(HiveOnTezServiceModelGenerator.ROLE_TYPE, roleProps);
+
+    Set<ServiceModel> models = ServiceModelFactory.generateServiceModels(null, service, createApiServiceConfigMock(Collections.emptyMap()), roleConfigList, null);
+
+    assertTrue("A service with an invalid transport mode should produce no model", models.isEmpty());
+  }
+
+  @Test
+  public void testNoGeneratorsForServiceTypeProducesNoModel() throws ApiException {
+    ApiService service = createApiServiceMock("NO_SUCH_SERVICE_TYPE");
+    ApiRoleConfigList roleConfigList = roleConfigList("NO_SUCH_ROLE_TYPE", Collections.emptyMap());
+
+    Set<ServiceModel> models = ServiceModelFactory.generateServiceModels(null, service, createApiServiceConfigMock(Collections.emptyMap()), roleConfigList, null);
+
+    assertTrue("A service type with no registered generators should produce no model", models.isEmpty());
+  }
+
+  @Test
+  public void testEmptyRoleConfigListProducesNoModel() throws ApiException {
+    ApiService service = createApiServiceMock(SolrServiceModelGenerator.SERVICE_TYPE);
+    ApiRoleConfigList roleConfigList = new ApiRoleConfigList().items(Collections.emptyList());
+
+    Set<ServiceModel> models = ServiceModelFactory.generateServiceModels(null, service, createApiServiceConfigMock(Collections.emptyMap()), roleConfigList, null);
+
+    assertTrue("No roles should produce no model", models.isEmpty());
+  }
+
+  private ApiRoleConfigList roleConfigList(final String roleType, final Map<String, String> roleProps) {
+    ApiRoleConfig roleConfig = new ApiRoleConfig()
+        .name(roleType + "-1")
+        .roleType(roleType)
+        .hostRef(new ApiHostRef().hostname("host1").hostId("hostId1"))
+        .config(createApiConfigListMock(roleProps));
+    return new ApiRoleConfigList().addItemsItem(roleConfig);
+  }
+}

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolderTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/ServiceModelGeneratorsHolderTest.java
@@ -18,12 +18,15 @@ package org.apache.knox.gateway.topology.discovery.cm;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
 
 public class ServiceModelGeneratorsHolderTest {
 
@@ -45,6 +48,20 @@ public class ServiceModelGeneratorsHolderTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testGetAllRoleTypesIsUnmodifiable() {
         ServiceModelGeneratorsHolder.getInstance().getAllRoleTypes().add("SOME_ROLE_TYPE");
+    }
+
+    @Test
+    public void testGetServiceTypesForServicesMapsKnoxNamesToCmTypes() {
+        Set<String> serviceTypes =
+                ServiceModelGeneratorsHolder.getInstance().getServiceTypesForServices(Arrays.asList("SOLR", "NAMENODE"));
+        assertThat("Knox service names should map to their CM service types",
+                serviceTypes, hasItems("SOLR", "HDFS"));
+    }
+
+    @Test
+    public void testGetServiceTypesForUnknownServiceIsEmpty() {
+        assertTrue("An unknown Knox service maps to no CM service type",
+                ServiceModelGeneratorsHolder.getInstance().getServiceTypesForServices(Collections.singletonList("NO_SUCH_SERVICE")).isEmpty());
     }
 
 }

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClusterConfigurationCacheTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ClusterConfigurationCacheTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.knox.gateway.topology.discovery.cm.monitor;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClusterConfigurationCacheTest {
+
+  private static final String ADDRESS = "https://host:7183";
+  private static final String CLUSTER = "Cluster 1";
+
+  @Test
+  public void testMergeFullReplaceWhenScopeNull() {
+    ClusterConfigurationCache cache = new ClusterConfigurationCache();
+    cache.addServiceConfiguration(ADDRESS, CLUSTER, mutableMap("A", "B"));
+
+    // null scope == unfiltered discovery -> replace the whole cluster baseline
+    Map<String, ServiceConfigurationModel> merged =
+        cache.mergeServiceConfiguration(ADDRESS, CLUSTER, mutableMap("C"), null);
+
+    assertEquals(Collections.singleton("C"), merged.keySet());
+    assertEquals(Collections.singleton("C"), cache.getClusterServiceConfigurations(ADDRESS, CLUSTER).keySet());
+  }
+
+  @Test
+  public void testMergeScopedReplacePreservesOutOfScope() {
+    ClusterConfigurationCache cache = new ClusterConfigurationCache();
+    cache.addServiceConfiguration(ADDRESS, CLUSTER, mutableMap("A", "B"));
+
+    // Re-discovering only A must refresh A and preserve B (belonging to another descriptor)
+    Map<String, ServiceConfigurationModel> merged =
+        cache.mergeServiceConfiguration(ADDRESS, CLUSTER, mutableMap("A"), new HashSet<>(Collections.singletonList("A")));
+
+    assertEquals(new HashSet<>(java.util.Arrays.asList("A", "B")), merged.keySet());
+  }
+
+  @Test
+  public void testMergeScopedRemovesInScopeServiceWithNoModel() {
+    ClusterConfigurationCache cache = new ClusterConfigurationCache();
+    cache.addServiceConfiguration(ADDRESS, CLUSTER, mutableMap("A", "B"));
+
+    // A is in scope but produced no model this run (became invalid / removed) -> dropped; B preserved
+    Map<String, ServiceConfigurationModel> merged =
+        cache.mergeServiceConfiguration(ADDRESS, CLUSTER, mutableMap(), new HashSet<>(Collections.singletonList("A")));
+
+    assertFalse("A should have been removed", merged.containsKey("A"));
+    assertTrue("B should be preserved", merged.containsKey("B"));
+  }
+
+  @Test
+  public void testMergeIntoEmptyBaseline() {
+    ClusterConfigurationCache cache = new ClusterConfigurationCache();
+
+    Map<String, ServiceConfigurationModel> merged =
+        cache.mergeServiceConfiguration(ADDRESS, CLUSTER, mutableMap("A"), new HashSet<>(Collections.singletonList("A")));
+
+    assertEquals(Collections.singleton("A"), merged.keySet());
+  }
+
+  private Map<String, ServiceConfigurationModel> mutableMap(String... serviceTypes) {
+    Map<String, ServiceConfigurationModel> map = new HashMap<>();
+    for (String serviceType : serviceTypes) {
+      ServiceConfigurationModel model = new ServiceConfigurationModel();
+      model.addServiceProperty("type", serviceType);
+      map.put(serviceType, model);
+    }
+    return map;
+  }
+}

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -147,9 +147,36 @@ public class PollingConfigurationAnalyzerTest {
                                          PollingConfigurationAnalyzer.START_COMMAND,
                                          PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
 
+    // No prior baseline, but the new service now produces a (valid) model -> discovery should be triggered.
+    final Map<String, ServiceConfigurationModel> currentModels = new HashMap<>();
+    final ServiceConfigurationModel nnModel = new ServiceConfigurationModel();
+    nnModel.addRoleProperty(NameNodeServiceModelGenerator.ROLE_TYPE, "namenode_port", "8020");
+    currentModels.put(NameNodeServiceModelGenerator.SERVICE, nnModel);
+
+    ChangeListener listener =
+            doTestEvent(startEvent, address, clusterName, Collections.emptyMap(), currentModels);
+    assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
+  }
+
+  /**
+   * A service that had no prior (valid) baseline and still produces no model (e.g. an invalid configuration such as
+   * Hive with binary transport mode) must not trigger discovery: it was invalid and remains invalid.
+   */
+  @Test
+  public void testInvalidServiceRemainsInvalidDoesNotNotify() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster I";
+
+    ApiEvent startEvent = createApiEvent(clusterName,
+                                         NameNodeServiceModelGenerator.SERVICE_TYPE,
+                                         NameNodeServiceModelGenerator.SERVICE,
+                                         PollingConfigurationAnalyzer.START_COMMAND,
+                                         PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+
+    // Empty baseline and no current model stubbed -> getCurrentServiceConfiguration returns null (still invalid).
     ChangeListener listener =
             doTestEvent(startEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
-    assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
+    assertFalse("Invalid-and-still-invalid service must not trigger discovery", listener.wasNotified(address, clusterName));
   }
 
   /**
@@ -823,7 +850,8 @@ public class PollingConfigurationAnalyzerTest {
     @Override
     protected ServiceConfigurationModel getCurrentServiceConfiguration(String address,
                                                                        String clusterName,
-                                                                       String service) {
+                                                                       String service,
+                                                                       String serviceType) {
       return serviceConfigModels.get(getServiceConfigModelKey(address, clusterName, service));
     }
 

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -556,6 +556,67 @@ public class PollingConfigurationAnalyzerTest {
     assertFalse("Excluded service type must not trigger a scale-event notification", listener.wasNotified(address, clusterName));
   }
 
+  /**
+   * A scale (role added/removed) event whose role type is explicitly excluded from discovery via
+   * gateway.cloudera.manager.service.discovery.excluded.role.types must not be treated as relevant, so it does not
+   * trigger an unnecessary re-discovery - even though the service type has a generator, is not excluded and is
+   * referenced. Mirrors how discovery itself skips such role types (see ServiceRoleCollectorBuilder / TypeNameFilter).
+   */
+  @Test
+  public void testExcludedRoleTypeScaleEventIsNotRelevant() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster RX";
+
+    final ApiEvent scaleEvent = createScaleApiEvent(clusterName, HiveOnTezServiceModelGenerator.SERVICE_TYPE,
+        HiveOnTezServiceModelGenerator.SERVICE, HiveOnTezServiceModelGenerator.ROLE_TYPE,
+        PollingConfigurationAnalyzer.EVENT_CODE_ROLE_CREATED);
+
+    final ChangeListener listener = new ChangeListener();
+    final TestablePollingConfigAnalyzer pca = buildPollingConfigAnalyzer(address, clusterName, Collections.emptyMap(),
+        listener, true, Collections.emptySet(), Collections.singleton(HiveOnTezServiceModelGenerator.ROLE_TYPE));
+
+    doTestEvent(scaleEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
+    assertFalse("Excluded role type must not trigger a change notification", listener.wasNotified(address, clusterName));
+  }
+
+  /**
+   * A scale event for a role type that no ServiceModelGenerator uses (absent from
+   * ServiceModelGeneratorsHolder.getAllRoleTypes()) must not be treated as relevant, even with an empty
+   * excluded-role-types config: discovery never collects such a role type's config, so a change to it cannot alter
+   * any service model. This is the "match discovery" allow-list behavior.
+   */
+  @Test
+  public void testNonRequiredRoleTypeScaleEventIsNotRelevant() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster RN";
+
+    // DATANODE belongs to HDFS (a generator-backed, non-excluded service) but no generator declares it as its role type.
+    final ApiEvent scaleEvent = createScaleApiEvent(clusterName, NameNodeServiceModelGenerator.SERVICE_TYPE,
+        NameNodeServiceModelGenerator.SERVICE, "DATANODE", PollingConfigurationAnalyzer.EVENT_CODE_ROLE_CREATED);
+
+    final ChangeListener listener =
+        doTestEvent(scaleEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
+    assertFalse("A role type no generator uses must not trigger discovery", listener.wasNotified(address, clusterName));
+  }
+
+  /**
+   * A scale event for a generator-backed role type (present in getAllRoleTypes()) that is not excluded remains
+   * relevant and triggers re-discovery - guarding against the role filter over-suppressing.
+   */
+  @Test
+  public void testRequiredRoleTypeScaleEventIsRelevant() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster RR";
+
+    final ApiEvent scaleEvent = createScaleApiEvent(clusterName, NameNodeServiceModelGenerator.SERVICE_TYPE,
+        NameNodeServiceModelGenerator.SERVICE, NameNodeServiceModelGenerator.ROLE_TYPE,
+        PollingConfigurationAnalyzer.EVENT_CODE_ROLE_CREATED);
+
+    final ChangeListener listener =
+        doTestEvent(scaleEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
+    assertTrue("A generator-backed role type must trigger discovery", listener.wasNotified(address, clusterName));
+  }
+
   @Test
   public void shouldNotPerformClusterConfigurationChangeMonitoringIfKnoxGatewayIsNotYetReady() throws AliasServiceException {
     final String address = "http://host1:1234";
@@ -771,10 +832,18 @@ public class PollingConfigurationAnalyzerTest {
   private TestablePollingConfigAnalyzer buildPollingConfigAnalyzer(final String address, final String clusterName,
       final Map<String, ServiceConfigurationModel> serviceConfigurationModels, ChangeListener listener, boolean isKnoxGatewayReady,
       Collection<String> excludedServiceTypes) throws AliasServiceException {
+    return buildPollingConfigAnalyzer(address, clusterName, serviceConfigurationModels, listener, isKnoxGatewayReady,
+            excludedServiceTypes, Collections.emptySet());
+  }
+
+  private TestablePollingConfigAnalyzer buildPollingConfigAnalyzer(final String address, final String clusterName,
+      final Map<String, ServiceConfigurationModel> serviceConfigurationModels, ChangeListener listener, boolean isKnoxGatewayReady,
+      Collection<String> excludedServiceTypes, Collection<String> excludedRoleTypes) throws AliasServiceException {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(gatewayConfig.getIncludedSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(gatewayConfig.getIncludedSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.expect(gatewayConfig.getClouderaManagerServiceDiscoveryExcludedServiceTypes()).andReturn(excludedServiceTypes).anyTimes();
+    EasyMock.expect(gatewayConfig.getClouderaManagerServiceDiscoveryExcludedRoleTypes()).andReturn(excludedRoleTypes).anyTimes();
     EasyMock.replay(gatewayConfig);
 
     // Mock the service discovery details
@@ -926,6 +995,17 @@ public class PollingConfigurationAnalyzerTest {
     attrs.add(createEventAttribute("COMMAND_STATUS", commandStatues));
     attrs.add(createEventAttribute("EVENTCODE", eventCode));
     return createApiEvent(ApiEventCategory.AUDIT_EVENT, attrs, id);
+  }
+
+  private ApiEvent createScaleApiEvent(final String clusterName, final String serviceType, final String service,
+                                       final String roleType, final String eventCode) {
+    final List<ApiEventAttribute> attrs = new ArrayList<>();
+    attrs.add(createEventAttribute("CLUSTER", clusterName));
+    attrs.add(createEventAttribute("SERVICE_TYPE", serviceType));
+    attrs.add(createEventAttribute("SERVICE", service));
+    attrs.add(createEventAttribute("ROLE_TYPE", roleType));
+    attrs.add(createEventAttribute("EVENTCODE", eventCode));
+    return createApiEvent(ApiEventCategory.AUDIT_EVENT, attrs, null);
   }
 
   private ApiEvent createApiEvent(final ApiEventCategory category, final List<ApiEventAttribute> attrs, String id) {

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -34,6 +34,7 @@ import org.apache.knox.gateway.topology.ClusterConfigurationMonitorService;
 import org.apache.knox.gateway.topology.discovery.ServiceDiscoveryConfig;
 import org.apache.knox.gateway.topology.discovery.cm.model.hdfs.NameNodeServiceModelGenerator;
 import org.apache.knox.gateway.topology.discovery.cm.model.hive.HiveOnTezServiceModelGenerator;
+import org.apache.knox.gateway.topology.discovery.cm.model.solr.SolrServiceModelGenerator;
 import org.apache.knox.gateway.util.TruststorePasswordSetter;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -177,6 +178,32 @@ public class PollingConfigurationAnalyzerTest {
     ChangeListener listener =
             doTestEvent(startEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
     assertFalse("Invalid-and-still-invalid service must not trigger discovery", listener.wasNotified(address, clusterName));
+  }
+
+  /**
+   * A service that had a valid baseline but now produces no model (e.g. HiveServer2 transport mode changed to binary)
+   * must trigger re-discovery so it is dropped from the affected topologies.
+   */
+  @Test
+  public void testValidServiceBecameInvalidTriggers() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster BI";
+
+    ApiEvent startEvent = createApiEvent(clusterName,
+                                         NameNodeServiceModelGenerator.SERVICE_TYPE,
+                                         NameNodeServiceModelGenerator.SERVICE,
+                                         PollingConfigurationAnalyzer.START_COMMAND,
+                                         PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+
+    // Baseline has a valid service; no current model is stubbed -> current is null (became invalid).
+    final Map<String, ServiceConfigurationModel> baseline = new HashMap<>();
+    final ServiceConfigurationModel nnModel = new ServiceConfigurationModel();
+    nnModel.addRoleProperty(NameNodeServiceModelGenerator.ROLE_TYPE, "namenode_port", "8020");
+    baseline.put(NameNodeServiceModelGenerator.SERVICE_TYPE, nnModel);
+
+    ChangeListener listener =
+            doTestEvent(startEvent, address, clusterName, baseline, Collections.emptyMap());
+    assertTrue("A service that became invalid must trigger re-discovery", listener.wasNotified(address, clusterName));
   }
 
   /**
@@ -547,6 +574,131 @@ public class PollingConfigurationAnalyzerTest {
     listener.clearNotification();
     doTestEvent(rollingRestartEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
     assertFalse("Unexpected change notification", listener.wasNotified(address, clusterName));
+  }
+
+  /**
+   * A start event for a service type that no deployed descriptor references must not be relevant, even though a
+   * generator exists and a (valid) current model would otherwise be discovered.
+   */
+  @Test
+  public void testUnreferencedServiceStartEventIsNotRelevant() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster REF1";
+
+    ApiEvent solrStart = createApiEvent(clusterName, SolrServiceModelGenerator.SERVICE_TYPE,
+        SolrServiceModelGenerator.SERVICE, PollingConfigurationAnalyzer.START_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+    ServiceConfigurationModel solrModel = new ServiceConfigurationModel();
+    solrModel.addRoleProperty(SolrServiceModelGenerator.ROLE_TYPE, "solr_http_port", "8983");
+
+    // Descriptor references NAMENODE only -> a SOLR event is not relevant.
+    boolean notified = runReferenceAwareScenario(address, clusterName, NameNodeServiceModelGenerator.SERVICE,
+        solrStart, SolrServiceModelGenerator.SERVICE, solrModel);
+    assertFalse("An event for a service no descriptor references must not trigger discovery", notified);
+  }
+
+  /**
+   * A start event for a service type a deployed descriptor references is relevant and (as a new/now-valid service)
+   * triggers re-discovery.
+   */
+  @Test
+  public void testReferencedServiceStartEventIsRelevant() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster REF2";
+
+    ApiEvent nnStart = createApiEvent(clusterName, NameNodeServiceModelGenerator.SERVICE_TYPE,
+        NameNodeServiceModelGenerator.SERVICE, PollingConfigurationAnalyzer.START_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+    ServiceConfigurationModel nnModel = new ServiceConfigurationModel();
+    nnModel.addRoleProperty(NameNodeServiceModelGenerator.ROLE_TYPE, "namenode_port", "8020");
+
+    boolean notified = runReferenceAwareScenario(address, clusterName, NameNodeServiceModelGenerator.SERVICE,
+        nnStart, NameNodeServiceModelGenerator.SERVICE, nnModel);
+    assertTrue("An event for a referenced service must trigger discovery", notified);
+  }
+
+  private boolean runReferenceAwareScenario(final String address, final String clusterName,
+      final String descriptorServiceName, final ApiEvent event, final String currentServiceName,
+      final ServiceConfigurationModel currentModel) throws AliasServiceException {
+    final String descContent =
+        "{\n" +
+        "  \"discovery-type\": \"ClouderaManager\",\n" +
+        "  \"discovery-address\": \"" + address + "\",\n" +
+        "  \"cluster\": \"" + clusterName + "\",\n" +
+        "  \"provider-config-ref\": \"ldap\",\n" +
+        "  \"services\": [\n" +
+        "    {\n" +
+        "      \"name\": \"" + descriptorServiceName + "\"\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    File descriptor = null;
+    try {
+      descriptor = File.createTempFile("test", ".json");
+      FileUtils.writeStringToFile(descriptor, descContent, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
+    EasyMock.expect(gatewayConfig.getIncludedSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
+    EasyMock.expect(gatewayConfig.getIncludedSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.replay(gatewayConfig);
+
+    ServiceDiscoveryConfig sdc = EasyMock.createNiceMock(ServiceDiscoveryConfig.class);
+    EasyMock.expect(sdc.getCluster()).andReturn(clusterName).anyTimes();
+    EasyMock.expect(sdc.getAddress()).andReturn(address).anyTimes();
+    EasyMock.expect(sdc.getUser()).andReturn("u").anyTimes();
+    EasyMock.expect(sdc.getPasswordAlias()).andReturn("a").anyTimes();
+    EasyMock.replay(sdc);
+
+    final ClusterConfigurationCache configCache = new ClusterConfigurationCache();
+    configCache.addDiscoveryConfig(sdc);
+    // Register the cluster with an empty baseline so the monitor iterates it (getClusterNames is driven by the
+    // service-configuration cache); the event's service type is intentionally absent from the baseline.
+    configCache.addServiceConfiguration(address, clusterName, new HashMap<>());
+
+    TopologyService ts = EasyMock.createNiceMock(TopologyService.class);
+    EasyMock.expect(ts.getDescriptors()).andReturn(Collections.singletonList(descriptor)).anyTimes();
+
+    final GatewayStatusService gatewayStatusService = EasyMock.createNiceMock(GatewayStatusService.class);
+    EasyMock.expect(gatewayStatusService.status()).andReturn(Boolean.TRUE).anyTimes();
+
+    GatewayServices gws = EasyMock.createNiceMock(GatewayServices.class);
+    EasyMock.expect(gws.getService(ServiceType.TOPOLOGY_SERVICE)).andReturn(ts).anyTimes();
+    EasyMock.expect(gws.getService(ServiceType.GATEWAY_STATUS_SERVICE)).andReturn(gatewayStatusService).anyTimes();
+    EasyMock.replay(ts, gatewayStatusService, gws);
+
+    AliasService aliasService = EasyMock.createNiceMock(AliasService.class);
+    EasyMock.expect(aliasService.getPasswordFromAliasForGateway(TruststorePasswordSetter.TRUSTSTORE_PASSWORD_ALIAS)).andReturn(null).anyTimes();
+    EasyMock.replay(aliasService);
+
+    final ChangeListener listener = new ChangeListener();
+    try {
+      setGatewayServices(gws);
+
+      TestablePollingConfigAnalyzer pca = new TestablePollingConfigAnalyzer(gatewayConfig, configCache, aliasService, listener);
+      pca.setInterval(5);
+      if (currentServiceName != null) {
+        pca.addCurrentServiceConfigModel(address, clusterName, currentServiceName, currentModel);
+      }
+      pca.addRestartEvent(clusterName, event);
+
+      ExecutorService pollingThreadExecutor = Executors.newSingleThreadExecutor();
+      pollingThreadExecutor.execute(pca);
+      pollingThreadExecutor.shutdown();
+      try {
+        pollingThreadExecutor.awaitTermination(10, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        //
+      }
+      pca.stop();
+    } finally {
+      setGatewayServices(null);
+      if (descriptor != null && descriptor.exists()) {
+        descriptor.deleteOnExit();
+      }
+    }
+    return listener.wasNotified(address, clusterName);
   }
 
   private void doTestStartEvent(final ApiEventCategory category) {

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -46,6 +46,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -381,14 +382,29 @@ public class PollingConfigurationAnalyzerTest {
         "  ]\n" +
         "}";
 
-    File descriptor = null;
-    try {
-      descriptor = File.createTempFile("test", ".json");
-      FileUtils.writeStringToFile(descriptor, descContent, StandardCharsets.UTF_8);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    // The descriptor references a different discovery-address, so this cluster is no longer referenced and the
+    // cache entry must be torn down.
+    final File descriptor = createTempDescriptor("test", ".json", descContent);
+    assertEquals("Expected the config cache entry for " + clusterName + " to have been removed.",
+                 0, runClusterReferenceTerminationScenario(descriptor, address, clusterName));
+  }
 
+  /**
+   * A descriptor that cannot be read/parsed must not be interpreted as "no references"; clusterReferencesExist must
+   * fail open (assume references remain) so a transient read/parse problem does not tear down a live cluster's cache.
+   */
+  @Test
+  public void testUnparseableDescriptorDoesNotTearDownCache() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster 7B";
+
+    final File descriptor = createTempDescriptor("broken", ".json", "{ this is not valid descriptor json ");
+    assertEquals("An unparseable descriptor must fail open (assume references remain) and not tear down the cache.",
+                 1, runClusterReferenceTerminationScenario(descriptor, address, clusterName));
+  }
+
+  private int runClusterReferenceTerminationScenario(final File descriptor, final String address,
+      final String clusterName) throws AliasServiceException {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(gatewayConfig.getIncludedSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(gatewayConfig.getIncludedSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
@@ -472,9 +488,7 @@ public class PollingConfigurationAnalyzerTest {
         descriptor.deleteOnExit();
       }
 
-      assertEquals("Expected the config cache entry for " + clusterName + " to have been removed.",
-                   0,
-                   configCache.getClusterNames().get(address).size());
+      return configCache.getClusterNames().get(address).size();
     } finally {
       // Reset the GatewayServices field of GatewayServer
       setGatewayServices(null);
@@ -676,6 +690,58 @@ public class PollingConfigurationAnalyzerTest {
     assertTrue("An event for a referenced service must trigger discovery", notified);
   }
 
+  /**
+   * A descriptor that cannot be parsed (malformed content, {@link IOException} from Jackson) contributes no referenced
+   * services: it cannot be re-generated until fixed, so a re-discovery now could not act on it. getReferencedServiceTypes
+   * skips it (logged), so an event for a service only such a descriptor would reference is not treated as relevant.
+   */
+  @Test
+  public void testUnparseableDescriptorIsSkippedForReferenceFiltering() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster REF3";
+
+    ApiEvent nnStart = createApiEvent(clusterName, NameNodeServiceModelGenerator.SERVICE_TYPE,
+        NameNodeServiceModelGenerator.SERVICE, PollingConfigurationAnalyzer.START_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+    ServiceConfigurationModel nnModel = new ServiceConfigurationModel();
+    nnModel.addRoleProperty(NameNodeServiceModelGenerator.ROLE_TYPE, "namenode_port", "8020");
+
+    final File descriptor = createTempDescriptor("broken", ".json", "{ this is not valid descriptor json ");
+    boolean notified = runReferenceAwareScenario(descriptor, address, clusterName, nnStart,
+        NameNodeServiceModelGenerator.SERVICE, nnModel);
+    assertFalse("An unparseable descriptor contributes no referenced services, so the event must not be relevant", notified);
+  }
+
+  /**
+   * With one unparseable descriptor (unsupported extension -> unchecked IllegalArgumentException from
+   * SimpleDescriptorFactory.parse) alongside a valid one, the broken descriptor must be caught and skipped without
+   * aborting the monitoring cycle, and an event for a service referenced by the valid descriptor must still trigger
+   * re-discovery.
+   */
+  @Test
+  public void testValidDescriptorStillTriggersWhenAnotherDescriptorIsUnparseable() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster REF4";
+
+    ApiEvent nnStart = createApiEvent(clusterName, NameNodeServiceModelGenerator.SERVICE_TYPE,
+        NameNodeServiceModelGenerator.SERVICE, PollingConfigurationAnalyzer.START_COMMAND, PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+    ServiceConfigurationModel nnModel = new ServiceConfigurationModel();
+    nnModel.addRoleProperty(NameNodeServiceModelGenerator.ROLE_TYPE, "namenode_port", "8020");
+
+    final File validDescriptor = createTempDescriptor("valid", ".json",
+        "{\n" +
+        "  \"discovery-type\": \"ClouderaManager\",\n" +
+        "  \"discovery-address\": \"" + address + "\",\n" +
+        "  \"cluster\": \"" + clusterName + "\",\n" +
+        "  \"provider-config-ref\": \"ldap\",\n" +
+        "  \"services\": [ { \"name\": \"" + NameNodeServiceModelGenerator.SERVICE + "\" } ]\n" +
+        "}");
+    final File brokenDescriptor = createTempDescriptor("broken", ".txt", "not a descriptor");
+
+    boolean notified = runReferenceAwareScenario(Arrays.asList(validDescriptor, brokenDescriptor), address, clusterName,
+        nnStart, NameNodeServiceModelGenerator.SERVICE, nnModel);
+    assertTrue("A valid descriptor's referenced-service event must still trigger discovery despite a broken descriptor", notified);
+  }
+
   private boolean runReferenceAwareScenario(final String address, final String clusterName,
       final String descriptorServiceName, final ApiEvent event, final String currentServiceName,
       final ServiceConfigurationModel currentModel) throws AliasServiceException {
@@ -692,14 +758,20 @@ public class PollingConfigurationAnalyzerTest {
         "  ]\n" +
         "}";
 
-    File descriptor = null;
-    try {
-      descriptor = File.createTempFile("test", ".json");
-      FileUtils.writeStringToFile(descriptor, descContent, StandardCharsets.UTF_8);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
+    final File descriptor = createTempDescriptor("test", ".json", descContent);
+    return runReferenceAwareScenario(descriptor, address, clusterName, event, currentServiceName, currentModel);
+  }
 
+  private boolean runReferenceAwareScenario(final File descriptor, final String address, final String clusterName,
+      final ApiEvent event, final String currentServiceName,
+      final ServiceConfigurationModel currentModel) throws AliasServiceException {
+    return runReferenceAwareScenario(Collections.singletonList(descriptor), address, clusterName, event,
+        currentServiceName, currentModel);
+  }
+
+  private boolean runReferenceAwareScenario(final List<File> descriptors, final String address, final String clusterName,
+      final ApiEvent event, final String currentServiceName,
+      final ServiceConfigurationModel currentModel) throws AliasServiceException {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(gatewayConfig.getIncludedSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(gatewayConfig.getIncludedSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
@@ -719,7 +791,7 @@ public class PollingConfigurationAnalyzerTest {
     configCache.addServiceConfiguration(address, clusterName, new HashMap<>());
 
     TopologyService ts = EasyMock.createNiceMock(TopologyService.class);
-    EasyMock.expect(ts.getDescriptors()).andReturn(Collections.singletonList(descriptor)).anyTimes();
+    EasyMock.expect(ts.getDescriptors()).andReturn(descriptors).anyTimes();
 
     final GatewayStatusService gatewayStatusService = EasyMock.createNiceMock(GatewayStatusService.class);
     EasyMock.expect(gatewayStatusService.status()).andReturn(Boolean.TRUE).anyTimes();
@@ -755,8 +827,10 @@ public class PollingConfigurationAnalyzerTest {
       pca.stop();
     } finally {
       setGatewayServices(null);
-      if (descriptor != null && descriptor.exists()) {
-        descriptor.deleteOnExit();
+      for (File descriptor : descriptors) {
+        if (descriptor != null && descriptor.exists()) {
+          descriptor.deleteOnExit();
+        }
       }
     }
     return listener.wasNotified(address, clusterName);
@@ -962,6 +1036,17 @@ public class PollingConfigurationAnalyzerTest {
     } catch (Exception e) {
       e.printStackTrace();
     }
+  }
+
+  private File createTempDescriptor(final String prefix, final String suffix, final String content) {
+    File descriptor = null;
+    try {
+      descriptor = File.createTempFile(prefix, suffix);
+      FileUtils.writeStringToFile(descriptor, content, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return descriptor;
   }
 
   private ApiEvent createApiEvent(final String clusterName,

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/PollingConfigurationAnalyzerTest.java
@@ -45,6 +45,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -149,6 +150,32 @@ public class PollingConfigurationAnalyzerTest {
     ChangeListener listener =
             doTestEvent(startEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap());
     assertTrue("Expected a change notification", listener.wasNotified(address, clusterName));
+  }
+
+  /**
+   * Test that a start event for a service type excluded from discovery via
+   * gateway.cloudera.manager.service.discovery.excluded.service.types is not treated as relevant, so it does not
+   * trigger an unnecessary re-discovery. This is the same scenario as {@link #testNewServiceStartEvent()} (absent
+   * baseline, which would otherwise be read as a "new service"), but with the service type excluded.
+   */
+  @Test
+  public void testExcludedServiceTypeStartEventIsNotRelevant() throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster X";
+
+    // Simulate a service Start event for a service type that is excluded from discovery
+    ApiEvent startEvent = createApiEvent(clusterName,
+                                         NameNodeServiceModelGenerator.SERVICE_TYPE,
+                                         NameNodeServiceModelGenerator.SERVICE,
+                                         PollingConfigurationAnalyzer.START_COMMAND,
+                                         PollingConfigurationAnalyzer.SUCCEEDED_STATUS);
+
+    final ChangeListener listener = new ChangeListener();
+    final TestablePollingConfigAnalyzer pca = buildPollingConfigAnalyzer(address, clusterName, Collections.emptyMap(),
+            listener, true, Collections.singleton(NameNodeServiceModelGenerator.SERVICE_TYPE));
+
+    doTestEvent(startEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
+    assertFalse("Excluded service type must not trigger a change notification", listener.wasNotified(address, clusterName));
   }
 
   /**
@@ -432,6 +459,49 @@ public class PollingConfigurationAnalyzerTest {
     doTestEventWithConfigChange(revisionEvent, clusterName);
   }
 
+  /**
+   * A down-scale (role deleted) event for a service type excluded from discovery via
+   * gateway.cloudera.manager.service.discovery.excluded.service.types must not be treated as relevant, so it does not
+   * trigger an unnecessary re-discovery. Counterpart of {@link #testNotificationSentAfterDownScaleEvent()} with the
+   * service type excluded.
+   */
+  @Test
+  public void testExcludedServiceTypeDownScaleEventIsNotRelevant() throws AliasServiceException {
+    doTestExcludedServiceTypeScaleEventIsNotRelevant(PollingConfigurationAnalyzer.EVENT_CODE_ROLE_DELETED);
+  }
+
+  /**
+   * An up-scale (role created) event for a service type excluded from discovery via
+   * gateway.cloudera.manager.service.discovery.excluded.service.types must not be treated as relevant, so it does not
+   * trigger an unnecessary re-discovery. Counterpart of {@link #testNotificationSentAfterUpScaleEvent()} with the
+   * service type excluded.
+   */
+  @Test
+  public void testExcludedServiceTypeUpScaleEventIsNotRelevant() throws AliasServiceException {
+    doTestExcludedServiceTypeScaleEventIsNotRelevant(PollingConfigurationAnalyzer.EVENT_CODE_ROLE_CREATED);
+  }
+
+  private void doTestExcludedServiceTypeScaleEventIsNotRelevant(final String eventCode) throws AliasServiceException {
+    final String address = "http://host1:1234";
+    final String clusterName = "Cluster T";
+
+    final List<ApiEventAttribute> revisionEventAttrs = new ArrayList<>();
+    revisionEventAttrs.add(createEventAttribute("CLUSTER", clusterName));
+    revisionEventAttrs.add(createEventAttribute("SERVICE_TYPE", HiveOnTezServiceModelGenerator.SERVICE_TYPE));
+    revisionEventAttrs.add(createEventAttribute("SERVICE", HiveOnTezServiceModelGenerator.SERVICE));
+    revisionEventAttrs.add(createEventAttribute("ROLE_TYPE", HiveOnTezServiceModelGenerator.ROLE_TYPE));
+    revisionEventAttrs.add(createEventAttribute("REVISION", "215"));
+    revisionEventAttrs.add(createEventAttribute("EVENTCODE", eventCode));
+    final ApiEvent revisionEvent = createApiEvent(ApiEventCategory.AUDIT_EVENT, revisionEventAttrs, null);
+
+    final ChangeListener listener = new ChangeListener();
+    final TestablePollingConfigAnalyzer pca = buildPollingConfigAnalyzer(address, clusterName, Collections.emptyMap(),
+            listener, true, Collections.singleton(HiveOnTezServiceModelGenerator.SERVICE_TYPE));
+
+    doTestEvent(revisionEvent, address, clusterName, Collections.emptyMap(), Collections.emptyMap(), pca);
+    assertFalse("Excluded service type must not trigger a scale-event notification", listener.wasNotified(address, clusterName));
+  }
+
   @Test
   public void shouldNotPerformClusterConfigurationChangeMonitoringIfKnoxGatewayIsNotYetReady() throws AliasServiceException {
     final String address = "http://host1:1234";
@@ -516,9 +586,16 @@ public class PollingConfigurationAnalyzerTest {
 
   private TestablePollingConfigAnalyzer buildPollingConfigAnalyzer(final String address, final String clusterName,
       final Map<String, ServiceConfigurationModel> serviceConfigurationModels, ChangeListener listener, boolean isKnoxGatewayReady) throws AliasServiceException {
+    return buildPollingConfigAnalyzer(address, clusterName, serviceConfigurationModels, listener, isKnoxGatewayReady, Collections.emptySet());
+  }
+
+  private TestablePollingConfigAnalyzer buildPollingConfigAnalyzer(final String address, final String clusterName,
+      final Map<String, ServiceConfigurationModel> serviceConfigurationModels, ChangeListener listener, boolean isKnoxGatewayReady,
+      Collection<String> excludedServiceTypes) throws AliasServiceException {
     final GatewayConfig gatewayConfig = EasyMock.createNiceMock(GatewayConfig.class);
     EasyMock.expect(gatewayConfig.getIncludedSSLCiphers()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(gatewayConfig.getIncludedSSLProtocols()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(gatewayConfig.getClouderaManagerServiceDiscoveryExcludedServiceTypes()).andReturn(excludedServiceTypes).anyTimes();
     EasyMock.replay(gatewayConfig);
 
     // Mock the service discovery details

--- a/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ServiceConfigurationModelTest.java
+++ b/gateway-discovery-cm/src/test/java/org/apache/knox/gateway/topology/discovery/cm/monitor/ServiceConfigurationModelTest.java
@@ -19,8 +19,10 @@ package org.apache.knox.gateway.topology.discovery.cm.monitor;
 import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiRole;
 import org.apache.knox.gateway.topology.discovery.cm.AbstractCMDiscoveryTest;
+import org.apache.knox.gateway.topology.discovery.cm.ServiceModel;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class ServiceConfigurationModelTest extends AbstractCMDiscoveryTest {
 
@@ -112,6 +115,44 @@ public class ServiceConfigurationModelTest extends AbstractCMDiscoveryTest {
     validateServiceConfigurationModel(model, serviceConfig, roleConfig);
   }
 
+
+  @Test
+  public void testFromServiceModelsEmpty() {
+    assertTrue("No models should yield an empty map",
+        ServiceConfigurationModel.fromServiceModels(Collections.emptyList()).isEmpty());
+    assertTrue("Null models should yield an empty map",
+        ServiceConfigurationModel.fromServiceModels(null).isEmpty());
+  }
+
+  @Test
+  public void testFromServiceModelsGroupsByServiceTypeAndCopiesProps() {
+    // Two models of the same service type (e.g. an API and a UI model) should merge into a single entry.
+    ServiceModel apiModel = new ServiceModel(ServiceModel.Type.API, "SOLR", "SOLR", "SOLR_SERVER", "https://host:8985");
+    apiModel.addServiceProperty("solr_use_ssl", "true");
+    apiModel.addRoleProperty("SOLR_SERVER", "solr_https_port", "8985");
+
+    ServiceModel uiModel = new ServiceModel(ServiceModel.Type.UI, "SOLRUI", "SOLR", "SOLR_SERVER", "https://host:8985");
+    uiModel.addRoleProperty("SOLR_SERVER", "solr_http_port", "8983");
+
+    // A model of a different service type should produce a separate entry.
+    ServiceModel nnModel = new ServiceModel(ServiceModel.Type.API, "NAMENODE", "HDFS", "NAMENODE", "hdfs://host:8020");
+    nnModel.addRoleProperty("NAMENODE", "namenode_port", "8020");
+
+    Map<String, ServiceConfigurationModel> result =
+        ServiceConfigurationModel.fromServiceModels(Arrays.asList(apiModel, uiModel, nnModel));
+
+    assertEquals("Should be grouped into two service types", 2, result.size());
+
+    ServiceConfigurationModel solr = result.get("SOLR");
+    assertNotNull(solr);
+    assertEquals("true", solr.getServiceProps().get("solr_use_ssl"));
+    assertEquals("8985", solr.getRoleProps("SOLR_SERVER").get("solr_https_port"));
+    assertEquals("8983", solr.getRoleProps("SOLR_SERVER").get("solr_http_port"));
+
+    ServiceConfigurationModel hdfs = result.get("HDFS");
+    assertNotNull(hdfs);
+    assertEquals("8020", hdfs.getRoleProps("NAMENODE").get("namenode_port"));
+  }
 
   private void validateServiceConfigurationModel(final ServiceConfigurationModel        model,
                                                  final Map<String, String>              expectedServiceConfig,


### PR DESCRIPTION
[KNOX-2900](https://issues.apache.org/jira/browse/KNOX-2900) - Re-enable service-based discovery filter

## What changes were proposed in this pull request?

PollingConfigurationAnalyzer changes:
- Ignore excluded service types in CM config monitor event relevance
- Ignore excluded role types in scale events
- Prevent rediscovery of services that remained in an invalid config state (use the same workflow for service configuration data discovery as ClouderaManagerServiceDiscovery)
- Re-enable per-descriptor service filtering in CM discovery (cluster configuration cache data is merged after each topology discovery) 

## How was this patch tested?

Still needs to be tested. 

## Integration Tests


